### PR TITLE
feat(whitenoise/accounts_groups): add dm_peer_pubkey and find_latest_dm_group_with_peer method

### DIFF
--- a/db_migrations/0026_add_dm_peer_pubkey_to_accounts_groups.sql
+++ b/db_migrations/0026_add_dm_peer_pubkey_to_accounts_groups.sql
@@ -1,0 +1,11 @@
+-- Add dm_peer_pubkey column to accounts_groups for efficient DM peer lookups.
+-- NULL for regular group chats. For DM groups, stores the other participant's
+-- pubkey from this account's perspective. Populated at creation time and
+-- backfilled on startup for existing records.
+ALTER TABLE accounts_groups ADD COLUMN dm_peer_pubkey TEXT DEFAULT NULL;
+
+-- Partial index for efficient DM peer lookups. Only indexes rows where
+-- dm_peer_pubkey is populated (DM groups), keeping the index small.
+CREATE INDEX idx_accounts_groups_dm_peer
+  ON accounts_groups(account_pubkey, dm_peer_pubkey)
+  WHERE dm_peer_pubkey IS NOT NULL;

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -10,7 +10,7 @@ use crate::whitenoise::{
     accounts_groups::AccountGroup,
     chat_list_streaming::ChatListUpdateTrigger,
     error::{Result, WhitenoiseError},
-    group_information::GroupInformation,
+    group_information::{GroupInformation, GroupType},
     relays::Relay,
 };
 
@@ -86,6 +86,17 @@ impl Whitenoise {
         let group_name = welcome.group_name.clone();
         let welcomer_pubkey = welcome.welcomer;
 
+        // For DM groups (empty name), the welcomer is the other participant.
+        // In the Marmot protocol, DM welcomes are always sent by the initiator,
+        // who is the only other member in a two-party DM group.
+        let dm_peer_pubkey = if GroupInformation::infer_group_type_from_group_name(&group_name)
+            == GroupType::DirectMessage
+        {
+            Some(welcomer_pubkey)
+        } else {
+            None
+        };
+
         let account_group = AccountGroup {
             id: None,
             account_pubkey: account.pubkey,
@@ -94,6 +105,7 @@ impl Whitenoise {
             welcomer_pubkey: Some(welcomer_pubkey),
             last_read_message_id: None,
             pin_order: None,
+            dm_peer_pubkey,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -385,6 +397,7 @@ impl Whitenoise {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::whitenoise::accounts_groups::AccountGroup;
     use crate::whitenoise::relays::Relay;
     use crate::whitenoise::test_utils::*;
 
@@ -581,8 +594,7 @@ mod tests {
         let welcomer_pubkey = whitenoise.create_identity().await.unwrap().pubkey;
 
         // Pre-create AccountGroup to simulate synchronous creation in process_welcome
-        use crate::whitenoise::accounts_groups::AccountGroup;
-        AccountGroup::get_or_create(&whitenoise, &account.pubkey, &group_id)
+        AccountGroup::get_or_create(&whitenoise, &account.pubkey, &group_id, None)
             .await
             .unwrap();
 
@@ -618,8 +630,7 @@ mod tests {
         let welcomer_pubkey = whitenoise.create_identity().await.unwrap().pubkey;
 
         // Pre-create AccountGroup to simulate synchronous creation in process_welcome
-        use crate::whitenoise::accounts_groups::AccountGroup;
-        AccountGroup::get_or_create(&whitenoise, &account.pubkey, &group_id)
+        AccountGroup::get_or_create(&whitenoise, &account.pubkey, &group_id, None)
             .await
             .unwrap();
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -398,6 +398,15 @@ impl Whitenoise {
             "Message cache synchronization complete"
         );
 
+        // Backfill dm_peer_pubkey for existing DM groups missing it
+        if let Err(e) = whitenoise_ref.backfill_dm_peer_pubkeys().await {
+            tracing::warn!(
+                target: "whitenoise::initialize_whitenoise",
+                "DM peer pubkey backfill failed (non-fatal): {}",
+                e
+            );
+        }
+
         tracing::debug!(
             target: "whitenoise::initialize_whitenoise",
             "Starting event processing loop for loaded accounts"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted DM peer tracking so the app can identify the other participant for direct-message groups.

* **Performance Improvements**
  * Faster, more reliable DM lookups and chat list generation via a targeted persisted-peer index, improving DM retrieval and newest-DM selection.

* **Chores**
  * Startup backfill populates missing DM peer data for existing conversations to ensure consistent DM discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->