### PR TITLE
Bump rust nostr, update to image_hash and byte arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 [[package]]
 name = "nostr"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2416,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "nostr-blossom"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "base64 0.22.1",
  "nostr",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "flatbuffers",
  "lru",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "nostr-lmdb"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "async-utility",
  "flume",
@@ -2452,9 +2452,8 @@ dependencies = [
 [[package]]
 name = "nostr-mls"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
- "aes-gcm",
  "hex",
  "nostr",
  "nostr-mls-storage",
@@ -2469,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-sqlite-storage"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
@@ -2485,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-storage"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "nostr",
  "openmls",
@@ -2497,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2514,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2600,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=84b1a016cffc30625567a03e2d3bcae86463f075#84b1a016cffc30625567a03e2d3bcae86463f075"
+source = "git+https://github.com/rust-nostr/nostr?rev=fadf1a6b3d8c5457e5a66d95d6c1677b4353e653#fadf1a6b3d8c5457e5a66d95d6c1677b4353e653"
 dependencies = [
  "async-utility",
  "nostr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-nostr-mls = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "84b1a016cffc30625567a03e2d3bcae86463f075" }
-nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "84b1a016cffc30625567a03e2d3bcae86463f075" }
-nwc = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "84b1a016cffc30625567a03e2d3bcae86463f075" }
-nostr-blossom = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "84b1a016cffc30625567a03e2d3bcae86463f075" }
-nostr-sdk = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "84b1a016cffc30625567a03e2d3bcae86463f075", features = [
+nostr-mls = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "fadf1a6b3d8c5457e5a66d95d6c1677b4353e653" }
+nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "fadf1a6b3d8c5457e5a66d95d6c1677b4353e653" }
+nwc = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "fadf1a6b3d8c5457e5a66d95d6c1677b4353e653" }
+nostr-blossom = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "fadf1a6b3d8c5457e5a66d95d6c1677b4353e653" }
+nostr-sdk = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "fadf1a6b3d8c5457e5a66d95d6c1677b4353e653", features = [
     "lmdb",
     "nip04",
     "nip44",

--- a/src/integration_tests/test_cases/shared/create_group.rs
+++ b/src/integration_tests/test_cases/shared/create_group.rs
@@ -53,7 +53,7 @@ impl TestCase for CreateGroupTestCase {
                 NostrGroupConfigData::new(
                     self.group_name.clone(),
                     self.group_description.clone(),
-                    None, // image_url
+                    None, // image_hash
                     None, // image_key
                     None, // image_nonce
                     vec![RelayUrl::parse("ws://localhost:8080").unwrap()],

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -580,7 +580,7 @@ mod tests {
         // Verify group metadata matches configuration
         assert_eq!(group.name, config.name);
         assert_eq!(group.description, config.description);
-        assert_eq!(group.image_url, config.image_url);
+        assert_eq!(group.image_hash, config.image_hash);
         assert_eq!(group.image_key, config.image_key);
 
         // Verify admin configuration
@@ -893,9 +893,9 @@ mod tests {
         let new_group_data = nostr_mls::groups::NostrGroupDataUpdate {
             name: Some("Updated Group Name".to_string()),
             description: Some("Updated description".to_string()),
-            image_url: Some(Some("https://example.com/new_image.png".to_string())),
-            image_key: Some(Some(b"new image key".to_vec())),
-            image_nonce: Some(Some(b"new image nonce".to_vec())),
+            image_hash: Some(Some([3u8; 32])), // 32-byte hash for new image
+            image_key: Some(Some([4u8; 32])),  // 32-byte encryption key
+            image_nonce: Some(Some([5u8; 12])), // 12-byte nonce
             admins: None,
             relays: None,
         };
@@ -925,7 +925,7 @@ mod tests {
             updated_group.description,
             new_group_data.description.unwrap()
         );
-        assert_eq!(updated_group.image_url, new_group_data.image_url.unwrap());
+        assert_eq!(updated_group.image_hash, new_group_data.image_hash.unwrap());
         assert_eq!(updated_group.image_key, new_group_data.image_key.unwrap());
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -561,9 +561,9 @@ pub mod test_utils {
         NostrGroupConfigData {
             name: "Test group".to_owned(),
             description: "test description".to_owned(),
-            image_url: Some("http://test_blossom:53232/fake_img.png".to_owned()),
-            image_key: Some(b"fake key to encrypt image".to_vec()),
-            image_nonce: Some(b"fake nonce to encrypt image".to_vec()),
+            image_hash: Some([0u8; 32]),  // 32-byte hash for fake image
+            image_key: Some([1u8; 32]),   // 32-byte encryption key
+            image_nonce: Some([2u8; 12]), // 12-byte nonce
             relays: vec![RelayUrl::parse("ws://localhost:8080/").unwrap()],
             admins,
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced privacy for group images by switching to hashed image metadata with standardized encryption parameters; user experience remains unchanged.
- Refactor
  - Migrated group image handling from URL-based fields to hash/key/nonce format across group data flows.
- Chores
  - Updated NostR-related dependencies to the latest revisions for compatibility and stability.
- Tests
  - Updated test cases to align with the new image metadata format, ensuring consistent validation of group creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->