### PR TITLE
Remove all #[allow(dead_code)] annotations and add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,14 @@ jobs:
 
       - name: Comment on PR
         if: steps.check.outputs.found == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@159c67730ed0a9748d0d480c02879eaf352efd8e # v3
         with:
           header: dead-code-allows
           message: ${{ steps.check.outputs.body }}
 
       - name: Remove comment if clean
         if: steps.check.outputs.found == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@159c67730ed0a9748d0d480c02879eaf352efd8e # v3
         with:
           header: dead-code-allows
           delete: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +100,7 @@ jobs:
       - name: Check for allow(dead_code) annotations
         id: check
         run: |
-          matches=$(grep -rn '#\[allow(dead_code)\]' src/ --include='*.rs' || true)
+          matches=$(grep -rn -E 'allow\s*\(\s*([^)]*,\s*)?dead_code\s*(,\s*[^)]*)?\)' src/ --include='*.rs' || true)
           if [ -n "$matches" ]; then
             {
               echo "body<<EOF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,51 @@ jobs:
       - name: Clippy check
         run: cargo clippy --all-targets --all-features --no-deps -- -D warnings -A clippy::uninlined_format_args
 
+  dead-code-allows:
+    name: Flag allow(dead_code)
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for allow(dead_code) annotations
+        id: check
+        run: |
+          matches=$(grep -rn '#\[allow(dead_code)\]' src/ --include='*.rs' || true)
+          if [ -n "$matches" ]; then
+            {
+              echo "body<<EOF"
+              echo "## ⚠️ \`#[allow(dead_code)]\` detected"
+              echo ""
+              echo "The following files contain \`#[allow(dead_code)]\` annotations. Please remove them and either delete the dead code or gate it with \`#[cfg(test)]\`."
+              echo ""
+              echo '```'
+              echo "$matches"
+              echo '```'
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR
+        if: steps.check.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: dead-code-allows
+          message: ${{ steps.check.outputs.body }}
+
+      - name: Remove comment if clean
+        if: steps.check.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: dead-code-allows
+          delete: true
+
   docs:
     name: Documentation
     needs: changes

--- a/justfile
+++ b/justfile
@@ -332,17 +332,22 @@ fmt:
 check-docs:
     @bash scripts/check-docs.sh
 
+# Check for #[allow(dead_code)] annotations
+check-dead-code-allows:
+    @bash scripts/check-dead-code-allows.sh
+
 # Check all (fast checks before running tests)
 check:
     @bash scripts/check-all.sh
 
 # Pre-commit checks: quiet mode with minimal output (recommended for agents/CI)
 precommit:
-    @just _run-quiet "check-fmt"    "fmt"
-    @just _run-quiet "check-docs"   "docs"
-    @just _run-quiet "check-clippy" "clippy"
-    @just _run-quiet "test"         "tests"
-    @just _run-quiet "int-test"     "integration tests"
+    @just _run-quiet "check-fmt"                "fmt"
+    @just _run-quiet "check-docs"               "docs"
+    @just _run-quiet "check-clippy"             "clippy"
+    @just _run-quiet "check-dead-code-allows"   "dead_code"
+    @just _run-quiet "test"                     "tests"
+    @just _run-quiet "int-test"                 "integration tests"
     @echo "PRECOMMIT PASSED"
 
 # Pre-commit checks with verbose output (shows all command output)
@@ -350,10 +355,11 @@ precommit-verbose: check test int-test
 
 # Quick pre-commit: quiet mode, skip integration tests (recommended for agents/CI)
 precommit-quick:
-    @just _run-quiet "check-fmt"    "fmt"
-    @just _run-quiet "check-docs"   "docs"
-    @just _run-quiet "check-clippy" "clippy"
-    @just _run-quiet "test-unit"    "tests"
+    @just _run-quiet "check-fmt"                "fmt"
+    @just _run-quiet "check-docs"               "docs"
+    @just _run-quiet "check-clippy"             "clippy"
+    @just _run-quiet "check-dead-code-allows"   "dead_code"
+    @just _run-quiet "test-unit"                "tests"
     @echo "PRECOMMIT PASSED"
 
 # Unit tests only (no integration-tests feature, no e2e binaries).

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -10,6 +10,7 @@ echo
 ./scripts/check-fmt.sh check
 ./scripts/check-docs.sh
 ./scripts/check-clippy.sh
+./scripts/check-dead-code-allows.sh
 
 echo "===================="
 echo "✅ All checks passed!"

--- a/scripts/check-dead-code-allows.sh
+++ b/scripts/check-dead-code-allows.sh
@@ -2,9 +2,11 @@
 
 set -euo pipefail
 
-echo "🔍 Checking for #[allow(dead_code)] annotations..."
+echo "🔍 Checking for allow(dead_code) annotations..."
 
-matches=$(grep -rn '#\[allow(dead_code)\]' src/ --include='*.rs' || true)
+# Matches all forms: #[allow(dead_code)], #![allow(dead_code)],
+# #[cfg_attr(..., allow(dead_code))], #[allow(unused, dead_code)], etc.
+matches=$(grep -rn -E 'allow\s*\(\s*([^)]*,\s*)?dead_code\s*(,\s*[^)]*)?\)' src/ --include='*.rs' || true)
 
 if [ -n "$matches" ]; then
     echo "❌ Found #[allow(dead_code)] annotations:"

--- a/scripts/check-dead-code-allows.sh
+++ b/scripts/check-dead-code-allows.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "🔍 Checking for #[allow(dead_code)] annotations..."
+
+matches=$(grep -rn '#\[allow(dead_code)\]' src/ --include='*.rs' || true)
+
+if [ -n "$matches" ]; then
+    echo "❌ Found #[allow(dead_code)] annotations:"
+    echo "$matches"
+    echo
+    echo "Remove #[allow(dead_code)] and either delete the dead code or gate it with #[cfg(test)]."
+    exit 1
+fi
+
+echo "✅ No #[allow(dead_code)] annotations found"
+echo

--- a/src/relay_control/groups.rs
+++ b/src/relay_control/groups.rs
@@ -16,25 +16,6 @@ use crate::{
     types::{GroupPlaneGroupStateSnapshot, GroupPlaneStateSnapshot, ProcessableEvent},
 };
 
-/// Configuration for the long-lived group-message plane.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
-pub(crate) struct GroupPlaneConfig {
-    pub(crate) relays: Vec<RelayUrl>,
-    pub(crate) group_ids: Vec<String>,
-    pub(crate) reconnect_policy: RelaySessionReconnectPolicy,
-}
-
-impl Default for GroupPlaneConfig {
-    fn default() -> Self {
-        Self {
-            relays: Vec::new(),
-            group_ids: Vec::new(),
-            reconnect_policy: RelaySessionReconnectPolicy::FreshnessBiased,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GroupSubscriptionSpec {
     pub(crate) group_id: String,
@@ -196,7 +177,6 @@ impl GroupPlane {
             .map(|state| state.groups.clone())
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn has_account(&self, pubkey: &PublicKey) -> bool {
         self.accounts.read().await.contains_key(pubkey)
@@ -399,17 +379,6 @@ mod tests {
     use super::*;
     use futures::future::join_all;
     use tokio::sync::mpsc;
-
-    #[test]
-    fn test_default_uses_explicit_group_reconnect_policy() {
-        let config = GroupPlaneConfig::default();
-        assert_eq!(config.relays, Vec::<RelayUrl>::new());
-        assert_eq!(config.group_ids, Vec::<String>::new());
-        assert_eq!(
-            config.reconnect_policy,
-            RelaySessionReconnectPolicy::FreshnessBiased
-        );
-    }
 
     #[tokio::test]
     async fn test_group_plane_hash_is_stable_for_account() {

--- a/src/relay_control/groups.rs
+++ b/src/relay_control/groups.rs
@@ -177,7 +177,7 @@ impl GroupPlane {
             .map(|state| state.groups.clone())
     }
 
-    #[perf_instrument("relay")]
+    #[cfg(test)]
     pub(crate) async fn has_account(&self, pubkey: &PublicKey) -> bool {
         self.accounts.read().await.contains_key(pubkey)
     }

--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -70,8 +70,6 @@ pub(crate) struct RelayControlPlane {
     account_inbox_activation_locks: Mutex<HashMap<PublicKey, Arc<Mutex<()>>>>,
     group_plane: groups::GroupPlane,
     ephemeral: ephemeral::EphemeralPlane,
-    #[allow(dead_code)]
-    router: router::RelayRouter,
     observability: observability::RelayObservability,
     telemetry_persistors_started: AtomicBool,
     telemetry_handles: Mutex<HashMap<String, JoinHandle<()>>>,
@@ -110,7 +108,6 @@ impl RelayControlPlane {
             account_inbox_activation_locks: Mutex::new(HashMap::new()),
             group_plane,
             ephemeral,
-            router: router::RelayRouter::default(),
             observability,
             telemetry_persistors_started: AtomicBool::new(false),
             telemetry_handles: Mutex::new(HashMap::new()),
@@ -143,25 +140,16 @@ impl RelayControlPlane {
     }
 
     /// Access to the shared application database for later relay-control phases.
-    #[allow(dead_code)]
     pub(crate) fn database(&self) -> &Arc<Database> {
         &self.database
     }
 
-    /// Local relay-routing metadata owned by the control plane.
-    #[allow(dead_code)]
-    pub(crate) fn router(&self) -> &router::RelayRouter {
-        &self.router
-    }
-
     /// Structured relay observability configuration and helpers.
-    #[allow(dead_code)]
     pub(crate) fn observability(&self) -> &observability::RelayObservability {
         &self.observability
     }
 
     /// Persist structured relay telemetry for later observability and retry work.
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn record_relay_telemetry(
         &self,
@@ -528,7 +516,6 @@ impl RelayControlPlane {
             .await
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn publish_metadata_with_signer(
         &self,
@@ -554,7 +541,6 @@ impl RelayControlPlane {
             .await
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn publish_follow_list_with_signer(
         &self,
@@ -704,19 +690,6 @@ pub(crate) enum SubscriptionStream {
     AccountInboxGiftwraps,
 }
 
-impl SubscriptionStream {
-    /// Stable identifier used only within White Noise.
-    #[allow(dead_code)]
-    pub(crate) fn as_str(&self) -> &'static str {
-        match self {
-            Self::DiscoveryUserData => "discovery_user_data",
-            Self::DiscoveryFollowLists => "discovery_follow_lists",
-            Self::GroupMessages => "group_messages",
-            Self::AccountInboxGiftwraps => "account_inbox_giftwraps",
-        }
-    }
-}
-
 pub(crate) fn hash_pubkey_for_subscription_id(
     session_salt: &[u8; 16],
     pubkey: &PublicKey,
@@ -759,14 +732,6 @@ mod tests {
     fn test_relay_plane_from_str() {
         assert_eq!("group".parse::<RelayPlane>().unwrap(), RelayPlane::Group);
         assert!("not-a-plane".parse::<RelayPlane>().is_err());
-    }
-
-    #[test]
-    fn test_subscription_stream_as_str() {
-        assert_eq!(
-            SubscriptionStream::AccountInboxGiftwraps.as_str(),
-            "account_inbox_giftwraps"
-        );
     }
 
     async fn setup_test_db() -> Database {

--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -139,11 +139,6 @@ impl RelayControlPlane {
             .clone()
     }
 
-    /// Access to the shared application database for later relay-control phases.
-    pub(crate) fn database(&self) -> &Arc<Database> {
-        &self.database
-    }
-
     /// Structured relay observability configuration and helpers.
     pub(crate) fn observability(&self) -> &observability::RelayObservability {
         &self.observability

--- a/src/relay_control/observability.rs
+++ b/src/relay_control/observability.rs
@@ -229,7 +229,7 @@ impl RelayTelemetry {
         self
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn with_occurred_at(mut self, occurred_at: DateTime<Utc>) -> Self {
         self.occurred_at = occurred_at;
         self
@@ -302,11 +302,6 @@ impl RelayObservability {
         Self { config }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn config(&self) -> &RelayObservabilityConfig {
-        &self.config
-    }
-
     #[perf_instrument("relay")]
     pub(crate) async fn record(
         &self,
@@ -357,37 +352,6 @@ impl RelayObservability {
         RelayStatusRecord::upsert_from_telemetry(telemetry, database).await?;
 
         Ok(())
-    }
-
-    #[allow(dead_code)]
-    #[perf_instrument("relay")]
-    pub(crate) async fn status(
-        &self,
-        database: &Database,
-        relay_url: &RelayUrl,
-        plane: RelayPlane,
-        account_pubkey: Option<PublicKey>,
-    ) -> Result<Option<RelayStatusRecord>, DatabaseError> {
-        RelayStatusRecord::find(relay_url, plane, account_pubkey, database).await
-    }
-
-    #[allow(dead_code)]
-    #[perf_instrument("relay")]
-    pub(crate) async fn recent_events(
-        &self,
-        database: &Database,
-        relay_url: &RelayUrl,
-        plane: RelayPlane,
-        account_pubkey: Option<PublicKey>,
-    ) -> Result<Vec<RelayEventRecord>, DatabaseError> {
-        RelayEventRecord::list_recent_for_scope(
-            relay_url,
-            plane,
-            account_pubkey,
-            self.config.recent_event_limit,
-            database,
-        )
-        .await
     }
 }
 

--- a/src/relay_control/sessions/config.rs
+++ b/src/relay_control/sessions/config.rs
@@ -21,13 +21,6 @@ pub(crate) enum RelaySessionReconnectPolicy {
     Disabled,
 }
 
-/// Session-level relay membership policy.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-pub(crate) enum RelaySessionRelayPolicy {
-    #[default]
-    Dynamic,
-}
-
 /// Shared session configuration reused by all future relay planes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RelaySessionConfig {
@@ -35,7 +28,6 @@ pub(crate) struct RelaySessionConfig {
     pub(crate) telemetry_account_pubkey: Option<PublicKey>,
     pub(crate) auth_policy: RelaySessionAuthPolicy,
     pub(crate) reconnect_policy: RelaySessionReconnectPolicy,
-    pub(crate) relay_policy: RelaySessionRelayPolicy,
     pub(crate) connect_timeout: Duration,
     /// Minimum number of relays that must be connected before proceeding.
     /// When set, `prepare_relay_urls` returns as soon as this threshold is
@@ -52,7 +44,6 @@ impl RelaySessionConfig {
             telemetry_account_pubkey: None,
             auth_policy: RelaySessionAuthPolicy::Disabled,
             reconnect_policy: RelaySessionReconnectPolicy::Disabled,
-            relay_policy: RelaySessionRelayPolicy::Dynamic,
             connect_timeout: Duration::from_secs(5),
             min_connected_relays: None,
         }

--- a/src/relay_control/sessions/config.rs
+++ b/src/relay_control/sessions/config.rs
@@ -10,8 +10,6 @@ pub(crate) enum RelaySessionAuthPolicy {
     #[default]
     Disabled,
     Allowed,
-    #[allow(dead_code)]
-    Required,
 }
 
 /// Session-level reconnect policy.
@@ -28,8 +26,6 @@ pub(crate) enum RelaySessionReconnectPolicy {
 pub(crate) enum RelaySessionRelayPolicy {
     #[default]
     Dynamic,
-    #[allow(dead_code)]
-    ExplicitOnly,
 }
 
 /// Shared session configuration reused by all future relay planes.

--- a/src/relay_control/sessions/mod.rs
+++ b/src/relay_control/sessions/mod.rs
@@ -2,8 +2,5 @@ mod config;
 pub(crate) mod notifications;
 pub(crate) mod session;
 
-pub(crate) use config::{
-    RelaySessionAuthPolicy, RelaySessionConfig, RelaySessionReconnectPolicy,
-    RelaySessionRelayPolicy,
-};
+pub(crate) use config::{RelaySessionAuthPolicy, RelaySessionConfig, RelaySessionReconnectPolicy};
 pub(crate) use session::{QuorumPublishResult, RelaySession};

--- a/src/relay_control/sessions/notifications.rs
+++ b/src/relay_control/sessions/notifications.rs
@@ -20,15 +20,6 @@ pub(crate) enum RelayNotification {
         challenge: String,
         failure_category: Option<RelayFailureCategory>,
     },
-    #[allow(dead_code)]
-    Connected { relay_url: RelayUrl },
-    #[allow(dead_code)]
-    Disconnected {
-        relay_url: RelayUrl,
-        failure_category: Option<RelayFailureCategory>,
-    },
-    #[allow(dead_code)]
-    Shutdown,
 }
 
 impl RelayNotification {

--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -836,7 +836,6 @@ impl RelaySession {
         self.client.shutdown().await;
     }
 
-
     pub(crate) async fn snapshot(&self, known_relays: &[RelayUrl]) -> RelaySessionStateSnapshot {
         let notification_handler_registered = self.notification_handler_registered();
         let router_context_count = self.router.context_count().await;

--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -89,12 +89,9 @@ impl RelaySession {
         session
     }
 
+    #[cfg(test)]
     pub(crate) fn client(&self) -> &Client {
         &self.client
-    }
-
-    pub(crate) fn config(&self) -> &RelaySessionConfig {
-        &self.config
     }
 
     pub(crate) fn telemetry(&self) -> broadcast::Receiver<RelayTelemetry> {
@@ -839,22 +836,6 @@ impl RelaySession {
         self.client.shutdown().await;
     }
 
-    #[perf_instrument("relay")]
-    pub(crate) async fn unsubscribe_all(&self) {
-        let subscription_ids: Vec<SubscriptionId> = self
-            .state
-            .subscription_relays
-            .read()
-            .await
-            .keys()
-            .cloned()
-            .collect();
-
-        for subscription_id in subscription_ids {
-            self.unsubscribe(&subscription_id).await;
-        }
-        self.client.unsubscribe_all().await;
-    }
 
     pub(crate) async fn snapshot(&self, known_relays: &[RelayUrl]) -> RelaySessionStateSnapshot {
         let notification_handler_registered = self.notification_handler_registered();

--- a/src/relay_control/sessions/session.rs
+++ b/src/relay_control/sessions/session.rs
@@ -11,7 +11,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use nostr_sdk::prelude::*;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc::Sender};
 
-use super::{RelaySessionConfig, RelaySessionRelayPolicy, notifications::RelayNotification};
+use super::{RelaySessionConfig, notifications::RelayNotification};
 use crate::{
     nostr_manager::{NostrManagerError, Result},
     perf_instrument, perf_span,
@@ -89,12 +89,10 @@ impl RelaySession {
         session
     }
 
-    #[allow(dead_code)]
     pub(crate) fn client(&self) -> &Client {
         &self.client
     }
 
-    #[allow(dead_code)]
     pub(crate) fn config(&self) -> &RelaySessionConfig {
         &self.config
     }
@@ -293,7 +291,6 @@ impl RelaySession {
         })
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn fetch_events_from(
         &self,
@@ -842,7 +839,6 @@ impl RelaySession {
         self.client.shutdown().await;
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("relay")]
     pub(crate) async fn unsubscribe_all(&self) {
         let subscription_ids: Vec<SubscriptionId> = self
@@ -1248,27 +1244,6 @@ impl RelaySession {
                     telemetry,
                 ));
             }
-            RelayNotification::Connected { relay_url } => {
-                let _ = telemetry_sender.send(Self::apply_telemetry_scope(
-                    telemetry_account_pubkey,
-                    RelayTelemetry::new(RelayTelemetryKind::Connected, plane, relay_url),
-                ));
-            }
-            RelayNotification::Disconnected {
-                relay_url,
-                failure_category,
-            } => {
-                let mut telemetry =
-                    RelayTelemetry::new(RelayTelemetryKind::Disconnected, plane, relay_url);
-                if let Some(failure_category) = failure_category {
-                    telemetry = telemetry.with_failure_category(failure_category);
-                }
-                let _ = telemetry_sender.send(Self::apply_telemetry_scope(
-                    telemetry_account_pubkey,
-                    telemetry,
-                ));
-            }
-            RelayNotification::Shutdown => return Ok(true),
         }
 
         Ok(false)
@@ -1308,18 +1283,10 @@ impl RelaySession {
     async fn ensure_relay_in_client(&self, relay_url: &RelayUrl) -> Result<bool> {
         match self.client.relay(relay_url).await {
             Ok(_) => Ok(false),
-            Err(_) => match self.config.relay_policy {
-                RelaySessionRelayPolicy::Dynamic => {
-                    self.client.add_relay(relay_url.clone()).await?;
-                    Ok(true)
-                }
-                RelaySessionRelayPolicy::ExplicitOnly => {
-                    Err(NostrManagerError::WhitenoiseInstance(format!(
-                        "relay {} is not allowed by explicit-only session policy",
-                        relay_url
-                    )))
-                }
-            },
+            Err(_) => {
+                self.client.add_relay(relay_url.clone()).await?;
+                Ok(true)
+            }
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,19 +58,12 @@ impl Default for RetryInfo {
 /// This enum supports gradual migration from legacy subscription management to
 /// the relay-plane architecture. Events flow through one of two paths:
 ///
-/// - **Legacy path**: Old `NostrManager` subscriptions identify streams by an
-///   opaque string subscription ID. The processor inspects the ID prefix to
-///   determine whether the event is global- or account-scoped.
+/// Event source context attached by relay-plane sessions at receipt time.
 ///
-/// - **Relay-plane path**: New relay-plane sessions attach a typed
-///   [`SubscriptionContext`] at event receipt time, so the processor never
-///   needs to parse subscription IDs.
+/// Relay-plane sessions attach a typed [`SubscriptionContext`] at event receipt
+/// time, so the processor never needs to parse subscription IDs.
 #[derive(Debug, Clone)]
 pub enum EventSource {
-    /// Legacy compatibility: the raw subscription ID from the old NostrManager.
-    /// `None` when the event arrived without a subscription ID.
-    #[allow(dead_code)]
-    LegacySubscriptionId(Option<String>),
     /// Relay-plane path: fully typed routing context attached by the session.
     RelaySubscription(SubscriptionContext),
 }
@@ -90,16 +83,6 @@ pub enum ProcessableEvent {
 }
 
 impl ProcessableEvent {
-    /// Create a new legacy NostrEvent with default retry settings.
-    #[allow(dead_code)]
-    pub fn new_nostr_event(event: Event, subscription_id: Option<String>) -> Self {
-        Self::NostrEvent {
-            event,
-            source: EventSource::LegacySubscriptionId(subscription_id),
-            retry_info: RetryInfo::new(),
-        }
-    }
-
     /// Create a new relay-plane NostrEvent with default retry settings.
     pub fn new_routed_nostr_event(event: Event, source: SubscriptionContext) -> Self {
         Self::NostrEvent {

--- a/src/whitenoise/database/relay_events.rs
+++ b/src/whitenoise/database/relay_events.rs
@@ -99,7 +99,7 @@ impl RelayEventRecord {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) async fn list_recent_for_scope(
         relay_url: &RelayUrl,
         plane: RelayPlane,

--- a/src/whitenoise/database/relay_status.rs
+++ b/src/whitenoise/database/relay_status.rs
@@ -107,7 +107,6 @@ impl RelayStatusRecord {
         }
     }
 
-    #[allow(dead_code)]
     #[perf_instrument("db::relay_status")]
     pub(crate) async fn find(
         relay_url: &RelayUrl,

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -228,20 +228,6 @@ impl Whitenoise {
     #[perf_instrument("event_processor")]
     async fn account_from_event_source(&self, source: &EventSource) -> Result<Account> {
         let target_pubkey = match source {
-            EventSource::LegacySubscriptionId(Some(subscription_id)) => self
-                .extract_pubkey_from_subscription_id(subscription_id)
-                .await
-                .map_err(|_| {
-                    WhitenoiseError::InvalidEvent(format!(
-                        "Cannot extract pubkey from subscription ID: {}",
-                        subscription_id
-                    ))
-                })?,
-            EventSource::LegacySubscriptionId(None) => {
-                return Err(WhitenoiseError::InvalidEvent(
-                    "Cannot resolve account for missing legacy subscription ID".to_string(),
-                ));
-            }
             EventSource::RelaySubscription(context) => {
                 context.account_pubkey.ok_or(WhitenoiseError::InvalidEvent(
                     "Relay subscription context missing account pubkey".to_string(),

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -483,7 +483,6 @@ impl Whitenoise {
     /// advance local state after confirming the relay accepted the event.
     /// If all publish attempts fail, the pending commit is never merged and
     /// the group state remains unchanged.
-    #[allow(dead_code)]
     #[perf_instrument("event_handlers")]
     async fn perform_self_update(
         whitenoise: &Whitenoise,

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -21,7 +21,10 @@ use crate::{
     },
 };
 #[cfg(test)]
-use crate::{relay_control::hash_pubkey_for_subscription_id, types::EventSource};
+use crate::{
+    relay_control::{RelayPlane, SubscriptionContext, SubscriptionStream},
+    types::EventSource,
+};
 
 impl Whitenoise {
     #[perf_instrument("event_handlers")]
@@ -1917,22 +1920,18 @@ mod tests {
         let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
         let event_id = event.id;
 
-        // Build a valid subscription ID for this account.
-        let sub_id = format!(
-            "{}_mls_messages",
-            hash_pubkey_for_subscription_id(
-                whitenoise.relay_control.session_salt(),
-                &creator_account.pubkey
-            )
-        );
+        // Build a relay-plane source context for this account.
+        let source = EventSource::RelaySubscription(SubscriptionContext {
+            plane: RelayPlane::Group,
+            account_pubkey: Some(creator_account.pubkey),
+            relay_url: RelayUrl::parse("wss://relay.example.com").unwrap(),
+            stream: SubscriptionStream::GroupMessages,
+            group_ids: vec![],
+        });
 
         // First pass through process_account_event: succeeds, event is tracked.
         whitenoise
-            .process_account_event(
-                event.clone(),
-                EventSource::LegacySubscriptionId(Some(sub_id.clone())),
-                Default::default(),
-            )
+            .process_account_event(event.clone(), source.clone(), Default::default())
             .await;
 
         let tracked_after_first = whitenoise
@@ -1950,11 +1949,7 @@ mod tests {
         // is not advanced for a duplicate.  This is the intended guard.
         // We verify the skip path by confirming it doesn't panic or double-advance.
         whitenoise
-            .process_account_event(
-                event.clone(),
-                EventSource::LegacySubscriptionId(Some(sub_id.clone())),
-                Default::default(),
-            )
+            .process_account_event(event.clone(), source.clone(), Default::default())
             .await;
 
         // Still tracked — no double-entry, no crash.

--- a/src/whitenoise/event_processor/global_event_processor.rs
+++ b/src/whitenoise/event_processor/global_event_processor.rs
@@ -1,12 +1,11 @@
 use nostr_sdk::prelude::*;
 
+#[cfg(test)]
+use crate::whitenoise::error::WhitenoiseError;
 use crate::{
     perf_instrument,
     types::{EventSource, RetryInfo},
-    whitenoise::{
-        Whitenoise,
-        error::{Result, WhitenoiseError},
-    },
+    whitenoise::{Whitenoise, error::Result},
 };
 
 impl Whitenoise {
@@ -17,21 +16,6 @@ impl Whitenoise {
         source: EventSource,
         retry_info: RetryInfo,
     ) {
-        // Relay-plane events already carry typed source context. The
-        // `global_users_*` prefix check only exists for the legacy shared-client
-        // compatibility path.
-        if let EventSource::LegacySubscriptionId(Some(subscription_id)) = &source
-            && self
-                .validate_batched_subscription_id(subscription_id)
-                .is_err()
-        {
-            tracing::error!(
-                target: "whitenoise::event_processor::process_global_event",
-                "Invalid batched subscription ID: {}", subscription_id
-            );
-            return;
-        }
-
         match self.should_skip_global_event_processing(&event).await {
             Some(skip_reason) => {
                 tracing::debug!(
@@ -135,6 +119,7 @@ impl Whitenoise {
         }
     }
 
+    #[cfg(test)]
     fn validate_batched_subscription_id(&self, subscription_id: &str) -> Result<()> {
         // Simple validation format: global_users_abc123_0
         // we could have a more robust validation here but this is good enough for now

--- a/src/whitenoise/event_processor/mod.rs
+++ b/src/whitenoise/event_processor/mod.rs
@@ -77,40 +77,20 @@ impl Whitenoise {
                                     return;
                                 }
 
-                                match &source {
-                                    EventSource::LegacySubscriptionId(subscription_id) => {
-                                        let Some(sub_id) = subscription_id.clone() else {
-                                            tracing::warn!(
-                                                target: "whitenoise::event_processor::process_events",
-                                                "Event received without subscription ID, skipping"
-                                            );
-                                            return;
-                                        };
-
-                                        if whitenoise.is_event_global(&sub_id) {
-                                            whitenoise
-                                                .process_global_event(event, source, retry_info)
-                                                .await;
-                                        } else {
-                                            whitenoise
-                                                .process_account_event(event, source, retry_info)
-                                                .await;
-                                        }
+                                let EventSource::RelaySubscription(context) = &source;
+                                match context.stream {
+                                    SubscriptionStream::DiscoveryUserData => {
+                                        whitenoise
+                                            .process_global_event(event, source, retry_info)
+                                            .await;
                                     }
-                                    EventSource::RelaySubscription(context) => match context.stream {
-                                        SubscriptionStream::DiscoveryUserData => {
-                                            whitenoise
-                                                .process_global_event(event, source, retry_info)
-                                                .await;
-                                        }
-                                        SubscriptionStream::DiscoveryFollowLists
-                                        | SubscriptionStream::GroupMessages
-                                        | SubscriptionStream::AccountInboxGiftwraps => {
-                                            whitenoise
-                                                .process_account_event(event, source, retry_info)
-                                                .await;
-                                        }
-                                    },
+                                    SubscriptionStream::DiscoveryFollowLists
+                                    | SubscriptionStream::GroupMessages
+                                    | SubscriptionStream::AccountInboxGiftwraps => {
+                                        whitenoise
+                                            .process_account_event(event, source, retry_info)
+                                            .await;
+                                    }
                                 }
                             }
                             ProcessableEvent::RelayMessage(relay_url, message) => {
@@ -155,6 +135,7 @@ impl Whitenoise {
         );
     }
 
+    #[cfg(test)]
     fn is_event_global(&self, subscription_id: &str) -> bool {
         subscription_id.starts_with("global_users_")
     }
@@ -206,6 +187,7 @@ mod tests {
     use nostr_sdk::prelude::*;
 
     use crate::nostr_manager::utils::is_event_timestamp_valid;
+    use crate::relay_control::{RelayPlane, SubscriptionContext, SubscriptionStream};
     use crate::types::{EventSource, RetryInfo};
     use crate::whitenoise::error::WhitenoiseError;
     use crate::whitenoise::test_utils::*;
@@ -294,7 +276,13 @@ mod tests {
         // Should not panic; spawns a delayed re-queue task
         whitenoise.schedule_retry(
             event,
-            EventSource::LegacySubscriptionId(Some("global_users_abc123_0".to_string())),
+            EventSource::RelaySubscription(SubscriptionContext {
+                plane: RelayPlane::Discovery,
+                account_pubkey: None,
+                relay_url: RelayUrl::parse("wss://relay.example.com").unwrap(),
+                stream: SubscriptionStream::DiscoveryUserData,
+                group_ids: vec![],
+            }),
             retry_info,
             error,
         );
@@ -323,7 +311,13 @@ mod tests {
         // Should not spawn any task since retries are exhausted
         whitenoise.schedule_retry(
             event,
-            EventSource::LegacySubscriptionId(Some("global_users_abc123_0".to_string())),
+            EventSource::RelaySubscription(SubscriptionContext {
+                plane: RelayPlane::Discovery,
+                account_pubkey: None,
+                relay_url: RelayUrl::parse("wss://relay.example.com").unwrap(),
+                stream: SubscriptionStream::DiscoveryUserData,
+                group_ids: vec![],
+            }),
             retry_info,
             error,
         );

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -148,7 +148,6 @@ pub struct Whitenoise {
     database: Arc<Database>,
     event_tracker: std::sync::Arc<dyn event_tracker::EventTracker>,
     content_parser: crate::nostr_manager::parser::ContentParser,
-    #[allow(dead_code)]
     relay_control: Arc<RelayControlPlane>,
     secrets_store: SecretsStore,
     storage: storage::Storage,


### PR DESCRIPTION
![marmot](https://blossom.primal.net/02e47ab36d17b0c9de2d1a942c7de4e9f049104109081943bf2d0516b5b6f539.jpg)

Fixes #595

This marmot swept through every burrow in the codebase and cleared out all 29 `#[allow(dead_code)]` annotations across 20 files.

## What changed

Each annotation was triaged into one of three categories:

- **Removed**: Dead code got deleted. This includes `GroupPlaneConfig`, the `router` field on `RelayControlPlane`, `SubscriptionStream::as_str()`, and three unused `RelayNotification` variants (`Connected`, `Disconnected`, `Shutdown`). Two unused enum variants in session config (`Required`, `ExplicitOnly`) were also removed along with their match arms.
- **Gated with `#[cfg(test)]`**: Methods only called from tests (`with_occurred_at`, `list_recent_for_scope`, `is_event_global`, `validate_batched_subscription_id`) now compile only in test builds.
- **Kept as-is**: Methods that are called in production code but the compiler couldn't see through (e.g. trait indirection, async dispatch) had their annotations removed with no other changes.

## Legacy event routing removed

The `LegacySubscriptionId` variant of `EventSource` and its entire code path through the event processor are gone. All event routing now goes through the typed `RelaySubscription(SubscriptionContext)` path. Tests that previously constructed legacy subscription IDs were updated to use `SubscriptionContext` directly.

## Prevention

A new CI job (`dead-code-allows`) runs on every PR and posts a sticky comment if any `#[allow(dead_code)]` annotations appear in `src/`. The same check runs locally via `just precommit-quick` and `just precommit`. A shell script at `scripts/check-dead-code-allows.sh` does the actual grep.

## Stats

- 20 files changed
- ~278 lines removed, ~137 lines added
- Net: -141 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced legacy subscription-ID handling with context-based event routing for clearer, more reliable event processing.
  * Removed several unused structures, methods, and enum variants to simplify internals and reduce maintenance surface.
  * Added CI and local pre-commit checks that detect and report Rust dead-code suppression attributes, enforcing code hygiene and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->