### PR TITLE
 fix: remove conflicting build directive from blossom service

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,15 @@ To get started contributing you'll need to have the [Rust](https://www.rust-lang
 
 1. Clone the repo: `git clone https://github.com/parres-hq/whitenoise.git` and `cd whitenoise`.
 1. Install recommended development tools: `just install-tools` (optional but recommended)
-1. In one terminal start the development services (two Nostr relays; nostr-rs-relay and strfry, and a blossom server) by running `docker compose up`.
-1. Now you can run the integration test if you'd like.
+1. Start the development services (two Nostr relays; nostr-rs-relay and strfry, and a blossom server):
+   ```bash
+   docker compose up -d
+   ```
+   Or if using older Docker versions:
+   ```bash
+   docker-compose up -d
+   ```
+1. Now you can run the integration tests with `just int-test`.
 
 ### Development Tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
 
   blossom:
     image: ghcr.io/hzrd149/blossom-server:master
-    build: .
     volumes:
       - ./dev/data/blossom-ts-server:/app/data
       - ./dev/blossom-server-ts-config.yml:/app/config.yml


### PR DESCRIPTION
The docker-compose.yml file had both 'image:' and 'build: .' directives for the blossom service, causing Docker to attempt building from a non-existent Dockerfile instead of pulling the pre-built image.

Changes:
- Remove 'build: .' from blossom service configuration
- Update README.md to clarify Docker setup with -d flag
- Improve Docker command examples for both new and old versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development setup instructions with clearer Docker Compose commands and fallback options for older Docker versions.
  * Expanded Development Tools section with comprehensive list of recommended tools and usage guidance.

* **Chores**
  * Updated Docker Compose configuration to use prebuilt image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->