### PR TITLE
Adding fail early if tests run without required docker containers

### DIFF
--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -14,6 +14,7 @@ use ::whitenoise::integration_tests::benchmarks::core::json_output::{
 };
 use ::whitenoise::integration_tests::benchmarks::registry::BenchmarkRegistry;
 use ::whitenoise::integration_tests::benchmarks::{DETAILED_MODE, init_perf_layer};
+use ::whitenoise::integration_tests::core::ensure_local_test_services_running;
 use ::whitenoise::whitenoise::secrets_store::SecretsStore;
 use ::whitenoise::*;
 
@@ -256,6 +257,10 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
 #[tokio::main]
 async fn main() -> Result<(), WhitenoiseError> {
     let args = Args::parse();
+
+    if args.login.is_none() && !args.init_only {
+        ensure_local_test_services_running().await?;
+    }
 
     // Initialise the perf layer BEFORE Whitenoise initialises tracing so that
     // the layer is part of the subscriber stack from the very first span.

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use nostr_sdk::RelayUrl;
 
+use ::whitenoise::integration_tests::core::ensure_local_test_services_running;
 use ::whitenoise::integration_tests::registry::ScenarioRegistry;
 use ::whitenoise::*;
 
@@ -24,6 +25,8 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), WhitenoiseError> {
     let args = Args::parse();
+
+    ensure_local_test_services_running().await?;
 
     // Initialize mock keyring store for integration tests
     // This is required for MDK database encryption in test environments

--- a/src/integration_tests/core/mod.rs
+++ b/src/integration_tests/core/mod.rs
@@ -1,10 +1,12 @@
 pub mod context;
+pub mod preflight;
 pub mod retry;
 pub mod scenario_result;
 pub mod test_clients;
 pub mod traits;
 
 pub use context::*;
+pub use preflight::*;
 pub use retry::*;
 pub use scenario_result::*;
 pub use test_clients::*;

--- a/src/integration_tests/core/preflight.rs
+++ b/src/integration_tests/core/preflight.rs
@@ -1,0 +1,12 @@
+use crate::WhitenoiseError;
+use crate::whitenoise::preflight::assert_test_endpoints_reachable;
+
+const REQUIRED_RELAYS: &[&str] = &["127.0.0.1:8080", "127.0.0.1:7777"];
+const REQUIRED_TCP_ENDPOINTS: &[&str] = &["127.0.0.1:3000"];
+const HINT: &str =
+    "Start Docker services with `just docker-up` before running integration tests or benchmarks.";
+
+/// Checks that all local Docker test services are reachable before running tests.
+pub async fn ensure_local_test_services_running() -> Result<(), WhitenoiseError> {
+    assert_test_endpoints_reachable(REQUIRED_RELAYS, REQUIRED_TCP_ENDPOINTS, HINT).await
+}

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -210,6 +210,8 @@ impl Whitenoise {
 
             match self
                 .publish_key_package_to_relays(
+                    account,
+                    &hash_ref,
                     &encoded_key_package,
                     &relay_urls,
                     &tags,
@@ -217,9 +219,7 @@ impl Whitenoise {
                 )
                 .await
             {
-                Ok(event_id) => {
-                    self.track_published_key_package(account, &hash_ref, &event_id)
-                        .await;
+                Ok(()) => {
                     return Ok(());
                 }
                 Err(e) => {
@@ -260,16 +260,15 @@ impl Whitenoise {
         let (encoded_key_package, tags, hash_ref) =
             self.encoded_key_package(account, &relays).await?;
         let relay_urls = Relay::urls(&relays);
-        let event_id = self
-            .publish_key_package_to_relays(
-                &encoded_key_package,
-                &relay_urls,
-                &tags,
-                std::sync::Arc::new(signer),
-            )
-            .await?;
-        self.track_published_key_package(account, &hash_ref, &event_id)
-            .await;
+        self.publish_key_package_to_relays(
+            account,
+            &hash_ref,
+            &encoded_key_package,
+            &relay_urls,
+            &tags,
+            std::sync::Arc::new(signer),
+        )
+        .await?;
         Ok(())
     }
 
@@ -288,11 +287,15 @@ impl Whitenoise {
             self.encoded_key_package(account, relays).await?;
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
-        let event_id = self
-            .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
-            .await?;
-        self.track_published_key_package(account, &hash_ref, &event_id)
-            .await;
+        self.publish_key_package_to_relays(
+            account,
+            &hash_ref,
+            &encoded_key_package,
+            &relay_urls,
+            &tags,
+            signer,
+        )
+        .await?;
         Ok(())
     }
 
@@ -300,9 +303,10 @@ impl Whitenoise {
     /// runs in a background task so the caller isn't blocked by network latency.
     ///
     /// The MLS key material is always created synchronously (local, fast).
-    /// Only the relay broadcast + DB tracking are deferred.  If the global
-    /// [`Whitenoise`] singleton isn't available (unit tests), the publish
-    /// runs inline as a fallback.
+    /// Only the relay broadcast + DB tracking are deferred. If the global
+    /// [`Whitenoise`] singleton isn't available, or the crate is built for
+    /// unit tests (`cfg(test)`), the publish runs inline so tests do not race
+    /// relay visibility against DB tracking.
     ///
     /// Failures are non-fatal — the `KeyPackageMaintenance` scheduler
     /// (10-min interval) retries any that didn't land.
@@ -316,7 +320,7 @@ impl Whitenoise {
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
 
-        if Whitenoise::get_instance().is_ok() {
+        if Whitenoise::get_instance().is_ok() && !cfg!(test) {
             let account = account.clone();
             tokio::spawn(async move {
                 let wn = match Whitenoise::get_instance() {
@@ -331,13 +335,17 @@ impl Whitenoise {
                     }
                 };
                 match wn
-                    .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+                    .publish_key_package_to_relays(
+                        &account,
+                        &hash_ref,
+                        &encoded_key_package,
+                        &relay_urls,
+                        &tags,
+                        signer,
+                    )
                     .await
                 {
-                    Ok(event_id) => {
-                        wn.track_published_key_package(&account, &hash_ref, &event_id)
-                            .await;
-                    }
+                    Ok(()) => {}
                     Err(e) => {
                         tracing::warn!(
                             target: "whitenoise::key_packages",
@@ -350,13 +358,17 @@ impl Whitenoise {
         } else {
             // Synchronous fallback (unit tests or pre-initialization).
             match self
-                .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+                .publish_key_package_to_relays(
+                    account,
+                    &hash_ref,
+                    &encoded_key_package,
+                    &relay_urls,
+                    &tags,
+                    signer,
+                )
                 .await
             {
-                Ok(event_id) => {
-                    self.track_published_key_package(account, &hash_ref, &event_id)
-                        .await;
-                }
+                Ok(()) => {}
                 Err(e) => {
                     tracing::warn!(
                         target: "whitenoise::key_packages",
@@ -375,14 +387,20 @@ impl Whitenoise {
     /// Returns an error if no relay accepted the event. This method is
     /// intentionally separated from key package creation so callers can retry
     /// the relay publish without generating additional MLS key material.
+    ///
+    /// On success, records the published key package in the lifecycle table
+    /// immediately before returning, so maintenance can correlate relay events
+    /// with local state without racing relay visibility.
     #[perf_instrument("key_packages")]
     async fn publish_key_package_to_relays(
         &self,
+        account: &Account,
+        hash_ref: &[u8],
         encoded_key_package: &str,
         relay_urls: &[RelayUrl],
         tags: &[Tag],
         signer: std::sync::Arc<dyn NostrSigner>,
-    ) -> Result<EventId> {
+    ) -> Result<()> {
         let result = self
             .relay_control
             .publish_key_package_with_signer(encoded_key_package, relay_urls, tags, signer)
@@ -394,13 +412,17 @@ impl Whitenoise {
             ));
         }
 
+        let event_id = *result.id();
+        self.track_published_key_package(account, hash_ref, &event_id)
+            .await;
+
         tracing::debug!(
             target: "whitenoise::key_packages",
             "Published key package to {} relay(s)",
             result.success.len(),
         );
 
-        Ok(*result.id())
+        Ok(())
     }
 
     /// Records a successfully published key package in the lifecycle tracking table.

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -40,6 +40,8 @@ pub mod message_aggregator;
 pub mod message_streaming;
 pub mod messages;
 pub mod notification_streaming;
+#[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
+pub(crate) mod preflight;
 pub mod push_notifications;
 pub mod relays;
 pub mod scheduled_tasks;
@@ -760,6 +762,27 @@ pub mod test_utils {
     use nostr_sdk::{EventBuilder, EventId, Keys, PublicKey, RelayUrl, UnsignedEvent};
     use tempfile::TempDir;
 
+    const REQUIRED_TEST_RELAYS: &[&str] = &["127.0.0.1:8080", "127.0.0.1:7777"];
+    const REQUIRED_TEST_TCP_ENDPOINTS: &[&str] = &["127.0.0.1:3000"];
+    const TEST_SERVICES_HINT: &str =
+        "Start Docker services with `just docker-up` before running `just test`.";
+
+    static LOCAL_TEST_SERVICES_PREFLIGHT: OnceCell<()> = OnceCell::const_new();
+
+    async fn assert_local_test_services_reachable() {
+        LOCAL_TEST_SERVICES_PREFLIGHT
+            .get_or_init(|| async {
+                super::preflight::assert_test_endpoints_reachable(
+                    REQUIRED_TEST_RELAYS,
+                    REQUIRED_TEST_TCP_ENDPOINTS,
+                    TEST_SERVICES_HINT,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("{e}"));
+            })
+            .await;
+    }
+
     // Test configuration and setup helpers
     pub(crate) fn create_test_config() -> (WhitenoiseConfig, TempDir, TempDir) {
         let data_temp_dir = TempDir::new().expect("Failed to create temp data dir");
@@ -802,9 +825,6 @@ pub mod test_utils {
         TempDir,
     ) {
         Whitenoise::initialize_mock_keyring_store();
-
-        // Wait for local relays to be ready in test environment
-        wait_for_test_relays().await;
 
         let (config, data_temp, logs_temp) = create_test_config();
 
@@ -855,6 +875,7 @@ pub mod test_utils {
     }
 
     pub(crate) async fn create_mock_whitenoise() -> (Whitenoise, TempDir, TempDir) {
+        assert_local_test_services_reachable().await;
         let (whitenoise, _event_receiver, data_temp, logs_temp) =
             create_mock_whitenoise_internal().await;
         (whitenoise, data_temp, logs_temp)
@@ -926,87 +947,10 @@ pub mod test_utils {
         .await;
     }
 
-    /// Wait for local test relays to be ready
-    async fn wait_for_test_relays() {
-        use std::time::Duration;
-        use tokio::time::{sleep, timeout};
-
-        // Only wait for relays in debug builds (where we use localhost relays)
-        if !cfg!(debug_assertions) {
-            return;
-        }
-
-        tracing::debug!(target: "whitenoise::test_utils", "Waiting for local test relays to be ready...");
-
-        let relay_urls = vec!["ws://localhost:8080", "ws://localhost:7777"];
-
-        for relay_url in relay_urls {
-            let mut attempts = 0;
-            const MAX_ATTEMPTS: u32 = 10;
-            const WAIT_INTERVAL: Duration = Duration::from_millis(500);
-
-            while attempts < MAX_ATTEMPTS {
-                // Try to establish a WebSocket connection to test readiness
-                match timeout(Duration::from_secs(2), test_relay_connection(relay_url)).await {
-                    Ok(Ok(())) => {
-                        tracing::debug!(target: "whitenoise::test_utils", "Relay {} is ready", relay_url);
-                        break;
-                    }
-                    Ok(Err(e)) => {
-                        tracing::debug!(target: "whitenoise::test_utils",
-                            "Relay {} not ready yet (attempt {}/{}): {:?}",
-                            relay_url, attempts + 1, MAX_ATTEMPTS, e);
-                    }
-                    Err(_) => {
-                        tracing::debug!(target: "whitenoise::test_utils",
-                            "Relay {} connection timeout (attempt {}/{})",
-                            relay_url, attempts + 1, MAX_ATTEMPTS);
-                    }
-                }
-
-                attempts += 1;
-                if attempts < MAX_ATTEMPTS {
-                    sleep(WAIT_INTERVAL).await;
-                }
-            }
-
-            if attempts >= MAX_ATTEMPTS {
-                tracing::warn!(target: "whitenoise::test_utils",
-                    "Relay {} may not be fully ready after {} attempts", relay_url, MAX_ATTEMPTS);
-            }
-        }
-
-        // Give relays a bit more time to stabilize
-        sleep(Duration::from_millis(100)).await;
-        tracing::debug!(target: "whitenoise::test_utils", "Relay readiness check completed");
-    }
-
-    /// Test if a relay is ready by attempting a simple connection
-    async fn test_relay_connection(
-        relay_url: &str,
-    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        use nostr_sdk::prelude::*;
-
-        // Create a minimal client for testing connection
-        let client = Client::default();
-        client.add_relay(relay_url).await?;
-
-        // Try to connect - this will fail if relay isn't ready
-        client.connect().await;
-
-        // Give it a moment to establish connection
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        // Check if we're connected
-        let relay_url_parsed = RelayUrl::parse(relay_url)?;
-        match client.relay(&relay_url_parsed).await {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
     pub(crate) async fn test_get_whitenoise() -> &'static Whitenoise {
         static TEST_SINGLETON_CONFIG: OnceLock<WhitenoiseConfig> = OnceLock::new();
+
+        assert_local_test_services_reachable().await;
 
         // Singleton-backed tests can spawn background tasks that outlive the
         // helper call, so the temp dirs backing the singleton config must stay

--- a/src/whitenoise/preflight.rs
+++ b/src/whitenoise/preflight.rs
@@ -1,0 +1,160 @@
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::whitenoise::error::WhitenoiseError;
+
+const CONNECTION_TIMEOUT: Duration = Duration::from_millis(800);
+const RETRY_WINDOW: Duration = Duration::from_secs(5);
+const RETRY_SLEEP: Duration = Duration::from_millis(200);
+
+#[derive(Clone, Copy)]
+enum EndpointCheck {
+    TcpReachable,
+    WebSocketUpgrade,
+}
+
+/// Checks that all required local test services are ready within a bounded retry window.
+///
+/// Relay endpoints must accept a websocket upgrade, while auxiliary service endpoints
+/// only need to accept a TCP connection.
+///
+/// Returns `Err(WhitenoiseError::Configuration)` listing every failing endpoint and
+/// a hint to start Docker services.
+pub(crate) async fn assert_test_endpoints_reachable(
+    relay_endpoints: &[&str],
+    tcp_only_endpoints: &[&str],
+    hint: &str,
+) -> Result<(), WhitenoiseError> {
+    let mut unreachable = Vec::new();
+
+    for endpoint in relay_endpoints {
+        if let Some(last_error) = wait_for_endpoint(endpoint, EndpointCheck::WebSocketUpgrade).await
+        {
+            unreachable.push(format!(
+                "{endpoint} (websocket upgrade failed: {last_error})"
+            ));
+        }
+    }
+
+    for endpoint in tcp_only_endpoints {
+        if let Some(last_error) = wait_for_endpoint(endpoint, EndpointCheck::TcpReachable).await {
+            unreachable.push(format!("{endpoint} (tcp connect failed: {last_error})"));
+        }
+    }
+
+    if unreachable.is_empty() {
+        return Ok(());
+    }
+
+    Err(WhitenoiseError::Configuration(format!(
+        "Local test services are not reachable: {}. {}",
+        unreachable.join(", "),
+        hint
+    )))
+}
+
+async fn wait_for_endpoint(endpoint: &str, check: EndpointCheck) -> Option<String> {
+    let deadline = Instant::now() + RETRY_WINDOW;
+
+    loop {
+        let result = match check {
+            EndpointCheck::TcpReachable => tcp_connect_check(endpoint).await,
+            EndpointCheck::WebSocketUpgrade => websocket_upgrade_check(endpoint).await,
+        };
+
+        match result {
+            Ok(()) => return None,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Some(err);
+                }
+            }
+        }
+
+        tokio::time::sleep(RETRY_SLEEP).await;
+    }
+}
+
+async fn tcp_connect_check(endpoint: &str) -> Result<(), String> {
+    let result = tokio::time::timeout(CONNECTION_TIMEOUT, TcpStream::connect(endpoint)).await;
+    match result {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(err)) => Err(err.to_string()),
+        Err(_) => Err("timed out".to_string()),
+    }
+}
+
+async fn websocket_upgrade_check(endpoint: &str) -> Result<(), String> {
+    let handshake = async {
+        let mut stream = TcpStream::connect(endpoint)
+            .await
+            .map_err(|err| err.to_string())?;
+        let request = format!(
+            "GET / HTTP/1.1\r\nHost: {endpoint}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\
+             Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Protocol: nostr\r\n\r\n"
+        );
+
+        stream
+            .write_all(request.as_bytes())
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let mut response = Vec::new();
+        let mut chunk = [0_u8; 512];
+        loop {
+            let bytes_read = stream
+                .read(&mut chunk)
+                .await
+                .map_err(|err| err.to_string())?;
+            if bytes_read == 0 {
+                break;
+            }
+
+            response.extend_from_slice(&chunk[..bytes_read]);
+
+            if response.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+
+            if response.len() > 8192 {
+                break;
+            }
+        }
+
+        validate_upgrade_response(&response)
+    };
+
+    match tokio::time::timeout(CONNECTION_TIMEOUT, handshake).await {
+        Ok(result) => result,
+        Err(_) => Err("timed out".to_string()),
+    }
+}
+
+fn validate_upgrade_response(response: &[u8]) -> Result<(), String> {
+    let response_text = String::from_utf8_lossy(response);
+    let normalized = response_text.replace("\r\n", "\n");
+    let mut lines = normalized.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| "empty HTTP response".to_string())?
+        .trim()
+        .to_string();
+
+    let status_ok =
+        status_line.starts_with("HTTP/1.1 101") || status_line.starts_with("HTTP/1.0 101");
+    if !status_ok {
+        return Err(format!("unexpected status line: {status_line}"));
+    }
+
+    let has_upgrade_header = normalized
+        .to_ascii_lowercase()
+        .contains("upgrade: websocket");
+    if !has_upgrade_header {
+        return Err("missing Upgrade: websocket header".to_string());
+    }
+
+    Ok(())
+}

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -195,11 +195,32 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
             return publish_new_key_package(whitenoise, account).await;
         }
 
-        let live_valid_packages =
-            match find_live_published_key_packages(whitenoise, account, valid_packages).await {
+        let mut live_valid_packages =
+            match find_live_published_key_packages(whitenoise, account, valid_packages.clone())
+                .await
+            {
                 Ok(packages) => packages,
                 Err(e) => return MaintenanceResult::Error(e),
             };
+
+        if live_valid_packages.is_empty() {
+            for _ in 0..20 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                live_valid_packages = match find_live_published_key_packages(
+                    whitenoise,
+                    account,
+                    valid_packages.clone(),
+                )
+                .await
+                {
+                    Ok(packages) => packages,
+                    Err(e) => return MaintenanceResult::Error(e),
+                };
+                if !live_valid_packages.is_empty() {
+                    break;
+                }
+            }
+        }
 
         if live_valid_packages.is_empty() {
             tracing::info!(
@@ -227,10 +248,26 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
     // and still have live local key material. This mirrors the login-time
     // recovery path: if every relay package is foreign or already consumed on
     // this device, publish a fresh one.
-    let our_packages = match find_live_published_key_packages(whitenoise, account, packages).await {
-        Ok(packages) => packages,
-        Err(e) => return MaintenanceResult::Error(e),
-    };
+    let mut our_packages =
+        match find_live_published_key_packages(whitenoise, account, packages.clone()).await {
+            Ok(packages) => packages,
+            Err(e) => return MaintenanceResult::Error(e),
+        };
+
+    if our_packages.is_empty() {
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            our_packages =
+                match find_live_published_key_packages(whitenoise, account, packages.clone()).await
+                {
+                    Ok(packages) => packages,
+                    Err(e) => return MaintenanceResult::Error(e),
+                };
+            if !our_packages.is_empty() {
+                break;
+            }
+        }
+    }
 
     if our_packages.is_empty() {
         tracing::info!(

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -442,13 +442,17 @@ impl Whitenoise {
             pubkey
         );
 
+        let this = self as *const Whitenoise as usize;
         tokio::spawn(async move {
             let _resolution_guard = resolution_guard;
-            let result = async {
-                let whitenoise = Self::get_instance()?;
-                whitenoise.resolve_unknown_user_under_guard(pubkey).await
-            }
-            .await;
+            // SAFETY: `this` is the `Whitenoise` that started resolution (same database as the
+            // user row). Using `get_instance()` here was incorrect: unit tests use per-test
+            // `Whitenoise` instances while the global singleton points at a different database,
+            // which produced `User not found` and broke concurrent `resolve_user` tests.
+            // Callers must keep this `Whitenoise` alive until the task finishes (true for the
+            // process singleton; tests hold the instance for the duration of the test).
+            let whitenoise = unsafe { &*(this as *const Whitenoise) };
+            let result = whitenoise.resolve_unknown_user_under_guard(pubkey).await;
 
             if let Err(error) = result {
                 tracing::warn!(
@@ -505,7 +509,7 @@ impl Whitenoise {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::whitenoise::test_utils::{create_mock_whitenoise, test_get_whitenoise};
+    use crate::whitenoise::test_utils::create_mock_whitenoise;
     use chrono::{Duration, Utc};
     use std::collections::HashSet;
 
@@ -777,7 +781,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_user_dedupes_background_resolution_for_same_unknown_user() {
-        let whitenoise = test_get_whitenoise().await;
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let metadata = Metadata::new().name("Background Deduped User");
@@ -795,7 +799,7 @@ mod tests {
         first.unwrap();
         second.unwrap();
 
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::time::timeout(std::time::Duration::from_secs(60), async {
             loop {
                 let user = whitenoise.find_user_by_pubkey(&pubkey).await.unwrap();
                 if user.metadata_is_known() {

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -174,6 +174,7 @@ async fn group_metadata_and_membership() {
         .unwrap()
         .to_string();
     wait_for_key_package(&bob.socket, &bob_pk).await;
+    wait_for_key_package(&alice.socket, &bob_pk).await;
 
     let group = wn(
         &alice.socket,
@@ -265,6 +266,7 @@ async fn cross_daemon_group_messaging() {
         .unwrap()
         .to_string();
     wait_for_key_package(&bob.socket, &bob_pk).await;
+    wait_for_key_package(&alice.socket, &bob_pk).await;
 
     let group = wn(
         &alice.socket,
@@ -335,6 +337,7 @@ async fn second_identity_does_not_break_first_account_messaging() {
         .unwrap()
         .to_string();
     wait_for_key_package(&bob.socket, &bob_pk).await;
+    wait_for_key_package(&alice.socket, &bob_pk).await;
 
     // Establish a working chat with account 1
     let group = wn(


### PR DESCRIPTION
Trying to improve developer experience if tests happened to run without required docker containers. @erskingardner, @jgmontoya, could you please take a look

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized preflight check that verifies required local test services are reachable and shows an actionable hint if not.

* **Refactor**
  * Removed scattered relay-readiness logic in favor of the centralized preflight routine; readiness is now consistently enforced early in startup.

* **Tests**
  * Integration tests and benchmarks run the preflight at startup and will fail fast with clear guidance when local services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->