### PR TITLE
fix: bound MIP-05 token-list response task concurrency with semaphore

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -839,6 +839,8 @@ impl Whitenoise {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use mdk_core::mip05::{
         ENCRYPTED_TOKEN_LEN, LeafTokenTag, TokenTag, build_token_list_response_rumor,
         build_token_removal_rumor, build_token_request_rumor,
@@ -2101,6 +2103,55 @@ mod tests {
         );
 
         let _ = admin_account;
+    }
+
+    #[tokio::test]
+    async fn test_scheduled_token_response_task_runs_and_clears_pending_entry() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+
+        let token_tag = make_token_tag(22);
+        let request =
+            build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![token_tag])
+                .unwrap();
+        let request_event_id = request.id.expect("447 rumor must have an event id");
+        let event = admin_mdk.create_message(&group_id, request).unwrap();
+
+        whitenoise
+            .handle_mls_message(&member_account, event)
+            .await
+            .unwrap();
+
+        assert!(whitenoise.has_pending_token_response(
+            &member_account.pubkey,
+            &group_id,
+            &request_event_id,
+        ));
+
+        // In tests the spawn delay is 0ms; wait for the spawned task to clear the entry.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if !whitenoise.has_pending_token_response(
+                    &member_account.pubkey,
+                    &group_id,
+                    &request_event_id,
+                ) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for spawned token-response task to complete");
     }
 
     #[tokio::test]

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1008,7 +1008,8 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        mdk.create_message(&group.mls_group_id, inner, None).unwrap();
+        mdk.create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         let message = mdk
             .get_message(&group.mls_group_id, &message_id)
@@ -1081,7 +1082,9 @@ mod tests {
             "Valid message".to_string(),
         );
         inner.ensure_id();
-        let valid_event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
+        let valid_event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // Corrupt the event by changing its kind (MLS processing should fail)
         let mut bad_event = valid_event;
@@ -1135,7 +1138,9 @@ mod tests {
             "+".to_string(), // Use simple emoji that won't be normalized
         );
         orphaned_reaction.ensure_id();
-        let reaction_event = mdk.create_message(group_id, orphaned_reaction, None).unwrap();
+        let reaction_event = mdk
+            .create_message(group_id, orphaned_reaction, None)
+            .unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -1251,7 +1256,9 @@ mod tests {
             "".to_string(), // Empty content is invalid
         );
         invalid_reaction.ensure_id();
-        let invalid_event = mdk.create_message(group_id, invalid_reaction, None).unwrap();
+        let invalid_event = mdk
+            .create_message(group_id, invalid_reaction, None)
+            .unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, invalid_event)
@@ -1414,7 +1421,9 @@ mod tests {
                 format!("Message {}", i),
             );
             inner.ensure_id();
-            let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
+            let event = mdk
+                .create_message(&group.mls_group_id, inner, None)
+                .unwrap();
 
             whitenoise
                 .handle_mls_message(&creator_account, event)
@@ -1423,10 +1432,13 @@ mod tests {
         }
 
         // Verify all messages are in cache
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(messages.len(), 3, "All messages should be cached");
         let mut contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
@@ -1493,7 +1505,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1564,7 +1576,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1617,7 +1629,7 @@ mod tests {
         assert!(stored.is_empty());
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1885,7 +1897,9 @@ mod tests {
             "Test message".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // First processing: should succeed
         let first = whitenoise
@@ -1958,7 +1972,9 @@ mod tests {
             "Unprocessable test".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
         let event_id = event.id;
 
         // Build a relay-plane source context for this account.
@@ -2065,16 +2081,18 @@ mod tests {
     #[tokio::test]
     async fn test_duplicate_token_request_does_not_create_second_task() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let admin_account = whitenoise.create_identity().await.unwrap();
+        let _admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
 
         let fake_event_id = EventId::all_zeros();
         let fake_group_id = GroupId::from_slice(&[1u8; 32]);
 
-        // First schedule: inserts the key.
-        whitenoise.schedule_token_response_for_test(
-            member_account.clone(),
+        // Pre-insert the key to simulate an in-flight task holding it. This
+        // avoids the race where a spawned task with delay_ms=0 could clear the
+        // key before the assertion runs.
+        whitenoise.insert_pending_token_response_for_test(
+            member_account.pubkey,
             fake_group_id.clone(),
             fake_event_id,
         );
@@ -2085,7 +2103,7 @@ mod tests {
             &fake_event_id,
         ));
 
-        // Second schedule with the same key hits the duplicate-dedup early-return;
+        // Schedule with the same key hits the duplicate-dedup early-return;
         // the existing entry must remain intact.
         whitenoise.schedule_token_response_for_test(
             member_account.clone(),
@@ -2101,8 +2119,6 @@ mod tests {
             ),
             "pending entry should still be present after duplicate request"
         );
-
-        let _ = admin_account;
     }
 
     #[tokio::test]
@@ -2124,7 +2140,7 @@ mod tests {
             build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![token_tag])
                 .unwrap();
         let request_event_id = request.id.expect("447 rumor must have an event id");
-        let event = admin_mdk.create_message(&group_id, request).unwrap();
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -2061,6 +2061,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_duplicate_token_request_does_not_create_second_task() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        let fake_event_id = EventId::all_zeros();
+        let fake_group_id = GroupId::from_slice(&[1u8; 32]);
+
+        // First schedule: inserts the key.
+        whitenoise.schedule_token_response_for_test(
+            member_account.clone(),
+            fake_group_id.clone(),
+            fake_event_id,
+        );
+
+        assert!(whitenoise.has_pending_token_response(
+            &member_account.pubkey,
+            &fake_group_id,
+            &fake_event_id,
+        ));
+
+        // Second schedule with the same key hits the duplicate-dedup early-return;
+        // the existing entry must remain intact.
+        whitenoise.schedule_token_response_for_test(
+            member_account.clone(),
+            fake_group_id.clone(),
+            fake_event_id,
+        );
+
+        assert!(
+            whitenoise.has_pending_token_response(
+                &member_account.pubkey,
+                &fake_group_id,
+                &fake_event_id,
+            ),
+            "pending entry should still be present after duplicate request"
+        );
+
+        let _ = admin_account;
+    }
+
+    #[tokio::test]
     async fn test_token_request_dropped_when_semaphore_exhausted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let admin_account = whitenoise.create_identity().await.unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1006,8 +1006,7 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        mdk.create_message(&group.mls_group_id, inner, None)
-            .unwrap();
+        mdk.create_message(&group.mls_group_id, inner, None).unwrap();
 
         let message = mdk
             .get_message(&group.mls_group_id, &message_id)
@@ -1080,9 +1079,7 @@ mod tests {
             "Valid message".to_string(),
         );
         inner.ensure_id();
-        let valid_event = mdk
-            .create_message(&group.mls_group_id, inner, None)
-            .unwrap();
+        let valid_event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
 
         // Corrupt the event by changing its kind (MLS processing should fail)
         let mut bad_event = valid_event;
@@ -1136,9 +1133,7 @@ mod tests {
             "+".to_string(), // Use simple emoji that won't be normalized
         );
         orphaned_reaction.ensure_id();
-        let reaction_event = mdk
-            .create_message(group_id, orphaned_reaction, None)
-            .unwrap();
+        let reaction_event = mdk.create_message(group_id, orphaned_reaction, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -1254,9 +1249,7 @@ mod tests {
             "".to_string(), // Empty content is invalid
         );
         invalid_reaction.ensure_id();
-        let invalid_event = mdk
-            .create_message(group_id, invalid_reaction, None)
-            .unwrap();
+        let invalid_event = mdk.create_message(group_id, invalid_reaction, None).unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, invalid_event)
@@ -1419,9 +1412,7 @@ mod tests {
                 format!("Message {}", i),
             );
             inner.ensure_id();
-            let event = mdk
-                .create_message(&group.mls_group_id, inner, None)
-                .unwrap();
+            let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
 
             whitenoise
                 .handle_mls_message(&creator_account, event)
@@ -1430,13 +1421,10 @@ mod tests {
         }
 
         // Verify all messages are in cache
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group.mls_group_id,
-            None,
-            &whitenoise.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
+                .await
+                .unwrap();
 
         assert_eq!(messages.len(), 3, "All messages should be cached");
         let mut contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
@@ -1503,7 +1491,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1574,7 +1562,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1627,7 +1615,7 @@ mod tests {
         assert!(stored.is_empty());
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1895,9 +1883,7 @@ mod tests {
             "Test message".to_string(),
         );
         inner.ensure_id();
-        let event = mdk
-            .create_message(&group.mls_group_id, inner, None)
-            .unwrap();
+        let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
 
         // First processing: should succeed
         let first = whitenoise
@@ -1970,9 +1956,7 @@ mod tests {
             "Unprocessable test".to_string(),
         );
         inner.ensure_id();
-        let event = mdk
-            .create_message(&group.mls_group_id, inner, None)
-            .unwrap();
+        let event = mdk.create_message(&group.mls_group_id, inner, None).unwrap();
         let event_id = event.id;
 
         // Build a relay-plane source context for this account.
@@ -2073,6 +2057,46 @@ mod tests {
             message_event.is_ok(),
             "Admin should be able to create messages after auto-committed removal: {:?}",
             message_event.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_token_request_dropped_when_semaphore_exhausted() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+
+        // Hold all semaphore permits so the next scheduled response task is dropped.
+        let _guard = whitenoise.exhaust_token_response_semaphore();
+
+        let token_tag = make_token_tag(20);
+        let request =
+            build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![token_tag])
+                .unwrap();
+        let request_event_id = request.id.expect("447 rumor must have an event id");
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
+
+        whitenoise
+            .handle_mls_message(&member_account, event)
+            .await
+            .unwrap();
+
+        // The task should have been dropped; no pending entry should remain.
+        assert!(
+            !whitenoise.has_pending_token_response(
+                &member_account.pubkey,
+                &group_id,
+                &request_event_id,
+            ),
+            "pending entry should be removed when the concurrency cap is reached"
         );
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -184,8 +184,7 @@ pub struct Whitenoise {
     /// In-memory coordination for delayed MIP-05 token-list responses.
     pending_push_token_responses: Arc<DashMap<(PublicKey, GroupId, EventId), ()>>,
     /// Bounds the number of concurrently-active delayed MIP-05 token-list response tasks.
-    /// Tasks that cannot acquire a permit are dropped; the deduplication map ensures the
-    /// requester can retry via a subsequent request event.
+    /// See [`push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS`] for the cap value.
     token_response_semaphore: Arc<Semaphore>,
 }
 
@@ -271,7 +270,9 @@ impl Whitenoise {
             pending_logins: DashMap::new(),
             discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
             pending_push_token_responses: Arc::new(DashMap::new()),
-            token_response_semaphore: Arc::new(Semaphore::new(10)),
+            token_response_semaphore: Arc::new(Semaphore::new(
+                push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,
+            )),
         }
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -183,6 +183,10 @@ pub struct Whitenoise {
     discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker,
     /// In-memory coordination for delayed MIP-05 token-list responses.
     pending_push_token_responses: Arc<DashMap<(PublicKey, GroupId, EventId), ()>>,
+    /// Bounds the number of concurrently-active delayed MIP-05 token-list response tasks.
+    /// Tasks that cannot acquire a permit are dropped; the deduplication map ensures the
+    /// requester can retry via a subsequent request event.
+    token_response_semaphore: Arc<Semaphore>,
 }
 
 static GLOBAL_WHITENOISE: OnceCell<Whitenoise> = OnceCell::const_new();
@@ -220,6 +224,7 @@ impl std::fmt::Debug for Whitenoise {
             .field("scheduler_shutdown", &"<REDACTED>")
             .field("scheduler_handles", &"<REDACTED>")
             .field("pending_push_token_responses", &"<REDACTED>")
+            .field("token_response_semaphore", &"<REDACTED>")
             .finish()
     }
 }
@@ -266,6 +271,7 @@ impl Whitenoise {
             pending_logins: DashMap::new(),
             discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
             pending_push_token_responses: Arc::new(DashMap::new()),
+            token_response_semaphore: Arc::new(Semaphore::new(10)),
         }
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -8,6 +8,7 @@ use std::{
     str::FromStr,
 };
 
+#[cfg(not(test))]
 use ::rand::Rng;
 use chrono::{DateTime, Utc};
 use mdk_core::mip05::{
@@ -128,6 +129,11 @@ impl fmt::Debug for GroupPushToken {
             .finish()
     }
 }
+
+/// Maximum number of concurrently-active delayed MIP-05 token-list response tasks.
+/// Tasks that cannot acquire a permit are dropped; the requester can retry via a
+/// subsequent token request event.
+pub(crate) const MAX_CONCURRENT_TOKEN_RESPONSE_TASKS: usize = 10;
 
 const PUSH_GROUP_MESSAGE_KINDS: [u16; 3] = [
     mdk_core::mip05::TOKEN_REQUEST_KIND,
@@ -795,7 +801,7 @@ impl Whitenoise {
     pub(crate) fn exhaust_token_response_semaphore(&self) -> tokio::sync::OwnedSemaphorePermit {
         self.token_response_semaphore
             .clone()
-            .try_acquire_many_owned(10)
+            .try_acquire_many_owned(MAX_CONCURRENT_TOKEN_RESPONSE_TASKS as u32)
             .expect("semaphore should be fully available at start of test")
     }
 
@@ -859,7 +865,10 @@ impl Whitenoise {
         }
 
         // Key is freshly owned by us; now enforce the concurrency cap.
-        let _permit = match self.token_response_semaphore.clone().try_acquire_owned() {
+        // The permit is moved into the spawned task and held for the full
+        // duration (sleep + dispatch) so the cap applies to in-flight tasks,
+        // not just to the moment of scheduling.
+        let permit = match self.token_response_semaphore.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
                 tracing::warn!(
@@ -881,7 +890,10 @@ impl Whitenoise {
             pending_push_token_responses: Arc::clone(&self.pending_push_token_responses),
             relay_control: Arc::clone(&self.relay_control),
         };
+        #[cfg(not(test))]
         let delay_ms = ::rand::rng().random_range(1_000..=3_000);
+        #[cfg(test)]
+        let delay_ms = 0u64;
 
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
@@ -899,6 +911,10 @@ impl Whitenoise {
                     "Failed to send delayed MIP-05 token-list response"
                 );
             }
+
+            // Permit is held across the sleep + dispatch and released here,
+            // freeing a slot for the next waiting task.
+            drop(permit);
         });
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -805,6 +805,19 @@ impl Whitenoise {
             .expect("semaphore should be fully available at start of test")
     }
 
+    /// Directly inserts a key into the pending token response map without
+    /// spawning a task. Used in tests to simulate an in-flight request.
+    #[cfg(test)]
+    pub(crate) fn insert_pending_token_response_for_test(
+        &self,
+        account_pubkey: PublicKey,
+        group_id: GroupId,
+        request_event_id: EventId,
+    ) {
+        self.pending_push_token_responses
+            .insert((account_pubkey, group_id, request_event_id), ());
+    }
+
     #[cfg(test)]
     pub(crate) fn has_pending_token_response(
         &self,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -823,7 +823,34 @@ impl Whitenoise {
         request_event_id: EventId,
     ) {
         let key = (account.pubkey, group_id.clone(), request_event_id);
-        self.pending_push_token_responses.insert(key, ());
+
+        // If the key was already present, an identical request is already in-flight.
+        // Inserting again is a no-op (value is `()`), so we use the return value to
+        // detect duplicates atomically before touching the semaphore.
+        if self
+            .pending_push_token_responses
+            .insert(key.clone(), ())
+            .is_some()
+        {
+            return;
+        }
+
+        // Key is freshly owned by us; now enforce the concurrency cap.
+        let permit = match self.token_response_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                tracing::warn!(
+                    target: "whitenoise::push_notifications",
+                    account = %account.pubkey.to_hex(),
+                    group_id = %hex::encode(group_id.as_slice()),
+                    request_event_id = %request_event_id.to_hex(),
+                    "Dropping MIP-05 token-list response task: concurrency limit reached"
+                );
+                // Safe to remove: we are the ones who inserted this key above.
+                self.pending_push_token_responses.remove(&key);
+                return;
+            }
+        };
 
         let context = PendingTokenResponseContext {
             config: self.config.clone(),
@@ -849,6 +876,8 @@ impl Whitenoise {
                     "Failed to send delayed MIP-05 token-list response"
                 );
             }
+
+            drop(permit);
         });
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -776,6 +776,18 @@ impl Whitenoise {
         Ok(true)
     }
 
+    /// Calls `schedule_pending_token_response` directly. Used in tests to exercise
+    /// the scheduling logic without going through the full MLS message pipeline.
+    #[cfg(test)]
+    pub(crate) fn schedule_token_response_for_test(
+        &self,
+        account: Account,
+        group_id: GroupId,
+        request_event_id: EventId,
+    ) {
+        self.schedule_pending_token_response(account, group_id, request_event_id);
+    }
+
     /// Acquires all permits from the token-response semaphore and returns the
     /// owned guard. Dropping the guard releases the permits. Used in tests to
     /// simulate a fully-saturated semaphore.
@@ -847,7 +859,7 @@ impl Whitenoise {
         }
 
         // Key is freshly owned by us; now enforce the concurrency cap.
-        let permit = match self.token_response_semaphore.clone().try_acquire_owned() {
+        let _permit = match self.token_response_semaphore.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
                 tracing::warn!(
@@ -887,8 +899,6 @@ impl Whitenoise {
                     "Failed to send delayed MIP-05 token-list response"
                 );
             }
-
-            drop(permit);
         });
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -776,6 +776,17 @@ impl Whitenoise {
         Ok(true)
     }
 
+    /// Acquires all permits from the token-response semaphore and returns the
+    /// owned guard. Dropping the guard releases the permits. Used in tests to
+    /// simulate a fully-saturated semaphore.
+    #[cfg(test)]
+    pub(crate) fn exhaust_token_response_semaphore(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.token_response_semaphore
+            .clone()
+            .try_acquire_many_owned(10)
+            .expect("semaphore should be fully available at start of test")
+    }
+
     #[cfg(test)]
     pub(crate) fn has_pending_token_response(
         &self,


### PR DESCRIPTION
Fixes #706.

`schedule_pending_token_response` previously spawned an unbounded `tokio::spawn` for every incoming MIP-05 token request, allowing memory and DB contention to grow without limit under a request flood.

## Changes

- Added `token_response_semaphore: Arc<Semaphore>` (capacity 10) to `Whitenoise`
- In `schedule_pending_token_response`, `try_acquire_owned()` is called after the dedup-map insert; tasks that cannot acquire a permit are dropped immediately and their dedup key is removed
- The `OwnedSemaphorePermit` is held for the lifetime of the spawned task and released on completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a concurrency cap (10) for delayed token-list responses and ensure each scheduled response respects the limit for its entire lifetime.
  * Added atomic deduplication so repeated scheduling requests for the same token response are ignored.

* **Bug Fixes**
  * If concurrency is exhausted, scheduling is canceled (with a logged warning) and no stray pending entry is left behind.

* **Tests**
  * Added tests and test helpers validating deduplication and behavior when concurrency is exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->