### PR TITLE
feat(whitenoise/chat_list): add dm_peer_pubkey to ChatListItem

### DIFF
--- a/src/integration_tests/test_cases/chat_list/verify_dm_chat_list_item.rs
+++ b/src/integration_tests/test_cases/chat_list/verify_dm_chat_list_item.rs
@@ -79,6 +79,13 @@ impl TestCase for VerifyDmChatListItemTestCase {
             "DM profile picture URL should match other user's picture"
         );
 
+        // Verify dm_peer_pubkey is set to the other user
+        assert_eq!(
+            item.dm_peer_pubkey,
+            Some(other_user_account.pubkey),
+            "DM dm_peer_pubkey should be the other user's pubkey"
+        );
+
         tracing::info!(
             "✓ DM chat list item '{}' verification passed",
             self.dm_group_context_name

--- a/src/whitenoise/chat_list_streaming/manager.rs
+++ b/src/whitenoise/chat_list_streaming/manager.rs
@@ -87,6 +87,7 @@ mod tests {
             welcomer_pubkey: None,
             unread_count: 0,
             pin_order: None,
+            dm_peer_pubkey: None,
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Direct Message functionality with improved tracking of chat peer information in chat lists.

* **Tests**
  * Updated test coverage to validate Direct Message peer references and group chat item integrity across various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->