### PR TITLE
fix: preserve delivery status on echoed outgoing messages

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -812,6 +812,16 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(second.delivery_status, Some(DeliveryStatus::Sent(1)));
+
+        let persisted = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(persisted.delivery_status, Some(DeliveryStatus::Sent(1)));
     }
 
     /// Test error handling for invalid MLS messages


### PR DESCRIPTION
## Summary
- Preserve existing `delivery_status` when reprocessing a kind-9 relay echo so stream payloads reflect the latest cached state.
- Prevent `NewMessage` echo events from regressing client state after a prior `DeliveryStatusChanged` update.
- Add a regression test covering the sequence: initial cache (`None`) -> DB update to `Sent` -> relay echo reprocess.

## Validation
- Ran `just test` in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages now retain their delivery status when reprocessed or cached, preventing loss of status for locally-sent relay echoes and during reprocessing.

* **Tests**
  * Added tests to verify delivery status is preserved across initial caching, external updates, and subsequent reprocessing (in-memory and persisted state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->