### PR TITLE
feat(lib): export Language enum from crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export `Language` enum from crate root for library consumers ([erskingardner])
 - Search for contacts by npub or hex pubkey ([erskingardner])
 - Copy npub button in settings page([josefinalliende])
 - Basic NWC support for paying invoices in messages ([a-mpch], [F3r10], [jgmontoya], [josefinalliende])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use whitenoise::accounts::Account;
 pub use whitenoise::users::{User, UserSyncMode};
 
 // Settings and configuration
-pub use whitenoise::app_settings::{AppSettings, ThemeMode};
+pub use whitenoise::app_settings::{AppSettings, Language, ThemeMode};
 
 // Groups and relays
 pub use whitenoise::accounts_groups::AccountGroup;


### PR DESCRIPTION
## Summary

- Export the `Language` enum from the crate root so library consumers can use it directly
- Previously only `AppSettings` and `ThemeMode` were exported; `Language` was missing

## Test plan

- [x] `cargo check` passes
- [ ] Verify library consumers can import `Language` from `whitenoise::Language`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Language` enum is now publicly exported, making it available for direct use by library consumers alongside other configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->