### PR TITLE
Fixing preventing coverage gaps during account resubscribe

### DIFF
--- a/src/relay_control/groups.rs
+++ b/src/relay_control/groups.rs
@@ -111,7 +111,7 @@ impl GroupPlane {
         let normalized_groups = Self::normalize_group_specs(group_specs);
         let subscriptions = Self::build_relay_set_subscriptions(&normalized_groups);
 
-        // On any failure below, remove the accounts entry so that
+        // On any failure below, remove the account entry so that
         // has_active_subscription() returns false and recovery is triggered.
         // (The unsubscribe above already tore down the previous subscription,
         // so leaving stale relay info in the map would make the health check
@@ -120,15 +120,6 @@ impl GroupPlane {
         for subscription in &subscriptions {
             if subscription.relays.is_empty() || subscription.group_ids.is_empty() {
                 continue;
-            }
-
-            let mut filter = Filter::new().kind(Kind::MlsGroupMessage).custom_tags(
-                SingleLetterTag::lowercase(Alphabet::H),
-                subscription.group_ids.iter(),
-            );
-
-            if let Some(since) = since {
-                filter = filter.since(since);
             }
 
             if let Err(e) = self
@@ -140,6 +131,13 @@ impl GroupPlane {
                     .await;
                 self.accounts.write().await.remove(&pubkey);
                 return Err(e);
+            }
+            let mut filter = Filter::new().kind(Kind::MlsGroupMessage).custom_tags(
+                SingleLetterTag::lowercase(Alphabet::H),
+                subscription.group_ids.iter(),
+            );
+            if let Some(since) = since {
+                filter = filter.since(since);
             }
             if let Err(e) = self
                 .session
@@ -502,5 +500,269 @@ mod tests {
             .find(|group| group.group_id == "group-b")
             .unwrap();
         assert_eq!(group_b.relay_urls, vec![relay_c.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_update_account_empty_groups_clears_existing_state() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [3; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        // Seed state with a subscription that has no relays so unsubscribe is a no-op.
+        let groups = vec![GroupSubscriptionSpec {
+            group_id: "group-x".to_string(),
+            relays: vec![],
+        }];
+        let subscriptions = GroupPlane::build_relay_set_subscriptions(&groups);
+        plane.accounts.write().await.insert(
+            pubkey,
+            GroupAccountState {
+                groups,
+                subscriptions,
+            },
+        );
+
+        plane.update_account(pubkey, &[], None).await.unwrap();
+
+        let accounts = plane.accounts.read().await;
+        let state = accounts.get(&pubkey).unwrap();
+        assert!(state.groups.is_empty());
+        assert!(state.subscriptions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_account_skips_subscriptions_with_empty_relays() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [4; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        // A spec with no relays should be silently skipped (no relay connection
+        // is attempted, so the call succeeds without live infrastructure).
+        let groups = vec![GroupSubscriptionSpec {
+            group_id: "group-no-relay".to_string(),
+            relays: vec![],
+        }];
+
+        plane.update_account(pubkey, &groups, None).await.unwrap();
+
+        let accounts = plane.accounts.read().await;
+        let state = accounts.get(&pubkey).unwrap();
+        // Normalized groups are stored but the empty-relay subscription is
+        // filtered out by build_relay_set_subscriptions.
+        assert_eq!(state.groups.len(), 1);
+        assert_eq!(state.groups[0].group_id, "group-no-relay");
+    }
+
+    #[tokio::test]
+    async fn test_update_account_stale_subscriptions_removed_on_replace() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [5; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        // Seed two groups with no relays so update_account can succeed without
+        // live relay connections.
+        let old_groups = vec![
+            GroupSubscriptionSpec {
+                group_id: "old-group-1".to_string(),
+                relays: vec![],
+            },
+            GroupSubscriptionSpec {
+                group_id: "old-group-2".to_string(),
+                relays: vec![],
+            },
+        ];
+        plane
+            .update_account(pubkey, &old_groups, None)
+            .await
+            .unwrap();
+
+        let new_groups = vec![GroupSubscriptionSpec {
+            group_id: "new-group".to_string(),
+            relays: vec![],
+        }];
+        plane
+            .update_account(pubkey, &new_groups, None)
+            .await
+            .unwrap();
+
+        let accounts = plane.accounts.read().await;
+        let state = accounts.get(&pubkey).unwrap();
+        assert_eq!(state.groups.len(), 1);
+        assert_eq!(state.groups[0].group_id, "new-group");
+    }
+
+    #[tokio::test]
+    async fn test_update_account_idempotent_with_same_groups() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [6; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        let groups = vec![GroupSubscriptionSpec {
+            group_id: "stable-group".to_string(),
+            relays: vec![],
+        }];
+
+        plane.update_account(pubkey, &groups, None).await.unwrap();
+        plane.update_account(pubkey, &groups, None).await.unwrap();
+
+        let accounts = plane.accounts.read().await;
+        let state = accounts.get(&pubkey).unwrap();
+        assert_eq!(state.groups.len(), 1);
+        assert_eq!(state.groups[0].group_id, "stable-group");
+    }
+
+    #[tokio::test]
+    async fn test_has_active_subscription_false_for_unknown_account() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [8; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        assert!(!plane.has_active_subscription(&pubkey).await);
+    }
+
+    #[tokio::test]
+    async fn test_has_active_subscription_true_after_empty_update() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [10; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        plane.update_account(pubkey, &[], None).await.unwrap();
+
+        assert!(plane.has_active_subscription(&pubkey).await);
+    }
+
+    #[tokio::test]
+    async fn test_account_state_returns_none_for_unknown_account() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [11; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        assert!(plane.account_state(&pubkey).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_account_state_returns_groups_after_update() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [12; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        let groups = vec![GroupSubscriptionSpec {
+            group_id: "my-group".to_string(),
+            relays: vec![],
+        }];
+
+        plane.update_account(pubkey, &groups, None).await.unwrap();
+
+        let state = plane.account_state(&pubkey).await.unwrap();
+        assert_eq!(state.len(), 1);
+        assert_eq!(state[0].group_id, "my-group");
+    }
+
+    #[tokio::test]
+    async fn test_remove_account_clears_entry() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [13; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        plane.update_account(pubkey, &[], None).await.unwrap();
+        assert!(plane.has_account(&pubkey).await);
+
+        plane.remove_account(&pubkey).await;
+        assert!(!plane.has_account(&pubkey).await);
+    }
+
+    #[tokio::test]
+    async fn test_remove_nonexistent_account_is_noop() {
+        let (sender, _) = mpsc::channel(8);
+        let plane = GroupPlane::new(sender, [14; 16]);
+        let pubkey = Keys::generate().public_key();
+
+        // Should not panic.
+        plane.remove_account(&pubkey).await;
+        assert!(!plane.has_account(&pubkey).await);
+    }
+
+    #[test]
+    fn test_normalize_group_specs_deduplicates_relays() {
+        let relay_a = RelayUrl::parse("wss://relay-a.example.com").unwrap();
+        let relay_b = RelayUrl::parse("wss://relay-b.example.com").unwrap();
+
+        let specs = vec![
+            GroupSubscriptionSpec {
+                group_id: "group-1".to_string(),
+                relays: vec![relay_a.clone()],
+            },
+            GroupSubscriptionSpec {
+                group_id: "group-1".to_string(),
+                relays: vec![relay_b.clone()],
+            },
+        ];
+
+        let normalized = GroupPlane::normalize_group_specs(&specs);
+        assert_eq!(normalized.len(), 1);
+        assert_eq!(normalized[0].group_id, "group-1");
+        assert_eq!(normalized[0].relays.len(), 2);
+    }
+
+    #[test]
+    fn test_normalize_group_specs_sorts_by_group_id() {
+        let relay = RelayUrl::parse("wss://relay.example.com").unwrap();
+
+        let specs = vec![
+            GroupSubscriptionSpec {
+                group_id: "zzz".to_string(),
+                relays: vec![relay.clone()],
+            },
+            GroupSubscriptionSpec {
+                group_id: "aaa".to_string(),
+                relays: vec![relay.clone()],
+            },
+        ];
+
+        let normalized = GroupPlane::normalize_group_specs(&specs);
+        assert_eq!(normalized[0].group_id, "aaa");
+        assert_eq!(normalized[1].group_id, "zzz");
+    }
+
+    #[test]
+    fn test_build_relay_set_subscriptions_groups_by_relay_set() {
+        let relay_a = RelayUrl::parse("wss://relay-a.example.com").unwrap();
+        let relay_b = RelayUrl::parse("wss://relay-b.example.com").unwrap();
+
+        let groups = vec![
+            GroupSubscriptionSpec {
+                group_id: "group-1".to_string(),
+                relays: vec![relay_a.clone()],
+            },
+            GroupSubscriptionSpec {
+                group_id: "group-2".to_string(),
+                relays: vec![relay_a.clone()],
+            },
+            GroupSubscriptionSpec {
+                group_id: "group-3".to_string(),
+                relays: vec![relay_b.clone()],
+            },
+        ];
+
+        let subscriptions = GroupPlane::build_relay_set_subscriptions(&groups);
+        assert_eq!(subscriptions.len(), 2);
+
+        let relay_a_sub = subscriptions
+            .iter()
+            .find(|s| s.relays == vec![relay_a.clone()])
+            .unwrap();
+        assert_eq!(relay_a_sub.group_ids.len(), 2);
+
+        let relay_b_sub = subscriptions
+            .iter()
+            .find(|s| s.relays == vec![relay_b.clone()])
+            .unwrap();
+        assert_eq!(relay_b_sub.group_ids.len(), 1);
+    }
+
+    #[test]
+    fn test_build_relay_set_subscriptions_empty_input() {
+        let subscriptions = GroupPlane::build_relay_set_subscriptions(&[]);
+        assert!(subscriptions.is_empty());
     }
 }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -726,10 +726,17 @@ impl Whitenoise {
             .sync_account_group_subscriptions(
                 account.pubkey,
                 &group_specs,
-                account.since_timestamp(10),
+                Self::group_resubscribe_since(account),
             )
             .await
             .map_err(WhitenoiseError::from)
+    }
+
+    /// Replay anchor for any group-subscription rebuild path.
+    ///
+    /// Uses the widened resubscribe buffer to cover teardown/rebuild gaps.
+    fn group_resubscribe_since(account: &Account) -> Option<Timestamp> {
+        account.since_timestamp(Self::RESUBSCRIBE_BUFFER_SECS)
     }
 
     #[perf_instrument("accounts")]
@@ -747,7 +754,29 @@ impl Whitenoise {
             return Ok(());
         }
 
-        self.sync_group_subscriptions(account).await
+        let group_specs = self.extract_group_subscription_specs(account).await?;
+
+        for relay_url in group_specs.iter().flat_map(|group| group.relays.iter()) {
+            Relay::find_or_create_by_url(relay_url, &self.database).await?;
+        }
+
+        if Self::is_background_task_cancelled(cancel_rx) {
+            tracing::debug!(
+                target: "whitenoise::accounts::background_refresh_account_group_subscriptions",
+                account_pubkey = %account.pubkey,
+                "Skipping group subscription sync because the account was cancelled",
+            );
+            return Ok(());
+        }
+
+        self.relay_control
+            .sync_account_group_subscriptions(
+                account.pubkey,
+                &group_specs,
+                Self::group_resubscribe_since(account),
+            )
+            .await
+            .map_err(WhitenoiseError::from)
     }
 
     fn is_background_task_cancelled(cancel_rx: Option<&watch::Receiver<bool>>) -> bool {
@@ -832,13 +861,14 @@ impl Whitenoise {
             Relay::find_or_create_by_url(relay_url, &self.database).await?;
         }
 
-        // Compute per-account since with a 10s lookback buffer when available
-        let since = account.since_timestamp(10);
+        // Standard buffer for initial activation (no prior teardown gap to cover).
+        let since = account.since_timestamp(Self::SUBSCRIPTION_BUFFER_SECS);
         match since {
             Some(ts) => tracing::debug!(
                 target: "whitenoise::accounts",
-                "Computed per-account since={}s (10s buffer) for {}",
+                "Computed per-account since={}s ({}s buffer) for {}",
                 ts.as_secs(),
+                Self::SUBSCRIPTION_BUFFER_SECS,
                 account.pubkey.to_hex()
             ),
             None => tracing::debug!(
@@ -904,9 +934,11 @@ impl Whitenoise {
 
         let group_specs = self.extract_group_subscription_specs(account).await?;
 
-        // 10s buffer to avoid missing events at the boundary of the last sync window.
+        // Use a larger buffer when resubscribing after teardown to cover the gap
+        // window between deactivate and the new subscriptions going live.
+        // Any duplicate events are deduplicated by the event tracker.
         // Gift-wrap backdating is handled separately inside setup_giftwrap_subscription.
-        let since = account.since_timestamp(10);
+        let since = Self::group_resubscribe_since(account);
 
         let signer = self.get_signer_for_account(account)?;
 
@@ -1011,8 +1043,7 @@ mod tests {
         assert!(
             !whitenoise
                 .background_task_cancellation
-                .contains_key(&account_pubkey),
-            "test account should start without a cancellation channel"
+                .contains_key(&account_pubkey)
         );
 
         whitenoise.ensure_background_task_cancellation_channel(account_pubkey);
@@ -1070,10 +1101,7 @@ mod tests {
             .changed()
             .await
             .expect("existing receiver should observe cancellation");
-        assert!(
-            *existing_cancel_rx.borrow_and_update(),
-            "previous cancellation channel should be signalled before replacement"
-        );
+        assert!(*existing_cancel_rx.borrow_and_update());
 
         let cancel_tx = whitenoise
             .background_task_cancellation
@@ -1175,14 +1203,8 @@ mod tests {
         let spec = &group_specs[0];
 
         // Verify relays were extracted for the group
-        assert!(
-            spec.relays.contains(&relay1),
-            "Should contain relay1 from group config"
-        );
-        assert!(
-            spec.relays.contains(&relay2),
-            "Should contain relay2 from group config"
-        );
+        assert!(spec.relays.contains(&relay1));
+        assert!(spec.relays.contains(&relay2));
 
         // Verify group ID was extracted
         assert_eq!(
@@ -1295,10 +1317,7 @@ mod tests {
             .into_iter()
             .map(|relay| relay.url)
             .collect::<std::collections::BTreeSet<_>>();
-        assert!(
-            initial_urls.contains(&stale_relay.url),
-            "Test setup should create an initial stale relay entry"
-        );
+        assert!(initial_urls.contains(&stale_relay.url));
 
         whitenoise
             .sync_account_relays(
@@ -1323,10 +1342,7 @@ mod tests {
                 .into_iter()
                 .collect::<std::collections::BTreeSet<_>>()
         );
-        assert!(
-            !stored_urls.contains(&stale_relay.url),
-            "Stale relay should be removed during sync"
-        );
+        assert!(!stored_urls.contains(&stale_relay.url));
     }
 
     #[tokio::test]
@@ -1401,5 +1417,134 @@ mod tests {
 
         let event_id = EventId::all_zeros();
         assert!(!whitenoise.is_own_key_package(&pubkey, &event_id).await);
+    }
+
+    #[test]
+    fn test_is_background_task_cancelled_none_returns_true() {
+        assert!(Whitenoise::is_background_task_cancelled(None));
+    }
+
+    #[test]
+    fn test_is_background_task_cancelled_false_receiver_returns_false() {
+        let (_, rx) = watch::channel(false);
+        assert!(!Whitenoise::is_background_task_cancelled(Some(&rx)));
+    }
+
+    #[test]
+    fn test_is_background_task_cancelled_true_receiver_returns_true() {
+        let (_, rx) = watch::channel(true);
+        assert!(Whitenoise::is_background_task_cancelled(Some(&rx)));
+    }
+
+    async fn make_stub_account(whitenoise: &Whitenoise) -> Account {
+        let keys = Keys::generate();
+        let (account, _) = Account::new(whitenoise, Some(keys)).await.unwrap();
+        account
+    }
+
+    #[tokio::test]
+    async fn test_refresh_account_group_subscriptions_with_cancel_skips_when_cancelled_at_start() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = make_stub_account(&whitenoise).await;
+
+        let (_, rx) = watch::channel(true);
+        let result = whitenoise
+            .refresh_account_group_subscriptions_with_cancel(&account, Some(&rx))
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_account_group_subscriptions_with_cancel_succeeds_with_no_groups() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = make_stub_account(&whitenoise).await;
+
+        let (_, rx) = watch::channel(false);
+        let result = whitenoise
+            .refresh_account_group_subscriptions_with_cancel(&account, Some(&rx))
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_account_group_subscriptions_with_cancel_persists_group_relays() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let member_account = whitenoise.create_identity().await.unwrap();
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let relay_url = RelayUrl::parse("ws://127.0.0.1:9").unwrap();
+        let config = NostrGroupConfigData::new(
+            "Test Group".to_string(),
+            "Relay persistence test".to_string(),
+            None,
+            None,
+            None,
+            vec![relay_url.clone()],
+            vec![creator_account.pubkey],
+        );
+
+        whitenoise
+            .create_group(&creator_account, vec![member_account.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let (_, rx) = watch::channel(false);
+        let _ = whitenoise
+            .refresh_account_group_subscriptions_with_cancel(&creator_account, Some(&rx))
+            .await;
+
+        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(stored_relay.url, relay_url);
+    }
+
+    #[tokio::test]
+    async fn test_setup_subscriptions_persists_group_relays_before_activation() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let member_account = whitenoise.create_identity().await.unwrap();
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let relay_url = RelayUrl::parse("ws://127.0.0.1:9").unwrap();
+        let config = NostrGroupConfigData::new(
+            "Setup Group".to_string(),
+            "Setup relay persistence test".to_string(),
+            None,
+            None,
+            None,
+            vec![relay_url.clone()],
+            vec![creator_account.pubkey],
+        );
+
+        whitenoise
+            .create_group(&creator_account, vec![member_account.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let _ = whitenoise.setup_subscriptions(&creator_account, &[]).await;
+
+        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(stored_relay.url, relay_url);
+    }
+
+    #[tokio::test]
+    async fn test_background_refresh_account_group_subscriptions_no_channel_noop() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = make_stub_account(&whitenoise).await;
+
+        whitenoise.background_refresh_account_group_subscriptions(&account);
+        tokio::task::yield_now().await;
+
+        assert!(
+            !whitenoise
+                .background_task_cancellation
+                .contains_key(&account.pubkey)
+        );
     }
 }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -589,6 +589,12 @@ impl Whitenoise {
         Ok(())
     }
 
+    /// Buffer (in seconds) used when resubscribing after a teardown/rebuild
+    /// cycle. Larger than `SUBSCRIPTION_BUFFER_SECS` to cover the gap window
+    /// created by tearing down old subscriptions before new ones are live.
+    /// Any events fetched that were already processed are deduplicated by the
+    /// event tracker.
+    const RESUBSCRIBE_BUFFER_SECS: u64 = 60;
     /// Returns a reference to the global Whitenoise singleton instance.
     ///
     /// This method provides access to the globally initialized Whitenoise instance that was

--- a/src/whitenoise/subscriptions.rs
+++ b/src/whitenoise/subscriptions.rs
@@ -94,14 +94,14 @@ impl Whitenoise {
             {
                 Ok(()) => {
                     tracing::debug!(
-                        target: "whitenoise::initialize_whitenoise",
+                        target: "whitenoise::setup_accounts_subscriptions",
                         "Successfully set up subscriptions for account: {}",
                         account.pubkey.to_hex()
                     );
                 }
                 Err(e) => {
                     tracing::warn!(
-                        target: "whitenoise::initialize_whitenoise",
+                        target: "whitenoise::setup_accounts_subscriptions",
                         "Failed to set up subscriptions for account {}: {}",
                         account.pubkey.to_hex(),
                         e


### PR DESCRIPTION
Addressing #607 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient group subscription updates with targeted cleanup, improved cancellation handling, and ensuring relay records exist before syncing.

* **Behavior Changes**
  * Larger resubscribe lookback to cover teardown gaps; initial activation/lookback adjustments to reduce unnecessary refetches.

* **Refactor**
  * Centralized filter construction for consistent, idempotent subscription updates.

* **Tests**
  * Expanded tests for filter serialization, subscription/state behaviors, and cancellation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->