### PR TITLE
Fix other issues with data migration code

### DIFF
--- a/db_migrations/0006_data_migration.sql
+++ b/db_migrations/0006_data_migration.sql
@@ -19,32 +19,32 @@ WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.pubkey = contacts.pubkey);
 -- Extract from nip65_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM contacts,
      json_each(contacts.nip65_relays) as relay_value
 WHERE json_valid(contacts.nip65_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Extract from inbox_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM contacts,
      json_each(contacts.inbox_relays) as relay_value
 WHERE json_valid(contacts.inbox_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Extract from key_package_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM contacts,
      json_each(contacts.key_package_relays) as relay_value
 WHERE json_valid(contacts.key_package_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Step 3: Create user_relays relationships
 -- Insert nip65_relays relationships
@@ -55,11 +55,11 @@ SELECT DISTINCT
     'nip65' as relay_type
 FROM contacts c
 JOIN users u ON u.pubkey = c.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(c.nip65_relays) as relay_value
+CROSS JOIN json_each(c.nip65_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(c.nip65_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Insert inbox_relays relationships
 INSERT OR IGNORE INTO user_relays (user_id, relay_id, relay_type)
@@ -69,11 +69,11 @@ SELECT DISTINCT
     'inbox' as relay_type
 FROM contacts c
 JOIN users u ON u.pubkey = c.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(c.inbox_relays) as relay_value
+CROSS JOIN json_each(c.inbox_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(c.inbox_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Insert key_package_relays relationships
 INSERT OR IGNORE INTO user_relays (user_id, relay_id, relay_type)
@@ -83,42 +83,42 @@ SELECT DISTINCT
     'key_package' as relay_type
 FROM contacts c
 JOIN users u ON u.pubkey = c.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(c.key_package_relays) as relay_value
+CROSS JOIN json_each(c.key_package_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(c.key_package_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Step 4: Extract and insert unique relay URLs from accounts table
 -- Extract from accounts.nip65_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM accounts,
      json_each(accounts.nip65_relays) as relay_value
 WHERE json_valid(accounts.nip65_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Extract from accounts.inbox_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM accounts,
      json_each(accounts.inbox_relays) as relay_value
 WHERE json_valid(accounts.inbox_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Extract from accounts.key_package_relays
 INSERT OR IGNORE INTO relays (url)
 SELECT DISTINCT
-    json_extract(relay_value.value, '$') as url
+    relay_value.value as url
 FROM accounts,
      json_each(accounts.key_package_relays) as relay_value
 WHERE json_valid(accounts.key_package_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Step 5: Create user_relays relationships from accounts table
 -- Insert accounts.nip65_relays relationships
@@ -129,11 +129,11 @@ SELECT DISTINCT
     'nip65' as relay_type
 FROM accounts a
 JOIN users u ON u.pubkey = a.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(a.nip65_relays) as relay_value
+CROSS JOIN json_each(a.nip65_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(a.nip65_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Insert accounts.inbox_relays relationships
 INSERT OR IGNORE INTO user_relays (user_id, relay_id, relay_type)
@@ -143,11 +143,11 @@ SELECT DISTINCT
     'inbox' as relay_type
 FROM accounts a
 JOIN users u ON u.pubkey = a.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(a.inbox_relays) as relay_value
+CROSS JOIN json_each(a.inbox_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(a.inbox_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Insert accounts.key_package_relays relationships
 INSERT OR IGNORE INTO user_relays (user_id, relay_id, relay_type)
@@ -157,11 +157,11 @@ SELECT DISTINCT
     'key_package' as relay_type
 FROM accounts a
 JOIN users u ON u.pubkey = a.pubkey
-JOIN relays r ON r.url = json_extract(relay_value.value, '$'),
-     json_each(a.key_package_relays) as relay_value
+CROSS JOIN json_each(a.key_package_relays) as relay_value
+JOIN relays r ON r.url = relay_value.value
 WHERE json_valid(a.key_package_relays)
-  AND json_extract(relay_value.value, '$') IS NOT NULL
-  AND json_extract(relay_value.value, '$') != '';
+  AND relay_value.value IS NOT NULL
+  AND relay_value.value != '';
 
 -- Step 6: Migrate accounts to accounts_new table
 INSERT INTO accounts_new (pubkey, user_id, settings, last_synced_at)


### PR DESCRIPTION
"when using json_each(), the value field already contains the extracted JSON value. You don't need to extract from it again. This is causing the "malformed JSON" error."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or invalid relay URLs to reduce migration errors.
  * Ensured more reliable linking of relays for contacts and accounts during data migration.

* **Refactor**
  * Standardized the approach for extracting and joining relay data to improve consistency and readability in migrations.

* **Chores**
  * Updated data migration scripts to align with current relay data structures without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->