### PR TITLE
Fix TOCTOU race and orphaned discovery subscriptions in since-timestamp computation

### DIFF
--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -1178,6 +1178,15 @@ impl Whitenoise {
         // Delete the account from the database
         account.delete(&self.database).await?;
 
+        // Sync discovery subscriptions with remaining accounts (tears down on last logout)
+        if let Err(e) = self.sync_discovery_subscriptions().await {
+            tracing::warn!(
+                target: "whitenoise::accounts",
+                account_pubkey = %pubkey,
+                "Failed to refresh discovery subscriptions after logout: {e}"
+            );
+        }
+
         // Remove the private key from the secret store
         // For local accounts this is required; for external accounts this is best-effort cleanup
         let result = self.secrets_store.remove_private_key_for_pubkey(pubkey);
@@ -1869,6 +1878,33 @@ mod tests {
         assert!(
             result.is_ok(),
             "Logout should succeed for external account without stored key"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_logout_syncs_discovery_subscriptions() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let account = whitenoise.create_identity().await.unwrap();
+
+        // After login, global discovery subscriptions should be active
+        assert!(
+            whitenoise
+                .is_global_subscriptions_operational()
+                .await
+                .unwrap(),
+            "Global subscriptions should be operational after login"
+        );
+
+        whitenoise.logout(&account.pubkey).await.unwrap();
+
+        // After logging out the last account, discovery subscriptions should be torn down
+        assert!(
+            !whitenoise
+                .is_global_subscriptions_operational()
+                .await
+                .unwrap(),
+            "Global subscriptions should be torn down after last account logout"
         );
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -579,14 +579,20 @@ impl Whitenoise {
         whitenoise_ref.sync_discovery_subscriptions().await
     }
 
+    /// Buffer (in seconds) subtracted from `last_synced_at` timestamps when
+    /// computing subscription `since` values, to account for clock drift and
+    /// relay propagation delay.
+    const SUBSCRIPTION_BUFFER_SECS: u64 = 10;
+
     // Compute a shared since timestamp for global user subscriptions.
     // - Accepts the already-loaded account list to avoid TOCTOU races
     // - If any account is unsynced (last_synced_at = None), return None
-    // - Otherwise, use min(last_synced_at) minus a 10s buffer, floored at 0
+    // - Otherwise, use min(last_synced_at) minus a buffer, floored at 0
+    #[perf_instrument("whitenoise")]
     fn compute_global_since_timestamp(accounts: &[Account]) -> Option<nostr_sdk::Timestamp> {
         if accounts.is_empty() {
             tracing::debug!(
-                target: "whitenoise::setup_global_users_subscriptions",
+                target: "whitenoise::compute_global_since_timestamp",
                 "No accounts; defaulting to since=None"
             );
             return None;
@@ -598,34 +604,24 @@ impl Whitenoise {
                 .filter(|a| a.last_synced_at.is_none())
                 .count();
             tracing::info!(
-                target: "whitenoise::setup_global_users_subscriptions",
+                target: "whitenoise::compute_global_since_timestamp",
                 "Global subscriptions using since=None due to {} unsynced accounts",
                 unsynced
             );
             return None;
         }
 
-        const BUFFER_SECS: u64 = 10;
         let since = accounts
             .iter()
-            .filter_map(|a| a.since_timestamp(BUFFER_SECS))
+            .filter_map(|a| a.since_timestamp(Self::SUBSCRIPTION_BUFFER_SECS))
             .min_by_key(|t| t.as_secs());
 
-        match since {
-            Some(ts) => {
-                tracing::info!(
-                    target: "whitenoise::setup_global_users_subscriptions",
-                    "Global subscriptions using since={} ({}s buffer)",
-                    ts.as_secs(), BUFFER_SECS
-                );
-            }
-            None => {
-                tracing::debug!(
-                    target: "whitenoise::setup_global_users_subscriptions",
-                    "All accounts synced but since_timestamp returned None for all; \
-                     defaulting to since=None"
-                );
-            }
+        if let Some(ts) = since {
+            tracing::info!(
+                target: "whitenoise::compute_global_since_timestamp",
+                "Global subscriptions using since={} ({}s buffer)",
+                ts.as_secs(), Self::SUBSCRIPTION_BUFFER_SECS
+            );
         }
         since
     }
@@ -1307,7 +1303,12 @@ impl Whitenoise {
         let watched_users = User::all_pubkeys(&self.database).await?;
         let follow_list_accounts = accounts
             .iter()
-            .map(|account| (account.pubkey, account.since_timestamp(10)))
+            .map(|account| {
+                (
+                    account.pubkey,
+                    account.since_timestamp(Self::SUBSCRIPTION_BUFFER_SECS),
+                )
+            })
             .collect::<Vec<_>>();
         let public_since = Self::compute_global_since_timestamp(&accounts);
 
@@ -2711,10 +2712,22 @@ mod tests {
     }
 
     mod subscription_tests {
-        use chrono::{TimeDelta, Utc};
+        use chrono::{DateTime, TimeDelta, Utc};
         use nostr_sdk::Keys;
 
         use super::*;
+
+        fn make_account(user_id: i64, last_synced_at: Option<DateTime<Utc>>) -> Account {
+            Account {
+                id: None,
+                pubkey: Keys::generate().public_key(),
+                user_id,
+                account_type: AccountType::Local,
+                last_synced_at,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }
+        }
 
         #[tokio::test]
         async fn test_refresh_all_global_subscriptions_no_account_returns_ok() {
@@ -2735,15 +2748,7 @@ mod tests {
 
         #[test]
         fn test_compute_global_since_unsynced_account_returns_none() {
-            let accounts = vec![Account {
-                id: None,
-                pubkey: Keys::generate().public_key(),
-                user_id: 1,
-                account_type: AccountType::Local,
-                last_synced_at: None,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-            }];
+            let accounts = vec![make_account(1, None)];
             assert!(Whitenoise::compute_global_since_timestamp(&accounts).is_none());
         }
 
@@ -2753,30 +2758,11 @@ mod tests {
             let older = now - TimeDelta::seconds(200);
             let newer = now - TimeDelta::seconds(100);
 
-            let accounts = vec![
-                Account {
-                    id: None,
-                    pubkey: Keys::generate().public_key(),
-                    user_id: 1,
-                    account_type: AccountType::Local,
-                    last_synced_at: Some(older),
-                    created_at: now,
-                    updated_at: now,
-                },
-                Account {
-                    id: None,
-                    pubkey: Keys::generate().public_key(),
-                    user_id: 2,
-                    account_type: AccountType::Local,
-                    last_synced_at: Some(newer),
-                    created_at: now,
-                    updated_at: now,
-                },
-            ];
+            let accounts = vec![make_account(1, Some(older)), make_account(2, Some(newer))];
 
             let ts = Whitenoise::compute_global_since_timestamp(&accounts).unwrap();
-            // Should use the older timestamp minus the 10s buffer
-            let expected = (older.timestamp().max(0) as u64).saturating_sub(10);
+            let expected = (older.timestamp().max(0) as u64)
+                .saturating_sub(Whitenoise::SUBSCRIPTION_BUFFER_SECS);
             assert_eq!(ts.as_secs(), expected);
         }
 
@@ -2784,26 +2770,9 @@ mod tests {
         fn test_compute_global_since_mixed_synced_unsynced_returns_none() {
             let now = Utc::now();
             let accounts = vec![
-                Account {
-                    id: None,
-                    pubkey: Keys::generate().public_key(),
-                    user_id: 1,
-                    account_type: AccountType::Local,
-                    last_synced_at: Some(now - TimeDelta::seconds(100)),
-                    created_at: now,
-                    updated_at: now,
-                },
-                Account {
-                    id: None,
-                    pubkey: Keys::generate().public_key(),
-                    user_id: 2,
-                    account_type: AccountType::Local,
-                    last_synced_at: None,
-                    created_at: now,
-                    updated_at: now,
-                },
+                make_account(1, Some(now - TimeDelta::seconds(100))),
+                make_account(2, None),
             ];
-            // One unsynced account forces since=None
             assert!(Whitenoise::compute_global_since_timestamp(&accounts).is_none());
         }
     }


### PR DESCRIPTION
## Summary

- `compute_global_since_timestamp` loaded `Account::all()` independently from its caller, creating a TOCTOU window where a concurrent logout could empty the accounts table between queries — hitting a spurious WARN log repeatedly
- Changed the function from `async fn(&Whitenoise) -> Result<Option<Timestamp>>` to `fn(&[Account]) -> Option<Timestamp>`, accepting the caller's already-loaded accounts
- Moved the empty-account teardown from `setup_global_users_subscriptions` into `sync_discovery_subscriptions` so that all callers (`refresh_global_subscription_for_user`, `refresh_all_global_subscriptions`) also get proper cleanup — previously, after logout, watched users could keep discovery subscriptions alive with no accounts to consume them
- Added unit tests covering all branches of `compute_global_since_timestamp`

## Test plan

- [x] `just precommit-quick` passes (fmt, docs, clippy, unit tests)

Closes #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved subscription setup and timestamp handling to avoid race conditions and reduce redundant lookups, yielding more consistent subscription behavior.

* **Bug Fixes**
  * After logout, discovery subscriptions are refreshed; failures are non-fatal and logged as warnings to avoid interrupting logout.

* **Tests**
  * Added unit tests for timestamp calculation to strengthen reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->