### PR TITLE
chore(deps): bump mdk crates to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2624,9 +2624,10 @@ dependencies = [
 
 [[package]]
 name = "mdk-core"
-version = "0.6.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=bea6c48c6a63aab17188cdcfe05593822c8ba7e3#bea6c48c6a63aab17188cdcfe05593822c8ba7e3"
+version = "0.7.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
 dependencies = [
+ "base64",
  "blurhash",
  "chacha20poly1305",
  "hex",
@@ -2648,8 +2649,8 @@ dependencies = [
 
 [[package]]
 name = "mdk-sqlite-storage"
-version = "0.6.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=bea6c48c6a63aab17188cdcfe05593822c8ba7e3#bea6c48c6a63aab17188cdcfe05593822c8ba7e3"
+version = "0.7.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
 dependencies = [
  "getrandom 0.4.1",
  "hex",
@@ -2669,8 +2670,8 @@ dependencies = [
 
 [[package]]
 name = "mdk-storage-traits"
-version = "0.6.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=bea6c48c6a63aab17188cdcfe05593822c8ba7e3#bea6c48c6a63aab17188cdcfe05593822c8ba7e3"
+version = "0.7.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
 dependencies = [
  "nostr",
  "openmls",
@@ -2920,7 +2921,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3493,7 +3494,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3921,7 +3922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3978,7 +3979,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4592,7 +4593,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5413,7 +5414,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ infer = "0.19"
 keyring-core = "0.7"
 lightning-invoice = "0.33.1"
 
-mdk-core = { version = "0.6.0", git = "https://github.com/marmot-protocol/mdk", rev = "bea6c48c6a63aab17188cdcfe05593822c8ba7e3", features = [
+mdk-core = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3", features = [
     "mip04",
 ] }
-mdk-sqlite-storage = { version = "0.6.0", git = "https://github.com/marmot-protocol/mdk", rev = "bea6c48c6a63aab17188cdcfe05593822c8ba7e3" }
-mdk-storage-traits = { version = "0.6.0", git = "https://github.com/marmot-protocol/mdk", rev = "bea6c48c6a63aab17188cdcfe05593822c8ba7e3" }
+mdk-sqlite-storage = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3" }
+mdk-storage-traits = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3" }
 
 nwc = "0.44"
 nostr-blossom = "0.44"
@@ -43,8 +43,8 @@ nostr-sdk = { version = "0.44", features = [
 ] }
 
 # LOCAL MDK FOR DEVELOPMENT
-# mdk-core = { version = "0.6.0", path="../mdk/crates/mdk-core" }
-# mdk-sqlite-storage = { version = "0.6.0", path="../mdk/crates/mdk-sqlite-storage" }
+# mdk-core = { version = "0.7.0", path="../mdk/crates/mdk-core" }
+# mdk-sqlite-storage = { version = "0.7.0", path="../mdk/crates/mdk-sqlite-storage" }
 
 # LOCAL RUST_NOSTR FOR DEVELOPMENT
 # nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }


### PR DESCRIPTION
## Summary
- bump `mdk-core`, `mdk-sqlite-storage`, and `mdk-storage-traits` from `0.6.0` to `0.7.0`
- pin all three MDK dependencies to commit `491e24923cafd07c37d4cb3ea99aa0788ffbe1f3` for reproducible builds
- regenerate `Cargo.lock` to align transitive dependency resolution with the MDK update

## Verification
- `just precommit-quick`
- `just int-test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core infrastructure dependencies to version 0.7.0 for improved stability and enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->