### PR TITLE
fix(subscriptions): use incremental group plane update for welcome processing

### DIFF
--- a/src/relay_control/groups.rs
+++ b/src/relay_control/groups.rs
@@ -225,6 +225,16 @@ impl GroupPlane {
         }
     }
 
+    /// Returns the number of groups tracked in the group plane for an account.
+    pub(crate) async fn account_group_count(&self, pubkey: &PublicKey) -> usize {
+        self.accounts
+            .read()
+            .await
+            .get(pubkey)
+            .map(|state| state.groups.len())
+            .unwrap_or(0)
+    }
+
     pub(crate) fn telemetry(&self) -> broadcast::Receiver<super::observability::RelayTelemetry> {
         self.session.telemetry()
     }

--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -364,6 +364,11 @@ impl RelayControlPlane {
         Ok(())
     }
 
+    /// Returns the number of groups in the group plane for an account.
+    pub(crate) async fn group_plane_account_group_count(&self, pubkey: &PublicKey) -> usize {
+        self.group_plane.account_group_count(pubkey).await
+    }
+
     #[perf_instrument("relay")]
     pub(crate) async fn sync_account_group_subscriptions(
         &self,

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -658,6 +658,19 @@ impl Whitenoise {
         Ok(())
     }
 
+    /// Returns the number of active groups in MDK for an account.
+    ///
+    /// Cheaper than `extract_group_subscription_specs` — counts without
+    /// fetching per-group relay lists.
+    pub(crate) fn active_group_count(&self, account: &Account) -> Result<usize> {
+        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let groups = mdk.get_groups()?;
+        Ok(groups
+            .iter()
+            .filter(|g| g.state == GroupState::Active)
+            .count())
+    }
+
     /// Extract per-group relay specs for subscription setup.
     #[perf_instrument("accounts")]
     pub(crate) async fn extract_group_subscription_specs(
@@ -682,6 +695,36 @@ impl Whitenoise {
         Ok(group_specs)
     }
 
+    /// Syncs group plane subscriptions for an account without touching the inbox.
+    ///
+    /// Reads active groups from MDK, ensures relay records exist, and updates
+    /// the group plane. Unlike `refresh_account_subscriptions`, this does not
+    /// tear down or rebuild inbox subscriptions.
+    #[perf_instrument("accounts")]
+    pub(crate) async fn sync_group_subscriptions(&self, account: &Account) -> Result<()> {
+        let group_specs = self.extract_group_subscription_specs(account).await?;
+
+        for relay_url in group_specs.iter().flat_map(|spec| spec.relays.iter()) {
+            if let Err(e) = Relay::find_or_create_by_url(relay_url, &self.database).await {
+                tracing::warn!(
+                    target: "whitenoise::accounts",
+                    relay = %relay_url,
+                    error = %e,
+                    "Failed to create relay record",
+                );
+            }
+        }
+
+        self.relay_control
+            .sync_account_group_subscriptions(
+                account.pubkey,
+                &group_specs,
+                account.since_timestamp(10),
+            )
+            .await
+            .map_err(WhitenoiseError::from)
+    }
+
     #[perf_instrument("accounts")]
     async fn refresh_account_group_subscriptions_with_cancel(
         &self,
@@ -697,29 +740,7 @@ impl Whitenoise {
             return Ok(());
         }
 
-        let group_specs = self.extract_group_subscription_specs(account).await?;
-
-        for relay_url in group_specs.iter().flat_map(|group| group.relays.iter()) {
-            Relay::find_or_create_by_url(relay_url, &self.database).await?;
-        }
-
-        if Self::is_background_task_cancelled(cancel_rx) {
-            tracing::debug!(
-                target: "whitenoise::accounts::background_refresh_account_group_subscriptions",
-                account_pubkey = %account.pubkey,
-                "Skipping group subscription sync because the account was cancelled",
-            );
-            return Ok(());
-        }
-
-        self.relay_control
-            .sync_account_group_subscriptions(
-                account.pubkey,
-                &group_specs,
-                account.since_timestamp(10),
-            )
-            .await
-            .map_err(WhitenoiseError::from)
+        self.sync_group_subscriptions(account).await
     }
 
     fn is_background_task_cancelled(cancel_rx: Option<&watch::Receiver<bool>>) -> bool {
@@ -960,6 +981,38 @@ mod tests {
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
     use crate::whitenoise::test_utils::*;
     use mdk_core::prelude::*;
+
+    #[tokio::test]
+    async fn test_active_group_count_no_groups() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+
+        assert_eq!(
+            whitenoise.active_group_count(&account).unwrap(),
+            0,
+            "New account should have 0 active groups"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_active_group_count_with_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let member_account = whitenoise.create_identity().await.unwrap();
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let config = create_nostr_group_config_data(vec![creator_account.pubkey]);
+        whitenoise
+            .create_group(&creator_account, vec![member_account.pubkey], config, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            whitenoise.active_group_count(&creator_account).unwrap(),
+            1,
+            "Creator should have 1 active group"
+        );
+    }
 
     #[tokio::test]
     async fn test_extract_group_subscription_specs_no_groups() {

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -1,6 +1,3 @@
-use std::collections::BTreeSet;
-use std::sync::Arc;
-
 use chrono::Utc;
 use mdk_core::GroupId;
 use nostr_sdk::prelude::*;
@@ -15,7 +12,6 @@ use crate::{
         database::published_key_packages::PublishedKeyPackage,
         error::{Result, WhitenoiseError},
         group_information::{GroupInformation, GroupType},
-        relays::Relay,
     },
 };
 
@@ -263,24 +259,13 @@ impl Whitenoise {
         key_package_event_id: EventId,
         welcomer_pubkey: PublicKey,
     ) {
-        // Get signer early - needed for subscriptions
-        let signer = match whitenoise.get_signer_for_account(account) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!(
-                    target: "whitenoise::event_processor::process_welcome::background",
-                    account = %account.pubkey.to_hex(),
-                    error = %e,
-                    "Failed to get signer; aborting welcome finalization"
-                );
-                return;
-            }
-        };
-
         // --- Step 1: subscription setup (must happen before catch-up and self-update) ---
-        let _subscription_ok = match Self::setup_group_subscriptions(whitenoise, account, signer)
-            .await
-        {
+        //
+        // Uses sync_group_subscriptions which only updates the group plane.
+        // Unlike refresh_account_subscriptions, this does NOT tear down the
+        // inbox or existing group subscriptions — avoiding a cascade failure
+        // when relay connections are flaky (e.g. mobile resuming from background).
+        let _subscription_ok = match whitenoise.sync_group_subscriptions(account).await {
             Ok(()) => {
                 tracing::debug!(
                     target: "whitenoise::event_processor::process_welcome::background",
@@ -392,34 +377,6 @@ impl Whitenoise {
         group_name: &str,
     ) -> Result<()> {
         GroupInformation::create_for_group(whitenoise, group_id, None, group_name).await?;
-        Ok(())
-    }
-
-    /// Set up Nostr subscriptions for group messages
-    #[perf_instrument("event_handlers")]
-    async fn setup_group_subscriptions(
-        whitenoise: &Whitenoise,
-        account: &Account,
-        _signer: Arc<dyn NostrSigner>,
-    ) -> Result<()> {
-        let (group_ids, group_relays) =
-            Self::get_group_subscription_info(whitenoise, &account.pubkey)?;
-
-        // Create relay records (idempotent)
-        for relay in &group_relays {
-            if let Err(e) = Relay::find_or_create_by_url(relay, &whitenoise.database).await {
-                tracing::warn!(
-                    target: "whitenoise::event_processor::process_welcome::background",
-                    "Failed to create relay record for {}: {}",
-                    relay,
-                    e
-                );
-            }
-        }
-
-        let _ = group_ids;
-        whitenoise.refresh_account_subscriptions(account).await?;
-
         Ok(())
     }
 
@@ -551,27 +508,6 @@ impl Whitenoise {
         );
 
         Ok(())
-    }
-
-    /// Helper to get group subscription info (group IDs and relay URLs) for an account.
-    fn get_group_subscription_info(
-        whitenoise: &Whitenoise,
-        pubkey: &PublicKey,
-    ) -> Result<(Vec<String>, Vec<RelayUrl>)> {
-        let mdk = whitenoise.create_mdk_for_account(*pubkey)?;
-        let groups = mdk.get_groups()?;
-        let mut group_relays_set = BTreeSet::new();
-        let group_ids = groups
-            .iter()
-            .map(|g| hex::encode(g.nostr_group_id))
-            .collect::<Vec<_>>();
-
-        for group in &groups {
-            let relays = mdk.get_relays(&group.mls_group_id)?;
-            group_relays_set.extend(relays);
-        }
-
-        Ok((group_ids, group_relays_set.into_iter().collect()))
     }
 }
 
@@ -838,42 +774,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_group_subscription_info_no_groups() {
+    async fn test_sync_group_subscriptions_no_groups() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
 
-        // New account has no groups
-        let result = Whitenoise::get_group_subscription_info(&whitenoise, &account.pubkey);
+        // New account has no groups — sync should succeed as a no-op
+        let result = whitenoise.sync_group_subscriptions(&account).await;
         assert!(result.is_ok());
-
-        let (group_ids, relays) = result.unwrap();
-        assert!(group_ids.is_empty());
-        assert!(relays.is_empty());
     }
 
     #[tokio::test]
-    async fn test_get_group_subscription_info_with_group() {
+    async fn test_sync_group_subscriptions_with_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        // Create creator and member accounts
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
+        wait_for_key_package_publication(&whitenoise, &[&members[0].0]).await;
 
-        // Create a group
         let config = create_nostr_group_config_data(vec![creator_account.pubkey]);
         whitenoise
             .create_group(&creator_account, vec![member_pubkey], config, None)
             .await
             .unwrap();
 
-        // Creator should now have one group with relays
-        let result = Whitenoise::get_group_subscription_info(&whitenoise, &creator_account.pubkey);
+        // Creator should have one group — sync should update the group plane
+        let result = whitenoise.sync_group_subscriptions(&creator_account).await;
         assert!(result.is_ok());
 
-        let (group_ids, relays) = result.unwrap();
-        assert_eq!(group_ids.len(), 1, "Creator should have one group");
-        assert!(!relays.is_empty(), "Group should have relays");
+        // Group plane should contain the group
+        let plane_count = whitenoise
+            .relay_control
+            .group_plane_account_group_count(&creator_account.pubkey)
+            .await;
+        assert_eq!(plane_count, 1, "Group plane should have one group");
     }
 
     #[tokio::test]
@@ -1007,11 +941,91 @@ mod tests {
         );
     }
 
-    /// When the account's signing key is not in the secrets store,
-    /// `finalize_welcome_with_instance` must return early without panicking.
-    /// This covers the signer-not-found early-return path (lines 238-245).
+    /// After welcome finalization, the new group must appear in the group
+    /// plane and the account's subscriptions must remain operational.
+    /// This is the core regression test for the background subscription bug:
+    /// the old code tore down all subscriptions (inbox + groups) and rebuilt
+    /// from scratch, which could cascade-fail on mobile. The fix uses an
+    /// incremental group plane update that leaves the inbox untouched.
     #[tokio::test]
-    async fn test_finalize_welcome_no_signer_returns_early() {
+    async fn test_finalize_welcome_adds_group_to_plane() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        // Member starts with subscriptions but no groups
+        assert!(
+            whitenoise
+                .is_account_subscriptions_operational(&member_account)
+                .await
+                .unwrap(),
+            "Member should be operational before welcome"
+        );
+        assert_eq!(
+            whitenoise
+                .relay_control
+                .group_plane_account_group_count(&member_account.pubkey)
+                .await,
+            0,
+            "Member should have 0 groups in plane before welcome"
+        );
+
+        // Build and process a real MLS Welcome
+        let giftwrap_event =
+            build_welcome_giftwrap(&whitenoise, &creator_account, member_account.pubkey).await;
+        whitenoise
+            .handle_giftwrap(&member_account, giftwrap_event)
+            .await
+            .unwrap();
+
+        // Get the group ID from MDK (accept_welcome already ran)
+        let mdk = whitenoise
+            .create_mdk_for_account(member_account.pubkey)
+            .unwrap();
+        let groups = mdk.get_groups().unwrap();
+        assert!(!groups.is_empty(), "Member should have a group in MDK");
+        let group = &groups[0];
+
+        // Run finalize_welcome_with_instance
+        Whitenoise::finalize_welcome_with_instance(
+            &whitenoise,
+            &member_account,
+            &group.mls_group_id,
+            &group.name,
+            EventId::all_zeros(),
+            creator_account.pubkey,
+        )
+        .await;
+
+        // The new group must be in the group plane
+        let plane_count = whitenoise
+            .relay_control
+            .group_plane_account_group_count(&member_account.pubkey)
+            .await;
+        assert_eq!(
+            plane_count, 1,
+            "Group plane should have 1 group after welcome finalization"
+        );
+
+        // Subscriptions must still be operational (inbox survived)
+        assert!(
+            whitenoise
+                .is_account_subscriptions_operational(&member_account)
+                .await
+                .unwrap(),
+            "Subscriptions should remain operational after welcome finalization"
+        );
+    }
+
+    /// When the account's signing key is not in the secrets store,
+    /// `finalize_welcome_with_instance` must complete without panicking.
+    /// Operations that need a signer (e.g. key rotation) fail gracefully
+    /// while others (subscription sync, group info) proceed normally.
+    #[tokio::test]
+    async fn test_finalize_welcome_no_signer_completes_gracefully() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = mdk_core::GroupId::from_slice(&[99; 32]);
@@ -1022,7 +1036,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Remove the private key so get_signer_for_account returns an error
+        // Remove the private key so signer-dependent operations fail
         whitenoise
             .secrets_store
             .remove_private_key_for_pubkey(&account.pubkey)
@@ -1039,11 +1053,11 @@ mod tests {
         )
         .await;
 
-        // AccountGroup must still exist (early return does not destroy it)
+        // AccountGroup must still exist
         let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
             .await
             .unwrap();
-        assert!(ag.is_some(), "AccountGroup must survive an early return");
+        assert!(ag.is_some(), "AccountGroup must survive missing signer");
     }
 
     /// When the DB lookup for the key package fails (e.g. table missing),

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1316,16 +1316,43 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Checks if account subscriptions are operational
+    /// Checks if account subscriptions are operational.
     ///
-    /// Returns true if the account inbox plane exists and at least one of its
-    /// relays is connected or connecting.
+    /// Returns true when:
+    /// 1. The inbox plane and group plane both have connected relays, AND
+    /// 2. The number of groups in the group plane matches MDK's active groups.
+    ///
+    /// The group count parity check catches groups that were added to MDK
+    /// (e.g. via `accept_welcome`) but never made it into the group plane
+    /// (e.g. because the background subscription setup failed on mobile).
     #[perf_instrument("whitenoise")]
     pub async fn is_account_subscriptions_operational(&self, account: &Account) -> Result<bool> {
-        Ok(self
+        let relay_healthy = self
             .relay_control
             .has_account_subscriptions(&account.pubkey)
-            .await)
+            .await;
+
+        if !relay_healthy {
+            return Ok(false);
+        }
+
+        let mdk_count = self.active_group_count(account)?;
+        let plane_count = self
+            .relay_control
+            .group_plane_account_group_count(&account.pubkey)
+            .await;
+
+        if mdk_count != plane_count {
+            tracing::info!(
+                target: "whitenoise::is_account_subscriptions_operational",
+                account = %account.pubkey.to_hex(),
+                mdk_groups = mdk_count,
+                plane_groups = plane_count,
+                "Group count mismatch between MDK and group plane",
+            );
+        }
+
+        Ok(mdk_count == plane_count)
     }
 
     /// Checks if global subscriptions are operational without refreshing.
@@ -2189,6 +2216,87 @@ mod tests {
             assert!(
                 is_operational,
                 "Account should be operational after create_identity"
+            );
+        }
+
+        /// When MDK has more active groups than the group plane, the parity
+        /// check should detect the mismatch and report non-operational.
+        #[tokio::test]
+        async fn test_is_account_operational_detects_group_count_mismatch() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+            let creator_account = whitenoise.create_identity().await.unwrap();
+            let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+            let member_pubkey = members[0].0.pubkey;
+            wait_for_key_package_publication(&whitenoise, &[&members[0].0]).await;
+
+            // Starts operational (0 groups in MDK, 0 in plane)
+            assert!(
+                whitenoise
+                    .is_account_subscriptions_operational(&creator_account)
+                    .await
+                    .unwrap(),
+                "Should be operational with zero groups"
+            );
+
+            // Create a group — this adds it to MDK and (via background task)
+            // to the group plane
+            let config = create_nostr_group_config_data(vec![creator_account.pubkey]);
+            whitenoise
+                .create_group(&creator_account, vec![member_pubkey], config, None)
+                .await
+                .unwrap();
+
+            // Tear down subscriptions to simulate the welcome-processing
+            // cascade failure (group exists in MDK but not in group plane)
+            whitenoise
+                .relay_control
+                .deactivate_account_subscriptions(&creator_account.pubkey)
+                .await;
+
+            // Re-activate inbox only (without groups) to isolate the test
+            // to the group count parity check — inbox is healthy, groups are not
+            let signer = whitenoise.get_signer_for_account(&creator_account).unwrap();
+            let inbox_relays = crate::whitenoise::relays::Relay::urls(
+                &creator_account
+                    .effective_inbox_relays(&whitenoise)
+                    .await
+                    .unwrap(),
+            );
+            whitenoise
+                .relay_control
+                .activate_account_subscriptions(
+                    creator_account.pubkey,
+                    &inbox_relays,
+                    &[], // empty group specs — simulates the missing group
+                    creator_account.since_timestamp(10),
+                    signer,
+                )
+                .await
+                .unwrap();
+
+            let is_operational = whitenoise
+                .is_account_subscriptions_operational(&creator_account)
+                .await
+                .unwrap();
+            assert!(
+                !is_operational,
+                "Should detect mismatch: MDK has 1 group, plane has 0"
+            );
+
+            // Recovery via ensure should fix it
+            whitenoise
+                .ensure_account_subscriptions(&creator_account)
+                .await
+                .unwrap();
+
+            let is_operational = whitenoise
+                .is_account_subscriptions_operational(&creator_account)
+                .await
+                .unwrap();
+            assert!(
+                is_operational,
+                "Should be operational after ensure recovery"
             );
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved group subscription synchronization to be more resilient (best-effort relay handling, no teardown of existing inbox/subscriptions) and added a consistency check between local and plane group counts with logging on mismatch.

* **Tests**
  * Added tests validating group subscription sync, active group counting, and detection/recovery of account operational status when counts diverge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->