### PR TITLE
docs: illustrate README with marmot pixel art for each section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,33 @@ A secure, private, and decentralized chat app built on Nostr, using the MLS prot
 
 ## Overview
 
+![Overview](https://blossom.primal.net/c47602a6ea11e092b43fd39482e66c3e3e961cb706a443b89e7396cee025875d.png)
+
 White Noise aims to be the most secure private chat app on Nostr, with a focus on privacy and security. Under the hood, it uses the [Messaging Layer Security](https://www.rfc-editor.org/rfc/rfc9420.html) (MLS) protocol to manage group communications in a highly secure way. Nostr is used as the transport protocol and as the framework for the ongoing conversation in each chat.
 
 This crate is the core library that powers our [Flutter app](https://github.com/marmot-protocol/whitenoise). It is front-end agnostic and will allow for CLI and other interfaces to operate groups in the future.
 
 ## Status
 
+![Status](https://blossom.primal.net/8edb242c987646d02bb3723cd92e30d2ac2eca1779306e22dac1b9a6214de531.png)
+
 ![CI](https://github.com/marmot-protocol/whitenoise-rs/actions/workflows/ci.yml/badge.svg?event=push)
 
 ## The Spec
+
+![The Spec](https://blossom.primal.net/6a3288895d4e67fd23f8e873056bf424f3e63c0f043467e2a406c09cff3e2535.png)
 
 White Noise implements the [Marmot protocol](https://github.com/marmot-protocol/marmot), which brings MLS group messaging to Nostr.
 
 ## Releases
 
+![Releases](https://blossom.primal.net/be38014386130840a38503b2876e88d186ca7ce40b9966d8e7f31ef16e842f3e.png)
+
 Coming soon
 
 ## Building White Noise Yourself
+
+![Building](https://blossom.primal.net/0ad7960c55f72c48f2609de66973960fafedb6c0fbef8fe1743186fcdcc95e68.png)
 
 White Noise is a standard rust crate. Check it out and use it like you would any other crate.
 
@@ -45,6 +55,8 @@ just precommit
 ```
 
 ## Contributing
+
+![Contributing](https://blossom.primal.net/9ee0c0d6fe86b85aab3dc9983155a83a894e42d8bdc292b0cf02cd17abfd5301.png)
 
 To get started contributing you'll need to have the [Rust](https://www.rust-lang.org/tools/install) toolchain installed (version 1.90.0 or later) and [Docker](https://www.docker.com).
 
@@ -125,5 +137,7 @@ open target/llvm-cov/html/index.html
 Coverage is automatically tracked in CI as part of the test suite. PRs that decrease coverage will be blocked.
 
 ## License
+
+![License](https://blossom.primal.net/d6c4287303eb9024c83adc9214ff6c44ed705aed2f8370461b85cadf3dd00021.png)
 
 White Noise is free and open source software, released under the Gnu AGPL v3 license. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
![marmot](https://blossom.primal.net/9b5bdc2cb507c378cd6f075e695ff222dc50a152e57afc40d6eb658f5e6d3438.png)

Every section of the README now has its own SNES-style 16-bit marmot illustration, because a project this secure deserves art this pixel-perfect. The colony has decorated the burrow walls — Overview, Status, The Spec, Releases, Building, Contributing, and License each get their own thematic marmot to guide the reader through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with improved organization through additional section headings and status badges for better readability and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->