### PR TITLE
chore(release): bump crate version and MDK revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7341dd5c9f52bff133ad7f16e127f8163e9b0ffa#7341dd5c9f52bff133ad7f16e127f8163e9b0ffa"
 dependencies = [
  "base64",
  "blurhash",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7341dd5c9f52bff133ad7f16e127f8163e9b0ffa#7341dd5c9f52bff133ad7f16e127f8163e9b0ffa"
 dependencies = [
  "getrandom 0.4.1",
  "hex",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=491e24923cafd07c37d4cb3ea99aa0788ffbe1f3#491e24923cafd07c37d4cb3ea99aa0788ffbe1f3"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7341dd5c9f52bff133ad7f16e127f8163e9b0ffa#7341dd5c9f52bff133ad7f16e127f8163e9b0ffa"
 dependencies = [
  "nostr",
  "openmls",
@@ -3494,7 +3494,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3922,7 +3922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3979,7 +3979,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4593,7 +4593,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5353,7 +5353,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whitenoise"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5414,7 +5414,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitenoise"
-version = "0.1.0"
+version = "0.2.0"
 description = "A secure messenger built on MLS and Nostr"
 authors = ["White Noise Authors"]
 edition = "2024"
@@ -27,11 +27,11 @@ infer = "0.19"
 keyring-core = "0.7"
 lightning-invoice = "0.33.1"
 
-mdk-core = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3", features = [
+mdk-core = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "7341dd5c9f52bff133ad7f16e127f8163e9b0ffa", features = [
     "mip04",
 ] }
-mdk-sqlite-storage = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3" }
-mdk-storage-traits = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "491e24923cafd07c37d4cb3ea99aa0788ffbe1f3" }
+mdk-sqlite-storage = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "7341dd5c9f52bff133ad7f16e127f8163e9b0ffa" }
+mdk-storage-traits = { version = "0.7.0", git = "https://github.com/marmot-protocol/mdk", rev = "7341dd5c9f52bff133ad7f16e127f8163e9b0ffa" }
 
 nwc = "0.44"
 nostr-blossom = "0.44"


### PR DESCRIPTION
## Summary
- bump crate version from `0.1.0` to `0.2.0` in `Cargo.toml`
- update MDK git dependencies to the latest `master` revision (`7341dd5c9f52bff133ad7f16e127f8163e9b0ffa`)
- refresh `Cargo.lock` to align resolved MDK sources and lockfile metadata with the new release/dependency pins

## Validation
- `just precommit-quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.0
  * Updated core dependencies to latest revisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->