### PR TITLE
fix: create AccountGroup synchronously to prevent race condition with…

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -165,8 +165,6 @@ impl Whitenoise {
         };
 
         // Run independent operations concurrently
-        // Note: AccountGroup is already created synchronously in process_welcome
-        // to prevent race condition with Flutter polling
         let (group_info_result, subscription_result, key_rotation_result, image_sync_result) = tokio::join!(
             Self::create_group_info(whitenoise, group_id, group_name),
             Self::setup_group_subscriptions(whitenoise, account, data_dir, keys),


### PR DESCRIPTION
… Flutter polling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account group is now created synchronously when the welcome handler runs, preventing timing-related race conditions; background finalization now runs other steps in parallel without creating the group.

* **Tests**
  * Added and updated tests to verify the account group exists and is pending immediately after the handler returns, preserving idempotency and finalize-flow expectations.

* **Diagnostics**
  * Added debug logging to report account group creation outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->