### PR TITLE
fix: unify key-package relay resolution across status checks and group creation

### DIFF
--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -90,11 +90,10 @@ impl Whitenoise {
 
     /// Resolves a single member for group creation: finds or creates the user record,
     /// syncs relay lists and metadata for new users, fetches and validates the key package.
-    async fn resolve_member_key_package(
-        &self,
-        pk: &PublicKey,
-        fallback_account: &Account,
-    ) -> Result<(User, Event)> {
+    ///
+    /// Key-package relay resolution is delegated to [`User::key_package_event`] so that
+    /// preflight status checks and actual group creation use the same fallback chain.
+    async fn resolve_member_key_package(&self, pk: &PublicKey) -> Result<(User, Event)> {
         let (mut user, created) = User::find_or_create_by_pubkey(pk, &self.database).await?;
         if created {
             if let Err(e) = user.update_relay_lists(self).await {
@@ -115,31 +114,8 @@ impl Whitenoise {
             }
         }
 
-        let mut kp_relays = user.relays(RelayType::KeyPackage, &self.database).await?;
-        if kp_relays.is_empty() {
-            tracing::warn!(
-                target: "whitenoise::accounts::groups::create_group",
-                "User {} has no key package relays configured, falling back to account {} relays",
-                user.pubkey,
-                fallback_account.pubkey
-            );
-            kp_relays = fallback_account.nip65_relays(self).await?;
-            if kp_relays.is_empty() {
-                tracing::warn!(
-                    target: "whitenoise::accounts::groups::create_group",
-                    "Account {} has no fallback relays configured, using defaults",
-                    fallback_account.pubkey
-                );
-                kp_relays = Relay::defaults();
-            }
-        }
-
-        let kp_relays_urls = Relay::urls(&kp_relays);
         let _kp_fetch = perf_span!("groups::fetch_key_package");
-        let some_event = self
-            .relay_control
-            .fetch_user_key_package(*pk, &kp_relays_urls)
-            .await?;
+        let some_event = user.key_package_event(self).await?;
         drop(_kp_fetch);
 
         let event = some_event.ok_or(WhitenoiseError::MdkCoreError(
@@ -336,7 +312,7 @@ impl Whitenoise {
         // Resolve members and fetch key packages concurrently
         let member_futures = member_pubkeys
             .iter()
-            .map(|pk| self.resolve_member_key_package(pk, creator_account));
+            .map(|pk| self.resolve_member_key_package(pk));
         let resolved_members = try_join_all(member_futures).await?;
         let (members, key_package_events): (Vec<User>, Vec<Event>) =
             resolved_members.into_iter().unzip();

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -1065,6 +1065,106 @@ mod tests {
         assert_eq!(result.unwrap(), None);
     }
 
+    mod key_package_relay_urls_tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_returns_key_package_relays_when_present() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let test_pubkey = nostr_sdk::Keys::generate().public_key();
+            let user = User {
+                id: None,
+                pubkey: test_pubkey,
+                metadata: Metadata::new(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            };
+            let saved_user = user.save(&whitenoise.database).await.unwrap();
+
+            let kp_url = RelayUrl::parse("wss://kp.example.com").unwrap();
+            let kp_relay = whitenoise
+                .find_or_create_relay_by_url(&kp_url)
+                .await
+                .unwrap();
+            saved_user
+                .add_relay(&kp_relay, RelayType::KeyPackage, &whitenoise.database)
+                .await
+                .unwrap();
+
+            // Also add NIP-65 to prove KP takes priority
+            let nip65_url = RelayUrl::parse("wss://nip65.example.com").unwrap();
+            let nip65_relay = whitenoise
+                .find_or_create_relay_by_url(&nip65_url)
+                .await
+                .unwrap();
+            saved_user
+                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+                .await
+                .unwrap();
+
+            let urls = saved_user
+                .key_package_relay_urls(&whitenoise)
+                .await
+                .unwrap();
+            assert_eq!(urls, vec![kp_url]);
+        }
+
+        #[tokio::test]
+        async fn test_falls_back_to_nip65_when_no_kp_relays() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let test_pubkey = nostr_sdk::Keys::generate().public_key();
+            let user = User {
+                id: None,
+                pubkey: test_pubkey,
+                metadata: Metadata::new(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            };
+            let saved_user = user.save(&whitenoise.database).await.unwrap();
+
+            let nip65_url = RelayUrl::parse("wss://nip65.example.com").unwrap();
+            let nip65_relay = whitenoise
+                .find_or_create_relay_by_url(&nip65_url)
+                .await
+                .unwrap();
+            saved_user
+                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+                .await
+                .unwrap();
+
+            let urls = saved_user
+                .key_package_relay_urls(&whitenoise)
+                .await
+                .unwrap();
+            assert_eq!(urls, vec![nip65_url]);
+        }
+
+        #[tokio::test]
+        async fn test_falls_back_to_discovery_relays_when_no_user_relays() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let test_pubkey = nostr_sdk::Keys::generate().public_key();
+            let user = User {
+                id: None,
+                pubkey: test_pubkey,
+                metadata: Metadata::new(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            };
+            let saved_user = user.save(&whitenoise.database).await.unwrap();
+
+            let urls = saved_user
+                .key_package_relay_urls(&whitenoise)
+                .await
+                .unwrap();
+            let expected = whitenoise.fallback_relay_urls().await;
+            assert_eq!(urls, expected);
+            assert!(
+                !urls.is_empty(),
+                "Discovery relays should be available as final fallback"
+            );
+        }
+    }
+
     mod should_update_metadata_tests {
         use super::*;
         use crate::whitenoise::database::processed_events::ProcessedEvent;

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use nostr_sdk::prelude::*;
 
 use crate::perf_instrument;
@@ -22,51 +20,66 @@ pub enum KeyPackageStatus {
 }
 
 impl User {
-    /// Fetches the user's MLS key package event from their configured key package relays.
+    /// Returns the relay URLs to query for this user's key package.
     ///
-    /// This method retrieves the user's published MLS (Message Layer Security) key package
-    /// from the Nostr network. Key packages are cryptographic objects that contain the user's
-    /// public keys and credentials needed to add them to MLS group conversations.
+    /// Fallback order:
+    /// 1. User's KeyPackage relays (kind 10051)
+    /// 2. User's NIP-65 relays (kind 10002)
+    /// 3. Whitenoise discovery/fallback relays
+    #[perf_instrument("users")]
+    pub async fn key_package_relay_urls(&self, whitenoise: &Whitenoise) -> Result<Vec<RelayUrl>> {
+        let kp_relays = self
+            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .await?;
+        if !kp_relays.is_empty() {
+            return Ok(Relay::urls(&kp_relays));
+        }
+
+        tracing::warn!(
+            target: "whitenoise::users::key_package",
+            "User {} has no key package relays, trying NIP-65 relays",
+            self.pubkey
+        );
+
+        let nip65_relays = self.relays(RelayType::Nip65, &whitenoise.database).await?;
+        if !nip65_relays.is_empty() {
+            return Ok(Relay::urls(&nip65_relays));
+        }
+
+        tracing::warn!(
+            target: "whitenoise::users::key_package",
+            "User {} has no NIP-65 relays either, using fallback relays",
+            self.pubkey
+        );
+
+        Ok(whitenoise.fallback_relay_urls().await)
+    }
+
+    /// Fetches the user's MLS key package event from relays.
     ///
-    /// The method first retrieves the user's key package relay list (NIP-65 kind 10051 events),
-    /// then fetches the most recent MLS key package event (kind 443) from those relays.
+    /// Relay resolution follows [`key_package_relay_urls`](Self::key_package_relay_urls):
+    /// the user's KeyPackage relays, then NIP-65, then discovery fallbacks.
     ///
     /// # Arguments
     ///
     /// * `whitenoise` - The Whitenoise instance used to access the Nostr client and database
     #[perf_instrument("users")]
     pub async fn key_package_event(&self, whitenoise: &Whitenoise) -> Result<Option<Event>> {
-        let key_package_relays = self
-            .relays(RelayType::KeyPackage, &whitenoise.database)
-            .await?;
-        let mut key_package_relays_urls_set: HashSet<RelayUrl> =
-            Relay::urls(&key_package_relays).into_iter().collect();
-        if key_package_relays.is_empty() {
+        let relay_urls = self.key_package_relay_urls(whitenoise).await?;
+        if relay_urls.is_empty() {
             tracing::warn!(
-                target: "whitenoise::users::key_package_event",
-                "User {} has no key package relays, using nip65 relays",
-                self.pubkey
-            );
-            key_package_relays_urls_set.extend(Relay::urls(
-                &self.relays(RelayType::Nip65, &whitenoise.database).await?,
-            ));
-        }
-        if key_package_relays_urls_set.is_empty() {
-            tracing::warn!(
-                target: "whitenoise::users::key_package_event",
-                "User {} has neither key package nor NIP-65 relays; returning None",
+                target: "whitenoise::users::key_package",
+                "No relays available for user {}; returning None",
                 self.pubkey
             );
             return Ok(None);
         }
 
-        let key_package_relays_urls: Vec<RelayUrl> =
-            key_package_relays_urls_set.into_iter().collect();
-        let key_package_event = whitenoise
+        let event = whitenoise
             .relay_control
-            .fetch_user_key_package(self.pubkey, &key_package_relays_urls)
+            .fetch_user_key_package(self.pubkey, &relay_urls)
             .await?;
-        Ok(key_package_event)
+        Ok(event)
     }
 
     /// Checks the status of a user's key package on relays.


### PR DESCRIPTION
## Summary
- Extracted `User::key_package_relay_urls` with a canonical fallback chain: KeyPackage relays → NIP-65 → discovery relays
- `key_package_event` and `resolve_member_key_package` now use the same relay resolution
- Removed inconsistent fallback to creator account's NIP-65 relays in group creation

## Test plan
- [x] `just precommit-quick` passes (fmt, docs, clippy, tests)

Closes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified and centralized key package discovery with an improved relay fallback mechanism, enhancing reliability when resolving group members.

* **Tests**
  * Added comprehensive tests for relay selection and fallback logic to ensure consistent key package discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->