### PR TITLE
feat(read-tracking): implement read tracking with basic functionalities

### DIFF
--- a/db_migrations/0020_add_last_read_message_id_to_accounts_groups.sql
+++ b/db_migrations/0020_add_last_read_message_id_to_accounts_groups.sql
@@ -1,0 +1,4 @@
+-- Add last_read_message_id to track read marker per account-group
+ALTER TABLE accounts_groups ADD COLUMN last_read_message_id TEXT
+    CHECK (last_read_message_id IS NULL OR
+           (length(last_read_message_id) = 64 AND last_read_message_id NOT GLOB '*[^0-9a-fA-F]*'));

--- a/src/integration_tests/test_cases/chat_list/mark_message_read.rs
+++ b/src/integration_tests/test_cases/chat_list/mark_message_read.rs
@@ -1,0 +1,59 @@
+use crate::WhitenoiseError;
+use crate::integration_tests::core::*;
+use async_trait::async_trait;
+use nostr_sdk::EventId;
+
+/// Marks a message as read for an account.
+pub struct MarkMessageReadTestCase {
+    account_name: String,
+    message_id_key: String,
+}
+
+impl MarkMessageReadTestCase {
+    pub fn new(account_name: &str, message_id_key: &str) -> Self {
+        Self {
+            account_name: account_name.to_string(),
+            message_id_key: message_id_key.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl TestCase for MarkMessageReadTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        tracing::info!(
+            "Marking message '{}' as read for account: {}",
+            self.message_id_key,
+            self.account_name
+        );
+
+        let account = context.get_account(&self.account_name)?;
+        let message_id_hex = context.get_message_id(&self.message_id_key)?;
+        let message_id = EventId::from_hex(message_id_hex).map_err(|e| {
+            WhitenoiseError::Configuration(format!(
+                "Invalid message ID '{}': {}",
+                message_id_hex, e
+            ))
+        })?;
+
+        let updated_account_group = context
+            .whitenoise
+            .mark_message_read(account, &message_id)
+            .await?;
+
+        // Verify the last_read_message_id was actually updated
+        assert_eq!(
+            updated_account_group.last_read_message_id,
+            Some(message_id),
+            "Expected last_read_message_id to be set to {}",
+            message_id
+        );
+
+        tracing::info!(
+            "✓ Marked message '{}' as read for {} (last_read_message_id verified)",
+            self.message_id_key,
+            self.account_name
+        );
+        Ok(())
+    }
+}

--- a/src/integration_tests/test_cases/chat_list/mod.rs
+++ b/src/integration_tests/test_cases/chat_list/mod.rs
@@ -1,9 +1,11 @@
 mod create_dm;
+mod mark_message_read;
 mod verify_chat_list;
 mod verify_chat_list_item;
 mod verify_dm_chat_list_item;
 
 pub use create_dm::CreateDmTestCase;
+pub use mark_message_read::MarkMessageReadTestCase;
 pub use verify_chat_list::VerifyChatListTestCase;
 pub use verify_chat_list_item::VerifyChatListItemTestCase;
 pub use verify_dm_chat_list_item::VerifyDmChatListItemTestCase;

--- a/src/integration_tests/test_cases/chat_list/verify_chat_list_item.rs
+++ b/src/integration_tests/test_cases/chat_list/verify_chat_list_item.rs
@@ -12,6 +12,7 @@ pub struct VerifyChatListItemTestCase {
     expected_pending_confirmation: Option<bool>,
     expected_welcomer_account: Option<String>,
     assert_no_welcomer: bool,
+    expected_unread_count: Option<usize>,
 }
 
 impl VerifyChatListItemTestCase {
@@ -25,6 +26,7 @@ impl VerifyChatListItemTestCase {
             expected_pending_confirmation: None,
             expected_welcomer_account: None,
             assert_no_welcomer: false,
+            expected_unread_count: None,
         }
     }
 
@@ -71,6 +73,12 @@ impl VerifyChatListItemTestCase {
     pub fn expecting_no_welcomer(mut self) -> Self {
         self.assert_no_welcomer = true;
         self.expected_welcomer_account = None;
+        self
+    }
+
+    /// Verifies the unread_count field matches the expected value.
+    pub fn expecting_unread_count(mut self, count: usize) -> Self {
+        self.expected_unread_count = Some(count);
         self
     }
 }
@@ -155,6 +163,15 @@ impl TestCase for VerifyChatListItemTestCase {
                 "Expected welcomer_pubkey to be {}'s pubkey but got {:?}",
                 welcomer_account_name,
                 item.welcomer_pubkey
+            );
+        }
+
+        // Verify unread_count
+        if let Some(expected_count) = self.expected_unread_count {
+            assert_eq!(
+                item.unread_count, expected_count,
+                "Expected unread_count={} but got {}",
+                expected_count, item.unread_count
             );
         }
 

--- a/src/whitenoise/chat_list_streaming/manager.rs
+++ b/src/whitenoise/chat_list_streaming/manager.rs
@@ -85,6 +85,7 @@ mod tests {
             last_message: None,
             pending_confirmation: false,
             welcomer_pubkey: None,
+            unread_count: 0,
         }
     }
 

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -34,6 +34,9 @@ pub enum WhitenoiseError {
     #[error("Group not found")]
     GroupNotFound,
 
+    #[error("Message not found")]
+    MessageNotFound,
+
     #[error("Group has no relays configured")]
     GroupMissingRelays,
 

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -72,6 +72,7 @@ impl Whitenoise {
             mls_group_id: group_id.clone(),
             user_confirmation: None,
             welcomer_pubkey: Some(welcomer_pubkey),
+            last_read_message_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can mark messages as read; the system tracks each account’s last-read message per chat.
  * Chat list items now show per-chat unread message counts.

* **Tests**
  * Added integration and unit tests covering marking-as-read, unread-count calculations, and related edge cases.

* **Chores**
  * Database migration added to persist per-chat last-read markers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->