### PR TITLE
Disable relay authentication (NIP-42) by default

### DIFF
--- a/src/relay_control/account_inbox.rs
+++ b/src/relay_control/account_inbox.rs
@@ -29,7 +29,7 @@ impl AccountInboxPlaneConfig {
         Self {
             account_pubkey,
             inbox_relays,
-            auth_policy: RelaySessionAuthPolicy::Allowed,
+            auth_policy: RelaySessionAuthPolicy::Disabled,
             reconnect_policy: RelaySessionReconnectPolicy::Conservative,
         }
     }
@@ -149,7 +149,7 @@ mod tests {
     fn test_new_sets_account_inbox_defaults() {
         let config = AccountInboxPlaneConfig::new(Keys::generate().public_key(), Vec::new());
 
-        assert_eq!(config.auth_policy, RelaySessionAuthPolicy::Allowed);
+        assert_eq!(config.auth_policy, RelaySessionAuthPolicy::Disabled);
         assert_eq!(
             config.reconnect_policy,
             RelaySessionReconnectPolicy::Conservative

--- a/src/relay_control/sessions/config.rs
+++ b/src/relay_control/sessions/config.rs
@@ -5,6 +5,19 @@ use nostr_sdk::PublicKey;
 use crate::relay_control::RelayPlane;
 
 /// Session-level auth policy.
+///
+/// Controls the nostr-sdk `automatic_authentication` setting on the underlying
+/// `Client`. When `Disabled`, the client will not respond to NIP-42 AUTH
+/// challenges from relays.
+///
+/// Auth is disabled by default because the current shared-client and
+/// temporary-signer model is a poor fit for long-lived NIP-42 authenticated
+/// reconnect behaviour. Re-enabling auth requires:
+///
+/// - Ensuring each authenticated session has a stable, long-lived signer
+///   (not the current set/unset pattern around activation/deactivation).
+/// - Handling auth-required relay reconnection without amplifying retry churn.
+/// - Separating auth-capable relay pools from unauthenticated discovery pools.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub(crate) enum RelaySessionAuthPolicy {

--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -55,7 +55,10 @@ pub(crate) struct RelaySession {
 
 impl RelaySession {
     pub(crate) fn new(config: RelaySessionConfig, event_sender: Sender<ProcessableEvent>) -> Self {
-        let opts = ClientOptions::default().verify_subscriptions(true);
+        let automatic_auth = config.auth_policy != super::RelaySessionAuthPolicy::Disabled;
+        let opts = ClientOptions::default()
+            .verify_subscriptions(true)
+            .automatic_authentication(automatic_auth);
         let client = Client::builder().opts(opts).build();
         let (telemetry_sender, _) = broadcast::channel(256);
 


### PR DESCRIPTION
## Summary
- Explicitly disable nostr-sdk `automatic_authentication` on all `Client` instances (previously defaulted to `true` upstream, meaning all sessions were silently responding to NIP-42 AUTH challenges)
- Wire `RelaySessionAuthPolicy` to actually control the SDK setting — it was dead configuration before
- Change `AccountInboxPlane` default auth policy from `Allowed` to `Disabled`
- Document architectural prerequisites for safely re-enabling auth

## Why
The current shared-client and temporary-signer model (set on activate, unset on deactivate) is a poor fit for long-lived NIP-42 authenticated reconnect behaviour. Auth-required relays were contributing to connection failures and retry churn because:
- AUTH challenges arriving after `deactivate()` would fail (no signer)
- AUTH challenges during reconnect could fire before a signer is set
- The SDK's auto-auth would silently attempt and fail, generating noise

## Test plan
- [x] `just precommit-quick` passes (fmt, docs, clippy, tests)
- [x] All 1228 unit tests pass
- [x] Verified `RelaySessionAuthPolicy` is `Disabled` for all planes (Discovery, Group, Ephemeral, AccountInbox)
- [x] Verified legacy `NostrManager` client also has auto-auth disabled

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default authentication policy for relay sessions changed to Disabled (tests updated accordingly).

* **New Features**
  * Relay client now toggles automatic authentication based on the configured policy.

* **Documentation**
  * Added comprehensive guidance on authentication policy options and their runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->