### PR TITLE
fix(keyring): use protected-data store on macOS Apple Silicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,18 @@ rpassword = { version = "7", optional = true }
 indicatif = { version = "0.18.3", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-apple-native-keyring-store = { version = "0.2", features = ["keychain"] }
+# keychain: used on x86_64 (non-provisioned command-line/dev builds).
+# protected: used on aarch64 (Apple Silicon) where the Flutter app is always
+#   code-signed by a provisioning profile.  The protected::Store symbol is only
+#   compiled when this feature is enabled, so both features must be listed even
+#   though a given binary only calls one of them.
+# NOTE: apple_native_keyring_store::protected::Store requires the binary to be
+#   code-signed with a provisioning profile that grants the
+#   com.apple.security.application-groups or keychain-access-groups entitlement.
+#   Running an unsigned binary (e.g. `cargo run` on a developer Mac without a
+#   profile) will panic at start-up with an entitlement error.  Use an x86_64
+#   host or the `keychain` path for local development without a profile.
+apple-native-keyring-store = { version = "0.2", features = ["keychain", "protected"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 apple-native-keyring-store = { version = "0.2", features = ["protected"] }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -279,6 +279,17 @@ impl Whitenoise {
                         .expect("Failed to create macOS Keychain credential store");
                     keyring_core::set_default_store(store);
                 }
+                // Apple Silicon (aarch64) macOS: use the Protected Data store, which
+                // synchronises credentials across devices via iCloud.
+                //
+                // RUNTIME REQUIREMENT: the binary must be code-signed with a
+                // provisioning profile that includes the
+                // com.apple.security.application-groups (or equivalent
+                // keychain-access-groups) entitlement.  The Flutter app build
+                // pipeline satisfies this automatically.  An unsigned `cargo run`
+                // on a developer Mac will panic here with an entitlement error;
+                // in that case build for x86_64 or use the integration-test
+                // feature flag (which substitutes the mock store).
                 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
                 {
                     let store = apple_native_keyring_store::protected::Store::new()


### PR DESCRIPTION
![marmot](https://blossom.primal.net/83a669f08fb37708c7362a84f81d8448911d59d2c460504715e6b2c07df54004.png)

`initialize_keyring_store` was routing all macOS builds to the legacy keychain store regardless of architecture. Apple Silicon Macs support the protected-data store (available since macOS 10.15), which has stronger data handling guarantees and integrates with the Secure Enclave (the same store iOS has always used).

This splits the macOS `cfg` predicate by `target_arch`:

- `aarch64` (Apple Silicon) -> `protected::Store`
- `x86_64` (Intel) -> `keychain::Store` (unchanged)

Fixes the finding from the Least Authority audit (issue #630).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS credential storage to properly support both Intel and Apple Silicon by selecting the appropriate secure store per architecture, improving reliability on newer Macs and reducing credential-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->