### PR TITLE
Remove unnecessary event_sender.clone() in RelayControlPlane::new()

### DIFF
--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -83,7 +83,7 @@ impl RelayControlPlane {
 
         Self {
             database,
-            event_sender: event_sender.clone(),
+            event_sender,
             session_salt,
             discovery,
             account_inbox_planes: RwLock::new(HashMap::new()),


### PR DESCRIPTION
The event_sender parameter is owned and its last use before being stored
in the struct field was on line 80 (passed to EphemeralPlane::new). The
subsequent .clone() when assigning to self.event_sender was redundant
since the original value could simply be moved. The field itself is
retained because it is read later in activate_account_subscriptions().

Closes #612

https://claude.ai/code/session_01LFrTPLU1Rp3mobozd9fgrf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal event sender ownership handling in relay control logic for improved resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->