### PR TITLE
feat(cli): add --send flag to media upload command

### DIFF
--- a/src/cli/commands/media.rs
+++ b/src/cli/commands/media.rs
@@ -16,6 +16,14 @@ pub enum MediaCmd {
 
         /// Path to the file to upload
         file_path: String,
+
+        /// Send a message with the uploaded media attachment
+        #[arg(long)]
+        send: bool,
+
+        /// Caption text for the message (implies --send)
+        #[arg(long)]
+        message: Option<String>,
     },
 
     /// Download a media file from a group chat
@@ -45,7 +53,20 @@ impl MediaCmd {
             Self::Upload {
                 group_id,
                 file_path,
-            } => upload(socket, json, account_flag, group_id, file_path).await,
+                send,
+                message,
+            } => {
+                upload(
+                    socket,
+                    json,
+                    account_flag,
+                    group_id,
+                    file_path,
+                    send,
+                    message,
+                )
+                .await
+            }
             Self::Download {
                 group_id,
                 file_hash,
@@ -61,14 +82,20 @@ async fn upload(
     account_flag: Option<&str>,
     group_id: String,
     file_path: String,
+    send: bool,
+    message: Option<String>,
 ) -> anyhow::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
+    // --message implies --send
+    let send = send || message.is_some();
     let resp = client::send(
         socket,
         &Request::UploadMedia {
             account: pubkey,
             group_id,
             file_path,
+            send,
+            message,
         },
     )
     .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -314,7 +314,9 @@ pub async fn dispatch(req: Request) -> Response {
             account,
             group_id,
             file_path,
-        } => match upload_media(wn, &account, &group_id, &file_path).await {
+            send,
+            message,
+        } => match upload_media(wn, &account, &group_id, &file_path, send, message).await {
             Ok(resp) => resp,
             Err(resp) => resp,
         },
@@ -1338,6 +1340,8 @@ async fn upload_media(
     account_str: &str,
     group_id_hex: &str,
     file_path: &str,
+    send: bool,
+    message: Option<String>,
 ) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
     let group_id = parse_group_id(group_id_hex)?;
@@ -1347,7 +1351,69 @@ async fn upload_media(
         .await
         .map_err(|e| Response::err(e.to_string()))?;
 
-    Ok(to_response(&media_file))
+    if !send {
+        return Ok(to_response(&media_file));
+    }
+
+    let imeta_tag = build_imeta_tag(&media_file)?;
+    let caption = message.unwrap_or_default();
+
+    let msg_result = wn
+        .send_message_to_group(&account, &group_id, caption, 9, Some(vec![imeta_tag]))
+        .await
+        .map_err(|e| Response::err(e.to_string()))?;
+
+    Ok(to_response(&serde_json::json!({
+        "media": serde_json::to_value(&media_file).map_err(|e| Response::err(e.to_string()))?,
+        "message": serde_json::to_value(&msg_result).map_err(|e| Response::err(e.to_string()))?,
+    })))
+}
+
+/// Build an `imeta` tag from an uploaded `MediaFile` per MIP-04.
+fn build_imeta_tag(
+    media_file: &crate::whitenoise::database::media_files::MediaFile,
+) -> Result<nostr_sdk::Tag, Response> {
+    let blossom_url = media_file
+        .blossom_url
+        .as_deref()
+        .ok_or_else(|| Response::err("uploaded media has no blossom URL"))?;
+
+    let original_hash_hex = media_file
+        .original_file_hash
+        .as_ref()
+        .map(hex::encode)
+        .ok_or_else(|| Response::err("uploaded media has no original file hash"))?;
+
+    let mut parts: Vec<String> = vec![
+        "imeta".to_string(),
+        format!("url {}", blossom_url),
+        format!("m {}", media_file.mime_type),
+        format!("x {}", original_hash_hex),
+    ];
+
+    if let Some(ref fm) = media_file.file_metadata {
+        if let Some(ref filename) = fm.original_filename {
+            parts.push(format!("filename {}", filename));
+        }
+        if let Some(ref blurhash) = fm.blurhash {
+            parts.push(format!("blurhash {}", blurhash));
+        }
+        if let Some(ref dim) = fm.dimensions {
+            parts.push(format!("dim {}", dim));
+        }
+    }
+
+    if let Some(ref nonce) = media_file.nonce {
+        parts.push(format!("n {}", nonce));
+    }
+
+    if let Some(ref version) = media_file.scheme_version {
+        parts.push(format!("v {}", version));
+    }
+
+    let parts_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+    nostr_sdk::Tag::parse(parts_refs)
+        .map_err(|e| Response::err(format!("failed to create imeta tag: {e}")))
 }
 
 async fn download_media(

--- a/src/cli/protocol.rs
+++ b/src/cli/protocol.rs
@@ -182,6 +182,12 @@ pub enum Request {
         account: String,
         group_id: String,
         file_path: String,
+        /// When true, send a kind-9 message with the imeta tag after upload.
+        #[serde(default)]
+        send: bool,
+        /// Optional caption text for the message (only used when `send` is true).
+        #[serde(default)]
+        message: Option<String>,
     },
     #[serde(rename = "download_media")]
     DownloadMedia {
@@ -974,15 +980,57 @@ mod tests {
             account: "npub1abc".to_string(),
             group_id: "abcd1234".to_string(),
             file_path: "/tmp/image.png".to_string(),
+            send: false,
+            message: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert!(matches!(
             parsed,
-            Request::UploadMedia { account, group_id, file_path }
+            Request::UploadMedia { account, group_id, file_path, send, message }
             if account == "npub1abc"
                 && group_id == "abcd1234"
                 && file_path == "/tmp/image.png"
+                && !send
+                && message.is_none()
+        ));
+    }
+
+    #[test]
+    fn upload_media_minimal_roundtrip() {
+        // Old-style wire format without send/message — defaults apply
+        let wire = r#"{"method":"upload_media","params":{"account":"npub1abc","group_id":"abcd1234","file_path":"/tmp/image.png"}}"#;
+        let parsed: Request = serde_json::from_str(wire).unwrap();
+        assert!(matches!(
+            parsed,
+            Request::UploadMedia { account, group_id, file_path, send, message }
+            if account == "npub1abc"
+                && group_id == "abcd1234"
+                && file_path == "/tmp/image.png"
+                && !send
+                && message.is_none()
+        ));
+    }
+
+    #[test]
+    fn upload_media_with_send_roundtrip() {
+        let req = Request::UploadMedia {
+            account: "npub1abc".to_string(),
+            group_id: "abcd1234".to_string(),
+            file_path: "/tmp/image.png".to_string(),
+            send: true,
+            message: Some("check this out".to_string()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            Request::UploadMedia { account, group_id, file_path, send, message }
+            if account == "npub1abc"
+                && group_id == "abcd1234"
+                && file_path == "/tmp/image.png"
+                && send
+                && message.as_deref() == Some("check this out")
         ));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a --send flag for media uploads to optionally send the uploaded media as a message.
* Added an optional --message parameter to include captions or text with uploaded media.
* Supplying --message automatically enables sending, so captions are delivered with the media.
* Upload responses now return sent-message details when a send is performed, otherwise they return only media upload info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->