### PR TITLE
fix(security): add post-decryption SHA-256 integrity check for chat media (issue F)

### DIFF
--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -747,11 +747,27 @@ impl Whitenoise {
             nonce,
         };
 
-        media_manager
+        let decrypted = media_manager
             .decrypt_from_download(&encrypted_data, &reference)
             .map_err(|e| {
                 WhitenoiseError::Other(anyhow::anyhow!("Failed to decrypt chat media: {}", e))
-            })
+            })?;
+
+        // MIP-04 requires an explicit SHA-256 check on the plaintext after decryption.
+        // ChaCha20-Poly1305 authenticates the ciphertext, but does not guarantee the
+        // decrypted output matches the original file — a different plaintext encrypted
+        // under a valid derived key would pass AEAD authentication. Verify here.
+        let mut hasher = sha2::Sha256::new();
+        sha2::Digest::update(&mut hasher, &decrypted);
+        let actual_hash: [u8; 32] = hasher.finalize().into();
+        if actual_hash != *original_file_hash {
+            return Err(WhitenoiseError::HashMismatch {
+                expected: hex::encode(original_file_hash),
+                actual: hex::encode(actual_hash),
+            });
+        }
+
+        Ok(decrypted)
     }
 
     async fn store_and_record_group_image(


### PR DESCRIPTION
![marmot](https://blossom.primal.net/e1212910de7f8671edf199ce5e5e65805007317581126c542b796173bb0a09e9.png)

After `decrypt_from_download` returns, the decrypted bytes went straight to the caller with no plaintext hash check. ChaCha20-Poly1305 authenticates the ciphertext, but it doesn't verify the plaintext matches what was originally uploaded. MIP-04 treats these as separate guarantees.

This adds the missing check: compute `SHA-256` of the decrypted output and compare it against `original_file_hash`. If they differ, return `WhitenoiseError::HashMismatch` before the bytes reach the caller.

Fixes #626.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added integrity verification for media files following decryption to detect and prevent acceptance of corrupted or modified content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->