### PR TITLE
Add nonce and scheme_version to MediaReference for MIP-04 v2

### DIFF
--- a/db_migrations/0021_add_encryption_metadata_to_media_files.sql
+++ b/db_migrations/0021_add_encryption_metadata_to_media_files.sql
@@ -1,0 +1,33 @@
+-- Migration 0021: Add encryption metadata to media_files for MIP-04 decryption
+--
+-- This migration adds nonce and scheme_version columns required for MDK's
+-- decrypt_from_download() function. These values are extracted from the IMETA tag
+-- when receiving chat media.
+--
+-- Both fields are required for decryption:
+-- - nonce: Encryption nonce (hex-encoded, 24 chars for 12 bytes)
+-- - scheme_version: Encryption version (e.g., "mip04-v2")
+--
+-- IMPORTANT: Old chat_media records (created before this migration) cannot be
+-- decrypted because they lack these required fields. This is a breaking change
+-- from MDK - the encryption parameters were previously not stored in IMETA tags.
+-- Group images are unaffected as they use a different encryption scheme (key/nonce).
+--
+-- See: MDK MediaReference struct requirements
+-- See: MIP-04 specification https://github.com/marmot-protocol/marmot/blob/master/04.md
+
+-- Add nonce column
+-- NULL for existing records and group_images (which use key/nonce encryption, not MDK)
+-- Required for chat_media going forward
+ALTER TABLE media_files ADD COLUMN nonce TEXT;
+
+-- Add scheme_version column
+-- NULL for existing records and group_images
+-- Required for chat_media going forward
+ALTER TABLE media_files ADD COLUMN scheme_version TEXT;
+
+-- Add index for scheme_version to optimize queries filtering by encryption version
+-- Partial index (WHERE NOT NULL) for better performance - only indexes chat_media records
+CREATE INDEX idx_media_files_scheme_version
+ON media_files(scheme_version)
+WHERE scheme_version IS NOT NULL;

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -61,6 +61,8 @@ pub(crate) struct MediaFileRow {
     pub blossom_url: Option<String>,
     pub nostr_key: Option<String>,
     pub file_metadata: Option<FileMetadata>,
+    pub nonce: Option<String>,               // Encryption nonce (hex-encoded, for chat_media)
+    pub scheme_version: Option<String>,      // Encryption version (e.g., "mip04-v2", for chat_media)
     pub created_at: DateTime<Utc>,
 }
 
@@ -116,6 +118,9 @@ where
             .try_get::<Option<String>, _>("file_metadata")?
             .and_then(|json_str| serde_json::from_str(&json_str).ok());
 
+        let nonce: Option<String> = row.try_get("nonce")?;
+        let scheme_version: Option<String> = row.try_get("scheme_version")?;
+
         let created_at = parse_timestamp(row, "created_at")?;
 
         Ok(Self {
@@ -130,6 +135,8 @@ where
             blossom_url,
             nostr_key,
             file_metadata,
+            nonce,
+            scheme_version,
             created_at,
         })
     }
@@ -146,6 +153,8 @@ pub struct MediaFileParams<'a> {
     pub blossom_url: Option<&'a str>,
     pub nostr_key: Option<&'a str>,
     pub file_metadata: Option<&'a FileMetadata>,
+    pub nonce: Option<&'a str>,                   // Encryption nonce (hex-encoded, for chat_media)
+    pub scheme_version: Option<&'a str>,          // Encryption version (e.g., "mip04-v2", for chat_media)
 }
 
 /// Represents a cached media file
@@ -162,6 +171,8 @@ pub struct MediaFile {
     pub blossom_url: Option<String>,
     pub nostr_key: Option<String>,
     pub file_metadata: Option<FileMetadata>,
+    pub nonce: Option<String>,               // Encryption nonce (hex-encoded, for chat_media)
+    pub scheme_version: Option<String>,      // Encryption version (e.g., "mip04-v2", for chat_media)
     pub created_at: DateTime<Utc>,
 }
 
@@ -179,6 +190,8 @@ impl From<MediaFileRow> for MediaFile {
             blossom_url: val.blossom_url,
             nostr_key: val.nostr_key,
             file_metadata: val.file_metadata,
+            nonce: val.nonce,
+            scheme_version: val.scheme_version,
             created_at: val.created_at,
         }
     }
@@ -207,7 +220,7 @@ impl MediaFile {
             "SELECT id, mls_group_id, account_pubkey, file_path,
                     original_file_hash, encrypted_file_hash,
                     mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, created_at
+                    file_metadata, nonce, scheme_version, created_at
              FROM media_files
              WHERE encrypted_file_hash = ?
              LIMIT 1",
@@ -261,15 +274,15 @@ impl MediaFile {
                 mls_group_id, account_pubkey, file_path,
                 original_file_hash, encrypted_file_hash,
                 mime_type, media_type, blossom_url, nostr_key,
-                file_metadata, created_at
+                file_metadata, nonce, scheme_version, created_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (mls_group_id, encrypted_file_hash, account_pubkey)
             DO NOTHING
             RETURNING id, mls_group_id, account_pubkey, file_path,
                       original_file_hash, encrypted_file_hash,
                       mime_type, media_type, blossom_url, nostr_key,
-                      file_metadata, created_at",
+                      file_metadata, nonce, scheme_version, created_at",
         )
         .bind(mls_group_id.as_slice())
         .bind(&account_pubkey_hex)
@@ -281,6 +294,8 @@ impl MediaFile {
         .bind(params.blossom_url)
         .bind(params.nostr_key)
         .bind(file_metadata_json)
+        .bind(params.nonce)
+        .bind(params.scheme_version)
         .bind(now_ms)
         .fetch_optional(&database.pool)
         .await
@@ -295,7 +310,7 @@ impl MediaFile {
             "SELECT id, mls_group_id, account_pubkey, file_path,
                     original_file_hash, encrypted_file_hash,
                     mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, created_at
+                    file_metadata, nonce, scheme_version, created_at
              FROM media_files
              WHERE mls_group_id = ? AND encrypted_file_hash = ? AND account_pubkey = ?
              LIMIT 1",
@@ -326,7 +341,7 @@ impl MediaFile {
             "SELECT id, mls_group_id, account_pubkey, file_path,
                     original_file_hash, encrypted_file_hash,
                     mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, created_at
+                    file_metadata, nonce, scheme_version, created_at
              FROM media_files
              WHERE mls_group_id = ?",
         )
@@ -382,7 +397,7 @@ impl MediaFile {
             "SELECT id, mls_group_id, account_pubkey, file_path,
                     original_file_hash, encrypted_file_hash,
                     mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, created_at
+                    file_metadata, nonce, scheme_version, created_at
              FROM media_files
              WHERE original_file_hash = ? AND mls_group_id = ? AND account_pubkey = ?
              LIMIT 1",
@@ -534,6 +549,8 @@ mod tests {
                 blossom_url: None,
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -579,6 +596,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob1"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -601,6 +620,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob2"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -656,6 +677,8 @@ mod tests {
                 blossom_url: Some("https://blossom.example.com/hash42"),
                 nostr_key: None,
                 file_metadata: Some(&metadata),
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -675,6 +698,8 @@ mod tests {
                 blossom_url: Some("https://another-server.com/hash42"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -787,6 +812,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob1a"),
                 nostr_key: Some("nostr_key_1a"),
                 file_metadata: Some(&metadata),
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -805,6 +832,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob1b"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -828,6 +857,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob2"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1188,6 +1219,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob"),
                 nostr_key: Some("test_key"),
                 file_metadata: Some(&metadata),
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1299,6 +1332,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob1"),
                 nostr_key: Some("test_key_1"),
                 file_metadata: Some(&metadata),
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1318,6 +1353,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob2"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1339,6 +1376,8 @@ mod tests {
                 blossom_url: Some("https://example.com/group_img"),
                 nostr_key: Some("group_key"),
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1444,6 +1483,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await
@@ -1463,6 +1504,8 @@ mod tests {
                 blossom_url: Some("https://example.com/blob"),
                 nostr_key: None,
                 file_metadata: None,
+                nonce: None,
+                scheme_version: None,
             },
         )
         .await

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -1130,12 +1130,34 @@ impl Whitenoise {
         let mdk = Account::create_mdk(*account_pubkey, data_dir)?;
         let media_manager = mdk.media_manager(group_id.clone());
 
+        // Retrieve nonce and scheme_version from database (required for MDK decryption)
+        let nonce_hex = media_file
+            .nonce
+            .as_ref()
+            .ok_or_else(|| WhitenoiseError::MediaCache("Missing nonce for chat media".to_string()))?;
+        let scheme_version = media_file
+            .scheme_version
+            .as_ref()
+            .ok_or_else(|| {
+                WhitenoiseError::MediaCache("Missing scheme_version for chat media".to_string())
+            })?
+            .clone();
+
+        // Decode nonce from hex string to bytes
+        let nonce_bytes = hex::decode(nonce_hex)
+            .map_err(|_| WhitenoiseError::MediaCache("Invalid nonce hex".to_string()))?;
+        let nonce: [u8; 12] = nonce_bytes
+            .try_into()
+            .map_err(|_| WhitenoiseError::MediaCache("Invalid nonce length".to_string()))?;
+
         let reference = MediaReference {
             url: String::new(),
             original_hash: *original_file_hash,
             mime_type: media_file.mime_type.clone(),
             filename: filename.to_string(),
             dimensions: None, // Not used in decryption (only display metadata)
+            scheme_version,
+            nonce,
         };
 
         media_manager

--- a/src/whitenoise/media_files.rs
+++ b/src/whitenoise/media_files.rs
@@ -205,6 +205,8 @@ impl<'a> MediaFiles<'a> {
                 blossom_url: upload.blossom_url,
                 nostr_key: upload.nostr_key.as_deref(),
                 file_metadata: upload.file_metadata,
+                nonce: None,            // Group images use key/nonce encryption, not MDK
+                scheme_version: None,   // Group images use key/nonce encryption, not MDK
             },
         )
         .await?;
@@ -352,6 +354,7 @@ impl<'a> MediaFiles<'a> {
             });
 
             // Create MediaFile record (without file yet - empty path until downloaded)
+            // Store nonce and scheme_version for MDK decryption
             MediaFile::save(
                 self.database,
                 group_id,
@@ -365,6 +368,8 @@ impl<'a> MediaFiles<'a> {
                     blossom_url: Some(&reference.url),
                     nostr_key: None, // Chat media uses MDK, not key/nonce
                     file_metadata: file_metadata.as_ref(),
+                    nonce: Some(&hex::encode(reference.nonce)),
+                    scheme_version: Some(&reference.scheme_version),
                 },
             )
             .await?;


### PR DESCRIPTION
This PR adds database schema changes and code updates to support MDK's `MediaReference` requirements for `nonce` and `scheme_version` fields, which are mandatory for MIP-04 v2 encrypted media decryption.

## Changes

### Database Migration
- **New migration 0021**: Adds `nonce` (TEXT) and `scheme_version` (TEXT) columns to `media_files` table
- Both fields are nullable for backward compatibility with existing records and group images
- Added partial index on `scheme_version` (WHERE NOT NULL) for query performance optimization

### Code Updates
- Updated `MediaFile`, `MediaFileRow`, and `MediaFileParams` structs with new optional fields
- Modified all SQL INSERT and SELECT queries to include new columns
- Extract and store `nonce` (hex-encoded) and `scheme_version` from MDK's `parse_imeta_tag()` when receiving chat media
- Retrieve and validate encryption metadata when decrypting chat media in `download_and_decrypt_chat_media_blob()`
- Updated all test cases (11 instances) to pass `None` for group images

### Technical Details
- **nonce**: Stored as hex-encoded string (24 chars for 12 bytes)
- **scheme_version**: Stored as string (e.g., "mip04-v2")
- Proper validation on retrieval: hex decode, length check (must be exactly 12 bytes)
- Clear separation: `None` for group images (use key/nonce encryption), required for chat_media

## Breaking Change ⚠️

**Old chat_media records** (created before this migration) cannot be decrypted because they lack the required encryption metadata. This is intentional - MDK removed support for MIP-04 v1 due to nonce reuse vulnerabilities.

**Group images are unaffected** as they use a different encryption scheme (key/nonce pairs, not MDK).

