### PR TITLE
fix: use IndexMap for insertion-order reaction ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,6 +4916,7 @@ dependencies = [
  "futures",
  "hex",
  "image 0.24.9",
+ "indexmap",
  "indicatif",
  "infer",
  "keyring-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.5.37", features = ["derive"] }
 dashmap = "6.1"
 hex = "0.4"
 image = "0.24"
+indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "0.7"
 lightning-invoice = "0.33.1"

--- a/src/whitenoise/message_aggregator/reaction_handler.rs
+++ b/src/whitenoise/message_aggregator/reaction_handler.rs
@@ -3,12 +3,13 @@
 //! This module handles the processing of reaction messages (kind 7) and manages
 //! the aggregation of reactions on target messages.
 
-use nostr_sdk::prelude::*;
 use std::collections::HashMap;
+
+use mdk_core::prelude::message_types::Message;
+use nostr_sdk::prelude::*;
 
 use super::emoji_utils;
 use super::types::{AggregatorConfig, ChatMessage, EmojiReaction, ProcessingError, UserReaction};
-use mdk_core::prelude::message_types::Message;
 
 /// Process a reaction message and update the target message's reaction summary
 pub fn process_reaction(
@@ -104,7 +105,7 @@ pub(crate) fn remove_reaction_from_message(
             target_message
                 .reactions
                 .by_emoji
-                .remove(&removed_reaction.emoji);
+                .shift_remove(&removed_reaction.emoji);
         }
     }
 
@@ -158,11 +159,12 @@ pub(crate) fn add_reaction_to_message(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::whitenoise::message_aggregator::types::ReactionSummary;
     use mdk_core::prelude::GroupId;
     use mdk_core::prelude::message_types::{Message, MessageState};
     use nostr_sdk::UnsignedEvent;
+
+    use super::*;
+    use crate::whitenoise::message_aggregator::types::ReactionSummary;
 
     fn create_chat_message(id: &str) -> ChatMessage {
         let keys = Keys::generate();

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -80,7 +79,7 @@ pub struct ChatMessageSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ReactionSummary {
     /// Map of emoji to reaction details
-    pub by_emoji: HashMap<String, EmojiReaction>,
+    pub by_emoji: IndexMap<String, EmojiReaction>,
 
     /// List of all users who have reacted and with what
     pub user_reactions: Vec<UserReaction>,
@@ -230,7 +229,7 @@ mod tests {
                 reaction_id: EventId::all_zeros(),
             };
 
-            let mut by_emoji = HashMap::new();
+            let mut by_emoji = IndexMap::new();
             by_emoji.insert("👍".to_string(), emoji_reaction);
 
             let summary = ReactionSummary {


### PR DESCRIPTION
## Summary
- Replace `HashMap<String, EmojiReaction>` with `IndexMap` in `ReactionSummary.by_emoji` to preserve insertion order
- Since MLS messages are processed in chronological order, the first emoji reacted with stays first
- Uses `shift_remove` to maintain order on removal
- Added `indexmap` as direct dependency (already a transitive dep via `serde_json`)

Ref marmot-protocol/whitenoise#370

## Notes
- `IndexMap` and `HashMap` share the same serde JSON format — no DB migration needed, existing rows deserialize correctly
- Once merged, the Flutter-side sort workaround in marmot-protocol/whitenoise#369 can be removed

## Test plan
- [x] `just precommit-quick` passes (fmt, docs, clippy, tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data structure handling for emoji reactions to enhance consistency and performance.
  * Cleaned up module imports for better code organization with no impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->