### PR TITLE
Remove default pet names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,15 +2019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,20 +2942,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petname"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
-dependencies = [
- "anyhow",
- "clap",
- "itertools",
- "proc-macro2",
- "quote",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "phf"
@@ -5078,7 +5055,6 @@ dependencies = [
  "nostr-blossom",
  "nostr-sdk",
  "nwc",
- "petname",
  "rand 0.9.2",
  "reqwest 0.11.27",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.22"
 blurhash = "0.2.3"
 chacha20poly1305 = "0.10"
 chrono = { version = "0.4.40", features = ["serde"] }
-clap = "4.5.37"
+clap = { version = "4.5.37", features = ["derive"] }
 dashmap = "6.1"
 hex = "0.4"
 image = "0.24"
@@ -61,7 +61,6 @@ nostr-sdk = { version = "0.43", features = [
 #     "nip59",
 # ] }
 
-petname = "2.0.2"
 rand = "0.9"
 reqwest = { version = "0.11", features = [
     "multipart",

--- a/src/integration_tests/test_cases/metadata_management/fetch_metadata.rs
+++ b/src/integration_tests/test_cases/metadata_management/fetch_metadata.rs
@@ -23,11 +23,11 @@ impl TestCase for FetchMetadataTestCase {
         let metadata = account.metadata(context.whitenoise).await?;
 
         assert!(
-            metadata.name.is_some(),
-            "Metadata name is missing for account {}",
-            self.account_name
+            metadata.name.is_none(),
+            "New account should have no metadata name set but got: {:?}",
+            metadata.name
         );
-        tracing::info!("✓ Metadata name is present: {:?}", metadata.name);
+        tracing::info!("✓ Metadata name is correctly empty for new account");
 
         tracing::info!("✓ Metadata fetched successfully for {}", self.account_name);
         Ok(())

--- a/src/whitenoise/utils.rs
+++ b/src/whitenoise/utils.rs
@@ -41,15 +41,6 @@ impl Whitenoise {
         let public_key = PublicKey::parse(npub).map_err(|_| WhitenoiseError::InvalidPublicKey)?;
         Ok(public_key.to_hex())
     }
-
-    /// Capitalizes the first letter of a word, leaving the rest unchanged
-    pub(crate) fn capitalize_first_letter(word: &str) -> String {
-        let mut chars = word.chars();
-        match chars.next() {
-            None => String::new(),
-            Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-        }
-    }
 }
 
 /// Converts a Nostr timestamp to a DateTime<Utc> with proper error handling.
@@ -81,14 +72,6 @@ pub(crate) fn timestamp_to_datetime(
 mod tests {
     use super::*;
     use chrono::Datelike;
-
-    #[test]
-    fn test_capitalize_first_letter() {
-        assert_eq!(Whitenoise::capitalize_first_letter("satoshi"), "Satoshi");
-        assert_eq!(Whitenoise::capitalize_first_letter("5atoshi"), "5atoshi");
-        assert_eq!(Whitenoise::capitalize_first_letter(""), "");
-        assert_eq!(Whitenoise::capitalize_first_letter("ßtraße"), "SStraße");
-    }
 
     #[test]
     fn test_hex_pubkey_from_npub() {


### PR DESCRIPTION
In the sloth flutter app we were having some issues with metadata on sign up: https://github.com/marmot-protocol/sloth/issues/41

In the whitenoise app, the identity was created before showing the singn up form, the metadata of the new identity was fetched (with the random pet name assigned by rust) and then the user could edit the metadata. The problem with this is that if the user closed the app before submitting the signup form of went back, the new identity was created anyways

In sloth we are showing the signup form with the metadata fields but only creating the identity when the user clicks the submit button, and then updating the metadata.

The problem with approach is that sometimes the metadata update with random pet names triggered here in the rust crate overrides the metadata update triggered from the flutter side on the form submission.  For this reason, we want to remove the initial metadata setup from rust and delegate that responsibility to the flutter side.


When removing the petname dependency, checks failed so I needed to add the "derive" feature in clap dependency to make them pass again.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies for improved compatibility and feature support.
  * Removed unused dependencies to streamline the project.

* **Bug Fixes**
  * Corrected metadata initialization behavior during account creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->