### PR TITLE
fix(): include connected relays to fallback alongside default relays

### DIFF
--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -316,6 +316,10 @@ impl Account {
         user.add_relay(relay, relay_type, &whitenoise.database)
             .await?;
         whitenoise
+            .nostr
+            .ensure_relays_connected(std::slice::from_ref(&relay.url))
+            .await?;
+        whitenoise
             .background_publish_account_relay_list(self, relay_type, None)
             .await?;
         tracing::debug!(target: "whitenoise::accounts", "Added relay to account: {:?}", relay.url);


### PR DESCRIPTION
Fixes https://github.com/marmot-protocol/whitenoise-rs/issues/342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay selection now combines default relays with currently connected relays (deduplicated) for subscriptions and queries.

* **Bug Fixes**
  * Adding a new relay performs a connectivity check before publishing; connection failures are surfaced.
  * Metadata and relay-list fetches may now surface network errors to callers.
  * Users with no stored relays fall back to the combined relay set.

* **Tests**
  * Added tests for fallback relay inclusion and deduplication.

* **Documentation**
  * Updated docs to reference connected-relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->