### PR TITLE
fix: detect and retry failed key package relay publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Better handling of long messages in chat ([josefinalliende])
 
+### Fixed
+
+- Fix key package publish reliability: detect failed relay publishes and retry with exponential backoff so accounts are never left with zero key packages ([mubarakcoded])
+
 ## [v0.1.0-alpha.3] - 2025-02-20
 
 ### Added
@@ -98,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [jgmontoya]: <https://github.com/jgmontoya> (nostr:npub1jgm0ntzjr03wuzj5788llhed7l6fst05um4ej2r86ueaa08etv6sgd669p)
 [a-mpch]: <https://github.com/a-mpch> (nostr:npub1mpchxagw3kaglylnyajzjmghdj63vly9q5eu7d62fl72f2gz8xfqk6nwkd)
 [F3r10]: <https://github.com/F3r10>
+[mubarakcoded]: <https://github.com/mubarakcoded> (nostr:npub1mlyye6fpsqnkuxwv3nzzf3cmrau8x6z3fhh095246me87ya0aprsun609q)
 
 
 

--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -873,9 +873,21 @@ impl Whitenoise {
                 .await?;
         }
         if key_package_event.is_none() {
-            self.publish_key_package_to_relays(account, key_package_relays)
-                .await?;
-            tracing::debug!(target: "whitenoise::accounts", "Published key package");
+            match self
+                .create_and_publish_key_package(account, key_package_relays)
+                .await
+            {
+                Ok(()) => {
+                    tracing::debug!(target: "whitenoise::accounts", "Published key package");
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::accounts",
+                        "Initial key package publish failed, scheduler will retry: {}",
+                        e
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -136,6 +136,9 @@ pub enum WhitenoiseError {
     #[error("Failed to download from Blossom server: {0}")]
     BlossomDownload(String),
 
+    #[error("Key package publish failed: {0}")]
+    KeyPackagePublishFailed(String),
+
     #[error("Image decryption failed: {0}")]
     ImageDecryptionFailed(String),
 
@@ -297,6 +300,10 @@ mod tests {
         assert_eq!(
             WhitenoiseError::BlossomDownload("timeout".to_string()).to_string(),
             "Failed to download from Blossom server: timeout"
+        );
+        assert_eq!(
+            WhitenoiseError::KeyPackagePublishFailed("no relays accepted".to_string()).to_string(),
+            "Key package publish failed: no relays accepted"
         );
         assert_eq!(
             WhitenoiseError::ImageDecryptionFailed("bad key".to_string()).to_string(),

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -1,10 +1,15 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::relays::Relay;
-use nostr_sdk::prelude::*;
-use std::sync::Arc;
-use std::time::Duration;
+
+/// Maximum number of relay publish attempts before giving up.
+const MAX_PUBLISH_ATTEMPTS: u32 = 3;
 
 impl Whitenoise {
     /// Gets the appropriate signer for an account.
@@ -53,15 +58,64 @@ impl Whitenoise {
     }
 
     /// Publishes the MLS key package for the given account to its key package relays.
+    ///
+    /// Creates a single MLS key package, then retries relay publishing up to
+    /// 3 times with exponential backoff (2s, 4s) if publishing fails. The key
+    /// package is created only once to avoid orphaning unused key material in
+    /// local MLS storage.
     pub async fn publish_key_package_for_account(&self, account: &Account) -> Result<()> {
         let relays = account.key_package_relays(self).await?;
 
         if relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
-        self.publish_key_package_to_relays(account, &relays).await?;
 
-        Ok(())
+        // Create the key package once — retries below only re-publish the same payload
+        let (encoded_key_package, tags) = self.encoded_key_package(account, &relays).await?;
+        let relay_urls = Relay::urls(&relays);
+        let signer = self.get_signer_for_account(account)?;
+
+        let mut last_error = None;
+
+        for attempt in 0..MAX_PUBLISH_ATTEMPTS {
+            if attempt > 0 {
+                let delay = Duration::from_secs(1 << attempt);
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Retrying key package publish for account {} (attempt {}/{})",
+                    account.pubkey.to_hex(),
+                    attempt + 1,
+                    MAX_PUBLISH_ATTEMPTS,
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            match self
+                .publish_key_package_to_relays(
+                    &encoded_key_package,
+                    &relay_urls,
+                    &tags,
+                    signer.clone(),
+                )
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Key package publish attempt {}/{} failed for account {}: {}",
+                        attempt + 1,
+                        MAX_PUBLISH_ATTEMPTS,
+                        account.pubkey.to_hex(),
+                        e,
+                    );
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        // `last_error` is always `Some` here because the loop runs at least once
+        Err(last_error.expect("loop ran at least once"))
     }
 
     /// Publishes the MLS key package using an external signer.
@@ -81,36 +135,56 @@ impl Whitenoise {
         }
 
         let (encoded_key_package, tags) = self.encoded_key_package(account, &relays).await?;
-        let relays_urls = Relay::urls(&relays);
-
-        let result = self
-            .nostr
-            .publish_key_package_with_signer(&encoded_key_package, &relays_urls, &tags, signer)
-            .await?;
-
-        tracing::debug!(
-            target: "whitenoise::publish_key_package_with_signer",
-            "Published key package with external signer: {:?}",
-            result
-        );
-
-        Ok(())
+        let relay_urls = Relay::urls(&relays);
+        self.publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+            .await
     }
 
-    pub(crate) async fn publish_key_package_to_relays(
+    /// Creates a new MLS key package for the account and publishes it to the given relays.
+    ///
+    /// This is a convenience wrapper that calls [`Self::encoded_key_package`] followed by
+    /// [`Self::publish_key_package_to_relays`]. If you need retry semantics, prefer calling
+    /// those two methods separately so the key package is only created once.
+    pub(crate) async fn create_and_publish_key_package(
         &self,
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
         let (encoded_key_package, tags) = self.encoded_key_package(account, relays).await?;
-        let relays_urls = Relay::urls(relays);
+        let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
+        self.publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+            .await
+    }
+
+    /// Publishes an already-encoded key package event to the given relays.
+    ///
+    /// Returns an error if no relay accepted the event. This method is
+    /// intentionally separated from key package creation so callers can retry
+    /// the relay publish without generating additional MLS key material.
+    async fn publish_key_package_to_relays(
+        &self,
+        encoded_key_package: &str,
+        relay_urls: &[RelayUrl],
+        tags: &[Tag],
+        signer: impl NostrSigner + 'static,
+    ) -> Result<()> {
         let result = self
             .nostr
-            .publish_key_package_with_signer(&encoded_key_package, &relays_urls, &tags, signer)
+            .publish_key_package_with_signer(encoded_key_package, relay_urls, tags, signer)
             .await?;
 
-        tracing::debug!(target: "whitenoise::publish_key_package_to_relays", "Published key package to relays: {:?}", result);
+        if result.success.is_empty() {
+            return Err(WhitenoiseError::KeyPackagePublishFailed(
+                "no relay accepted the key package event".to_string(),
+            ));
+        }
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Published key package to {} relay(s)",
+            result.success.len(),
+        );
 
         Ok(())
     }
@@ -571,11 +645,12 @@ impl Whitenoise {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+    use nostr_sdk::Keys;
+
     use super::*;
     use crate::whitenoise::accounts::AccountType;
     use crate::whitenoise::test_utils::*;
-    use chrono::Utc;
-    use nostr_sdk::Keys;
 
     fn create_local_account_struct() -> Account {
         Account {
@@ -599,6 +674,26 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    /// Creates a persisted account with a key package relay and stored keys.
+    async fn create_account_with_relay(whitenoise: &Whitenoise) -> Account {
+        let (account, keys) = create_test_account(whitenoise).await;
+        whitenoise
+            .secrets_store
+            .store_private_key(&keys)
+            .expect("Should store keys");
+        let user = account.user(&whitenoise.database).await.unwrap();
+        let relay = crate::whitenoise::relays::Relay::find_or_create_by_url(
+            &RelayUrl::parse("wss://unreachable.test.relay").unwrap(),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        user.add_relay(&relay, crate::RelayType::KeyPackage, &whitenoise.database)
+            .await
+            .unwrap();
+        account
     }
 
     #[tokio::test]
@@ -805,5 +900,127 @@ mod tests {
                 other
             ),
         }
+    }
+
+    #[tokio::test]
+    async fn test_publish_key_package_with_signer_without_relays_fails() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // Use create_test_account to get a persisted account (no key package relays)
+        let (account, _keys) = create_test_account(&whitenoise).await;
+        let signer_keys = Keys::generate();
+
+        let result = whitenoise
+            .publish_key_package_for_account_with_signer(&account, signer_keys)
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            WhitenoiseError::AccountMissingKeyPackageRelays => {}
+            other => panic!(
+                "Expected AccountMissingKeyPackageRelays error, got: {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_key_package_publish_failed_error_variant() {
+        let err = WhitenoiseError::KeyPackagePublishFailed(
+            "no relay accepted the key package event".to_string(),
+        );
+        assert!(err.to_string().contains("no relay accepted"));
+        assert!(matches!(err, WhitenoiseError::KeyPackagePublishFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn test_publish_key_package_for_account_retries_and_fails() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = create_account_with_relay(&whitenoise).await;
+
+        // With no real relay connected, publish will fail after all retry attempts
+        let result = whitenoise.publish_key_package_for_account(&account).await;
+        assert!(result.is_err(), "Should fail when relay is unreachable");
+    }
+
+    #[tokio::test]
+    async fn test_create_and_publish_key_package_fails_with_unreachable_relay() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = create_account_with_relay(&whitenoise).await;
+
+        let relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let result = whitenoise
+            .create_and_publish_key_package(&account, &relays)
+            .await;
+        assert!(result.is_err(), "Should fail when relay is unreachable");
+    }
+
+    #[tokio::test]
+    async fn test_publish_key_package_with_signer_fails_with_unreachable_relay() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = create_account_with_relay(&whitenoise).await;
+
+        let result = whitenoise
+            .publish_key_package_for_account_with_signer(&account, Keys::generate())
+            .await;
+        assert!(result.is_err(), "Should fail when relay is unreachable");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_all_key_packages_without_relays_fails() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, _keys) = create_test_account(&whitenoise).await;
+
+        let result = whitenoise
+            .fetch_all_key_packages_for_account(&account)
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WhitenoiseError::AccountMissingKeyPackageRelays
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_key_packages_without_relays_fails() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, _keys) = create_test_account(&whitenoise).await;
+
+        let result = whitenoise
+            .delete_all_key_packages_for_account(&account, false)
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WhitenoiseError::AccountMissingKeyPackageRelays
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_key_packages_with_signer_without_relays_fails() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, _keys) = create_test_account(&whitenoise).await;
+        let signer_keys = Keys::generate();
+
+        let result = whitenoise
+            .delete_all_key_packages_for_account_with_signer(&account, false, signer_keys)
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WhitenoiseError::AccountMissingKeyPackageRelays
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_key_packages_with_empty_events_returns_zero() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = create_account_with_relay(&whitenoise).await;
+
+        let result = whitenoise
+            .delete_key_packages_for_account(&account, vec![], false, 1)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Key package publishes previously returned `Ok(())` even when no relay accepted the event, silently leaving accounts unable to receive group invites
- Added `result.success.is_empty()` check after every relay publish, returning `KeyPackagePublishFailed` error when no relay accepts
- Added retry with exponential backoff (3 attempts, 2s/4s delays) for the main `publish_key_package_for_account` path
- Separated key package creation (`encoded_key_package`) from relay publishing (`send_key_package_to_relays`) so retries reuse the same MLS key material instead of orphaning unused key packages in local storage

## Test plan

- [x] `just precommit-quick` passes (fmt, docs, clippy, unit tests)
- [x] New unit tests for `KeyPackagePublishFailed` error variant and external signer relay validation
- [x] All existing key package tests pass unchanged

Closes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry with exponential backoff for publishing key packages, capped attempts to improve delivery reliability.
  * Safer key-package rotation: publishes replacement before cleanup and logs outcomes.

* **Bug Fixes**
  * Clearer publish-failure reporting and non-fatal handling when cleanup fails (scheduler will retry).

* **Tests**
  * Expanded coverage for missing relays, publish failures, retry flows, signer scenarios, and deletion outcomes.

* **Documentation**
  * Updated comments/docs reflecting retry, publish, and rotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->