### PR TITLE
refactor: remove AccountGroup lazy migration (#426)

### DIFF
--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -272,9 +272,9 @@ impl AccountGroup {
                last_read_message_id = excluded.last_read_message_id,
                pin_order = excluded.pin_order,
                -- Write-once: preserve existing dm_peer_pubkey if already set.
-               -- Many code paths construct AccountGroup without knowing the DM peer
-               -- (e.g. lazy migration), so we only fill this on first write and
-               -- never overwrite a correct value with NULL.
+               -- Many code paths construct AccountGroup without knowing the DM peer,
+               -- so we only fill this on first write and never overwrite a correct
+               -- value with NULL.
                dm_peer_pubkey = COALESCE(accounts_groups.dm_peer_pubkey, excluded.dm_peer_pubkey),
                updated_at = excluded.updated_at
              RETURNING *",

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -510,8 +510,8 @@ mod tests {
         assert!(result.is_ok());
 
         // CRITICAL: AccountGroup must exist immediately after handle_giftwrap returns
-        // (not just after background task completes). This prevents race condition
-        // where Flutter polls groups() and triggers lazy migration before AccountGroup exists.
+        // (not just after background task completes). This prevents race conditions
+        // where Flutter polls groups() before the AccountGroup record exists.
         let mdk = whitenoise
             .create_mdk_for_account(member_account.pubkey)
             .unwrap();


### PR DESCRIPTION
## Summary
- Remove `ensure_account_group_exists` lazy migration from `groups()` and `group()` methods
- Since we're doing a breaking change, pre-migration databases (groups created before the `accounts_groups` table) no longer need backwards compatibility
- Update comments in `handle_giftwrap.rs` and `accounts_groups.rs` to remove lazy migration references

## Test plan
- [x] `just precommit-quick` passes (fmt, docs, clippy, tests)
- [x] `test_groups_filtering` — `create_group()` already creates AccountGroup, no lazy migration needed
- [x] `test_visible_groups` — manually creates AccountGroup records, no lazy migration dependency
- [x] `test_group` — retrieves group created via `create_group()` which handles AccountGroup

Closes #426 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified group initialization by removing automatic account group creation logic; groups must now exist before visibility operations.

* **Tests**
  * Updated test documentation to reflect race condition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->