### PR TITLE
fix:(): move cli/wnd from protected store to keychain on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,11 +106,8 @@ indicatif = { version = "0.18.3", optional = true }
 #   compiled when this feature is enabled, so both features must be listed even
 #   though a given binary only calls one of them.
 # NOTE: apple_native_keyring_store::protected::Store requires the binary to be
-#   code-signed with a provisioning profile that grants the
-#   com.apple.security.application-groups or keychain-access-groups entitlement.
-#   Running an unsigned binary (e.g. `cargo run` on a developer Mac without a
-#   profile) will panic at start-up with an entitlement error.  Use an x86_64
-#   host or the `keychain` path for local development without a profile.
+#   code-signed with a provisioning profile. The `cli` feature automatically
+#   selects keychain::Store instead, so CLI builds work without signing.
 apple-native-keyring-store = { version = "0.2", features = ["keychain", "protected"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -283,21 +283,29 @@ impl Whitenoise {
                 not(feature = "benchmark-tests")
             ))]
             {
-                #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+                // CLI builds use the regular Keychain store on all macOS architectures.
+                // The `cli` feature gates the `wn`/`wnd` binaries, which are unsigned
+                // and cannot use the Protected Data store (it requires a provisioning
+                // profile with application-groups entitlement).
+                #[cfg(all(target_os = "macos", feature = "cli"))]
                 {
                     let store = apple_native_keyring_store::keychain::Store::new()
                         .expect("Failed to create macOS Keychain credential store");
                     keyring_core::set_default_store(store);
                 }
-                // Apple Silicon (aarch64) macOS: use the Protected Data store, which
-                // synchronises credentials across devices via iCloud.
-                //
-                // RUNTIME REQUIREMENT: the binary must be code-signed with a
-                // provisioning profile that includes the
-                // com.apple.security.application-groups (or equivalent
-                // keychain-access-groups) entitlement.  The Flutter app build
-                // pipeline satisfies this automatically.
-                #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+                // Intel Macs (non-CLI): use the regular Keychain store.
+                // Protected Data store is not available on x86_64.
+                #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "cli")))]
+                {
+                    let store = apple_native_keyring_store::keychain::Store::new()
+                        .expect("Failed to create macOS Keychain credential store");
+                    keyring_core::set_default_store(store);
+                }
+                // Apple Silicon (non-CLI): use the Protected Data store (audit #630).
+                // Requires code-signing with a provisioning profile that includes the
+                // com.apple.security.application-groups entitlement. The Flutter app
+                // build pipeline satisfies this.
+                #[cfg(all(target_os = "macos", target_arch = "aarch64", not(feature = "cli")))]
                 {
                     let store = apple_native_keyring_store::protected::Store::new()
                         .expect("Failed to create macOS protected-data credential store");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code signing and provisioning profile requirements for macOS and iOS builds.

* **Bug Fixes**
  * Improved macOS credential storage behavior for CLI builds and Apple Silicon (aarch64) architecture, ensuring proper keychain selection based on build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->