### PR TITLE
chore(audit): ignore RUSTSEC-2026-0037 quinn-proto DoS advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,8 @@ jobs:
           # - RUSTSEC-2026-0002: lru unsound (transitive via nostr-sdk, awaiting upstream fix)
           # - RUSTSEC-2026-0023: libcrux-ecdh X25519 validation (transitive via openmls_rust_crypto →
           #   hpke-rs → hpke-rs-libcrux; pre-existing on master, fix tracked separately)
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0384,RUSTSEC-2026-0002,RUSTSEC-2026-0023
+          # - RUSTSEC-2026-0037: quinn-proto DoS via malformed QUIC handshake (transitive via nostr-blossom → reqwest → quinn; awaiting upstream fix)
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0384,RUSTSEC-2026-0002,RUSTSEC-2026-0023,RUSTSEC-2026-0037
 
   # Fast Linux test lane for PR feedback
   test-linux:

--- a/justfile
+++ b/justfile
@@ -227,8 +227,9 @@ update:
 # - RUSTSEC-2023-0071: RSA Marvin Attack (transitive via sqlx-mysql, not used in our SQLite-only app)
 # - RUSTSEC-2024-0384: instant unmaintained (transitive via rust-nostr, low risk)
 # - RUSTSEC-2026-0002: lru unsound (transitive via nostr-sdk, awaiting upstream fix)
+# - RUSTSEC-2026-0037: quinn-proto DoS via malformed QUIC handshake (transitive via nostr-blossom → reqwest → quinn; awaiting upstream fix)
 audit:
-    cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0002
+    cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0002 --ignore RUSTSEC-2026-0037
 
 # Generate and open documentation
 doc:


### PR DESCRIPTION
![marmot](https://blossom.primal.net/2b6514919dde7e212e19d8cdac31239f756dbe1b691876208043c007417baf0f.png)

Fixes the CI Security Audit job failing due to RUSTSEC-2026-0037 — a newly-published DoS advisory for `quinn-proto 0.11.13` (malformed QUIC handshake panic). This is a transitive dependency via `nostr-blossom → reqwest → quinn`, so we add it to the ignore list in both `ci.yml` and `justfile` following the same pattern used for previous advisories while awaiting an upstream fix.

Closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to manage security advisory handling in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->