### PR TITLE
Perf/relay quorum

### DIFF
--- a/src/integration_tests/benchmarks/registry.rs
+++ b/src/integration_tests/benchmarks/registry.rs
@@ -1,7 +1,8 @@
 use crate::integration_tests::benchmarks::scenarios::{
-    GroupCreationBenchmark, IdentityCreationBenchmark, LoginMultistepPerformanceBenchmark,
-    LoginPerformanceBenchmark, LoginStartPerformanceBenchmark, MessageAggregationBenchmark,
-    MessagingPerformanceBenchmark, UserDiscoveryBenchmark, UserSearchBenchmark,
+    AddMembersPerformanceBenchmark, GroupCreationBenchmark, IdentityCreationBenchmark,
+    LoginMultistepPerformanceBenchmark, LoginPerformanceBenchmark, LoginStartPerformanceBenchmark,
+    MessageAggregationBenchmark, MessagingPerformanceBenchmark, UserDiscoveryBenchmark,
+    UserSearchBenchmark,
 };
 use crate::integration_tests::benchmarks::{BenchmarkResult, BenchmarkScenario};
 use crate::{Whitenoise, WhitenoiseError};
@@ -57,6 +58,7 @@ macro_rules! benchmark_registry {
 // BENCHMARK REGISTRY - Add new benchmarks here (one line each)
 // ============================================================================
 benchmark_registry! {
+    "add-members" => AddMembersPerformanceBenchmark::default(),
     "group-creation" => GroupCreationBenchmark::default(),
     "identity-creation" => IdentityCreationBenchmark::default(),
     "login-performance" => LoginPerformanceBenchmark::default(),
@@ -202,6 +204,7 @@ mod tests {
     #[test]
     fn test_parse_valid_scenario_names() {
         // Test all valid scenario names can be parsed and instantiated
+        assert!(parse_and_instantiate("add-members").is_ok());
         assert!(parse_and_instantiate("group-creation").is_ok());
         assert!(parse_and_instantiate("identity-creation").is_ok());
         assert!(parse_and_instantiate("login-performance").is_ok());
@@ -217,6 +220,7 @@ mod tests {
     #[test]
     fn test_parse_case_insensitive() {
         // Test case insensitivity
+        assert!(parse_and_instantiate("ADD-MEMBERS").is_ok());
         assert!(parse_and_instantiate("GROUP-CREATION").is_ok());
         assert!(parse_and_instantiate("IDENTITY-CREATION").is_ok());
         assert!(parse_and_instantiate("LOGIN-PERFORMANCE").is_ok());
@@ -244,7 +248,8 @@ mod tests {
     fn test_get_all_benchmark_names() {
         // Test that all benchmark names are returned
         let names = get_all_benchmark_names();
-        assert_eq!(names.len(), 10);
+        assert_eq!(names.len(), 11);
+        assert!(names.contains(&"add-members"));
         assert!(names.contains(&"group-creation"));
         assert!(names.contains(&"identity-creation"));
         assert!(names.contains(&"login-performance"));

--- a/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
@@ -1,0 +1,145 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use mdk_core::prelude::*;
+use nostr_sdk::prelude::*;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::benchmarks::test_cases::AddMembersBenchmark;
+use crate::integration_tests::benchmarks::{BenchmarkConfig, BenchmarkScenario, BenchmarkTestCase};
+use crate::integration_tests::core::ScenarioContext;
+
+/// Number of members added per iteration.
+const MEMBERS_PER_ITERATION: usize = 1;
+
+/// Benchmark scenario for measuring `add_members_to_group` performance.
+///
+/// This benchmarks the blocking publish path: `add_members_to_group` calls
+/// `publish_and_merge_commit`, which synchronously waits for relay acceptance
+/// before merging the MLS commit. This is the hot path where quorum-based
+/// publishing can reduce latency.
+///
+/// **Setup phase** (not timed):
+/// - Creates an admin account
+/// - Creates a group with one initial member
+/// - Creates N fresh member accounts (one set per iteration), each with
+///   key packages published via `create_identity()`
+///
+/// **Benchmark iteration** (timed):
+/// - Calls `add_members_to_group` with a fresh set of members
+#[derive(Default)]
+pub struct AddMembersPerformanceBenchmark {
+    test_case: Option<AddMembersBenchmark>,
+}
+
+#[async_trait]
+impl BenchmarkScenario for AddMembersPerformanceBenchmark {
+    fn name(&self) -> &str {
+        "Add Members Performance"
+    }
+
+    fn config(&self) -> BenchmarkConfig {
+        BenchmarkConfig {
+            iterations: 10,
+            warmup_iterations: 1,
+            cooldown_between_iterations: Duration::from_millis(500),
+        }
+    }
+
+    async fn setup(&mut self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let config = self.config();
+        let total_iterations = (config.iterations + config.warmup_iterations) as usize;
+        let total_members = total_iterations * MEMBERS_PER_ITERATION;
+
+        tracing::info!(
+            "Setting up add-members benchmark: {} iterations, {} members per iteration",
+            total_iterations,
+            MEMBERS_PER_ITERATION,
+        );
+
+        // Create admin account
+        let admin = context.whitenoise.create_identity().await?;
+        tracing::info!("Created admin account: {}", admin.pubkey.to_hex());
+        context.add_account("admin", admin.clone());
+
+        // Create an initial member so the group isn't empty
+        let initial_member = context.whitenoise.create_identity().await?;
+        tracing::info!(
+            "Created initial group member: {}",
+            initial_member.pubkey.to_hex()
+        );
+
+        // Brief pause to let relays index key packages
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Create the group
+        let group_config = NostrGroupConfigData::new(
+            "Add Members Benchmark Group".to_string(),
+            "Benchmark group for add_members_to_group performance".to_string(),
+            None,
+            None,
+            None,
+            context.test_relays(),
+            vec![admin.pubkey],
+        );
+
+        let group = context
+            .whitenoise
+            .create_group(&admin, vec![initial_member.pubkey], group_config, None)
+            .await?;
+        tracing::info!("Created benchmark group");
+        context.add_group("benchmark_group", group);
+
+        // Create member accounts for each iteration
+        let mut member_sets: Vec<Vec<String>> = Vec::with_capacity(total_iterations);
+
+        for i in 0..total_iterations {
+            let mut members_for_iteration = Vec::with_capacity(MEMBERS_PER_ITERATION);
+
+            for j in 0..MEMBERS_PER_ITERATION {
+                let member_name = format!("add_member_{}_{}", i, j);
+                let member = context.whitenoise.create_identity().await?;
+                context.add_account(&member_name, member);
+                members_for_iteration.push(member_name);
+            }
+
+            member_sets.push(members_for_iteration);
+
+            if (i + 1) % 5 == 0 || i + 1 == total_iterations {
+                tracing::info!(
+                    "Prepared member accounts for {}/{} iterations",
+                    i + 1,
+                    total_iterations
+                );
+            }
+        }
+
+        // Brief pause to let relays index published key packages
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        tracing::info!(
+            "Setup complete: 1 admin + 1 initial member + {} new members across {} iterations",
+            total_members,
+            total_iterations,
+        );
+
+        self.test_case = Some(AddMembersBenchmark::new(
+            "admin",
+            "benchmark_group",
+            member_sets,
+        ));
+
+        Ok(())
+    }
+
+    async fn single_iteration(
+        &self,
+        context: &mut ScenarioContext,
+    ) -> Result<Duration, WhitenoiseError> {
+        self.test_case
+            .as_ref()
+            .expect("test_case must be initialized in setup()")
+            .run_iteration(context)
+            .await
+    }
+}

--- a/src/integration_tests/benchmarks/scenarios/mod.rs
+++ b/src/integration_tests/benchmarks/scenarios/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_members_performance;
 pub mod group_creation;
 pub mod identity_creation;
 pub mod login_multistep_performance;
@@ -8,6 +9,7 @@ pub mod messaging_performance;
 pub mod user_discovery;
 pub mod user_search;
 
+pub use add_members_performance::*;
 pub use group_creation::*;
 pub use identity_creation::*;
 pub use login_multistep_performance::*;

--- a/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
@@ -1,0 +1,75 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use nostr_sdk::prelude::*;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::benchmarks::BenchmarkTestCase;
+use crate::integration_tests::core::ScenarioContext;
+
+/// Benchmark test case for measuring `add_members_to_group` performance.
+///
+/// Each iteration adds a fresh set of members (whose key packages are already
+/// published) to a pre-created group. MLS key packages are single-use, so
+/// each iteration needs unique members.
+///
+/// Only the `add_members_to_group` call is timed — account creation, group
+/// creation, and key package publishing all happen during the scenario's
+/// setup phase.
+pub struct AddMembersBenchmark {
+    /// Name of the admin account stored in ScenarioContext.
+    admin_account: String,
+    /// Name of the group stored in ScenarioContext.
+    group_name: String,
+    /// Pre-generated member accounts, one set per iteration.
+    member_sets: Vec<Vec<String>>,
+    /// Monotonic counter (not reset between warmup and benchmark phases).
+    next_set: AtomicUsize,
+}
+
+impl AddMembersBenchmark {
+    pub fn new(admin_account: &str, group_name: &str, member_sets: Vec<Vec<String>>) -> Self {
+        Self {
+            admin_account: admin_account.to_string(),
+            group_name: group_name.to_string(),
+            member_sets,
+            next_set: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl BenchmarkTestCase for AddMembersBenchmark {
+    async fn run_iteration(
+        &self,
+        context: &mut ScenarioContext,
+    ) -> Result<Duration, WhitenoiseError> {
+        let iteration = self.next_set.fetch_add(1, Ordering::Relaxed);
+        if iteration >= self.member_sets.len() {
+            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                "Add members benchmark iteration {} exceeds prepared member sets ({})",
+                iteration,
+                self.member_sets.len()
+            )));
+        }
+
+        let admin = context.get_account(&self.admin_account)?;
+        let group = context.get_group(&self.group_name)?;
+        let group_id = group.mls_group_id.clone();
+
+        let member_pubkeys: Vec<PublicKey> = self.member_sets[iteration]
+            .iter()
+            .map(|name| context.get_account(name).map(|acc| acc.pubkey))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let start = Instant::now();
+
+        context
+            .whitenoise
+            .add_members_to_group(admin, &group_id, member_pubkeys)
+            .await?;
+
+        Ok(start.elapsed())
+    }
+}

--- a/src/integration_tests/benchmarks/test_cases/groups/mod.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/mod.rs
@@ -1,3 +1,5 @@
+mod add_members_benchmark;
 mod create_group_benchmark;
 
+pub use add_members_benchmark::*;
 pub use create_group_benchmark::*;

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -228,8 +228,10 @@ impl EphemeralPlane {
                 .collect(),
         };
         let event_builder = EventBuilder::new(relay_type.into(), "").tags(tags);
+        let account_pubkey = signer.get_public_key().await?;
+        let event = event_builder.sign(&signer).await?;
 
-        self.publish_event_builder_with_signer(event_builder, target_relays, signer)
+        self.publish_event_with_quorum(event, &account_pubkey, target_relays, 2)
             .await?;
 
         Ok(())
@@ -383,6 +385,123 @@ impl EphemeralPlane {
         }
 
         Err(last_error.unwrap_or(NostrManagerError::NoRelayConnections))
+    }
+
+    #[perf_instrument("relay")]
+    pub(crate) async fn publish_event_with_quorum(
+        &self,
+        event: Event,
+        account_pubkey: &PublicKey,
+        relays: &[RelayUrl],
+        early_return_threshold: usize,
+    ) -> Result<Output<EventId>> {
+        let result = self
+            .executor
+            .publish_event_to_scope_quorum(
+                Some(*account_pubkey),
+                relays,
+                &event,
+                early_return_threshold,
+            )
+            .await?;
+
+        if result.output.success.is_empty() {
+            return Err(NostrManagerError::NoRelayAccepted);
+        }
+
+        if let Err(error) = self
+            .track_published_event(result.output.id(), account_pubkey)
+            .await
+        {
+            tracing::warn!(
+                target: "whitenoise::relay_control::ephemeral",
+                account_pubkey = %account_pubkey,
+                event_id = %result.output.id(),
+                "Quorum publish succeeded but event tracking failed: {error}"
+            );
+        }
+
+        let retry_relays: Vec<RelayUrl> = result
+            .pending
+            .into_iter()
+            .chain(result.output.failed.keys().cloned())
+            .collect();
+
+        if !retry_relays.is_empty() {
+            let executor = self.executor.clone();
+            let account_pubkey = *account_pubkey;
+
+            tokio::spawn(async move {
+                Self::retry_failed_relays(executor, event, account_pubkey, retry_relays).await;
+            });
+        }
+
+        Ok(result.output)
+    }
+
+    async fn retry_failed_relays(
+        executor: EphemeralExecutor,
+        event: Event,
+        account_pubkey: PublicKey,
+        mut remaining_relays: Vec<RelayUrl>,
+    ) {
+        const MAX_RETRIES: u32 = 4;
+
+        for attempt in 0..MAX_RETRIES {
+            let delay = Duration::from_secs(2u64.pow(attempt + 1)); // 2s, 4s, 8s, 16s
+            tokio::time::sleep(delay).await;
+
+            match executor
+                .publish_event_to_scope(Some(account_pubkey), &remaining_relays, &event)
+                .await
+            {
+                Ok(output) => {
+                    remaining_relays.retain(|u| !output.success.contains(u));
+
+                    if remaining_relays.is_empty() {
+                        tracing::debug!(
+                            target: "whitenoise::relay_control::ephemeral",
+                            account_pubkey = %account_pubkey,
+                            event_id = %event.id,
+                            attempt = attempt + 1,
+                            "Background retry: all relays succeeded"
+                        );
+                        return;
+                    }
+
+                    tracing::debug!(
+                        target: "whitenoise::relay_control::ephemeral",
+                        account_pubkey = %account_pubkey,
+                        event_id = %event.id,
+                        attempt = attempt + 1,
+                        succeeded = output.success.len(),
+                        remaining = remaining_relays.len(),
+                        "Background retry: partial progress"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::relay_control::ephemeral",
+                        account_pubkey = %account_pubkey,
+                        event_id = %event.id,
+                        attempt = attempt + 1,
+                        max_attempts = MAX_RETRIES,
+                        "Background relay retry failed: {e}"
+                    );
+                }
+            }
+        }
+
+        if !remaining_relays.is_empty() {
+            tracing::warn!(
+                target: "whitenoise::relay_control::ephemeral",
+                account_pubkey = %account_pubkey,
+                event_id = %event.id,
+                relays = ?remaining_relays,
+                "Background retry exhausted: {} relays never accepted the event",
+                remaining_relays.len()
+            );
+        }
     }
 
     #[perf_instrument("relay")]

--- a/src/relay_control/ephemeral_executor.rs
+++ b/src/relay_control/ephemeral_executor.rs
@@ -11,7 +11,8 @@ use super::{
     RelayPlane,
     observability::{RelayObservability, RelayTelemetry},
     sessions::{
-        RelaySession, RelaySessionAuthPolicy, RelaySessionConfig, RelaySessionReconnectPolicy,
+        QuorumPublishResult, RelaySession, RelaySessionAuthPolicy, RelaySessionConfig,
+        RelaySessionReconnectPolicy,
     },
 };
 use crate::{
@@ -114,6 +115,24 @@ impl EphemeralExecutor {
             .prepare_ad_hoc_relays(relays, self.config.ad_hoc_relay_ttl)
             .await?;
         entry.session.publish_event_to(relays, event).await
+    }
+
+    pub(crate) async fn publish_event_to_scope_quorum(
+        &self,
+        account_pubkey: Option<PublicKey>,
+        relays: &[RelayUrl],
+        event: &Event,
+        early_return_threshold: usize,
+    ) -> Result<QuorumPublishResult> {
+        let _span = perf_span!("relay::ephemeral_publish_event_quorum");
+        let entry = self.session_entry(account_pubkey).await;
+        entry
+            .prepare_ad_hoc_relays(relays, self.config.ad_hoc_relay_ttl)
+            .await?;
+        entry
+            .session
+            .publish_event_to_quorum(relays, event, early_return_threshold)
+            .await
     }
 
     pub(crate) async fn remove_account_scope(&self, account_pubkey: &PublicKey) {

--- a/src/relay_control/sessions/mod.rs
+++ b/src/relay_control/sessions/mod.rs
@@ -6,4 +6,4 @@ pub(crate) use config::{
     RelaySessionAuthPolicy, RelaySessionConfig, RelaySessionReconnectPolicy,
     RelaySessionRelayPolicy,
 };
-pub(crate) use session::RelaySession;
+pub(crate) use session::{QuorumPublishResult, RelaySession};

--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -14,7 +14,7 @@ use tokio::sync::{Mutex, RwLock, broadcast, mpsc::Sender};
 use super::{RelaySessionConfig, RelaySessionRelayPolicy, notifications::RelayNotification};
 use crate::{
     nostr_manager::{NostrManagerError, Result},
-    perf_instrument,
+    perf_instrument, perf_span,
     relay_control::{
         SubscriptionContext, SubscriptionStream,
         observability::{RelayTelemetry, RelayTelemetryKind},
@@ -43,6 +43,18 @@ struct RelaySetupOutcome {
     failed_relays: Vec<(RelayUrl, String)>,
     added_new_relay: bool,
     last_error: Option<NostrManagerError>,
+}
+
+/// Result of a quorum-based publish operation.
+///
+/// Contains the resolved output (succeeded + failed relays) plus a list of
+/// relay URLs that hadn't responded when quorum was reached. Their
+/// `send_event` futures were cancelled — the event may or may not have been
+/// delivered. Nostr events are idempotent (deduplicated by ID), so retrying
+/// pending relays is safe.
+pub(crate) struct QuorumPublishResult {
+    pub output: Output<EventId>,
+    pub pending: Vec<RelayUrl>,
 }
 
 /// Reusable single-client relay session used by relay planes.
@@ -418,7 +430,11 @@ impl RelaySession {
 
         let usable_relay_urls = prepared_relays.usable_relay_urls;
 
-        let result = self.client.send_event_to(&usable_relay_urls, event).await;
+        let result = {
+            let _span = perf_span!("relay::session_send_event_to");
+            self.client.send_event_to(&usable_relay_urls, event).await
+        };
+
         match result {
             Ok(output) => {
                 for relay_url in &usable_relay_urls {
@@ -451,6 +467,19 @@ impl RelaySession {
                     }
                 }
 
+                tracing::debug!(
+                    target: "whitenoise::relay_control::session",
+                    plane = self.config.plane.as_str(),
+                    event_id = %event.id,
+                    total = usable_relay_urls.len(),
+                    succeeded = output.success.len(),
+                    failed = output.failed.len(),
+                    failed_urls = ?output.failed.keys().collect::<Vec<_>>(),
+                    "Publish outcome: {}/{} relays accepted",
+                    output.success.len(),
+                    usable_relay_urls.len(),
+                );
+
                 Ok(output)
             }
             Err(error) => {
@@ -469,6 +498,170 @@ impl RelaySession {
                 Err(error.into())
             }
         }
+    }
+
+    #[perf_instrument("relay")]
+    pub(crate) async fn publish_event_to_quorum(
+        &self,
+        relay_urls: &[RelayUrl],
+        event: &Event,
+        early_return_threshold: usize,
+    ) -> Result<QuorumPublishResult> {
+        let _publish_guard = self.state.publish_lock.lock().await;
+
+        for relay_url in relay_urls {
+            self.emit_telemetry(Self::apply_telemetry_scope(
+                self.config.telemetry_account_pubkey,
+                RelayTelemetry::new(
+                    RelayTelemetryKind::PublishAttempt,
+                    self.config.plane,
+                    relay_url.clone(),
+                ),
+            ));
+        }
+
+        let prepared_relays = match self.prepare_relay_urls(relay_urls).await {
+            Ok(prepared_relays) => prepared_relays,
+            Err(error) => {
+                for relay_url in relay_urls {
+                    self.emit_telemetry(Self::apply_telemetry_scope(
+                        self.config.telemetry_account_pubkey,
+                        RelayTelemetry::new(
+                            RelayTelemetryKind::PublishFailure,
+                            self.config.plane,
+                            relay_url.clone(),
+                        )
+                        .with_message(error.to_string()),
+                    ));
+                }
+                return Err(error);
+            }
+        };
+
+        for (relay_url, message) in &prepared_relays.failed_relays {
+            self.emit_telemetry(Self::apply_telemetry_scope(
+                self.config.telemetry_account_pubkey,
+                RelayTelemetry::new(
+                    RelayTelemetryKind::PublishFailure,
+                    self.config.plane,
+                    relay_url.clone(),
+                )
+                .with_message(message.clone()),
+            ));
+        }
+
+        let usable_relay_urls = prepared_relays.usable_relay_urls;
+        let effective_quorum = early_return_threshold.max(1).min(usable_relay_urls.len());
+
+        let mut output = Output {
+            val: event.id,
+            success: HashSet::new(),
+            failed: HashMap::new(),
+        };
+
+        let _send_span = perf_span!("relay::session_send_event_to_quorum");
+        let pool = self.client.pool();
+        let mut futs = FuturesUnordered::new();
+
+        for url in &usable_relay_urls {
+            match pool.relay(url.clone()).await {
+                Ok(relay) => {
+                    let url = url.clone();
+                    futs.push(async move { (url, relay.send_event(event).await) });
+                }
+                Err(e) => {
+                    let message = e.to_string();
+                    self.emit_telemetry(Self::apply_telemetry_scope(
+                        self.config.telemetry_account_pubkey,
+                        RelayTelemetry::new(
+                            RelayTelemetryKind::PublishFailure,
+                            self.config.plane,
+                            url.clone(),
+                        )
+                        .with_message(message.clone()),
+                    ));
+                    output.failed.insert(url.clone(), message);
+                }
+            }
+        }
+
+        while let Some((url, result)) = futs.next().await {
+            match result {
+                Ok(_event_id) => {
+                    self.emit_telemetry(Self::apply_telemetry_scope(
+                        self.config.telemetry_account_pubkey,
+                        RelayTelemetry::new(
+                            RelayTelemetryKind::PublishSuccess,
+                            self.config.plane,
+                            url.clone(),
+                        ),
+                    ));
+                    output.success.insert(url);
+                }
+                Err(e) => {
+                    let message = e.to_string();
+                    self.emit_telemetry(Self::apply_telemetry_scope(
+                        self.config.telemetry_account_pubkey,
+                        RelayTelemetry::new(
+                            RelayTelemetryKind::PublishFailure,
+                            self.config.plane,
+                            url.clone(),
+                        )
+                        .with_message(message.clone()),
+                    ));
+                    tracing::warn!(
+                        target: "whitenoise::relay_control::session",
+                        plane = self.config.plane.as_str(),
+                        relay_url = %url,
+                        event_id = %event.id,
+                        "Relay rejected quorum publish: {message}"
+                    );
+                    output.failed.insert(url, message);
+                }
+            }
+
+            if output.success.len() >= effective_quorum {
+                let resolved: HashSet<&RelayUrl> =
+                    output.success.iter().chain(output.failed.keys()).collect();
+                let pending: Vec<RelayUrl> = usable_relay_urls
+                    .iter()
+                    .filter(|u| !resolved.contains(u))
+                    .cloned()
+                    .collect();
+
+                tracing::debug!(
+                    target: "whitenoise::relay_control::session",
+                    plane = self.config.plane.as_str(),
+                    event_id = %event.id,
+                    quorum = effective_quorum,
+                    succeeded = output.success.len(),
+                    failed = output.failed.len(),
+                    pending_count = pending.len(),
+                    "Quorum publish met: {}/{} relays accepted",
+                    output.success.len(),
+                    usable_relay_urls.len(),
+                );
+
+                return Ok(QuorumPublishResult { output, pending });
+            }
+        }
+
+        tracing::debug!(
+            target: "whitenoise::relay_control::session",
+            plane = self.config.plane.as_str(),
+            event_id = %event.id,
+            quorum = effective_quorum,
+            succeeded = output.success.len(),
+            failed = output.failed.len(),
+            "Quorum publish complete: {}/{} relays accepted",
+            output.success.len(),
+            usable_relay_urls.len(),
+        );
+
+        Ok(QuorumPublishResult {
+            output,
+            pending: vec![],
+        })
     }
 
     #[perf_instrument("relay")]
@@ -1275,6 +1468,42 @@ mod tests {
             .unwrap();
 
         let _ = session.publish_event_to(&[relay_url], &event).await;
+
+        let mut saw_attempt = false;
+        let mut saw_failure = false;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !(saw_attempt && saw_failure) {
+                match telemetry.recv().await.unwrap().kind {
+                    RelayTelemetryKind::PublishAttempt => saw_attempt = true,
+                    RelayTelemetryKind::PublishFailure => saw_failure = true,
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_quorum_publish_emits_attempt_and_failure_telemetry() {
+        let (sender, _) = mpsc::channel(8);
+        let mut config = RelaySessionConfig::new(RelayPlane::Ephemeral);
+        config.connect_timeout = std::time::Duration::from_millis(10);
+        let session = RelaySession::new(config, sender);
+        let mut telemetry = session.telemetry();
+
+        let relay_url = RelayUrl::parse("ws://127.0.0.1:1").unwrap();
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("quorum publish test")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let result = session
+            .publish_event_to_quorum(&[relay_url], &event, 1)
+            .await;
+
+        // Loopback relay fails to connect, so prepare_relay_urls returns error
+        assert!(result.is_err());
 
         let mut saw_attempt = false;
         let mut saw_failure = false;


### PR DESCRIPTION
- K-of-N quorum publishing for relay lists during login. Returns after K=2 relay acceptances via FuturesUnordered instead of waiting for all N relays, cutting tail latency on the blocking login path. Pending/failed relays are retried in the background with exponential backoff (2s→4s→8s→16s).

- Add-members benchmark for the blocking publish_and_merge_commit path. Used to evaluate extending quorum to MLS commit publishes — benchmarking showed publish is only ~30% of total add_members_to_group time, so quorum remains scoped to relay list publishes only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quorum-based event publishing for improved reliability and background retry when some relays don't accept events.

* **Tests**
  * New performance benchmark for "add-members" (measures group member addition); test coverage added for parsing and name enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->