### PR TITLE
refactor(nostr_manager): use pubkey instead of account on publisher methods

### DIFF
--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -159,7 +159,7 @@ impl Whitenoise {
                     &member_pubkey,
                     welcome_rumor.clone(),
                     &[Tag::expiration(one_month_future)],
-                    creator_account,
+                    creator_account.pubkey,
                     &Relay::urls(&relays_to_use),
                     keys.clone(),
                 )
@@ -322,7 +322,7 @@ impl Whitenoise {
         }
 
         self.nostr
-            .publish_event_to(evolution_event, account, &relay_urls)
+            .publish_event_to(evolution_event, &account.pubkey, &relay_urls)
             .await?;
 
         // Evolution event published successfully
@@ -364,7 +364,7 @@ impl Whitenoise {
                     &member_pubkey,
                     welcome_rumor.clone(),
                     &[Tag::expiration(one_month_future)],
-                    account,
+                    account.pubkey,
                     &relay_urls,
                     keys.clone(),
                 )
@@ -403,7 +403,7 @@ impl Whitenoise {
         };
 
         self.nostr
-            .publish_event_to(evolution_event, account, &relay_urls)
+            .publish_event_to(evolution_event, &account.pubkey, &relay_urls)
             .await?;
         Ok(())
     }
@@ -433,7 +433,7 @@ impl Whitenoise {
         };
 
         self.nostr
-            .publish_event_to(evolution_event, account, &relay_urls)
+            .publish_event_to(evolution_event, &account.pubkey, &relay_urls)
             .await?;
         Ok(())
     }
@@ -464,7 +464,7 @@ impl Whitenoise {
 
         // Publish the self-removal proposal to the group
         self.nostr
-            .publish_event_to(evolution_event, account, &relay_urls)
+            .publish_event_to(evolution_event, &account.pubkey, &relay_urls)
             .await?;
 
         // TODO: Do any local updates to ensure that we're accurately reflecting that the account is trying to leave this group

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -50,7 +50,7 @@ impl Whitenoise {
         // Publish message in background without blocking
         self.nostr.background_publish_event_to(
             message_event,
-            account,
+            account.pubkey,
             group_relays.into_iter().collect::<Vec<_>>(),
         );
 


### PR DESCRIPTION
Decouples the nostr-manager a bit further by removing the need to import Account.

Also add some tests for `publish_gift_wrap_to`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined event publishing, group management, and messaging flows to use public keys for signing and tracking, with no changes to visible behavior.
- Tests
  - Updated tests to use generated public keys and added scenarios for gift-wrapped publishing (including empty relay cases), improving coverage and reliability.
- Chores
  - Removed unnecessary time dependencies in tests to simplify setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->