### PR TITLE
fix(users): add nip65 relay fallback to User#key_package_event when user has no KeyPackage relays

### DIFF
--- a/src/nostr_manager/query.rs
+++ b/src/nostr_manager/query.rs
@@ -13,7 +13,7 @@ use crate::{
 impl NostrManager {
     pub(crate) async fn fetch_metadata_from(
         &self,
-        nip65_relays: &[Relay],
+        nip65_relays: &[Relay], // TODO: Replace with &[RelayUrl]
         pubkey: PublicKey,
     ) -> Result<Option<Metadata>> {
         let filter: Filter = Filter::new().author(pubkey).kind(Kind::Metadata).limit(1);
@@ -32,7 +32,7 @@ impl NostrManager {
         &self,
         pubkey: PublicKey,
         relay_type: RelayType,
-        nip65_relays: &[Relay],
+        nip65_relays: &[Relay], // TODO: Replace with &[RelayUrl]
     ) -> Result<HashSet<RelayUrl>> {
         let filter = Filter::new()
             .author(pubkey)
@@ -41,7 +41,7 @@ impl NostrManager {
         let urls: Vec<RelayUrl> = nip65_relays.iter().map(|r| r.url.clone()).collect();
         let relay_events = self
             .client
-            .fetch_events_from(urls, filter.clone(), self.timeout)
+            .fetch_events_from(urls, filter, self.timeout)
             .await?;
         tracing::debug!("Fetched relay events {:?}", relay_events);
 
@@ -54,16 +54,15 @@ impl NostrManager {
     pub(crate) async fn fetch_user_key_package(
         &self,
         pubkey: PublicKey,
-        relays: &[Relay],
+        relays: &[RelayUrl],
     ) -> Result<Option<Event>> {
-        let urls: Vec<RelayUrl> = relays.iter().map(|r| r.url.clone()).collect();
         let filter = Filter::new()
             .kind(Kind::MlsKeyPackage)
             .author(pubkey)
             .limit(1);
         let events = self
             .client
-            .fetch_events_from(urls, filter.clone(), self.timeout)
+            .fetch_events_from(relays, filter, self.timeout)
             .await?;
 
         Ok(events.first_owned())

--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -485,9 +485,13 @@ impl Whitenoise {
     async fn setup_key_package(&self, account: &Account) -> Result<()> {
         let relays = account.key_package_relays(self).await?;
         tracing::debug!(target: "whitenoise::setup_key_package", "Found {} key package relays", relays.len());
+        let relays_urls = relays
+            .iter()
+            .map(|r| r.url.clone())
+            .collect::<Vec<RelayUrl>>();
         let key_package_event = self
             .nostr
-            .fetch_user_key_package(account.pubkey, &relays)
+            .fetch_user_key_package(account.pubkey, &relays_urls)
             .await?;
         if key_package_event.is_none() {
             self.publish_key_package_for_account(account).await?;
@@ -1063,7 +1067,13 @@ mod tests {
             .nostr
             .fetch_user_key_package(
                 account.pubkey,
-                &account.nip65_relays(&whitenoise).await.unwrap(),
+                &account
+                    .nip65_relays(&whitenoise)
+                    .await
+                    .unwrap()
+                    .iter()
+                    .map(|r| r.url.clone())
+                    .collect::<Vec<RelayUrl>>(),
             )
             .await
             .unwrap();
@@ -1155,7 +1165,13 @@ mod tests {
             .nostr
             .fetch_user_key_package(
                 account.pubkey,
-                &account.key_package_relays(whitenoise).await.unwrap(),
+                &account
+                    .key_package_relays(whitenoise)
+                    .await
+                    .unwrap()
+                    .iter()
+                    .map(|r| r.url.clone())
+                    .collect::<Vec<RelayUrl>>(),
             )
             .await
             .unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -94,15 +94,16 @@ mod tests {
         member_pubkey: PublicKey,
     ) -> Event {
         // Fetch a real key package event for the member from relays
+        let relays_urls = creator_account
+            .key_package_relays(whitenoise)
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.url.clone())
+            .collect::<Vec<RelayUrl>>();
         let key_pkg_event = whitenoise
             .nostr
-            .fetch_user_key_package(
-                member_pubkey,
-                &creator_account
-                    .key_package_relays(whitenoise)
-                    .await
-                    .unwrap(),
-            )
+            .fetch_user_key_package(member_pubkey, &relays_urls)
             .await
             .unwrap()
             .expect("member must have a published key package");

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -103,7 +103,14 @@ impl Whitenoise {
                 }
             }
             let kp_relays = user.relays(RelayType::KeyPackage, &self.database).await?;
-            let some_event = self.nostr.fetch_user_key_package(*pk, &kp_relays).await?;
+            let kp_relays_urls = kp_relays
+                .iter()
+                .map(|r| r.url.clone())
+                .collect::<Vec<RelayUrl>>();
+            let some_event = self
+                .nostr
+                .fetch_user_key_package(*pk, &kp_relays_urls)
+                .await?;
             let event = some_event.ok_or(WhitenoiseError::NostrMlsError(
                 nostr_mls::Error::KeyPackage("Does not exist".to_owned()),
             ))?;
@@ -284,9 +291,13 @@ impl Whitenoise {
                 );
                 relays_to_use = account.nip65_relays(self).await?;
             }
+            let relays_to_use_urls = relays_to_use
+                .iter()
+                .map(|r| r.url.clone())
+                .collect::<Vec<RelayUrl>>();
             let some_event = self
                 .nostr
-                .fetch_user_key_package(*pk, &relays_to_use)
+                .fetch_user_key_package(*pk, &relays_to_use_urls)
                 .await?;
             let event = some_event.ok_or(WhitenoiseError::NostrMlsError(
                 nostr_mls::Error::KeyPackage("Does not exist".to_owned()),


### PR DESCRIPTION
Also replaces Relay with RelayUrl in NostrManager#fetch_user_key_package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More reliable key package retrieval with automatic fallback to alternative relays and a warning when none are configured.
- Bug Fixes
  - Deduplicates relay URLs to avoid redundant requests and improve success rates.
- Refactor
  - Standardized relay handling to use URLs across the app for key package fetching.
- Tests
  - Updated tests to reflect the new relay URL handling.
- Documentation
  - Minor comment updates clarifying future relay URL usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->