### PR TITLE
feat(accounts_groups): add pin_order

### DIFF
--- a/db_migrations/0021_add_pin_order_to_accounts_groups.sql
+++ b/db_migrations/0021_add_pin_order_to_accounts_groups.sql
@@ -1,0 +1,3 @@
+-- Add pin_order column to accounts_groups for chat pinning functionality.
+-- NULL = not pinned (default), lower values appear first in the chat list.
+ALTER TABLE accounts_groups ADD COLUMN pin_order INTEGER DEFAULT NULL;

--- a/src/whitenoise/chat_list_streaming/manager.rs
+++ b/src/whitenoise/chat_list_streaming/manager.rs
@@ -86,6 +86,7 @@ mod tests {
             pending_confirmation: false,
             welcomer_pubkey: None,
             unread_count: 0,
+            pin_order: None,
         }
     }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -73,6 +73,7 @@ impl Whitenoise {
             user_confirmation: None,
             welcomer_pubkey: Some(welcomer_pubkey),
             last_read_message_id: None,
+            pin_order: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now pin chats to keep them at the top of the chat list
  * Pinned chats are organized by custom order, with unpinned chats appearing below sorted by recent activity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->