### PR TITLE
test(integration/chat_list, chat_list_streaming): add tests for pin_order logic

### DIFF
--- a/src/integration_tests/test_cases/chat_list/mod.rs
+++ b/src/integration_tests/test_cases/chat_list/mod.rs
@@ -2,10 +2,12 @@ mod create_dm;
 mod mark_message_read;
 mod verify_chat_list;
 mod verify_chat_list_item;
+mod verify_chat_list_order;
 mod verify_dm_chat_list_item;
 
 pub use create_dm::CreateDmTestCase;
 pub use mark_message_read::MarkMessageReadTestCase;
 pub use verify_chat_list::VerifyChatListTestCase;
 pub use verify_chat_list_item::VerifyChatListItemTestCase;
+pub use verify_chat_list_order::VerifyChatListOrderTestCase;
 pub use verify_dm_chat_list_item::VerifyDmChatListItemTestCase;

--- a/src/integration_tests/test_cases/chat_list/verify_chat_list_item.rs
+++ b/src/integration_tests/test_cases/chat_list/verify_chat_list_item.rs
@@ -13,6 +13,7 @@ pub struct VerifyChatListItemTestCase {
     expected_welcomer_account: Option<String>,
     assert_no_welcomer: bool,
     expected_unread_count: Option<usize>,
+    expected_pin_order: Option<Option<i64>>,
 }
 
 impl VerifyChatListItemTestCase {
@@ -27,6 +28,7 @@ impl VerifyChatListItemTestCase {
             expected_welcomer_account: None,
             assert_no_welcomer: false,
             expected_unread_count: None,
+            expected_pin_order: None,
         }
     }
 
@@ -79,6 +81,18 @@ impl VerifyChatListItemTestCase {
     /// Verifies the unread_count field matches the expected value.
     pub fn expecting_unread_count(mut self, count: usize) -> Self {
         self.expected_unread_count = Some(count);
+        self
+    }
+
+    /// Verifies the pin_order field matches the expected value.
+    pub fn expecting_pin_order(mut self, order: i64) -> Self {
+        self.expected_pin_order = Some(Some(order));
+        self
+    }
+
+    /// Verifies the chat is not pinned.
+    pub fn expecting_not_pinned(mut self) -> Self {
+        self.expected_pin_order = Some(None);
         self
     }
 }
@@ -172,6 +186,15 @@ impl TestCase for VerifyChatListItemTestCase {
                 item.unread_count, expected_count,
                 "Expected unread_count={} but got {}",
                 expected_count, item.unread_count
+            );
+        }
+
+        // Verify pin_order
+        if let Some(expected_pin_order) = &self.expected_pin_order {
+            assert_eq!(
+                &item.pin_order, expected_pin_order,
+                "Expected pin_order={:?} but got {:?}",
+                expected_pin_order, item.pin_order
             );
         }
 

--- a/src/integration_tests/test_cases/chat_list/verify_chat_list_order.rs
+++ b/src/integration_tests/test_cases/chat_list/verify_chat_list_order.rs
@@ -1,0 +1,74 @@
+use crate::WhitenoiseError;
+use crate::integration_tests::core::*;
+use async_trait::async_trait;
+
+/// Verifies the order of chats in the chat list.
+pub struct VerifyChatListOrderTestCase {
+    account_name: String,
+    expected_order: Vec<String>,
+}
+
+impl VerifyChatListOrderTestCase {
+    pub fn new(account_name: &str) -> Self {
+        Self {
+            account_name: account_name.to_string(),
+            expected_order: Vec::new(),
+        }
+    }
+
+    /// Specifies the expected order of groups by their context names.
+    /// First item in the list should appear first in the chat list.
+    pub fn expecting_order(mut self, group_context_names: Vec<&str>) -> Self {
+        self.expected_order = group_context_names.into_iter().map(String::from).collect();
+        self
+    }
+}
+
+#[async_trait]
+impl TestCase for VerifyChatListOrderTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        tracing::info!(
+            "Verifying chat list order for account: {} (expecting {:?})",
+            self.account_name,
+            self.expected_order
+        );
+
+        let account = context.get_account(&self.account_name)?;
+        let chat_list = context.whitenoise.get_chat_list(account).await?;
+
+        // Build the expected group IDs in order
+        let expected_group_ids: Vec<_> = self
+            .expected_order
+            .iter()
+            .map(|name| context.get_group(name).map(|g| g.mls_group_id.clone()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Get actual group IDs from chat list (only for groups we're checking)
+        let actual_group_ids: Vec<_> = chat_list
+            .iter()
+            .map(|item| item.mls_group_id.clone())
+            .filter(|id| expected_group_ids.contains(id))
+            .collect();
+
+        // Compare orders
+        assert_eq!(
+            actual_group_ids.len(),
+            expected_group_ids.len(),
+            "Expected {} groups in order check but found {}",
+            expected_group_ids.len(),
+            actual_group_ids.len()
+        );
+
+        for (i, (actual, expected)) in actual_group_ids.iter().zip(&expected_group_ids).enumerate()
+        {
+            assert_eq!(
+                actual, expected,
+                "At position {}: expected group '{}' but got different group",
+                i, self.expected_order[i]
+            );
+        }
+
+        tracing::info!("✓ Chat list order verified: {:?}", self.expected_order);
+        Ok(())
+    }
+}

--- a/src/integration_tests/test_cases/shared/mod.rs
+++ b/src/integration_tests/test_cases/shared/mod.rs
@@ -2,10 +2,12 @@ pub mod create_accounts;
 pub mod create_group;
 pub mod delete_message;
 pub mod send_message;
+pub mod set_chat_pin_order;
 pub mod wait_for_welcome;
 
 pub use create_accounts::*;
 pub use create_group::*;
 pub use delete_message::*;
 pub use send_message::*;
+pub use set_chat_pin_order::*;
 pub use wait_for_welcome::*;

--- a/src/integration_tests/test_cases/shared/set_chat_pin_order.rs
+++ b/src/integration_tests/test_cases/shared/set_chat_pin_order.rs
@@ -1,0 +1,69 @@
+use crate::WhitenoiseError;
+use crate::integration_tests::core::*;
+use async_trait::async_trait;
+
+/// Sets the pin order for a chat.
+pub struct SetChatPinOrderTestCase {
+    account_name: String,
+    group_context_name: String,
+    pin_order: Option<i64>,
+}
+
+impl SetChatPinOrderTestCase {
+    pub fn new(account_name: &str, group_context_name: &str) -> Self {
+        Self {
+            account_name: account_name.to_string(),
+            group_context_name: group_context_name.to_string(),
+            pin_order: None,
+        }
+    }
+
+    /// Pins the chat with the specified order (lower values appear first).
+    pub fn with_pin_order(mut self, order: i64) -> Self {
+        self.pin_order = Some(order);
+        self
+    }
+
+    /// Unpins the chat.
+    pub fn unpinned(mut self) -> Self {
+        self.pin_order = None;
+        self
+    }
+}
+
+#[async_trait]
+impl TestCase for SetChatPinOrderTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let action = match self.pin_order {
+            Some(order) => format!("pin_order={}", order),
+            None => "unpinned".to_string(),
+        };
+        tracing::info!(
+            "Setting chat '{}' to {} for account: {}",
+            self.group_context_name,
+            action,
+            self.account_name
+        );
+
+        let account = context.get_account(&self.account_name)?;
+        let group = context.get_group(&self.group_context_name)?;
+
+        let updated = context
+            .whitenoise
+            .set_chat_pin_order(account, &group.mls_group_id, self.pin_order)
+            .await?;
+
+        assert_eq!(
+            updated.pin_order, self.pin_order,
+            "Expected pin_order={:?} but got {:?}",
+            self.pin_order, updated.pin_order
+        );
+
+        tracing::info!(
+            "✓ Chat '{}' set to {} successfully",
+            self.group_context_name,
+            action
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering pin-based chat ordering, including multi-step scenarios that pin, unpin, and verify list ordering.
  * Added test utilities to set/verify chat pin order and a new test case to assert overall chat list order.
  * Enhanced chat list item assertions to validate pin order (including “not pinned”) and added related logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->