### PR TITLE
feat: add KeyPackageStatus enum to detect incompatible key packages (#495)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use whitenoise::error::WhitenoiseError;
 
 // Account and user management
 pub use whitenoise::accounts::{Account, AccountType, LoginError, LoginResult, LoginStatus};
-pub use whitenoise::users::{User, UserSyncMode};
+pub use whitenoise::users::{KeyPackageStatus, User, UserSyncMode};
 
 // Settings and configuration
 pub use whitenoise::account_settings::AccountSettings;


### PR DESCRIPTION
## Summary
- Add `KeyPackageStatus` enum with three variants: `Valid`, `NotFound`, `Incompatible`
- Add `key_package_status()` method on `User` that wraps `key_package_event()` and checks for the required `["encoding", "base64"]` tag per MIP-00/MIP-02
- Old key packages published before the encoding tag requirement are now identified as `Incompatible` instead of being treated as valid
- Export `KeyPackageStatus` from the crate root

## Test plan
- [x] `test_valid_encoding_tag` — event with `["encoding", "base64"]` returns true
- [x] `test_no_encoding_tag` — event without encoding tag returns false
- [x] `test_wrong_encoding_value` — event with `["encoding", "hex"]` returns false
- [x] `test_encoding_tag_among_other_tags` — encoding tag found among other tags
- [x] `test_empty_tags` — event with no tags returns false
- [x] `just precommit-quick` passes (fmt, docs, clippy, tests)

Closes #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added key package status checking functionality to determine whether a user's key package is valid, incompatible, or not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->