### PR TITLE
Add event id to user reaction

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -266,6 +266,7 @@ impl Whitenoise {
             &reaction.pubkey,
             &emoji,
             reaction.created_at,
+            reaction.id,
         );
 
         AggregatedMessage::update_reactions(
@@ -479,6 +480,7 @@ impl Whitenoise {
                 &reaction.author,
                 &reaction_emoji,
                 reaction_timestamp,
+                reaction.event_id,
             );
 
             AggregatedMessage::update_reactions(

--- a/src/whitenoise/message_aggregator/tests.rs
+++ b/src/whitenoise/message_aggregator/tests.rs
@@ -104,6 +104,7 @@ mod integration_tests {
             user: keys.public_key(),
             emoji: "❤️".to_string(),
             created_at: Timestamp::now(),
+            reaction_id: EventId::all_zeros(),
         };
 
         let _stats = GroupStatistics {
@@ -150,6 +151,7 @@ mod integration_tests {
             user: user1,
             emoji: "👍".to_string(),
             created_at: Timestamp::now(),
+            reaction_id: EventId::all_zeros(),
         });
 
         // Add an emoji reaction

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -110,6 +110,8 @@ pub struct UserReaction {
 
     /// Timestamp of the reaction
     pub created_at: Timestamp,
+
+    pub reaction_id: EventId,
 }
 
 /// Configuration for the message aggregator
@@ -225,6 +227,7 @@ mod tests {
                 user: pubkey,
                 emoji: "👍".to_string(),
                 created_at: Timestamp::now(),
+                reaction_id: EventId::all_zeros(),
             };
 
             let mut by_emoji = HashMap::new();
@@ -295,16 +298,19 @@ mod tests {
             )
             .unwrap();
             let timestamp = Timestamp::now();
+            let reaction_id = EventId::all_zeros();
 
             let reaction = UserReaction {
                 user: pubkey,
                 emoji: "🎉".to_string(),
                 created_at: timestamp,
+                reaction_id,
             };
 
             assert_eq!(reaction.user, pubkey);
             assert_eq!(reaction.emoji, "🎉");
             assert_eq!(reaction.created_at, timestamp);
+            assert_eq!(reaction.reaction_id, reaction_id);
         }
     }
 


### PR DESCRIPTION
To be able to delete reactions, we need to know the reaction event id to then send the deletion request event

This PR adds a reaction_id field to the UserReaction with the event id. 

⚠️ I don't  know rust yet 🦀  so this is completely vibecoded 😬 . Hope it makes sense. I'm already using this changes locally for the app in sloth and they work. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactions now carry an associated reaction event identifier for improved traceability.

* **Refactor**
  * Reaction handling updated to propagate and store the reaction event identifier alongside reaction data (public-facing data shape updated).

* **Tests**
  * Tests updated to initialize and assert the new reaction event identifier tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->