### PR TITLE
Add fetch_messages_unread_with_minimum

### DIFF
--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -3193,8 +3193,14 @@ mod tests {
 
         // Insert 3 messages: seeds 1, 2, 3
         for i in 1u8..=3 {
-            insert_message_at(i, author, base_ts + u64::from(i), &group_id, &whitenoise.database)
-                .await;
+            insert_message_at(
+                i,
+                author,
+                base_ts + u64::from(i),
+                &group_id,
+                &whitenoise.database,
+            )
+            .await;
         }
 
         // Delete seed-2 message

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -707,7 +707,8 @@ impl Whitenoise {
             read_marker.as_ref(),
             minimum_val,
             &self.database,
-        ).await?)
+        )
+        .await?)
     }
 
     /// Fetch a single aggregated message by its event ID.


### PR DESCRIPTION
![marmot](https://blossom.primal.net/afefe8bc3b60222c1a1f5ff943401a1cdf67118c189b887d914e7bd5435f1561.jpg)

Adds `fetch_messages_unread_with_minimum`: a new public API method that returns all unread messages for a chat, but guarantees a minimum number of messages even when the unread count is low.

## What it does

The effective fetch size is `max(unread_count, minimum)`. Two cases:

- **More unreads than the minimum:** returns every unread message since the read marker. You get the full unread backlog.
- **Fewer unreads than the minimum:** the floor kicks in. You get at least a full page of the newest messages regardless of read state.

The default minimum is 50. Values above 200 are clamped.

## How it works

A single SQL CTE computes the unread count and uses `MAX(cnt, minimum)` as the LIMIT in the same query. One round-trip, no separate COUNT call. The unread boundary uses the same `created_at > marker_created_at` logic as the existing `count_unread_for_group`.

Messages come back oldest-first, same as `fetch_aggregated_messages_for_group`.

## Testing

Four unit tests covering:

- Unread count exceeds minimum: all unreads returned
- Unread count below minimum: floor applied, newest N messages returned
- No read marker: all messages treated as unread
- Unknown account: rejected with `AccountNotFound`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch unread group messages with a configurable minimum threshold (defaults to 50) so callers receive at least that many messages when available.
  * Deleted messages are returned as tombstones in results.

* **Behavior**
  * Results are selected newest-first but delivered oldest-first.
  * Missing read markers are treated as "all unread".
  * Unknown accounts return an explicit error.

* **Tests**
  * Added integration tests for unread/minimum behavior, tombstone inclusion, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->