### PR TITLE
fix: log warning when event channel drops messages

### DIFF
--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -1038,6 +1038,13 @@ impl RelaySession {
                                             ) {
                                                 Ok(()) => {}
                                                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                                    tracing::warn!(
+                                                        target: "whitenoise::relay_control::sessions",
+                                                        relay_url = %relay_url,
+                                                        subscription_id = %subscription_id,
+                                                        event_id = %event.id,
+                                                        "Event channel closed, dropping routed event"
+                                                    );
                                                     return Ok(true);
                                                 }
                                                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -1147,6 +1154,11 @@ impl RelaySession {
                 )) {
                     Ok(()) => {}
                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::warn!(
+                            target: "whitenoise::relay_control::sessions",
+                            %relay_url,
+                            "Event channel closed, dropping Notice"
+                        );
                         return Ok(true);
                     }
                     Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -1177,6 +1189,11 @@ impl RelaySession {
                 )) {
                     Ok(()) => {}
                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::warn!(
+                            target: "whitenoise::relay_control::sessions",
+                            %relay_url,
+                            "Event channel closed, dropping Closed"
+                        );
                         return Ok(true);
                     }
                     Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -1207,6 +1224,11 @@ impl RelaySession {
                 )) {
                     Ok(()) => {}
                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::warn!(
+                            target: "whitenoise::relay_control::sessions",
+                            %relay_url,
+                            "Event channel closed, dropping Auth"
+                        );
                         return Ok(true);
                     }
                     Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -1562,5 +1584,65 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_process_notification_exits_when_channel_closed() {
+        let (sender, receiver) = mpsc::channel(8);
+        drop(receiver);
+        let (telemetry_sender, _) = broadcast::channel(8);
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+
+        let result = RelaySession::process_notification(
+            RelayNotification::Notice {
+                relay_url,
+                message: "test".to_string(),
+                failure_category: None,
+            },
+            RelayPlane::Discovery,
+            None,
+            &sender,
+            &telemetry_sender,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result,
+            "expected Ok(true) to signal handler exit on closed channel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_notification_warns_and_continues_when_channel_full() {
+        let (sender, _receiver) = mpsc::channel(1);
+        // Fill the channel so the next send returns Full.
+        sender
+            .try_send(ProcessableEvent::RelayMessage(
+                RelayUrl::parse("wss://relay.example.com").unwrap(),
+                "filler".to_string(),
+            ))
+            .unwrap();
+        let (telemetry_sender, _) = broadcast::channel(8);
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+
+        let result = RelaySession::process_notification(
+            RelayNotification::Notice {
+                relay_url,
+                message: "test".to_string(),
+                failure_category: None,
+            },
+            RelayPlane::Discovery,
+            None,
+            &sender,
+            &telemetry_sender,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !result,
+            "expected Ok(false) to continue when channel is full"
+        );
     }
 }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -413,7 +413,7 @@ impl Whitenoise {
         }
 
         // Create event processing channels
-        let (event_sender, event_receiver) = mpsc::channel(500);
+        let (event_sender, event_receiver) = mpsc::channel(2000);
         let (shutdown_sender, shutdown_receiver) = mpsc::channel(1);
 
         // Create scheduler shutdown channel


### PR DESCRIPTION
## Summary
- Replaces silent `let _ = sender.send(...).await` with `tracing::warn!` when the event channel is closed
- Covers all 4 `event_sender` call sites: routed nostr events, Notice, Closed, and Auth
- Telemetry sender (`broadcast`) left as-is since `Err` there just means no subscribers (expected)

Closes #610

## Test plan
- [ ] Verify warnings appear in logs when event processor is shut down while relay sessions are still active
- [ ] Confirm no new warnings under normal operation (channel stays open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched to non-blocking notification delivery with explicit handling: the app now stops processing when a notification channel is closed and logs warnings when channels are full to improve reliability and observability.
* **Tests**
  * Added tests verifying behavior when notification channels are closed or full to prevent silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->