### PR TITLE
chore(deps): pin MDK to latest master and align integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,7 +5412,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whitenoise"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitenoise"
-version = "0.2.0"
+version = "0.2.1"
 description = "A secure messenger built on MLS and Nostr"
 authors = ["White Noise Authors"]
 edition = "2024"

--- a/src/integration_tests/scenarios/basic_messaging.rs
+++ b/src/integration_tests/scenarios/basic_messaging.rs
@@ -37,7 +37,10 @@ impl Scenario for BasicMessagingScenario {
             .await?;
 
         // Post-welcome self-update is temporarily disabled in production flow,
-        // so skip epoch advancement verification until self-update is re-enabled.
+        // so keep this check commented out until self-update is re-enabled.
+        // VerifySelfUpdateTestCase::for_account("basic_msg_member", "basic_messaging_test_group")
+        //     .execute(&mut self.context)
+        //     .await?;
 
         SendMessageTestCase::basic()
             .with_sender("basic_msg_creator")


### PR DESCRIPTION
## Summary
- pin `mdk-core`, `mdk-sqlite-storage`, and `mdk-storage-traits` to MDK master rev `ca0663ee332958aa92efadf916d19c6e1b1f99c7` (version `0.7.1`) and refresh `Cargo.lock`
- temporarily skip the `VerifySelfUpdateTestCase` step in `BasicMessagingScenario` because post-welcome self-update is currently disabled in production flow
- validate the branch with `just precommit-quick`, `just int-test basic-messaging`, and full `just int-test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.2.1 and updated underlying framework dependencies to 0.7.1 for core and storage modules.
* **Tests**
  * Adjusted integration tests to remove a now-disabled runtime verification, with a note left in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->