### PR TITLE
fix: add exponential backoff to notification handler restarts

### DIFF
--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -756,6 +756,9 @@ impl RelaySession {
             // disconnect does not permanently blind the session. The loop
             // exits on a graceful Shutdown notification (Ok return) or when
             // the event_sender channel closes (receiver dropped).
+            const MAX_BACKOFF_SECS: u64 = 30;
+            let mut backoff_secs: u64 = 1;
+
             loop {
                 // Clone per-iteration so the `move` closure owns fresh handles.
                 let sender_i = event_sender.clone();
@@ -763,6 +766,7 @@ impl RelaySession {
                 let router_i = router.clone();
                 let state_i = state.clone();
 
+                let started_at = tokio::time::Instant::now();
                 let result = client
                     .handle_notifications(move |notification| {
                         let sender = sender_i.clone();
@@ -892,11 +896,18 @@ impl RelaySession {
                         break;
                     }
                     Err(error) => {
+                        // Reset backoff if the handler ran long enough to
+                        // have processed events successfully before failing.
+                        if started_at.elapsed() >= std::time::Duration::from_secs(MAX_BACKOFF_SECS)
+                        {
+                            backoff_secs = 1;
+                        }
                         tracing::error!(
                             target: "whitenoise::relay_control::session",
-                            "Notification handler error: {error}. Restarting in 1s."
+                            "Notification handler error: {error}. Restarting in {backoff_secs}s."
                         );
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                        backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Replace fixed 1-second restart delay with exponential backoff (1s → 2s → 4s → 8s → 16s → 30s cap)
- Reset backoff to 1s when the handler ran for 30+ seconds before failing

## Problem

The notification handler restart delay was a fixed 1 second with no backoff. If a relay is persistently causing errors, this spins at 1 restart/second indefinitely, generating high log volume and wasted CPU.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] Integration tests (`just precommit`)

Closes #613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced relay session error recovery with exponential backoff mechanism, progressively increasing retry delays up to 30 seconds before resetting, improving stability during transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->