### PR TITLE
Retry key-package lookup when relay data is stale, not only empty

### DIFF
--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -2540,8 +2540,10 @@ mod tests {
             assert_eq!(status, KeyPackageStatus::NotFound);
         }
 
+        /// When the user has relays and fresh metadata, the retry guard should
+        /// not trigger — the first NotFound result is returned as-is.
         #[tokio::test]
-        async fn test_not_found_with_populated_relay_list_does_not_retry() {
+        async fn test_not_found_with_fresh_relay_data_does_not_retry() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let test_pubkey = Keys::generate().public_key();
 
@@ -2554,7 +2556,6 @@ mod tests {
             };
             let saved_user = user.save(&whitenoise.database).await.unwrap();
 
-            // Add a key package relay using a local test relay so the connection succeeds
             let relay_url = RelayUrl::parse("ws://localhost:8080").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
@@ -2565,8 +2566,42 @@ mod tests {
                 .await
                 .unwrap();
 
-            // With a relay present, key_package_status should return NotFound
-            // without attempting relay sync (no retry path).
+            // Relays present + fresh updated_at → should_retry returns false,
+            // so no relay sync is attempted.
+            let status = saved_user.key_package_status(&whitenoise).await.unwrap();
+            assert_eq!(status, KeyPackageStatus::NotFound);
+        }
+
+        /// When the user has relays but stale metadata (updated_at past TTL),
+        /// the retry guard triggers a relay sync before the second lookup.
+        #[tokio::test]
+        async fn test_not_found_with_stale_relay_data_retries_after_sync() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let test_pubkey = Keys::generate().public_key();
+
+            let user = User {
+                id: None,
+                pubkey: test_pubkey,
+                metadata: Metadata::new(),
+                created_at: Utc::now(),
+                updated_at: DateTime::<Utc>::UNIX_EPOCH,
+            };
+            let saved_user = user.save(&whitenoise.database).await.unwrap();
+
+            let relay_url = RelayUrl::parse("ws://localhost:8080").unwrap();
+            let relay = whitenoise
+                .find_or_create_relay_by_url(&relay_url)
+                .await
+                .unwrap();
+            saved_user
+                .add_relay(&relay, RelayType::KeyPackage, &whitenoise.database)
+                .await
+                .unwrap();
+
+            // Relays present but updated_at = epoch → needs_metadata_refresh()
+            // returns true, so should_retry triggers relay sync + second lookup.
+            // With no real relays the result is still NotFound, but the retry
+            // path is exercised.
             let status = saved_user.key_package_status(&whitenoise).await.unwrap();
             assert_eq!(status, KeyPackageStatus::NotFound);
         }

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -87,9 +87,9 @@ impl User {
     /// Similar to [`key_package_event`](Self::key_package_event), but returns a
     /// [`KeyPackageStatus`] that distinguishes between valid, missing, and incompatible.
     ///
-    /// If the initial lookup returns [`KeyPackageStatus::NotFound`] and the user has no
-    /// relay data yet (e.g. created by a background sync that hasn't finished), this
-    /// method will perform a blocking relay sync and retry once.
+    /// If the initial lookup returns [`KeyPackageStatus::NotFound`] and the user's
+    /// relay data is empty or stale, this method will perform a blocking relay sync
+    /// and retry once.
     #[perf_instrument("users")]
     pub async fn key_package_status(&self, whitenoise: &Whitenoise) -> Result<KeyPackageStatus> {
         let event = self.key_package_event(whitenoise).await?;
@@ -97,14 +97,11 @@ impl User {
 
         match status {
             KeyPackageStatus::NotFound
-                if self
-                    .relays(RelayType::KeyPackage, &whitenoise.database)
-                    .await?
-                    .is_empty() =>
+                if self.should_retry_key_package_lookup(whitenoise).await? =>
             {
                 tracing::debug!(
                     target: "whitenoise::users::key_package",
-                    "Key package not found for user {} with empty relay list, syncing relays and retrying",
+                    "Key package not found for user {} with empty or stale relay data, syncing relays and retrying",
                     self.pubkey
                 );
                 if let Err(e) = self.update_relay_lists(whitenoise).await {
@@ -121,6 +118,21 @@ impl User {
             }
             other => Ok(other),
         }
+    }
+
+    /// Determines whether a failed key-package lookup should trigger a relay
+    /// sync and retry.
+    ///
+    /// Returns `true` when the stored relay data is empty or stale, meaning a
+    /// fresh sync might discover relays that actually host the key package.
+    async fn should_retry_key_package_lookup(&self, whitenoise: &Whitenoise) -> Result<bool> {
+        let kp_relays = self
+            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .await?;
+        if kp_relays.is_empty() {
+            return Ok(true);
+        }
+        Ok(self.needs_metadata_refresh())
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #657

- Extracted `should_retry_key_package_lookup` helper in `key_package_status` that returns `true` when the user's key-package relay list is empty **or** `needs_metadata_refresh()` is true (updated_at older than 24h / epoch)
- Previously only the empty-relay-list case triggered a relay sync + retry, so users whose relay data was fetched once but became stale would get a permanent `NotFound`
- Retry remains bounded: at most one `update_relay_lists` + one re-lookup per call

## Test plan

- [x] `test_not_found_with_empty_relay_list_retries_after_sync` — empty relays triggers retry (existing, kept)
- [x] `test_not_found_with_fresh_relay_data_does_not_retry` — relays present + fresh updated_at skips retry
- [x] `test_not_found_with_stale_relay_data_retries_after_sync` — relays present + stale updated_at triggers retry
- [x] `just precommit-quick` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for relay metadata freshness validation, verifying proper handling of both fresh and stale data scenarios in key package operations.

* **Bug Fixes**
  * Improved retry logic for key package lookups to better detect and handle stale relay metadata, triggering automatic synchronization to ensure more reliable data access when metadata needs refreshing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->