### PR TITLE
fix: update derive_upload_keypair() with Secret type and version parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.5.3"
-source = "git+https://github.com/parres-hq/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
+source = "git+https://github.com/marmot-protocol/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
 dependencies = [
  "blurhash",
  "chacha20poly1305",
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.5.1"
-source = "git+https://github.com/parres-hq/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
+source = "git+https://github.com/marmot-protocol/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
 dependencies = [
  "getrandom 0.3.3",
  "hex",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.5.1"
-source = "git+https://github.com/parres-hq/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
+source = "git+https://github.com/marmot-protocol/mdk?rev=46738bd1e16e0aa78255c7f70b1d90698e968746#46738bd1e16e0aa78255c7f70b1d90698e968746"
 dependencies = [
  "nostr",
  "openmls",
@@ -5109,6 +5109,7 @@ dependencies = [
  "lightning-invoice",
  "mdk-core",
  "mdk-sqlite-storage",
+ "mdk-storage-traits",
  "mockito",
  "nostr-blossom",
  "nostr-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,11 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-mdk-core = { version = "0.5.1", git = "https://github.com/parres-hq/mdk", rev = "46738bd1e16e0aa78255c7f70b1d90698e968746", features = [
+mdk-core = { version = "0.5.1", git = "https://github.com/marmot-protocol/mdk", rev = "46738bd1e16e0aa78255c7f70b1d90698e968746", features = [
     "mip04",
 ] }
-mdk-sqlite-storage = { version = "0.5.1", git = "https://github.com/parres-hq/mdk", rev = "46738bd1e16e0aa78255c7f70b1d90698e968746" }
+mdk-sqlite-storage = { version = "0.5.1", git = "https://github.com/marmot-protocol/mdk", rev = "46738bd1e16e0aa78255c7f70b1d90698e968746" }
+mdk-storage-traits = { version = "0.5.1", git = "https://github.com/marmot-protocol/mdk", rev = "46738bd1e16e0aa78255c7f70b1d90698e968746" }
 
 nwc = "0.43"
 nostr-blossom = "0.43"

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -9,6 +9,7 @@ use mdk_core::extension::group_image;
 use mdk_core::media_processing::MediaProcessingOptions;
 use mdk_core::prelude::*;
 use mdk_sqlite_storage::MdkSqliteStorage;
+use mdk_storage_traits::Secret;
 use nostr_blossom::client::BlossomClient;
 use nostr_sdk::prelude::*;
 use sha2::{Digest, Sha256};
@@ -994,7 +995,8 @@ impl Whitenoise {
         let original_hash: [u8; 32] = hasher.finalize().into();
 
         // Derive the upload keypair from the image key for cleanup purposes
-        let upload_keypair = group_image::derive_upload_keypair(image_key).map_err(|e| {
+        let secret_key = Secret::new(*image_key);
+        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
             WhitenoiseError::Other(anyhow::anyhow!("Failed to derive upload keypair: {}", e))
         })?;
 
@@ -1168,7 +1170,8 @@ impl Whitenoise {
         let original_hash: [u8; 32] = hasher.finalize().into();
 
         // Derive the upload keypair from the image key for cleanup purposes
-        let upload_keypair = group_image::derive_upload_keypair(image_key).map_err(|e| {
+        let secret_key = Secret::new(*image_key);
+        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
             WhitenoiseError::Other(anyhow::anyhow!("Failed to derive upload keypair: {}", e))
         })?;
 


### PR DESCRIPTION
## Summary

Updates `derive_upload_keypair()` calls to match new signature from MDK security improvements.

## Changes

- Add `mdk-storage-traits` dependency for `Secret` type
- Wrap `image_key` in `Secret::new()` for proper zeroization
- Add version parameter (v2 for current extension format)

## Files Changed

- `Cargo.toml`: Added `mdk-storage-traits` dependency
- `src/whitenoise/groups.rs`: Updated two `derive_upload_keypair()` calls

## Note

Build will have errors until remaining breaking changes are fixed in subsequent PRs.

