### PR TITLE
Adding pre-validate fetched key package events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relay control plane with health monitoring scaffold ([erskingardner])
 - Relay observability persistence for connection metrics and failure tracking ([erskingardner])
 
+### Fixed
+
+- Pre-validate fetched Marmot key package signer and tag compatibility before group creation and member adds, returning aggregated incompatibility details instead of failing mid-operation ([sergey3bv])
+
 ## [v0.2.1] - 2026-03-05
 
 ### Added
@@ -213,7 +217,7 @@ Complete architectural rewrite from Tauri desktop/mobile app to a pure Rust libr
 [F3r10]: <https://github.com/F3r10>
 [mubarakcoded]: <https://github.com/mubarakcoded> (nostr:npub1mlyye6fpsqnkuxwv3nzzf3cmrau8x6z3fhh095246me87ya0aprsun609q)
 [johnathanCorgan]: <https://github.com/jcorgan>
-
+[sergey3bv]: <https://github.com/sergey3bv> (nostr:npub1e7prxjp36rmw82gks6jc0tzva5d6fctsjhwff2qkjfqh2n9anjysgl8g2h)
 
 
 <!-- Tags -->

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -202,3 +202,26 @@ macro_rules! perf_span {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_trace_id_increments() {
+        let a = next_trace_id();
+        let b = next_trace_id();
+        assert!(b > a);
+    }
+
+    #[tokio::test]
+    async fn with_trace_id_sets_current_trace_id_for_task() {
+        assert_eq!(current_trace_id(), 0);
+        let tid = 42_u64;
+        with_trace_id(tid, async {
+            assert_eq!(current_trace_id(), tid);
+        })
+        .await;
+        assert_eq!(current_trace_id(), 0);
+    }
+}

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -144,6 +144,15 @@ pub enum WhitenoiseError {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
+    #[error(
+        "Incompatible key package(s) while {context}: {} member(s) failed validation",
+        failures.len()
+    )]
+    KeyPackageIncompatibility {
+        context: &'static str,
+        failures: Vec<(PublicKey, WhitenoiseError)>,
+    },
+
     #[error("Invalid event kind: expected {expected}, got {got}")]
     InvalidEventKind { expected: String, got: String },
 

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -27,6 +27,13 @@ mod publish;
 pub use membership::{GroupWithInfoAndMembership, GroupWithMembership};
 
 impl Whitenoise {
+    fn key_package_incompatibility_error(
+        context: &'static str,
+        failures: Vec<(PublicKey, WhitenoiseError)>,
+    ) -> WhitenoiseError {
+        WhitenoiseError::KeyPackageIncompatibility { context, failures }
+    }
+
     #[perf_instrument("groups")]
     async fn resolve_member_delivery_relays(
         &self,
@@ -70,22 +77,19 @@ impl Whitenoise {
         Ok(fallback_relays)
     }
 
-    fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey) -> Result<()> {
+    fn validate_fetched_member_key_package(
+        event: &Event,
+        pk: &PublicKey,
+        expected_ciphersuite: &str,
+    ) -> Result<()> {
         if event.pubkey != *pk {
             return Err(WhitenoiseError::InvalidInput(format!(
-                "Fetched key package event {} signed by {} instead of expected {}",
+                "key package event {} is signed by {} instead of expected {}",
                 event.id, event.pubkey, pk
             )));
         }
 
-        validate_marmot_key_package_tags(event, REQUIRED_MLS_CIPHERSUITE_TAG).map_err(|e| {
-            WhitenoiseError::InvalidInput(format!(
-                "Incompatible key package event {} for member {}: {}",
-                event.id, pk, e
-            ))
-        })?;
-
-        Ok(())
+        validate_marmot_key_package_tags(event, expected_ciphersuite)
     }
 
     /// Resolves a single member for group creation: finds or creates the user record,
@@ -112,7 +116,7 @@ impl Whitenoise {
             mdk_core::Error::KeyPackage("Does not exist".to_owned()),
         ))?;
 
-        Self::validate_fetched_member_key_package(&event, pk)?;
+        Self::validate_fetched_member_key_package(&event, pk, REQUIRED_MLS_CIPHERSUITE_TAG)?;
 
         Ok((user, event))
     }
@@ -569,6 +573,7 @@ impl Whitenoise {
         let signer = self.get_signer_for_account(account)?;
         let mdk = self.create_mdk_for_account(account.pubkey)?;
         let mut users = Vec::new();
+        let mut incompatible_members: Vec<(PublicKey, WhitenoiseError)> = Vec::new();
 
         // Fetch key packages for all members
         for pk in members.iter() {
@@ -606,10 +611,24 @@ impl Whitenoise {
                 mdk_core::Error::KeyPackage("Does not exist".to_owned()),
             ))?;
 
-            Self::validate_fetched_member_key_package(&event, pk)?;
+            match Self::validate_fetched_member_key_package(
+                &event,
+                pk,
+                REQUIRED_MLS_CIPHERSUITE_TAG,
+            ) {
+                Ok(()) => {
+                    key_package_events.push(event);
+                    users.push(user);
+                }
+                Err(error) => incompatible_members.push((*pk, error)),
+            }
+        }
 
-            key_package_events.push(event);
-            users.push(user);
+        if !incompatible_members.is_empty() {
+            return Err(Self::key_package_incompatibility_error(
+                "adding members to group",
+                incompatible_members,
+            ));
         }
 
         let relay_urls = Self::ensure_group_relays(&mdk, group_id)?;
@@ -824,6 +843,156 @@ mod tests {
             size: blob.len().try_into().unwrap(),
             mime_type: Some(mime_type.to_string()),
             uploaded: Timestamp::now(),
+        }
+    }
+
+    fn create_compatible_key_package_event(keys: &Keys) -> Event {
+        EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+            .tag(Tag::custom(
+                TagKind::Custom("mls_ciphersuite".into()),
+                [REQUIRED_MLS_CIPHERSUITE_TAG],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_extensions".into()),
+                ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn create_incompatible_ciphersuite_key_package_event(keys: &Keys) -> Event {
+        EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+            .tag(Tag::custom(
+                TagKind::Custom("mls_ciphersuite".into()),
+                ["0x9999"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_extensions".into()),
+                ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_validate_fetched_member_key_package_rejects_wrong_signer() {
+        let expected_keys = Keys::generate();
+        let wrong_signer_keys = Keys::generate();
+        let event = create_compatible_key_package_event(&wrong_signer_keys);
+
+        let result = Whitenoise::validate_fetched_member_key_package(
+            &event,
+            &expected_keys.public_key(),
+            REQUIRED_MLS_CIPHERSUITE_TAG,
+        );
+
+        assert!(
+            result.is_err(),
+            "Expected key package validation to fail for wrong signer"
+        );
+        match result.unwrap_err() {
+            WhitenoiseError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("is signed by") && msg.contains("instead of expected"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected InvalidInput for wrong signer, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_fetched_member_key_package_accepts_matching_signer_and_tags() {
+        let keys = Keys::generate();
+        let event = create_compatible_key_package_event(&keys);
+
+        let result = Whitenoise::validate_fetched_member_key_package(
+            &event,
+            &keys.public_key(),
+            REQUIRED_MLS_CIPHERSUITE_TAG,
+        );
+
+        assert!(
+            result.is_ok(),
+            "Expected key package validation to pass for valid event"
+        );
+    }
+
+    #[test]
+    fn test_validate_fetched_member_key_package_rejects_incompatible_ciphersuite() {
+        let keys = Keys::generate();
+        let pk = keys.public_key();
+        let event = create_incompatible_ciphersuite_key_package_event(&keys);
+
+        let validation_err = Whitenoise::validate_fetched_member_key_package(
+            &event,
+            &pk,
+            REQUIRED_MLS_CIPHERSUITE_TAG,
+        )
+        .expect_err("wrong ciphersuite tag should fail validation");
+
+        assert!(
+            matches!(
+                &validation_err,
+                WhitenoiseError::IncompatibleMlsCiphersuite { .. }
+            ),
+            "Expected IncompatibleMlsCiphersuite, got: {:?}",
+            validation_err
+        );
+
+        let wrapped = Whitenoise::key_package_incompatibility_error(
+            "adding members to group",
+            vec![(pk, validation_err)],
+        );
+        match wrapped {
+            WhitenoiseError::KeyPackageIncompatibility { context, failures } => {
+                assert_eq!(context, "adding members to group");
+                assert_eq!(failures.len(), 1);
+                assert_eq!(failures[0].0, pk);
+                assert!(
+                    matches!(
+                        failures[0].1,
+                        WhitenoiseError::IncompatibleMlsCiphersuite { .. }
+                    ),
+                    "Unexpected incompatibility reason: {:?}",
+                    failures[0].1
+                );
+            }
+            other => panic!(
+                "Expected KeyPackageIncompatibility for incompatible key package, got: {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_key_package_incompatibility_error_includes_context_and_reasons() {
+        let first_pubkey = Keys::generate().public_key();
+        let second_pubkey = Keys::generate().public_key();
+        let failures = vec![
+            (first_pubkey, WhitenoiseError::MissingEncodingTag),
+            (
+                second_pubkey,
+                WhitenoiseError::InvalidInput("wrong signer".to_string()),
+            ),
+        ];
+
+        let error = Whitenoise::key_package_incompatibility_error("creating group", failures);
+        match error {
+            WhitenoiseError::KeyPackageIncompatibility { context, failures } => {
+                assert_eq!(context, "creating group");
+                assert_eq!(failures.len(), 2);
+                assert_eq!(failures[0].0, first_pubkey);
+                assert_eq!(failures[1].0, second_pubkey);
+                assert!(matches!(failures[0].1, WhitenoiseError::MissingEncodingTag));
+                assert!(
+                    matches!(failures[1].1, WhitenoiseError::InvalidInput(ref msg) if msg == "wrong signer")
+                );
+            }
+            other => panic!("Expected KeyPackageIncompatibility error, got: {:?}", other),
         }
     }
 

--- a/src/whitenoise/groups/membership.rs
+++ b/src/whitenoise/groups/membership.rs
@@ -55,3 +55,106 @@ impl GroupWithInfoAndMembership {
         self.membership.is_accepted()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use chrono::Utc;
+    use mdk_core::prelude::GroupId;
+    use mdk_core::prelude::group_types;
+    use nostr_sdk::prelude::*;
+
+    use crate::whitenoise::accounts_groups::AccountGroup;
+    use crate::whitenoise::group_information::{GroupInformation, GroupType};
+
+    use super::{GroupWithInfoAndMembership, GroupWithMembership};
+
+    fn minimal_group(mls_group_id: GroupId) -> group_types::Group {
+        group_types::Group {
+            mls_group_id,
+            nostr_group_id: [0u8; 32],
+            name: String::new(),
+            description: String::new(),
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            last_message_processed_at: None,
+            epoch: 0,
+            state: group_types::GroupState::Active,
+            self_update_state: group_types::SelfUpdateState::Required,
+        }
+    }
+
+    fn minimal_account_group(
+        account_pubkey: PublicKey,
+        mls_group_id: GroupId,
+        user_confirmation: Option<bool>,
+    ) -> AccountGroup {
+        let now = Utc::now();
+        AccountGroup {
+            id: None,
+            account_pubkey,
+            mls_group_id,
+            user_confirmation,
+            welcomer_pubkey: None,
+            last_read_message_id: None,
+            pin_order: None,
+            dm_peer_pubkey: None,
+            archived_at: None,
+            removed_at: None,
+            muted_until: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn group_with_membership_is_pending_and_is_accepted_delegate() {
+        let keys = Keys::generate();
+        let pk = keys.public_key();
+        let gid = GroupId::from_slice(&[7u8; 32]);
+        let mls_group = minimal_group(gid.clone());
+
+        let pending = GroupWithMembership {
+            group: mls_group.clone(),
+            membership: minimal_account_group(pk, gid.clone(), None),
+        };
+        assert!(pending.is_pending());
+        assert!(!pending.is_accepted());
+
+        let accepted = GroupWithMembership {
+            group: mls_group,
+            membership: minimal_account_group(pk, gid, Some(true)),
+        };
+        assert!(!accepted.is_pending());
+        assert!(accepted.is_accepted());
+    }
+
+    #[test]
+    fn group_with_info_and_membership_is_pending_and_is_accepted_delegate() {
+        let keys = Keys::generate();
+        let pk = keys.public_key();
+        let gid = GroupId::from_slice(&[8u8; 32]);
+        let mls_group = minimal_group(gid.clone());
+        let now = Utc::now();
+        let info = GroupInformation {
+            id: None,
+            mls_group_id: gid.clone(),
+            group_type: GroupType::Group,
+            created_at: now,
+            updated_at: now,
+        };
+
+        let pending = GroupWithInfoAndMembership {
+            group: mls_group,
+            info,
+            membership: minimal_account_group(pk, gid, None),
+        };
+        assert!(pending.is_pending());
+        assert!(!pending.is_accepted());
+    }
+}


### PR DESCRIPTION
Addressing #546 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-validate fetched member key packages (signer and ciphersuite/tag) before group creation or member addition; incompatible packages are now collected and reported together with contextual details (e.g., "creating group", "adding members") instead of aborting mid-operation.

* **Tests**
  * Added unit and integration tests covering signer/tag validation and aggregated incompatibility reporting.

* **Chores**
  * Updated changelog and contributor list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->