### PR TITLE
fix(welcome): reject Welcome on key package DB lookup failure

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -1024,4 +1024,35 @@ mod tests {
             .unwrap();
         assert!(ag.is_some(), "AccountGroup must survive an early return");
     }
+
+    /// When the DB lookup for the key package fails (e.g. table missing),
+    /// `handle_giftwrap` must return an error so the upstream retry logic kicks in.
+    /// This covers the `Err(e) => return Err(e.into())` path in `process_welcome`.
+    #[tokio::test]
+    async fn test_handle_giftwrap_welcome_db_error_rejects() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        // Build a real MLS Welcome giftwrap addressed to the member
+        let giftwrap_event =
+            build_welcome_giftwrap(&whitenoise, &creator_account, member_account.pubkey).await;
+
+        // Corrupt the database by dropping the published_key_packages table
+        sqlx::query("DROP TABLE published_key_packages")
+            .execute(&whitenoise.database.pool)
+            .await
+            .unwrap();
+
+        // Processing should fail because the DB lookup errors out
+        let result = whitenoise
+            .handle_giftwrap(&member_account, giftwrap_event)
+            .await;
+        assert!(
+            result.is_err(),
+            "Welcome with broken DB should return an error, got Ok"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #622 (Issue B: Welcome Message Processing Skips KeyPackage Ownership Verification and Mandatory Rotation)

- Completes the final remaining remediation item from the Least Authority audit: when the key package ownership database lookup returns an error, reject the Welcome instead of falling through to MLS processing
- The returned error triggers the existing retry mechanism in `process_account_event`, so transient DB failures cause a retry rather than silently accepting an unverified Welcome

### All three audit remediation items are now addressed:
1. **Reject Welcome if missing/unparseable `e` tag** — done in `6a52586`
2. **Return error on DB lookup failure** — this PR
3. **Return error from `rotate_key_package` when KP event ID absent** — done in `6a52586`

## Test plan

- [x] `cargo check` passes
- [x] All 11 `handle_giftwrap` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling for message processing to properly reject failed database operations instead of silently continuing. When database lookups fail, appropriate error rejection and retry mechanisms are now triggered, improving system resilience.

* **Tests**
  * Added test case to verify that database failures properly trigger error rejection and upstream retry logic, ensuring robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->