### PR TITLE
feat(whitenoise/accounts_groups): add monotonic update on mark_message_read and remove redundant mark_read method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 vibe-tools.config.json
 .cursor/rules/vibe-tools.mdc
 .goose/memory
+.opencode
 
 # Docker and Rust
 /target


### PR DESCRIPTION
Fixes #435 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read marker now only advances forward and uses an atomic compare-and-update to prevent regressions and race conditions.

* **Tests**
  * Added comprehensive tests for advancing, no-op, and edge-case read-marker behavior; included a test helper for creating aggregated messages.

* **Chores**
  * Updated project ignore rules to include a new pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->