### PR TITLE
Feat/add clear and delete chat methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -622,7 +622,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=93ae32479211d7a241ff379c34d3fe87ac161e7a#93ae32479211d7a241ff379c34d3fe87ac161e7a"
 dependencies = [
  "base64",
  "blurhash",
@@ -2512,12 +2512,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=93ae32479211d7a241ff379c34d3fe87ac161e7a#93ae32479211d7a241ff379c34d3fe87ac161e7a"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=93ae32479211d7a241ff379c34d3fe87ac161e7a#93ae32479211d7a241ff379c34d3fe87ac161e7a"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=93ae32479211d7a241ff379c34d3fe87ac161e7a#93ae32479211d7a241ff379c34d3fe87ac161e7a"
 dependencies = [
  "nostr",
  "openmls",
@@ -2764,7 +2764,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3797,7 +3797,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4174,7 +4174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4457,7 +4457,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5300,7 +5300,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "0.7"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "93ae32479211d7a241ff379c34d3fe87ac161e7a", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "93ae32479211d7a241ff379c34d3fe87ac161e7a" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "93ae32479211d7a241ff379c34d3fe87ac161e7a" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [

--- a/db_migrations/0044_add_chat_cleared_at.sql
+++ b/db_migrations/0044_add_chat_cleared_at.sql
@@ -1,0 +1,3 @@
+-- Add chat_cleared_at column for the "clear chat" feature.
+-- chat_cleared_at: messages at or before this timestamp are hidden from the UI.
+ALTER TABLE accounts_groups ADD COLUMN chat_cleared_at INTEGER DEFAULT NULL;

--- a/justfile
+++ b/justfile
@@ -451,6 +451,10 @@ install-tools:
 build-release:
     cargo build --release
 
+# Install wn and wnd CLI binaries to ~/.cargo/bin
+install-cli:
+    cargo install --path . --features cli
+
 ######################
 # Docker
 ######################

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -619,7 +619,7 @@ async fn messages_subscribe<W>(
     W: AsyncWriteExt + Unpin,
 {
     // Validate account and group_id
-    let _account = match find_account(wn, account_str).await {
+    let account = match find_account(wn, account_str).await {
         Ok(a) => a,
         Err(resp) => {
             let _ = write_response(writer, &resp).await;
@@ -637,7 +637,10 @@ async fn messages_subscribe<W>(
     };
 
     // Subscribe — gets initial snapshot + broadcast receiver
-    let subscription = match wn.subscribe_to_group_messages(&group_id, limit).await {
+    let subscription = match wn
+        .subscribe_to_group_messages(&account.pubkey, &group_id, limit)
+        .await
+    {
         Ok(sub) => sub,
         Err(e) => {
             let _ = write_response(writer, &Response::err(e.to_string())).await;

--- a/src/integration_tests/scenarios/message_streaming.rs
+++ b/src/integration_tests/scenarios/message_streaming.rs
@@ -123,7 +123,7 @@ impl MessageStreamingScenario {
     async fn phase3_verify_initial_snapshot(&mut self) -> Result<(), WhitenoiseError> {
         tracing::info!("=== Phase 3: Verify initial message snapshot ===");
 
-        VerifyInitialMessagesTestCase::new(Self::GROUP_NAME)
+        VerifyInitialMessagesTestCase::new(Self::GROUP_NAME, "stream_creator")
             .expect_messages(vec![
                 "msg_plain",
                 "msg_with_reaction",
@@ -143,9 +143,12 @@ impl MessageStreamingScenario {
 
         // Test 1: NewMessage trigger
         tracing::info!("--- Testing NewMessage update ---");
-        let new_msg_verifier =
-            VerifyStreamUpdateTestCase::new(Self::GROUP_NAME, UpdateTrigger::NewMessage)
-                .expect_message_key("msg_stream_new");
+        let new_msg_verifier = VerifyStreamUpdateTestCase::new(
+            Self::GROUP_NAME,
+            "stream_creator",
+            UpdateTrigger::NewMessage,
+        )
+        .expect_message_key("msg_stream_new");
         new_msg_verifier.subscribe(&self.context).await?;
 
         SendMessageTestCase::basic()
@@ -164,10 +167,13 @@ impl MessageStreamingScenario {
 
         // Test 2: ReactionAdded trigger
         tracing::info!("--- Testing ReactionAdded update ---");
-        let reaction_verifier =
-            VerifyStreamUpdateTestCase::new(Self::GROUP_NAME, UpdateTrigger::ReactionAdded)
-                .expect_message_key("msg_stream_new")
-                .expect_has_reactions(true);
+        let reaction_verifier = VerifyStreamUpdateTestCase::new(
+            Self::GROUP_NAME,
+            "stream_creator",
+            UpdateTrigger::ReactionAdded,
+        )
+        .expect_message_key("msg_stream_new")
+        .expect_has_reactions(true);
         reaction_verifier.subscribe(&self.context).await?;
 
         let msg_stream_new_id = self.context.get_message_id("msg_stream_new")?.clone();
@@ -187,10 +193,13 @@ impl MessageStreamingScenario {
 
         // Test 3: ReactionRemoved trigger
         tracing::info!("--- Testing ReactionRemoved update ---");
-        let reaction_removed_verifier =
-            VerifyStreamUpdateTestCase::new(Self::GROUP_NAME, UpdateTrigger::ReactionRemoved)
-                .expect_message_key("msg_stream_new")
-                .expect_has_reactions(false);
+        let reaction_removed_verifier = VerifyStreamUpdateTestCase::new(
+            Self::GROUP_NAME,
+            "stream_creator",
+            UpdateTrigger::ReactionRemoved,
+        )
+        .expect_message_key("msg_stream_new")
+        .expect_has_reactions(false);
         reaction_removed_verifier.subscribe(&self.context).await?;
 
         DeleteMessageTestCase::new("stream_member", Self::GROUP_NAME, "reaction_stream")
@@ -217,10 +226,13 @@ impl MessageStreamingScenario {
         // Increased delay to handle CI timing variations
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-        let delete_verifier =
-            VerifyStreamUpdateTestCase::new(Self::GROUP_NAME, UpdateTrigger::MessageDeleted)
-                .expect_message_key("msg_to_delete_stream")
-                .expect_deleted();
+        let delete_verifier = VerifyStreamUpdateTestCase::new(
+            Self::GROUP_NAME,
+            "stream_creator",
+            UpdateTrigger::MessageDeleted,
+        )
+        .expect_message_key("msg_to_delete_stream")
+        .expect_deleted();
         delete_verifier.subscribe(&self.context).await?;
 
         DeleteMessageTestCase::new("stream_creator", Self::GROUP_NAME, "msg_to_delete_stream")

--- a/src/integration_tests/test_cases/message_streaming/verify_initial_messages.rs
+++ b/src/integration_tests/test_cases/message_streaming/verify_initial_messages.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 /// contains all expected messages with correct state.
 pub struct VerifyInitialMessagesTestCase {
     group_name: String,
+    account_name: String,
     expected_message_keys: Vec<String>,
     expected_with_reactions: Vec<String>,
     expected_no_reactions: Vec<String>,
@@ -14,9 +15,10 @@ pub struct VerifyInitialMessagesTestCase {
 }
 
 impl VerifyInitialMessagesTestCase {
-    pub fn new(group_name: &str) -> Self {
+    pub fn new(group_name: &str, account_name: &str) -> Self {
         Self {
             group_name: group_name.to_string(),
+            account_name: account_name.to_string(),
             expected_message_keys: vec![],
             expected_with_reactions: vec![],
             expected_no_reactions: vec![],
@@ -53,11 +55,12 @@ impl TestCase for VerifyInitialMessagesTestCase {
             self.group_name
         );
 
+        let account = context.get_account(&self.account_name)?;
         let group = context.get_group(&self.group_name)?;
 
         let subscription = context
             .whitenoise
-            .subscribe_to_group_messages(&group.mls_group_id, None)
+            .subscribe_to_group_messages(&account.pubkey, &group.mls_group_id, None)
             .await?;
 
         tracing::info!(

--- a/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
+++ b/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
@@ -13,13 +13,14 @@ use tokio::sync::{Mutex, broadcast};
 ///
 /// Usage:
 /// ```ignore
-/// let verifier = VerifyStreamUpdateTestCase::new("group", UpdateTrigger::NewMessage);
+/// let verifier = VerifyStreamUpdateTestCase::new("group", "account", UpdateTrigger::NewMessage);
 /// verifier.subscribe(&context).await?;
 /// // ... perform action that triggers the update ...
 /// verifier.execute(&mut context).await?;
 /// ```
 pub struct VerifyStreamUpdateTestCase {
     group_name: String,
+    account_name: String,
     expected_trigger: UpdateTrigger,
     expected_message_key: Option<String>,
     expected_deleted: bool,
@@ -28,9 +29,10 @@ pub struct VerifyStreamUpdateTestCase {
 }
 
 impl VerifyStreamUpdateTestCase {
-    pub fn new(group_name: &str, expected_trigger: UpdateTrigger) -> Self {
+    pub fn new(group_name: &str, account_name: &str, expected_trigger: UpdateTrigger) -> Self {
         Self {
             group_name: group_name.to_string(),
+            account_name: account_name.to_string(),
             expected_trigger,
             expected_message_key: None,
             expected_deleted: false,
@@ -59,10 +61,11 @@ impl VerifyStreamUpdateTestCase {
 
     /// Subscribe to the group. Must be called before `execute()`.
     pub async fn subscribe(&self, context: &ScenarioContext) -> Result<(), WhitenoiseError> {
+        let account = context.get_account(&self.account_name)?;
         let group = context.get_group(&self.group_name)?;
         let subscription = context
             .whitenoise
-            .subscribe_to_group_messages(&group.mls_group_id, None)
+            .subscribe_to_group_messages(&account.pubkey, &group.mls_group_id, None)
             .await?;
 
         let mut guard = self.receiver.lock().await;

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use crate::perf_instrument;
 use crate::whitenoise::{
     Whitenoise, accounts::Account, aggregated_message::AggregatedMessage,
-    chat_list_streaming::ChatListUpdateTrigger, error::WhitenoiseError,
+    chat_list_streaming::ChatListUpdateTrigger, database::Database, drafts::Draft,
+    error::WhitenoiseError,
 };
 
 /// Represents the relationship between an account and an MLS group.
@@ -56,6 +57,10 @@ pub struct AccountGroup {
     /// - `Some(timestamp)` = muted until that time; use `MUTE_FOREVER` for
     ///   "always muted until manually unmuted"
     pub muted_until: Option<DateTime<Utc>>,
+    /// When this account last cleared the chat's messages.
+    /// - `None` = not cleared (all messages visible)
+    /// - `Some(timestamp)` = messages at or before this time are hidden
+    pub chat_cleared_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -187,6 +192,33 @@ impl AccountGroup {
     /// Returns true if this chat is muted forever (until manually unmuted).
     pub fn is_muted_forever(&self) -> bool {
         self.muted_until >= Some(MUTE_FOREVER)
+    }
+
+    /// Returns true if a message with the given timestamp is visible — i.e., it
+    /// was sent strictly after the chat was last cleared. When the chat has never
+    /// been cleared, every message is visible.
+    pub fn is_message_visible(&self, message_created_at: DateTime<Utc>) -> bool {
+        self.chat_cleared_at
+            .is_none_or(|cleared_at| message_created_at > cleared_at)
+    }
+
+    /// Look up the `chat_cleared_at` timestamp for an account/group pair and convert
+    /// it to milliseconds since the Unix epoch, matching the format used by message
+    /// query filters.
+    ///
+    /// Returns `Ok(None)` when the chat has never been cleared.
+    /// Returns `Err(GroupNotFound)` when the account-group row does not exist.
+    pub(crate) async fn chat_cleared_at_ms(
+        pubkey: &PublicKey,
+        group_id: &GroupId,
+        database: &Database,
+    ) -> Result<Option<i64>, WhitenoiseError> {
+        let account_group = Self::find_by_account_and_group(pubkey, group_id, database)
+            .await?
+            .ok_or(WhitenoiseError::GroupNotFound)?;
+        Ok(account_group
+            .chat_cleared_at
+            .map(|dt| dt.timestamp_millis()))
     }
 
     /// Creates or retrieves an AccountGroup for the given account and group.
@@ -682,6 +714,152 @@ impl Whitenoise {
         AccountGroup::find_latest_dm_group_with_peer(self, &account.pubkey, peer_pubkey).await
     }
 
+    /// Clears all messages from this account's view by setting a per-account
+    /// timestamp floor. Messages at or before the current time are hidden.
+    ///
+    /// The group remains in the chat list with no visible messages. This is a
+    /// local-only operation with no protocol-level side effects.
+    ///
+    /// Works correctly in multi-account scenarios: each account's
+    /// `chat_cleared_at` is independent. Messages are only physically deleted
+    /// when all accounts sharing the group have cleared.
+    #[perf_instrument("account_groups")]
+    pub async fn clear_chat(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<(), WhitenoiseError> {
+        let account_group = AccountGroup::get(self, &account.pubkey, group_id)
+            .await?
+            .ok_or(WhitenoiseError::GroupNotFound)?;
+
+        account_group
+            .clear_chat_state(Utc::now(), &self.database)
+            .await?;
+
+        if let Err(e) = Draft::delete(&account.pubkey, group_id, &self.database).await {
+            tracing::warn!(
+                target: "whitenoise::accounts_groups",
+                "Failed to delete draft during clear_chat: {}",
+                e
+            );
+        }
+
+        if let Err(e) = self.database.try_cleanup_cleared_messages(group_id).await {
+            tracing::warn!(
+                target: "whitenoise::accounts_groups",
+                "Failed to cleanup cleared messages: {}",
+                e
+            );
+        }
+
+        match self.create_mdk_for_account(account.pubkey) {
+            Ok(mdk) => {
+                if let Err(e) = mdk.delete_messages_for_group(group_id) {
+                    tracing::warn!(
+                        target: "whitenoise::accounts_groups",
+                        "Failed to delete MDK messages during clear_chat: {}",
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::accounts_groups",
+                    "Failed to create MDK for clear_chat message cleanup: {}",
+                    e
+                );
+            }
+        }
+
+        self.emit_chat_list_update(account, group_id, ChatListUpdateTrigger::ChatCleared)
+            .await;
+
+        Ok(())
+    }
+
+    /// Deletes all local data for a group from this account's perspective.
+    ///
+    /// The chat disappears from the account's chat list entirely. This is a
+    /// local-only operation -- no MLS proposals or Nostr events are published.
+    ///
+    /// If all accounts on this device have deleted the group, all shared data
+    /// (group_information, aggregated_messages, etc.) is also physically removed.
+    ///
+    /// **Warning**: If the account has not left the MLS group first
+    /// (`removed_at.is_none()`), they remain a member in the protocol -- other
+    /// members continue encrypting messages for them, and their key packages
+    /// remain published. The recommended flow is `leave_group` -> `delete_chat`.
+    #[perf_instrument("account_groups")]
+    pub async fn delete_chat(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<(), WhitenoiseError> {
+        // 1. Verify the AccountGroup exists
+        let Some(_account_group) = AccountGroup::get(self, &account.pubkey, group_id).await? else {
+            return Err(WhitenoiseError::GroupNotFound);
+        };
+
+        // 2. Pre-build the ChatListItem while data still exists
+        //    (MDK state and DB data are needed for build_chat_list_item)
+        let chat_list_item = self.build_chat_list_item(account, group_id).await;
+
+        // 3. Delete all DB data in a transaction (fallible — must run before
+        //    non-rollbackable MDK cleanup so a DB failure leaves state intact)
+        self.database
+            .delete_chat_data(&account.pubkey, group_id)
+            .await?;
+
+        // 4. Delete MDK group state for this account (best-effort)
+        match self.create_mdk_for_account(account.pubkey) {
+            Ok(mdk) => {
+                if let Err(e) = mdk.delete_group(group_id) {
+                    tracing::warn!(
+                        target: "whitenoise::accounts_groups",
+                        "Failed to delete MDK group during delete_chat: {}",
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::accounts_groups",
+                    "Failed to create MDK for delete_chat group cleanup: {}",
+                    e
+                );
+            }
+        }
+
+        // 5. Clean up orphaned media files from disk
+        let media_files =
+            crate::whitenoise::media_files::MediaFiles::new(&self.storage, &self.database);
+        if let Err(e) = media_files.cleanup_orphaned_files().await {
+            tracing::warn!(
+                target: "whitenoise::accounts_groups",
+                "Failed to cleanup orphaned media files: {}",
+                e
+            );
+        }
+
+        // 6. Emit ChatDeleted with pre-built item
+        if let Ok(Some(item)) = chat_list_item {
+            let update = crate::whitenoise::chat_list_streaming::ChatListUpdate {
+                trigger: ChatListUpdateTrigger::ChatDeleted,
+                item,
+            };
+            self.chat_list_stream_manager
+                .emit(&account.pubkey, update.clone());
+            self.archived_chat_list_stream_manager
+                .emit(&account.pubkey, update);
+        }
+
+        // 7. Refresh relay subscriptions
+        self.background_refresh_account_group_subscriptions(account);
+
+        Ok(())
+    }
+
     /// Backfills the `dm_peer_pubkey` column for existing DM groups that are
     /// missing it.
     ///
@@ -744,7 +922,7 @@ impl Whitenoise {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::whitenoise::group_information::GroupType;
+    use crate::whitenoise::group_information::{GroupInformation, GroupType};
     use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
 
     #[tokio::test]
@@ -1159,10 +1337,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_message_read_advances_forward() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-        use chrono::Utc;
-
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[100; 32]);
@@ -1225,10 +1399,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_message_read_does_not_regress() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-        use chrono::Utc;
-
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[101; 32]);
@@ -1292,10 +1462,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_message_read_equal_timestamp_is_noop() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-        use chrono::Utc;
-
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[102; 32]);
@@ -1855,6 +2021,8 @@ mod tests {
             self_removed: false,
             // Expired 10 seconds ago
             muted_until: Some(Utc::now() - chrono::Duration::seconds(10)),
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -2026,6 +2194,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -2181,6 +2351,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -2278,5 +2450,372 @@ mod tests {
             removed.self_removed,
             "self_removed must survive mark_as_removed no-op"
         );
+    }
+
+    #[tokio::test]
+    async fn test_clear_chat_nonexistent_group_returns_error() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[140; 32]);
+
+        let result = whitenoise.clear_chat(&account, &group_id).await;
+
+        assert!(matches!(result, Err(WhitenoiseError::GroupNotFound)));
+    }
+
+    #[tokio::test]
+    async fn test_chat_cleared_at_ms_returns_group_not_found_for_missing_row() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[141; 32]);
+
+        // No AccountGroup row exists for this pubkey/group_id
+        let result =
+            AccountGroup::chat_cleared_at_ms(&account.pubkey, &group_id, &whitenoise.database)
+                .await;
+
+        assert!(matches!(result, Err(WhitenoiseError::GroupNotFound)));
+    }
+
+    #[tokio::test]
+    async fn test_clear_chat_sets_timestamp() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[142; 32]);
+
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        let before = Utc::now();
+        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        let after = Utc::now();
+
+        let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let cleared_at = ag.chat_cleared_at.expect("chat_cleared_at must be set");
+        // Allow 1s tolerance for millisecond truncation in the database layer
+        let tolerance = chrono::Duration::seconds(1);
+        assert!(
+            cleared_at >= before - tolerance && cleared_at <= after + tolerance,
+            "chat_cleared_at should be approximately between before and after timestamps"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_chat_resets_last_read_message_id() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[143; 32]);
+
+        // Setup: create group_information (FK constraint) and account_group
+        GroupInformation::find_or_create_by_mls_group_id(
+            &group_id,
+            Some(GroupType::Group),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        // Create a message and mark it as read
+        let msg_id = EventId::from_hex(&format!("{:0>64}", "aab")).unwrap();
+        AggregatedMessage::create_for_test(
+            msg_id,
+            group_id.clone(),
+            account.pubkey,
+            Utc::now(),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let ag = whitenoise
+            .mark_message_read(&account, &msg_id)
+            .await
+            .unwrap();
+        assert_eq!(ag.last_read_message_id, Some(msg_id));
+
+        // Clear the chat
+        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+
+        // Verify last_read_message_id is reset
+        let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            ag.last_read_message_id.is_none(),
+            "last_read_message_id must be None after clear_chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_chat_idempotent() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[144; 32]);
+
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        // First clear
+        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        let ag1 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let first_cleared_at = ag1.chat_cleared_at.unwrap();
+
+        // Second clear should also succeed
+        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        let ag2 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let second_cleared_at = ag2.chat_cleared_at.unwrap();
+
+        assert!(
+            second_cleared_at >= first_cleared_at,
+            "second clear_chat must set a timestamp >= the first"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_nonexistent_group_returns_error() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[150; 32]);
+
+        let result = whitenoise.delete_chat(&account, &group_id).await;
+
+        assert!(matches!(result, Err(WhitenoiseError::GroupNotFound)));
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_removes_account_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[152; 32]);
+
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        whitenoise.delete_chat(&account, &group_id).await.unwrap();
+
+        let ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(
+            ag.is_none(),
+            "account_group row must be gone after delete_chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_hidden_from_visible_groups() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[153; 32]);
+
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        whitenoise.delete_chat(&account, &group_id).await.unwrap();
+
+        let visible = AccountGroup::visible_for_account(&whitenoise, &account.pubkey)
+            .await
+            .unwrap();
+        let group_ids: Vec<_> = visible.iter().map(|ag| ag.mls_group_id.clone()).collect();
+        assert!(
+            !group_ids.contains(&group_id),
+            "deleted group must not appear in visible groups"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_sole_account_removes_shared_data() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[154; 32]);
+
+        // Create group_information (required FK) and account_group
+        GroupInformation::find_or_create_by_mls_group_id(
+            &group_id,
+            Some(GroupType::Group),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        whitenoise.delete_chat(&account, &group_id).await.unwrap();
+
+        // group_information must be deleted by delete_chat_data
+        let gi_result =
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+        assert!(
+            gi_result.is_err(),
+            "group_information must be deleted when sole account deletes"
+        );
+
+        // accounts_groups row must also be physically deleted
+        let ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(
+            ag.is_none(),
+            "account_group row must be deleted when sole account deletes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_multi_account_preserves_shared_data() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account_a = whitenoise.create_identity().await.unwrap();
+        let account_b = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[155; 32]);
+
+        // Create group_information and both account_groups
+        GroupInformation::find_or_create_by_mls_group_id(
+            &group_id,
+            Some(GroupType::Group),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        whitenoise
+            .get_or_create_account_group(&account_a, &group_id, None)
+            .await
+            .unwrap();
+        whitenoise
+            .get_or_create_account_group(&account_b, &group_id, None)
+            .await
+            .unwrap();
+
+        // Account A deletes
+        whitenoise.delete_chat(&account_a, &group_id).await.unwrap();
+
+        // A's account_group row must be gone
+        let ag_a = AccountGroup::find_by_account_and_group(
+            &account_a.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(ag_a.is_none(), "A's row must be deleted");
+
+        // B's account_group must be unchanged
+        let ag_b = AccountGroup::find_by_account_and_group(
+            &account_b.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(ag_b.is_some(), "B's row must still exist");
+
+        // Shared data must still exist
+        let gi = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+        assert!(
+            gi.is_ok(),
+            "group_information must persist while B still has the group"
+        );
+
+        // Account B deletes
+        whitenoise.delete_chat(&account_b, &group_id).await.unwrap();
+
+        // Now everything should be cleaned up
+        let gi_after =
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+        assert!(
+            gi_after.is_err(),
+            "group_information must be deleted after all accounts delete"
+        );
+
+        let ag_a_after = AccountGroup::find_by_account_and_group(
+            &account_a.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(
+            ag_a_after.is_none(),
+            "A's row must be deleted after cleanup"
+        );
+
+        let ag_b_after = AccountGroup::find_by_account_and_group(
+            &account_b.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert!(
+            ag_b_after.is_none(),
+            "B's row must be deleted after cleanup"
+        );
+    }
+
+    #[test]
+    fn test_is_message_visible() {
+        let cleared_at = Utc::now();
+        let before = cleared_at - chrono::Duration::seconds(10);
+        let after = cleared_at + chrono::Duration::seconds(10);
+
+        let mut ag = AccountGroup {
+            id: None,
+            account_pubkey: Keys::generate().public_key(),
+            mls_group_id: GroupId::from_slice(&[0; 32]),
+            user_confirmation: Some(true),
+            welcomer_pubkey: None,
+            last_read_message_id: None,
+            pin_order: None,
+            dm_peer_pubkey: None,
+            archived_at: None,
+            removed_at: None,
+            self_removed: false,
+            muted_until: None,
+            chat_cleared_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        // No cleared-at: all messages visible
+        assert!(ag.is_message_visible(before));
+        assert!(ag.is_message_visible(cleared_at));
+        assert!(ag.is_message_visible(after));
+
+        // With cleared-at: only messages strictly after are visible
+        ag.chat_cleared_at = Some(cleared_at);
+        assert!(!ag.is_message_visible(before));
+        assert!(!ag.is_message_visible(cleared_at));
+        assert!(ag.is_message_visible(after));
     }
 }

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -196,13 +196,19 @@ fn assemble_chat_list_items(
                 }
             };
 
-            let last_message = last_message_map.get(&group.mls_group_id).map(|summary| {
-                let mut msg = summary.clone();
-                msg.author_display_name = resolve_display_name(users_by_pubkey.get(&msg.author));
-                msg
-            });
-
             let account_group = membership_map.get(&group.mls_group_id)?;
+
+            let last_message = last_message_map
+                .get(&group.mls_group_id)
+                .and_then(|summary| {
+                    if !account_group.is_message_visible(summary.created_at) {
+                        return None;
+                    }
+                    let mut msg = summary.clone();
+                    msg.author_display_name =
+                        resolve_display_name(users_by_pubkey.get(&msg.author));
+                    Some(msg)
+                });
             let pending_confirmation = account_group.is_pending();
             let welcomer_pubkey = account_group.welcomer_pubkey;
             let unread_count = *unread_counts.get(&group.mls_group_id).unwrap_or(&0);
@@ -307,7 +313,10 @@ impl Whitenoise {
 
         let group_markers: Vec<_> = membership_map
             .iter()
-            .map(|(gid, ag)| (gid.clone(), ag.last_read_message_id))
+            .map(|(gid, ag)| {
+                let cleared_ms = ag.chat_cleared_at.map(|dt| dt.timestamp_millis());
+                (gid.clone(), ag.last_read_message_id, cleared_ms)
+            })
             .collect();
         let unread_counts =
             AggregatedMessage::count_unread_for_groups(&group_markers, &self.database).await?;
@@ -387,7 +396,11 @@ impl Whitenoise {
         .await?;
         let last_message_summary = last_message_summaries.into_iter().next();
 
-        // 6. Lookup message author metadata and build final last_message
+        // 6. Lookup message author metadata and build final last_message.
+        //    Filter out messages at or before chat_cleared_at so the chat list
+        //    preview does not show a message the user explicitly cleared.
+        let last_message_summary = last_message_summary
+            .filter(|summary| account_group.is_message_visible(summary.created_at));
         let last_message = if let Some(mut summary) = last_message_summary {
             let author_user = User::find_by_pubkey(&summary.author, &self.database)
                 .await
@@ -419,10 +432,14 @@ impl Whitenoise {
         };
 
         // 8. Compute unread count
+        let cleared_ms = account_group
+            .chat_cleared_at
+            .map(|dt| dt.timestamp_millis());
         let unread_count = AggregatedMessage::count_unread_for_group(
             group_id,
             account_group.last_read_message_id.as_ref(),
             &self.database,
+            cleared_ms,
         )
         .await?;
 
@@ -558,8 +575,9 @@ impl Whitenoise {
             Ok(Some(item)) => {
                 let update = ChatListUpdate { trigger, item };
                 match trigger {
-                    ChatListUpdateTrigger::ChatArchiveChanged => {
-                        // Item is moving between lists — notify both channels
+                    ChatListUpdateTrigger::ChatArchiveChanged
+                    | ChatListUpdateTrigger::ChatDeleted => {
+                        // Item is moving between lists or being removed — notify both channels
                         if has_active {
                             self.chat_list_stream_manager.emit(pubkey, update.clone());
                         }

--- a/src/whitenoise/chat_list_streaming/types.rs
+++ b/src/whitenoise/chat_list_streaming/types.rs
@@ -25,6 +25,15 @@ pub enum ChatListUpdateTrigger {
     /// or deletes it. The item's `removed_at` and `self_removed` fields are set.
     /// Routing: same as RemovedFromGroup — active or archived based on archive status.
     LeftGroup,
+    /// All messages were cleared from this chat.
+    /// The group remains in the chat list with no messages.
+    /// Consumers should reset their message list to empty.
+    ChatCleared,
+    /// The chat was permanently deleted by this account.
+    /// Consumers must remove the item from their list.
+    /// Emitted to both active and archived channels since the group
+    /// could be in either state at the time of deletion.
+    ChatDeleted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,6 +71,8 @@ mod tests {
             ChatListUpdateTrigger::RemovedFromGroup,
             ChatListUpdateTrigger::ChatMuteChanged,
             ChatListUpdateTrigger::LeftGroup,
+            ChatListUpdateTrigger::ChatCleared,
+            ChatListUpdateTrigger::ChatDeleted,
         ];
 
         for trigger in triggers {
@@ -94,5 +105,11 @@ mod tests {
 
         let debug_str = format!("{:?}", ChatListUpdateTrigger::LeftGroup);
         assert!(debug_str.contains("LeftGroup"));
+
+        let debug_str = format!("{:?}", ChatListUpdateTrigger::ChatCleared);
+        assert!(debug_str.contains("ChatCleared"));
+
+        let debug_str = format!("{:?}", ChatListUpdateTrigger::ChatDeleted);
+        assert!(debug_str.contains("ChatDeleted"));
     }
 }

--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -24,6 +24,7 @@ struct AccountGroupRow {
     removed_at: Option<DateTime<Utc>>,
     self_removed: bool,
     muted_until: Option<DateTime<Utc>>,
+    chat_cleared_at: Option<DateTime<Utc>>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -78,6 +79,7 @@ where
         let self_removed_int: i64 = row.try_get("self_removed")?;
         let self_removed = self_removed_int != 0;
         let muted_until = parse_optional_timestamp(row, "muted_until")?;
+        let chat_cleared_at = parse_optional_timestamp(row, "chat_cleared_at")?;
 
         // Parse pubkey from hex string
         let account_pubkey =
@@ -123,6 +125,7 @@ where
             removed_at,
             self_removed,
             muted_until,
+            chat_cleared_at,
             created_at,
             updated_at,
         })
@@ -144,6 +147,7 @@ impl From<AccountGroupRow> for AccountGroup {
             removed_at: row.removed_at,
             self_removed: row.self_removed,
             muted_until: row.muted_until,
+            chat_cleared_at: row.chat_cleared_at,
             created_at: row.created_at,
             updated_at: row.updated_at,
         }
@@ -211,7 +215,8 @@ impl AccountGroup {
         let rows = sqlx::query_as::<_, AccountGroupRow>(
             "SELECT *
              FROM accounts_groups
-             WHERE account_pubkey = ? AND (user_confirmation IS NULL OR user_confirmation = 1)",
+             WHERE account_pubkey = ?
+               AND (user_confirmation IS NULL OR user_confirmation = 1)",
         )
         .bind(account_pubkey.to_hex())
         .fetch_all(&database.pool)
@@ -230,7 +235,9 @@ impl AccountGroup {
         let rows = sqlx::query_as::<_, AccountGroupRow>(
             "SELECT *
              FROM accounts_groups
-             WHERE account_pubkey = ? AND user_confirmation IS NULL AND removed_at IS NULL",
+             WHERE account_pubkey = ?
+               AND user_confirmation IS NULL
+               AND removed_at IS NULL",
         )
         .bind(account_pubkey.to_hex())
         .fetch_all(&database.pool)
@@ -399,6 +406,86 @@ impl AccountGroup {
              RETURNING *",
         )
         .bind(muted_until.map(|dt| dt.timestamp_millis()))
+        .bind(now_ms)
+        .bind(id)
+        .fetch_one(&database.pool)
+        .await?;
+
+        Ok(row.into())
+    }
+
+    /// Updates the chat_cleared_at timestamp for this AccountGroup.
+    ///
+    /// - `Some(timestamp)` = messages at or before this time are hidden
+    /// - `None` = not cleared (all messages visible)
+    #[perf_instrument("db::accounts_groups")]
+    pub(crate) async fn update_chat_cleared_at(
+        &self,
+        chat_cleared_at: Option<DateTime<Utc>>,
+        database: &Database,
+    ) -> Result<Self, sqlx::Error> {
+        let id = self.id.expect("AccountGroup must be persisted");
+        let now_ms = Utc::now().timestamp_millis();
+
+        let row = sqlx::query_as::<_, AccountGroupRow>(
+            "UPDATE accounts_groups
+             SET chat_cleared_at = ?, updated_at = ?
+             WHERE id = ?
+             RETURNING *",
+        )
+        .bind(chat_cleared_at.map(|dt| dt.timestamp_millis()))
+        .bind(now_ms)
+        .bind(id)
+        .fetch_one(&database.pool)
+        .await?;
+
+        Ok(row.into())
+    }
+
+    /// Clears the last_read_message_id for this AccountGroup.
+    #[perf_instrument("db::accounts_groups")]
+    pub(crate) async fn reset_last_read_message_id(
+        &self,
+        database: &Database,
+    ) -> Result<Self, sqlx::Error> {
+        let id = self.id.expect("AccountGroup must be persisted");
+        let now_ms = Utc::now().timestamp_millis();
+
+        let row = sqlx::query_as::<_, AccountGroupRow>(
+            "UPDATE accounts_groups
+             SET last_read_message_id = NULL, updated_at = ?
+             WHERE id = ?
+             RETURNING *",
+        )
+        .bind(now_ms)
+        .bind(id)
+        .fetch_one(&database.pool)
+        .await?;
+
+        Ok(row.into())
+    }
+
+    /// Sets `chat_cleared_at` and resets `last_read_message_id` in a single atomic write.
+    ///
+    /// Used by `clear_chat` to ensure both fields are updated together, preventing
+    /// a race with `mark_message_read` that could leave a stale read marker.
+    #[perf_instrument("db::accounts_groups")]
+    pub(crate) async fn clear_chat_state(
+        &self,
+        chat_cleared_at: DateTime<Utc>,
+        database: &Database,
+    ) -> Result<Self, sqlx::Error> {
+        let id = self.id.expect("AccountGroup must be persisted");
+        let now_ms = Utc::now().timestamp_millis();
+        let cleared_ms = chat_cleared_at.timestamp_millis();
+
+        let row = sqlx::query_as::<_, AccountGroupRow>(
+            "UPDATE accounts_groups
+             SET chat_cleared_at = ?, last_read_message_id = NULL, updated_at = ?
+             WHERE id = ?
+             RETURNING *",
+        )
+        .bind(cleared_ms)
         .bind(now_ms)
         .bind(id)
         .fetch_one(&database.pool)
@@ -965,6 +1052,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1000,6 +1089,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1022,6 +1113,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1065,6 +1158,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1716,6 +1811,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1904,6 +2001,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1958,5 +2057,106 @@ mod tests {
         );
         // A declined+removed group stays hidden
         assert!(!removed.is_visible());
+    }
+
+    #[tokio::test]
+    async fn test_update_chat_cleared_at_sets_value() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[90; 32]);
+
+        let (ag, _) =
+            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
+
+        assert!(ag.chat_cleared_at.is_none());
+
+        let now = Utc::now();
+        let updated = ag
+            .update_chat_cleared_at(Some(now), &whitenoise.database)
+            .await
+            .unwrap();
+
+        assert!(updated.chat_cleared_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_update_chat_cleared_at_clears_value() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[91; 32]);
+
+        let (ag, _) =
+            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
+
+        let cleared = ag
+            .update_chat_cleared_at(Some(Utc::now()), &whitenoise.database)
+            .await
+            .unwrap();
+        assert!(cleared.chat_cleared_at.is_some());
+
+        let uncleared = cleared
+            .update_chat_cleared_at(None, &whitenoise.database)
+            .await
+            .unwrap();
+        assert!(uncleared.chat_cleared_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reset_last_read_message_id() {
+        use crate::whitenoise::aggregated_message::AggregatedMessage;
+        use crate::whitenoise::group_information::{GroupInformation, GroupType};
+
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[94; 32]);
+
+        GroupInformation::find_or_create_by_mls_group_id(
+            &group_id,
+            Some(GroupType::Group),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let message_id = EventId::from_hex(&format!("{:0>64}", "ccc")).unwrap();
+        let message_time = Utc::now();
+
+        AggregatedMessage::create_for_test(
+            message_id,
+            group_id.clone(),
+            account.pubkey,
+            message_time,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let (ag, _) =
+            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
+
+        // Set the read marker first
+        let with_marker = ag
+            .update_last_read_if_newer(
+                &message_id,
+                message_time.timestamp_millis(),
+                &whitenoise.database,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(with_marker.last_read_message_id, Some(message_id));
+
+        // Reset
+        let reset = with_marker
+            .reset_last_read_message_id(&whitenoise.database)
+            .await
+            .unwrap();
+        assert!(reset.last_read_message_id.is_none());
     }
 }

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -259,6 +259,7 @@ impl AggregatedMessage {
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_by_group(
         group_id: &GroupId,
+        chat_cleared_at_ms: Option<i64>,
         database: &Database,
     ) -> Result<Vec<ChatMessage>> {
         let rows: Vec<AggregatedMessageRow> = sqlx::query_as(
@@ -267,10 +268,12 @@ impl AggregatedMessage {
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
              WHERE am.kind = 9 AND am.mls_group_id = ?
+               AND am.created_at > COALESCE(?, 0)
                AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              ORDER BY am.created_at",
         )
         .bind(group_id.as_slice())
+        .bind(chat_cleared_at_ms)
         .fetch_all(&database.pool)
         .await?;
 
@@ -307,6 +310,7 @@ impl AggregatedMessage {
         database: &Database,
         options: &PaginationOptions,
         limit: Option<u32>,
+        chat_cleared_at_ms: Option<i64>,
     ) -> Result<Vec<ChatMessage>> {
         // Clamp limit: default 50, max 200.
         let limit_val = i64::from(limit.unwrap_or(50).min(200));
@@ -395,12 +399,14 @@ impl AggregatedMessage {
                      LEFT JOIN message_delivery_status mds
                        ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
                      WHERE am.kind = 9 AND am.mls_group_id = ?
+                       AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at < ? OR (am.created_at = ? AND am.message_id < ?))
                        AND (mds.status IS NULL OR mds.status != '\"Retried\"')
                      ORDER BY am.created_at DESC, am.message_id DESC
                      LIMIT ?",
                 )
                 .bind(group_id.as_slice())
+                .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
                 .bind(cursor_ms)
                 .bind(&cursor_id_str)
@@ -415,12 +421,14 @@ impl AggregatedMessage {
                      LEFT JOIN message_delivery_status mds
                        ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
                      WHERE am.kind = 9 AND am.mls_group_id = ?
+                       AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at > ? OR (am.created_at = ? AND am.message_id > ?))
                        AND (mds.status IS NULL OR mds.status != '\"Retried\"')
                      ORDER BY am.created_at ASC, am.message_id ASC
                      LIMIT ?",
                 )
                 .bind(group_id.as_slice())
+                .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
                 .bind(cursor_ms)
                 .bind(&cursor_id_str)
@@ -466,6 +474,7 @@ impl AggregatedMessage {
         read_marker: Option<&EventId>,
         minimum: u32,
         database: &Database,
+        chat_cleared_at_ms: Option<i64>,
     ) -> Result<Vec<ChatMessage>> {
         let minimum_val = i64::from(minimum.min(200));
 
@@ -501,6 +510,7 @@ impl AggregatedMessage {
                     WHERE message_id = ? AND mls_group_id = ?),
                    0
                  )
+                 AND am.created_at > COALESCE(?, 0)
              )
              SELECT am.*, mds.status AS delivery_status
              FROM aggregated_messages am
@@ -509,6 +519,7 @@ impl AggregatedMessage {
               AND am.mls_group_id = mds.mls_group_id
              WHERE am.kind = 9
                AND am.mls_group_id = ?
+               AND am.created_at > COALESCE(?, 0)
                AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              ORDER BY am.created_at DESC, am.message_id DESC
              LIMIT MAX((SELECT cnt FROM unread_count), ?)",
@@ -516,7 +527,9 @@ impl AggregatedMessage {
         .bind(group_id.as_slice()) // unread CTE: mls_group_id
         .bind(marker_hex.as_deref()) // unread CTE: read marker message_id (NULL = no marker)
         .bind(group_id.as_slice()) // unread CTE: mls_group_id for marker lookup
+        .bind(chat_cleared_at_ms) // unread CTE: chat_cleared_at floor
         .bind(group_id.as_slice()) // outer SELECT: mls_group_id
+        .bind(chat_cleared_at_ms) // outer SELECT: chat_cleared_at floor
         .bind(minimum_val) // MAX(cnt, minimum)
         .fetch_all(&database.pool)
         .await?;
@@ -555,6 +568,7 @@ impl AggregatedMessage {
         query: &str,
         limit: u32,
         database: &Database,
+        chat_cleared_at_ms: Option<i64>,
     ) -> Result<Vec<SearchResult>> {
         let limit_val = i64::from(limit.min(200));
         let like_pattern = super::content_search::query_to_like_pattern(query);
@@ -569,15 +583,17 @@ impl AggregatedMessage {
                  ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
                WHERE am.kind = 9
                  AND am.mls_group_id = ?1
+                 AND am.created_at > COALESCE(?2, 0)
                  AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              )
              SELECT * FROM ranked
              WHERE deletion_event_id IS NULL
-               AND content_normalized LIKE ?2
+               AND content_normalized LIKE ?3
              ORDER BY created_at DESC, message_id DESC
-             LIMIT ?3",
+             LIMIT ?4",
         )
         .bind(group_id.as_slice())
+        .bind(chat_cleared_at_ms)
         .bind(&like_pattern)
         .bind(limit_val)
         .fetch_all(&database.pool)
@@ -1191,6 +1207,7 @@ impl AggregatedMessage {
         group_id: &GroupId,
         read_marker: Option<&EventId>,
         database: &Database,
+        chat_cleared_at_ms: Option<i64>,
     ) -> Result<usize> {
         let count: i64 = match read_marker {
             Some(message_id) => {
@@ -1204,11 +1221,13 @@ impl AggregatedMessage {
                            (SELECT created_at FROM aggregated_messages
                             WHERE message_id = ? AND mls_group_id = ?),
                            0
-                       )",
+                       )
+                       AND am.created_at > COALESCE(?, 0)",
                 )
                 .bind(group_id.as_slice())
                 .bind(message_id.to_hex())
                 .bind(group_id.as_slice())
+                .bind(chat_cleared_at_ms)
                 .fetch_one(&database.pool)
                 .await?
             }
@@ -1216,9 +1235,13 @@ impl AggregatedMessage {
                 // No read marker = all messages are unread
                 sqlx::query_scalar(
                     "SELECT COUNT(*) FROM aggregated_messages
-                     WHERE mls_group_id = ? AND kind = 9 AND deletion_event_id IS NULL",
+                     WHERE mls_group_id = ?
+                       AND kind = 9
+                       AND deletion_event_id IS NULL
+                       AND created_at > COALESCE(?, 0)",
                 )
                 .bind(group_id.as_slice())
+                .bind(chat_cleared_at_ms)
                 .fetch_one(&database.pool)
                 .await?
             }
@@ -1229,11 +1252,13 @@ impl AggregatedMessage {
 
     /// Count unread messages for multiple groups in a single batch query.
     ///
-    /// Takes a slice of (group_id, optional_read_marker) pairs and returns a map
-    /// of group_id -> unread_count. Groups with no messages return 0.
+    /// Takes a slice of `(group_id, optional_read_marker, optional_chat_cleared_at_ms)`
+    /// tuples and returns a map of group_id -> unread_count. Groups with no messages
+    /// return 0. When `chat_cleared_at_ms` is provided, only messages created after
+    /// that timestamp are considered.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn count_unread_for_groups(
-        group_markers: &[(GroupId, Option<EventId>)],
+        group_markers: &[(GroupId, Option<EventId>, Option<i64>)],
         database: &Database,
     ) -> Result<HashMap<GroupId, usize>> {
         use sqlx::Row;
@@ -1244,10 +1269,16 @@ impl AggregatedMessage {
 
         let groups_with_markers: Vec<_> = group_markers
             .iter()
-            .filter_map(|(gid, marker)| marker.as_ref().map(|m| (gid, m)))
+            .filter_map(|(gid, marker, _)| marker.as_ref().map(|m| (gid, m)))
             .collect();
 
-        let all_group_ids: Vec<Vec<u8>> = group_markers.iter().map(|(g, _)| g.to_vec()).collect();
+        let groups_with_cleared: Vec<_> = group_markers
+            .iter()
+            .filter_map(|(gid, _, cleared)| cleared.map(|c| (gid, c)))
+            .collect();
+
+        let all_group_ids: Vec<Vec<u8>> =
+            group_markers.iter().map(|(g, _, _)| g.to_vec()).collect();
 
         let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> =
             sqlx::QueryBuilder::new("WITH marker_input AS (");
@@ -1268,6 +1299,23 @@ impl AggregatedMessage {
             }
         }
 
+        // Build cleared_input CTE for chat_cleared_at timestamps
+        qb.push("), cleared_input AS (");
+        if groups_with_cleared.is_empty() {
+            qb.push("SELECT NULL AS group_id, NULL AS cleared_at WHERE 0");
+        } else {
+            for (i, (group_id, cleared_at)) in groups_with_cleared.iter().enumerate() {
+                if i > 0 {
+                    qb.push(" UNION ALL ");
+                }
+                qb.push("SELECT ");
+                qb.push_bind(group_id.as_slice());
+                qb.push(" AS group_id, ");
+                qb.push_bind(*cleared_at);
+                qb.push(" AS cleared_at");
+            }
+        }
+
         qb.push(
             "), marker_timestamps AS ( \
                  SELECT mi.group_id, am.created_at \
@@ -1279,6 +1327,7 @@ impl AggregatedMessage {
              SELECT am.mls_group_id, COUNT(*) as count \
              FROM aggregated_messages am \
              LEFT JOIN marker_timestamps mt ON am.mls_group_id = mt.group_id \
+             LEFT JOIN cleared_input ct ON am.mls_group_id = ct.group_id \
              WHERE am.mls_group_id IN (",
         );
 
@@ -1290,6 +1339,7 @@ impl AggregatedMessage {
             ") AND am.kind = 9 \
              AND am.deletion_event_id IS NULL \
              AND am.created_at > COALESCE(mt.created_at, 0) \
+             AND am.created_at > COALESCE(ct.cleared_at, 0) \
              GROUP BY am.mls_group_id",
         );
 
@@ -1305,7 +1355,7 @@ impl AggregatedMessage {
         }
 
         // Ensure all input groups are represented (groups with no messages get 0)
-        for (group_id, _) in group_markers {
+        for (group_id, _, _) in group_markers {
             results.entry(group_id.clone()).or_insert(0);
         }
 
@@ -1604,9 +1654,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert!(messages.is_empty());
     }
 
@@ -1631,9 +1682,10 @@ mod tests {
         assert_eq!(count, 1);
 
         // Verify we can retrieve it
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, message.id);
         assert_eq!(messages[0].content, message.content);
@@ -1664,9 +1716,10 @@ mod tests {
         assert_eq!(count, 3);
 
         // Verify we can retrieve all messages
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 3);
 
         // Verify event IDs
@@ -1717,9 +1770,10 @@ mod tests {
         assert_eq!(count_after, 1);
 
         // But the message should have deletion_event_id set
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_deleted);
     }
@@ -1766,9 +1820,10 @@ mod tests {
         assert_eq!(count_after, 0);
 
         // No messages should be found
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert!(messages.is_empty());
 
         // No event IDs should be found
@@ -1854,9 +1909,10 @@ mod tests {
         .unwrap();
 
         // Verify reactions were updated
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].reactions.by_emoji.len(), 1);
         assert!(messages[0].reactions.by_emoji.contains_key("👍"));
@@ -2085,7 +2141,7 @@ mod tests {
         }
 
         let count =
-            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database)
+            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database, None)
                 .await
                 .unwrap();
 
@@ -2115,6 +2171,7 @@ mod tests {
             &group_id,
             Some(&read_marker_id),
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -2149,7 +2206,7 @@ mod tests {
         .unwrap();
 
         let count =
-            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database)
+            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database, None)
                 .await
                 .unwrap();
 
@@ -2200,9 +2257,9 @@ mod tests {
         // Group 3: no messages
 
         let input = vec![
-            (group1.clone(), None),
-            (group2.clone(), None),
-            (group3.clone(), None),
+            (group1.clone(), None, None),
+            (group2.clone(), None, None),
+            (group3.clone(), None, None),
         ];
 
         let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
@@ -2253,8 +2310,8 @@ mod tests {
         let marker2 = EventId::from_hex(&group2_messages[2].id).unwrap();
 
         let input = vec![
-            (group1.clone(), Some(marker1)),
-            (group2.clone(), Some(marker2)),
+            (group1.clone(), Some(marker1), None),
+            (group2.clone(), Some(marker2), None),
         ];
 
         let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
@@ -2301,9 +2358,9 @@ mod tests {
         }
 
         let input = vec![
-            (group_with_marker.clone(), Some(marker)),
-            (group_without_marker.clone(), None),
-            (group_empty.clone(), None),
+            (group_with_marker.clone(), Some(marker), None),
+            (group_without_marker.clone(), None, None),
+            (group_empty.clone(), None, None),
         ];
 
         let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
@@ -2425,9 +2482,10 @@ mod tests {
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 2);
 
         let statuses: Vec<_> = messages.iter().map(|m| &m.delivery_status).collect();
@@ -2490,9 +2548,10 @@ mod tests {
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
 
         // Only normal and failed messages should appear, not retried
         assert_eq!(messages.len(), 2);
@@ -2530,7 +2589,7 @@ mod tests {
         .await
         .unwrap();
 
-        let input = vec![(group_id.clone(), None)];
+        let input = vec![(group_id.clone(), None, None)];
         let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
             .await
             .unwrap();
@@ -2646,9 +2705,10 @@ mod tests {
             .unwrap();
 
         // Both should have is_deleted=true
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert!(
             messages.iter().all(|m| m.is_deleted),
             "All messages should be marked as deleted"
@@ -2659,9 +2719,10 @@ mod tests {
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 2, "Both messages should still be present");
         assert!(
             messages.iter().all(|m| !m.is_deleted),
@@ -2700,9 +2761,10 @@ mod tests {
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
+                .await
+                .unwrap();
         let not_deleted: Vec<_> = messages.iter().filter(|m| !m.is_deleted).collect();
         assert_eq!(not_deleted.len(), 1, "Only msg1 should be un-deleted");
         assert_eq!(not_deleted[0].id, msg1.id);
@@ -2819,6 +2881,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2851,6 +2914,7 @@ mod tests {
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
+            None,
             None,
         )
         .await
@@ -2913,6 +2977,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2951,6 +3016,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -2995,6 +3061,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(u32::MAX),
+            None,
         )
         .await
         .unwrap();
@@ -3029,6 +3096,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(5),
+            None,
         )
         .await
         .unwrap();
@@ -3046,6 +3114,7 @@ mod tests {
                 ..Default::default()
             },
             Some(5),
+            None,
         )
         .await
         .unwrap();
@@ -3073,6 +3142,7 @@ mod tests {
                 ..Default::default()
             },
             Some(5),
+            None,
         )
         .await
         .unwrap();
@@ -3110,6 +3180,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3127,6 +3198,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3144,6 +3216,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3165,6 +3238,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3213,6 +3287,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -3231,6 +3306,7 @@ mod tests {
                 ),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3257,6 +3333,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -3274,6 +3351,7 @@ mod tests {
                 before_message_id: Some("00000000000000000000000000000001".to_string()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3318,6 +3396,7 @@ mod tests {
                 after_message_id: Some(cursor_id.clone()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3365,6 +3444,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3410,6 +3490,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3426,6 +3507,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3442,6 +3524,7 @@ mod tests {
                 ..Default::default()
             },
             Some(3),
+            None,
         )
         .await
         .unwrap();
@@ -3490,6 +3573,7 @@ mod tests {
                 after_message_id: Some(id.to_string()),
             },
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -3514,6 +3598,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -3532,6 +3617,7 @@ mod tests {
                 ),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3573,6 +3659,7 @@ mod tests {
                 after_message_id: Some(cursor_id.clone()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3625,6 +3712,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3632,6 +3720,7 @@ mod tests {
             &group_b,
             &whitenoise.database,
             &PaginationOptions::default(),
+            None,
             None,
         )
         .await
@@ -3683,6 +3772,7 @@ mod tests {
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
+            None,
             None,
         )
         .await
@@ -3743,6 +3833,7 @@ mod tests {
             None,
             3,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -3806,6 +3897,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3861,6 +3953,7 @@ mod tests {
                 ..Default::default()
             },
             None,
+            None,
         )
         .await
         .expect("uppercase cursor ID should be accepted and canonicalized");
@@ -3893,6 +3986,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3912,6 +4006,7 @@ mod tests {
                 before_message_id: Some(page1[0].id.clone()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -3949,6 +4044,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3967,6 +4063,7 @@ mod tests {
                 before_message_id: Some(page1[0].id.clone()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -4018,6 +4115,7 @@ mod tests {
                 &whitenoise.database,
                 &opts,
                 Some(1),
+                None,
             )
             .await
             .unwrap();
@@ -4077,6 +4175,7 @@ mod tests {
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4092,6 +4191,7 @@ mod tests {
                 before_message_id: Some(oldest.id.clone()),
                 ..Default::default()
             },
+            None,
             None,
         )
         .await
@@ -4141,6 +4241,7 @@ mod tests {
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
+            None,
             None,
         )
         .await
@@ -4214,6 +4315,7 @@ mod tests {
             "hello",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4228,6 +4330,7 @@ mod tests {
             "big plans",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4240,10 +4343,15 @@ mod tests {
         assert_eq!(results[0].position, 3);
 
         // Substring matching ("big" matches "bigger")
-        let results =
-            AggregatedMessage::search_messages_in_group(&group_id, "big", 50, &whitenoise.database)
-                .await
-                .unwrap();
+        let results = AggregatedMessage::search_messages_in_group(
+            &group_id,
+            "big",
+            50,
+            &whitenoise.database,
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(results.len(), 1);
 
         // Case insensitive
@@ -4252,6 +4360,7 @@ mod tests {
             "MARMOT",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4264,6 +4373,7 @@ mod tests {
             "日本語",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4276,6 +4386,7 @@ mod tests {
             "привет",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4287,6 +4398,7 @@ mod tests {
             "नमस्ते",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4299,25 +4411,36 @@ mod tests {
             "nonexistent",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
         assert!(results.is_empty());
 
         // Empty query matches all — positions are sequential newest-first
-        let results =
-            AggregatedMessage::search_messages_in_group(&group_id, "", 50, &whitenoise.database)
-                .await
-                .unwrap();
+        let results = AggregatedMessage::search_messages_in_group(
+            &group_id,
+            "",
+            50,
+            &whitenoise.database,
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(results.len(), 6);
         let positions: Vec<u64> = results.iter().map(|r| r.position).collect();
         assert_eq!(positions, vec![0, 1, 2, 3, 4, 5]);
 
         // Limit is respected
-        let results =
-            AggregatedMessage::search_messages_in_group(&group_id, "", 2, &whitenoise.database)
-                .await
-                .unwrap();
+        let results = AggregatedMessage::search_messages_in_group(
+            &group_id,
+            "",
+            2,
+            &whitenoise.database,
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -4368,6 +4491,7 @@ mod tests {
             "same-ts",
             50,
             &whitenoise.database,
+            None,
         )
         .await
         .unwrap();
@@ -4425,6 +4549,7 @@ mod tests {
                 removed_at: None,
                 self_removed: false,
                 muted_until: None,
+                chat_cleared_at: None,
                 created_at: now,
                 updated_at: now,
             };
@@ -4531,5 +4656,176 @@ mod tests {
                 .await
                 .unwrap();
         assert!(no_match.is_empty(), "no match should return empty");
+    }
+
+    // ── chat_cleared_at_ms filtering ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_find_messages_respects_chat_cleared_at() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[240; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let base_ts: u64 = 1_700_000_000;
+
+        // Insert 5 messages at known timestamps (seconds)
+        for i in 1u8..=5 {
+            insert_message_at(
+                i,
+                author,
+                base_ts + u64::from(i),
+                &group_id,
+                &whitenoise.database,
+            )
+            .await;
+        }
+
+        // cleared_at = message 3's timestamp in millis → messages 4, 5 survive
+        let cleared_at_ms = (base_ts + 3) as i64 * 1000;
+
+        // find_messages_by_group
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            Some(cleared_at_ms),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(messages.len(), 2, "only messages after cleared_at");
+        assert_eq!(messages[0].content, "message 4");
+        assert_eq!(messages[1].content, "message 5");
+
+        // find_messages_by_group_paginated
+        let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &group_id,
+            &whitenoise.database,
+            &PaginationOptions::default(),
+            None,
+            Some(cleared_at_ms),
+        )
+        .await
+        .unwrap();
+        assert_eq!(messages.len(), 2);
+
+        // find_messages_with_unread_minimum
+        let messages = AggregatedMessage::find_messages_with_unread_minimum(
+            &group_id,
+            None,
+            50,
+            &whitenoise.database,
+            Some(cleared_at_ms),
+        )
+        .await
+        .unwrap();
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_unread_respects_chat_cleared_at() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[241; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let base_ts: u64 = 1_700_000_000;
+
+        let mut messages = Vec::new();
+        for i in 1u8..=5 {
+            let msg = insert_message_at(
+                i,
+                author,
+                base_ts + u64::from(i),
+                &group_id,
+                &whitenoise.database,
+            )
+            .await;
+            messages.push(msg);
+        }
+
+        // cleared_at = message 2's timestamp → messages 3, 4, 5 are visible
+        let cleared_at_ms = (base_ts + 2) as i64 * 1000;
+
+        // count_unread_for_group with no read marker: 3 visible messages
+        let count = AggregatedMessage::count_unread_for_group(
+            &group_id,
+            None,
+            &whitenoise.database,
+            Some(cleared_at_ms),
+        )
+        .await
+        .unwrap();
+        assert_eq!(count, 3);
+
+        // count_unread_for_group with read marker at msg 3: messages 4, 5 unread
+        let marker = EventId::from_hex(&messages[2].id).unwrap();
+        let count = AggregatedMessage::count_unread_for_group(
+            &group_id,
+            Some(&marker),
+            &whitenoise.database,
+            Some(cleared_at_ms),
+        )
+        .await
+        .unwrap();
+        assert_eq!(count, 2);
+
+        // count_unread_for_groups batch API
+        let input = vec![(group_id.clone(), None, Some(cleared_at_ms))];
+        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(result[&group_id], 3);
+    }
+
+    #[tokio::test]
+    async fn test_search_respects_chat_cleared_at() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[242; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let base_ts: u64 = 1_700_000_000;
+
+        // Insert messages with searchable content at known timestamps
+        let contents = ["alpha hello", "bravo hello", "charlie hello", "delta hello"];
+        for (i, content) in contents.iter().enumerate() {
+            let msg = ChatMessage {
+                id: format!("{:0>64}", format!("{:x}", (i + 1) as u8)),
+                author,
+                content: content.to_string(),
+                created_at: Timestamp::from(base_ts + (i as u64) + 1),
+                tags: Tags::new(),
+                is_reply: false,
+                reply_to_id: None,
+                is_deleted: false,
+                content_tokens: vec![],
+                reactions: ReactionSummary::default(),
+                kind: 9,
+                media_attachments: vec![],
+                delivery_status: None,
+            };
+            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        }
+
+        // cleared_at = message 2's timestamp → messages 3, 4 visible
+        let cleared_at_ms = (base_ts + 2) as i64 * 1000;
+
+        let results = AggregatedMessage::search_messages_in_group(
+            &group_id,
+            "hello",
+            50,
+            &whitenoise.database,
+            Some(cleared_at_ms),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), 2);
+        let found_contents: Vec<&str> =
+            results.iter().map(|r| r.message.content.as_str()).collect();
+        assert!(found_contents.contains(&"charlie hello"));
+        assert!(found_contents.contains(&"delta hello"));
     }
 }

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -482,6 +482,19 @@ impl MediaFile {
         Ok(row.into())
     }
 
+    /// Returns all distinct non-empty file paths referenced by media_files records.
+    #[perf_instrument("db::media_files")]
+    pub(crate) async fn all_referenced_file_paths(
+        database: &Database,
+    ) -> Result<Vec<String>, WhitenoiseError> {
+        let paths: Vec<String> =
+            sqlx::query_scalar("SELECT DISTINCT file_path FROM media_files WHERE file_path != ''")
+                .fetch_all(&database.pool)
+                .await
+                .map_err(DatabaseError::Sqlx)?;
+        Ok(paths)
+    }
+
     /// Check if this media file is an image
     pub fn is_image(&self) -> bool {
         self.mime_type.starts_with("image/")

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -248,6 +248,136 @@ impl Database {
 
         Ok(())
     }
+
+    /// Deletes aggregated messages that all accounts have cleared.
+    ///
+    /// Only deletes messages whose `created_at` is at or before the minimum
+    /// `chat_cleared_at` across all accounts in the group, and only when
+    /// every account has set a `chat_cleared_at` value.
+    ///
+    /// Returns the number of rows deleted.
+    pub(crate) async fn try_cleanup_cleared_messages(
+        &self,
+        mls_group_id: &mdk_core::prelude::GroupId,
+    ) -> Result<u64, DatabaseError> {
+        retry_on_lock(|| self.try_cleanup_cleared_messages_inner(mls_group_id)).await
+    }
+
+    async fn try_cleanup_cleared_messages_inner(
+        &self,
+        mls_group_id: &mdk_core::prelude::GroupId,
+    ) -> Result<u64, DatabaseError> {
+        let result = sqlx::query(
+            "DELETE FROM aggregated_messages
+             WHERE mls_group_id = ?
+               AND created_at <= (
+                 SELECT MIN(chat_cleared_at) FROM accounts_groups
+                 WHERE mls_group_id = ?
+                 HAVING COUNT(*) = COUNT(chat_cleared_at)
+               )",
+        )
+        .bind(mls_group_id.as_slice())
+        .bind(mls_group_id.as_slice())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Delete all data for an account's association with a group.
+    ///
+    /// Removes the per-account row and data (accounts_groups, drafts, push tokens,
+    /// media files). If no other accounts reference this group after the deletion,
+    /// also removes shared data (group_information, which cascades to
+    /// aggregated_messages and drafts).
+    ///
+    /// Returns `true` if shared group data was also deleted (i.e., this was the
+    /// last account).
+    pub(crate) async fn delete_chat_data(
+        &self,
+        account_pubkey: &nostr_sdk::prelude::PublicKey,
+        mls_group_id: &mdk_core::prelude::GroupId,
+    ) -> Result<bool, DatabaseError> {
+        retry_on_lock(|| self.delete_chat_data_inner(account_pubkey, mls_group_id)).await
+    }
+
+    async fn delete_chat_data_inner(
+        &self,
+        account_pubkey: &nostr_sdk::prelude::PublicKey,
+        mls_group_id: &mdk_core::prelude::GroupId,
+    ) -> Result<bool, DatabaseError> {
+        let mut txn = self.pool.begin().await?;
+        let pubkey_hex = account_pubkey.to_hex();
+
+        // 1. Delete per-account data
+        sqlx::query(
+            "DELETE FROM accounts_groups
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pubkey_hex)
+        .bind(mls_group_id.as_slice())
+        .execute(&mut *txn)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM drafts
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pubkey_hex)
+        .bind(mls_group_id.as_slice())
+        .execute(&mut *txn)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM group_push_tokens
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pubkey_hex)
+        .bind(mls_group_id.as_slice())
+        .execute(&mut *txn)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM media_files
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pubkey_hex)
+        .bind(mls_group_id.as_slice())
+        .execute(&mut *txn)
+        .await?;
+
+        // 2. Check if any other accounts still reference this group
+        let (remaining,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM accounts_groups WHERE mls_group_id = ?")
+                .bind(mls_group_id.as_slice())
+                .fetch_one(&mut *txn)
+                .await?;
+
+        let last_account = remaining == 0;
+
+        if last_account {
+            // 3. Delete shared data (group_information cascades to
+            //    aggregated_messages and drafts via FK)
+            sqlx::query("DELETE FROM group_information WHERE mls_group_id = ?")
+                .bind(mls_group_id.as_slice())
+                .execute(&mut *txn)
+                .await?;
+
+            sqlx::query("DELETE FROM group_push_tokens WHERE mls_group_id = ?")
+                .bind(mls_group_id.as_slice())
+                .execute(&mut *txn)
+                .await?;
+
+            sqlx::query("DELETE FROM media_files WHERE mls_group_id = ?")
+                .bind(mls_group_id.as_slice())
+                .execute(&mut *txn)
+                .await?;
+        }
+
+        txn.commit().await?;
+
+        Ok(last_account)
+    }
 }
 
 /// Retry an async database operation on transient SQLite lock errors.
@@ -747,5 +877,314 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// Sets up a group_information row so FK constraints are satisfied.
+    async fn setup_group(db: &Database, group_id: &mdk_core::prelude::GroupId) {
+        let now = chrono::Utc::now().timestamp_millis();
+        sqlx::query(
+            "INSERT INTO group_information (mls_group_id, group_type, created_at, updated_at)
+             VALUES (?, 'group', ?, ?)",
+        )
+        .bind(group_id.as_slice())
+        .bind(now)
+        .bind(now)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    /// Sets up an account (user + account rows) so FK constraints are satisfied.
+    async fn setup_account(db: &Database, pubkey_hex: &str) {
+        sqlx::query("INSERT INTO users (pubkey, metadata) VALUES (?, '{}')")
+            .bind(pubkey_hex)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        let (user_id,): (i64,) = sqlx::query_as("SELECT id FROM users WHERE pubkey = ?")
+            .bind(pubkey_hex)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO accounts (pubkey, user_id, last_synced_at) VALUES (?, ?, NULL)")
+            .bind(pubkey_hex)
+            .bind(user_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+    }
+
+    /// Creates an accounts_groups row.
+    async fn setup_account_group(
+        db: &Database,
+        pubkey_hex: &str,
+        group_id: &mdk_core::prelude::GroupId,
+    ) -> i64 {
+        let now = chrono::Utc::now().timestamp_millis();
+        sqlx::query(
+            "INSERT INTO accounts_groups
+             (account_pubkey, mls_group_id, user_confirmation, created_at, updated_at)
+             VALUES (?, ?, 1, ?, ?)",
+        )
+        .bind(pubkey_hex)
+        .bind(group_id.as_slice())
+        .bind(now)
+        .bind(now)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        let (id,): (i64,) = sqlx::query_as(
+            "SELECT id FROM accounts_groups WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(pubkey_hex)
+        .bind(group_id.as_slice())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Inserts a minimal aggregated_messages row.
+    async fn setup_message(
+        db: &Database,
+        group_id: &mdk_core::prelude::GroupId,
+        message_id_hex: &str,
+        created_at_ms: i64,
+    ) {
+        let author_hex = "aa".repeat(32); // valid 64-char hex pubkey
+        sqlx::query(
+            "INSERT INTO aggregated_messages
+             (message_id, mls_group_id, author, created_at, kind, content, tags,
+              content_tokens, reactions, media_attachments)
+             VALUES (?, ?, ?, ?, 9, '', '[]', '[]', '{}', '[]')",
+        )
+        .bind(message_id_hex)
+        .bind(group_id.as_slice())
+        .bind(&author_hex)
+        .bind(created_at_ms)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    /// Returns the message count for a group.
+    async fn message_count(db: &Database, group_id: &mdk_core::prelude::GroupId) -> i64 {
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM aggregated_messages WHERE mls_group_id = ?")
+                .bind(group_id.as_slice())
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        count
+    }
+
+    #[tokio::test]
+    async fn test_try_cleanup_cleared_messages_deletes_when_all_accounts_cleared() {
+        let (db, _temp) = create_test_db().await;
+        let group_id = mdk_core::prelude::GroupId::from_slice(&[1; 32]);
+        let pk1 = "aa".repeat(32);
+        let pk2 = "bb".repeat(32);
+
+        setup_group(&db, &group_id).await;
+        setup_account(&db, &pk1).await;
+        setup_account(&db, &pk2).await;
+        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
+        let ag2_id = setup_account_group(&db, &pk2, &group_id).await;
+
+        // Insert messages at times 100 and 200
+        setup_message(&db, &group_id, &format!("{:0>64}", "1"), 100).await;
+        setup_message(&db, &group_id, &format!("{:0>64}", "2"), 200).await;
+
+        // Both accounts clear at 150 -- should delete only the message at 100
+        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
+            .bind(150_i64)
+            .bind(ag1_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
+            .bind(150_i64)
+            .bind(ag2_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
+        assert_eq!(deleted, 1, "only the message at t=100 should be deleted");
+        assert_eq!(message_count(&db, &group_id).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_try_cleanup_cleared_messages_respects_min() {
+        let (db, _temp) = create_test_db().await;
+        let group_id = mdk_core::prelude::GroupId::from_slice(&[2; 32]);
+        let pk1 = "cc".repeat(32);
+        let pk2 = "dd".repeat(32);
+
+        setup_group(&db, &group_id).await;
+        setup_account(&db, &pk1).await;
+        setup_account(&db, &pk2).await;
+        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
+        let ag2_id = setup_account_group(&db, &pk2, &group_id).await;
+
+        // Messages at 100, 200, 300
+        setup_message(&db, &group_id, &format!("{:0>64}", "a"), 100).await;
+        setup_message(&db, &group_id, &format!("{:0>64}", "b"), 200).await;
+        setup_message(&db, &group_id, &format!("{:0>64}", "c"), 300).await;
+
+        // Account 1 clears at 250, account 2 clears at 150
+        // MIN = 150, so only message at 100 should be deleted
+        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
+            .bind(250_i64)
+            .bind(ag1_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
+            .bind(150_i64)
+            .bind(ag2_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
+        assert_eq!(deleted, 1);
+        assert_eq!(message_count(&db, &group_id).await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_try_cleanup_cleared_messages_noop_when_not_all_cleared() {
+        let (db, _temp) = create_test_db().await;
+        let group_id = mdk_core::prelude::GroupId::from_slice(&[3; 32]);
+        let pk1 = "ee".repeat(32);
+        let pk2 = "ff".repeat(32);
+
+        setup_group(&db, &group_id).await;
+        setup_account(&db, &pk1).await;
+        setup_account(&db, &pk2).await;
+        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
+        setup_account_group(&db, &pk2, &group_id).await;
+
+        setup_message(&db, &group_id, &format!("{:0>64}", "d"), 100).await;
+
+        // Only account 1 clears -- account 2 still has chat_cleared_at = NULL
+        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
+            .bind(200_i64)
+            .bind(ag1_id)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
+        assert_eq!(
+            deleted, 0,
+            "must not delete when some accounts have not cleared"
+        );
+        assert_eq!(message_count(&db, &group_id).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_data_sole_account() {
+        let (db, _temp) = create_test_db().await;
+        let group_id = mdk_core::prelude::GroupId::from_slice(&[4; 32]);
+        let pk1 = "11".repeat(32);
+
+        setup_group(&db, &group_id).await;
+        setup_account(&db, &pk1).await;
+        setup_account_group(&db, &pk1, &group_id).await;
+        setup_message(&db, &group_id, &format!("{:0>64}", "e"), 100).await;
+
+        let pubkey = nostr_sdk::prelude::PublicKey::parse(&pk1).unwrap();
+        let was_last = db.delete_chat_data(&pubkey, &group_id).await.unwrap();
+        assert!(was_last, "sole account should return true");
+
+        // Verify everything is gone
+        let (gi_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
+                .bind(group_id.as_slice())
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(gi_count, 0);
+
+        let (ag_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM accounts_groups WHERE mls_group_id = ?")
+                .bind(group_id.as_slice())
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(ag_count, 0);
+
+        // Messages cascade from group_information delete
+        assert_eq!(message_count(&db, &group_id).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_chat_data_multi_account() {
+        let (db, _temp) = create_test_db().await;
+        let group_id = mdk_core::prelude::GroupId::from_slice(&[5; 32]);
+        let pk1 = "33".repeat(32);
+        let pk2 = "44".repeat(32);
+
+        setup_group(&db, &group_id).await;
+        setup_account(&db, &pk1).await;
+        setup_account(&db, &pk2).await;
+        setup_account_group(&db, &pk1, &group_id).await;
+        setup_account_group(&db, &pk2, &group_id).await;
+        setup_message(&db, &group_id, &format!("{:0>64}", "f"), 100).await;
+
+        let pubkey1 = nostr_sdk::prelude::PublicKey::parse(&pk1).unwrap();
+        let pubkey2 = nostr_sdk::prelude::PublicKey::parse(&pk2).unwrap();
+
+        // Account 1 deletes -- shared data should remain
+        let was_last = db.delete_chat_data(&pubkey1, &group_id).await.unwrap();
+        assert!(!was_last, "first account should return false");
+
+        // A's row gone
+        let (ag1_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM accounts_groups
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pk1)
+        .bind(group_id.as_slice())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(ag1_count, 0, "A's account_group must be deleted");
+
+        // B's row intact
+        let (ag2_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM accounts_groups
+             WHERE account_pubkey = ? AND mls_group_id = ?",
+        )
+        .bind(&pk2)
+        .bind(group_id.as_slice())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(ag2_count, 1, "B's account_group must still exist");
+
+        // Shared data preserved
+        let (gi_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
+                .bind(group_id.as_slice())
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(gi_count, 1);
+        assert_eq!(message_count(&db, &group_id).await, 1);
+
+        // Account 2 deletes -- everything should be gone
+        let was_last = db.delete_chat_data(&pubkey2, &group_id).await.unwrap();
+        assert!(was_last, "last account should return true");
+
+        let (gi_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
+                .bind(group_id.as_slice())
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(gi_count, 0);
+        assert_eq!(message_count(&db, &group_id).await, 0);
     }
 }

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -494,7 +494,7 @@ mod tests {
             "shared group relay event".to_string(),
         );
         inner.ensure_id();
-        let event = admin_mdk.create_message(&group_id, inner).unwrap();
+        let event = admin_mdk.create_message(&group_id, inner, None).unwrap();
         let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
 
         for account in [&admin_account, &member_account] {

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -180,6 +180,7 @@ impl Whitenoise {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -11,6 +11,7 @@ use crate::{
     whitenoise::{
         Whitenoise,
         accounts::Account,
+        accounts_groups::AccountGroup,
         aggregated_message::AggregatedMessage,
         chat_list_streaming::ChatListUpdateTrigger,
         error::{Result, WhitenoiseError},
@@ -25,6 +26,22 @@ use crate::{
     relay_control::{RelayPlane, SubscriptionContext, SubscriptionStream},
     types::EventSource,
 };
+
+/// Extracts the group ID from a `MessageProcessingResult`, if present.
+///
+/// Every variant except `PreviouslyFailed` carries an `mls_group_id`.
+fn extract_group_id(result: &MessageProcessingResult) -> Option<&GroupId> {
+    match result {
+        MessageProcessingResult::ApplicationMessage(msg) => Some(&msg.mls_group_id),
+        MessageProcessingResult::Commit { mls_group_id }
+        | MessageProcessingResult::PendingProposal { mls_group_id }
+        | MessageProcessingResult::ExternalJoinProposal { mls_group_id }
+        | MessageProcessingResult::Unprocessable { mls_group_id } => Some(mls_group_id),
+        MessageProcessingResult::IgnoredProposal { mls_group_id, .. } => Some(mls_group_id),
+        MessageProcessingResult::Proposal(update_result) => Some(&update_result.mls_group_id),
+        MessageProcessingResult::PreviouslyFailed => None,
+    }
+}
 
 impl Whitenoise {
     #[perf_instrument("event_handlers")]
@@ -69,6 +86,27 @@ impl Whitenoise {
             }
         };
         drop(_mls_proc);
+
+        // Guard: skip outcome handling if no AccountGroup exists for this group.
+        // MDK has already processed the message (updating MLS state), but we
+        // must not write application-level data for a group the user deleted.
+        if let Some(group_id) = extract_group_id(&outcome.result) {
+            let has_account_group =
+                AccountGroup::find_by_account_and_group(&account.pubkey, group_id, &self.database)
+                    .await?
+                    .is_some();
+
+            if !has_account_group {
+                tracing::info!(
+                    target: "whitenoise::event_handlers::handle_mls_message",
+                    group_id = %hex::encode(group_id.as_slice()),
+                    account = %account.pubkey.to_hex(),
+                    "Skipping outcome handling: no AccountGroup exists \
+                     (group may have been deleted)"
+                );
+                return Ok(());
+            }
+        }
 
         if let Some((group_id, inner_event, message)) = Self::extract_message_details(&outcome) {
             self.handle_application_message_outcome(
@@ -805,6 +843,7 @@ mod tests {
         ENCRYPTED_TOKEN_LEN, LeafTokenTag, TokenTag, build_token_list_response_rumor,
         build_token_removal_rumor, build_token_request_rumor,
     };
+    use mdk_core::prelude::UpdateGroupResult;
 
     use super::*;
     use crate::whitenoise::{
@@ -869,7 +908,7 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        let message_event = mdk.create_message(group_id, inner).unwrap();
+        let message_event = mdk.create_message(group_id, inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -892,7 +931,7 @@ mod tests {
             "👍".to_string(),
         );
         reaction_inner.ensure_id();
-        let reaction_event = mdk.create_message(group_id, reaction_inner).unwrap();
+        let reaction_event = mdk.create_message(group_id, reaction_inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -919,7 +958,7 @@ mod tests {
             String::new(),
         );
         deletion_inner.ensure_id();
-        let deletion_event = mdk.create_message(group_id, deletion_inner).unwrap();
+        let deletion_event = mdk.create_message(group_id, deletion_inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, deletion_event)
@@ -967,7 +1006,8 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        mdk.create_message(&group.mls_group_id, inner).unwrap();
+        mdk.create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         let message = mdk
             .get_message(&group.mls_group_id, &message_id)
@@ -1040,7 +1080,9 @@ mod tests {
             "Valid message".to_string(),
         );
         inner.ensure_id();
-        let valid_event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let valid_event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // Corrupt the event by changing its kind (MLS processing should fail)
         let mut bad_event = valid_event;
@@ -1094,7 +1136,9 @@ mod tests {
             "+".to_string(), // Use simple emoji that won't be normalized
         );
         orphaned_reaction.ensure_id();
-        let reaction_event = mdk.create_message(group_id, orphaned_reaction).unwrap();
+        let reaction_event = mdk
+            .create_message(group_id, orphaned_reaction, None)
+            .unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -1124,7 +1168,7 @@ mod tests {
             "Late message".to_string(),
         );
         actual_message.id = Some(future_message_id);
-        let message_event = mdk.create_message(group_id, actual_message).unwrap();
+        let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -1194,7 +1238,7 @@ mod tests {
             "👍".to_string(),
         );
         valid_reaction.ensure_id();
-        let valid_event = mdk.create_message(group_id, valid_reaction).unwrap();
+        let valid_event = mdk.create_message(group_id, valid_reaction, None).unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, valid_event)
@@ -1210,7 +1254,9 @@ mod tests {
             "".to_string(), // Empty content is invalid
         );
         invalid_reaction.ensure_id();
-        let invalid_event = mdk.create_message(group_id, invalid_reaction).unwrap();
+        let invalid_event = mdk
+            .create_message(group_id, invalid_reaction, None)
+            .unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, invalid_event)
@@ -1226,7 +1272,7 @@ mod tests {
             "Target message".to_string(),
         );
         actual_message.id = Some(future_message_id);
-        let message_event = mdk.create_message(group_id, actual_message).unwrap();
+        let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -1373,7 +1419,9 @@ mod tests {
                 format!("Message {}", i),
             );
             inner.ensure_id();
-            let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+            let event = mdk
+                .create_message(&group.mls_group_id, inner, None)
+                .unwrap();
 
             whitenoise
                 .handle_mls_message(&creator_account, event)
@@ -1382,10 +1430,13 @@ mod tests {
         }
 
         // Verify all messages are in cache
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(messages.len(), 3, "All messages should be cached");
         let mut contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
@@ -1427,7 +1478,7 @@ mod tests {
             vec![token_tag.clone()],
         )
         .unwrap();
-        let event = admin_mdk.create_message(&group_id, request).unwrap();
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1452,7 +1503,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1495,7 +1546,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let event = admin_mdk.create_message(&group_id, response).unwrap();
+        let event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1523,7 +1574,7 @@ mod tests {
         );
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1559,7 +1610,7 @@ mod tests {
         .unwrap();
 
         let removal = build_token_removal_rumor(admin_account.pubkey, Timestamp::now());
-        let event = admin_mdk.create_message(&group_id, removal).unwrap();
+        let event = admin_mdk.create_message(&group_id, removal, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1576,7 +1627,7 @@ mod tests {
         assert!(stored.is_empty());
 
         let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
                 .await
                 .unwrap();
         assert!(cached_messages.is_empty());
@@ -1602,7 +1653,7 @@ mod tests {
             build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![token_tag])
                 .unwrap();
         let request_event_id = request.id.expect("447 rumor must have an event id");
-        let event = admin_mdk.create_message(&group_id, request).unwrap();
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1647,7 +1698,7 @@ mod tests {
         )
         .unwrap();
         let request_event_id = request.id.expect("447 rumor must have an event id");
-        let request_event = admin_mdk.create_message(&group_id, request).unwrap();
+        let request_event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, request_event)
@@ -1670,7 +1721,7 @@ mod tests {
             }],
         )
         .unwrap();
-        let response_event = admin_mdk.create_message(&group_id, response).unwrap();
+        let response_event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, response_event)
@@ -1844,7 +1895,9 @@ mod tests {
             "Test message".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // First processing: should succeed
         let first = whitenoise
@@ -1917,7 +1970,9 @@ mod tests {
             "Unprocessable test".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
         let event_id = event.id;
 
         // Build a relay-plane source context for this account.
@@ -2013,11 +2068,126 @@ mod tests {
         );
         inner.ensure_id();
 
-        let message_event = admin_mdk.create_message(&group_id, inner);
+        let message_event = admin_mdk.create_message(&group_id, inner, None);
         assert!(
             message_event.is_ok(),
             "Admin should be able to create messages after auto-committed removal: {:?}",
             message_event.err()
+        );
+    }
+
+    /// Verify `extract_group_id` returns the correct group ID for every variant
+    /// that carries one, and `None` for `PreviouslyFailed`.
+    #[test]
+    fn test_extract_group_id_returns_correct_id_for_each_variant() {
+        let group_id = GroupId::from_slice(&[0xAB; 32]);
+        let pubkey = nostr_sdk::Keys::generate().public_key();
+
+        // ApplicationMessage
+        let mut inner_event = UnsignedEvent::new(
+            pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "test".to_string(),
+        );
+        inner_event.ensure_id();
+        let message = mdk_core::prelude::message_types::Message {
+            id: inner_event.id.unwrap(),
+            pubkey,
+            created_at: Timestamp::now(),
+            processed_at: Timestamp::now(),
+            kind: Kind::Custom(9),
+            tags: Tags::new(),
+            content: "test".to_string(),
+            mls_group_id: group_id.clone(),
+            event: inner_event,
+            wrapper_event_id: EventId::all_zeros(),
+            epoch: None,
+            state: mdk_core::prelude::message_types::MessageState::Processed,
+        };
+        let result = MessageProcessingResult::ApplicationMessage(message);
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "ApplicationMessage should return group_id"
+        );
+
+        // Commit
+        let result = MessageProcessingResult::Commit {
+            mls_group_id: group_id.clone(),
+        };
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "Commit should return group_id"
+        );
+
+        // PendingProposal
+        let result = MessageProcessingResult::PendingProposal {
+            mls_group_id: group_id.clone(),
+        };
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "PendingProposal should return group_id"
+        );
+
+        // IgnoredProposal
+        let result = MessageProcessingResult::IgnoredProposal {
+            mls_group_id: group_id.clone(),
+            reason: "test reason".to_string(),
+        };
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "IgnoredProposal should return group_id"
+        );
+
+        // ExternalJoinProposal
+        let result = MessageProcessingResult::ExternalJoinProposal {
+            mls_group_id: group_id.clone(),
+        };
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "ExternalJoinProposal should return group_id"
+        );
+
+        // Unprocessable
+        let result = MessageProcessingResult::Unprocessable {
+            mls_group_id: group_id.clone(),
+        };
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "Unprocessable should return group_id"
+        );
+
+        // Proposal (auto-committed) - requires constructing UpdateGroupResult with a
+        // signed Event; use a throwaway key to produce a valid one.
+        let keys = nostr_sdk::Keys::generate();
+        let dummy_event = nostr_sdk::EventBuilder::text_note("dummy")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let update_result = UpdateGroupResult {
+            evolution_event: dummy_event,
+            welcome_rumors: None,
+            mls_group_id: group_id.clone(),
+        };
+        let result = MessageProcessingResult::Proposal(update_result);
+        assert_eq!(
+            extract_group_id(&result),
+            Some(&group_id),
+            "Proposal should return group_id"
+        );
+
+        // PreviouslyFailed
+        let result = MessageProcessingResult::PreviouslyFailed;
+        assert_eq!(
+            extract_group_id(&result),
+            None,
+            "PreviouslyFailed should return None"
         );
     }
 }

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -166,11 +166,11 @@ impl Whitenoise {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
 
         let key_package_relay_urls = Relay::urls(key_package_relays);
-        let result = mdk
+        let data = mdk
             .create_key_package_for_event(&account.pubkey, key_package_relay_urls)
             .map_err(|e| WhitenoiseError::Configuration(format!("NostrMls error: {}", e)))?;
 
-        Ok(result)
+        Ok((data.content, data.tags_30443, data.hash_ref))
     }
 
     /// Publishes the MLS key package for the given account to its key package relays.

--- a/src/whitenoise/media_files.rs
+++ b/src/whitenoise/media_files.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use mdk_core::{
@@ -348,6 +349,80 @@ impl<'a> MediaFiles<'a> {
         }
 
         (blurhash, thumbhash)
+    }
+
+    /// Deletes media files from disk that have no database references.
+    ///
+    /// Scans the media cache directory and removes files not referenced by any
+    /// `media_files` row. This reclaims disk space after operations like
+    /// `delete_chat` that remove DB records but leave files on disk.
+    ///
+    /// Files are content-addressed and may be shared across groups -- a file
+    /// is only deleted when zero DB records reference it.
+    ///
+    /// Returns the number of files deleted.
+    #[perf_instrument("media_files")]
+    pub(crate) async fn cleanup_orphaned_files(&self) -> Result<u64> {
+        // 1. Get all distinct file paths referenced in the database
+        let referenced_paths: Vec<String> =
+            MediaFile::all_referenced_file_paths(self.database).await?;
+
+        let referenced: HashSet<PathBuf> =
+            referenced_paths.into_iter().map(PathBuf::from).collect();
+
+        // 2. Scan the cache directory
+        let cache_dir = self.storage.media_files.cache_dir();
+        if !cache_dir.exists() {
+            return Ok(0);
+        }
+
+        let mut entries = tokio::fs::read_dir(cache_dir).await.map_err(|e| {
+            WhitenoiseError::MediaCache(format!("Failed to read cache directory: {}", e))
+        })?;
+
+        // 3. Delete files not referenced by any DB record
+        let mut deleted = 0u64;
+        while let Some(entry) = entries.next_entry().await.map_err(|e| {
+            WhitenoiseError::MediaCache(format!("Failed to read directory entry: {}", e))
+        })? {
+            let path = entry.path();
+
+            // Skip directories (media_cache should be flat, but be defensive)
+            if !path.is_file() {
+                continue;
+            }
+
+            if !referenced.contains(&path) {
+                match tokio::fs::remove_file(&path).await {
+                    Ok(()) => {
+                        tracing::debug!(
+                            target: "whitenoise::media_files",
+                            "Deleted orphaned media file: {}",
+                            path.display()
+                        );
+                        deleted += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "whitenoise::media_files",
+                            "Failed to delete orphaned file {}: {}",
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if deleted > 0 {
+            tracing::info!(
+                target: "whitenoise::media_files",
+                "Cleaned up {} orphaned media file(s)",
+                deleted
+            );
+        }
+
+        Ok(deleted)
     }
 
     /// Stores parsed media references to the database
@@ -703,5 +778,162 @@ mod tests {
         let (blurhash, thumbhash) = MediaFiles::extract_hashes_from_tag(&tag);
         assert!(blurhash.is_none());
         assert!(thumbhash.is_none());
+    }
+
+    /// Helper: creates a user + account row so media_files FK constraints pass
+    async fn create_test_account(db: &Database, pubkey: &PublicKey) {
+        sqlx::query("INSERT INTO users (pubkey, created_at, updated_at) VALUES (?, ?, ?)")
+            .bind(pubkey.to_hex())
+            .bind(chrono::Utc::now().timestamp())
+            .bind(chrono::Utc::now().timestamp())
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let user_id: i64 = sqlx::query_scalar("SELECT id FROM users WHERE pubkey = ?")
+            .bind(pubkey.to_hex())
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO accounts (pubkey, user_id, created_at, updated_at) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(pubkey.to_hex())
+        .bind(user_id)
+        .bind(chrono::Utc::now().timestamp())
+        .bind(chrono::Utc::now().timestamp())
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_orphaned_files_deletes_unreferenced() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new(db_path).await.unwrap();
+        let storage = Storage::new(temp_dir.path()).await.unwrap();
+
+        // Put a file on disk with no DB record
+        storage
+            .media_files
+            .store_file("orphan.jpg", b"orphan data")
+            .await
+            .unwrap();
+
+        let media_files = MediaFiles::new(&storage, &db);
+        let deleted = media_files.cleanup_orphaned_files().await.unwrap();
+
+        assert_eq!(deleted, 1);
+        assert!(
+            storage
+                .media_files
+                .find_file_with_prefix("orphan")
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_orphaned_files_keeps_referenced() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new(db_path).await.unwrap();
+        let storage = Storage::new(temp_dir.path()).await.unwrap();
+
+        let group_id = GroupId::from_slice(&[1u8; 8]);
+        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
+        create_test_account(&db, &pubkey).await;
+
+        let media_files = MediaFiles::new(&storage, &db);
+
+        // Store file and record it in DB
+        let upload = MediaFileUpload {
+            data: b"referenced data",
+            original_file_hash: None,
+            encrypted_file_hash: [3u8; 32],
+            mime_type: "image/jpeg",
+            media_type: "test_media",
+            blossom_url: None,
+            nostr_key: None,
+            file_metadata: None,
+            nonce: None,
+            scheme_version: None,
+        };
+        let record = media_files
+            .store_and_record(&pubkey, &group_id, "referenced.jpg", upload)
+            .await
+            .unwrap();
+
+        let deleted = media_files.cleanup_orphaned_files().await.unwrap();
+
+        assert_eq!(deleted, 0);
+        assert!(record.file_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_orphaned_files_mixed() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new(db_path).await.unwrap();
+        let storage = Storage::new(temp_dir.path()).await.unwrap();
+
+        let group_id = GroupId::from_slice(&[1u8; 8]);
+        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
+        create_test_account(&db, &pubkey).await;
+
+        let media_files = MediaFiles::new(&storage, &db);
+
+        // Store a referenced file (has DB record)
+        let upload = MediaFileUpload {
+            data: b"keep me",
+            original_file_hash: None,
+            encrypted_file_hash: [4u8; 32],
+            mime_type: "image/png",
+            media_type: "test_media",
+            blossom_url: None,
+            nostr_key: None,
+            file_metadata: None,
+            nonce: None,
+            scheme_version: None,
+        };
+        let kept = media_files
+            .store_and_record(&pubkey, &group_id, "keep.png", upload)
+            .await
+            .unwrap();
+
+        // Store an orphan file (no DB record)
+        storage
+            .media_files
+            .store_file("orphan.png", b"delete me")
+            .await
+            .unwrap();
+
+        let deleted = media_files.cleanup_orphaned_files().await.unwrap();
+
+        assert_eq!(deleted, 1);
+        assert!(kept.file_path.exists());
+        assert!(
+            storage
+                .media_files
+                .find_file_with_prefix("orphan")
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_orphaned_files_empty_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new(db_path).await.unwrap();
+        let storage = Storage::new(temp_dir.path()).await.unwrap();
+
+        let media_files = MediaFiles::new(&storage, &db);
+        let deleted = media_files.cleanup_orphaned_files().await.unwrap();
+
+        assert_eq!(deleted, 0);
     }
 }

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -6,6 +6,7 @@ use crate::{
     whitenoise::{
         Whitenoise,
         accounts::Account,
+        accounts_groups::AccountGroup,
         aggregated_message::AggregatedMessage,
         chat_list_streaming::ChatListUpdateTrigger,
         database::{Database, retry_on_lock},
@@ -65,7 +66,7 @@ impl Whitenoise {
         }
 
         let _mls_span = perf_span!("messages::mls_create_message");
-        let message_event = mdk.create_message(group_id, inner_event)?;
+        let message_event = mdk.create_message(group_id, inner_event, None)?;
         let mdk_message =
             mdk.get_message(group_id, &event_id)?
                 .ok_or(WhitenoiseError::MdkCoreError(
@@ -673,11 +674,15 @@ impl Whitenoise {
     ) -> Result<Vec<ChatMessage>> {
         Account::find_by_pubkey(pubkey, &self.database).await?; // Verify account exists (security check)
 
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
+
         AggregatedMessage::find_messages_by_group_paginated(
             group_id,
             &self.database,
             options,
             limit,
+            cleared_at_ms,
         )
         .await
         .map_err(|e| match e {
@@ -716,6 +721,9 @@ impl Whitenoise {
 
         let read_marker = self.get_last_read_message_id(&account, group_id).await?;
 
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
+
         let minimum_val = minimum.unwrap_or(50);
 
         Ok(AggregatedMessage::find_messages_with_unread_minimum(
@@ -723,6 +731,7 @@ impl Whitenoise {
             read_marker.as_ref(),
             minimum_val,
             &self.database,
+            cleared_at_ms,
         )
         .await?)
     }
@@ -766,11 +775,18 @@ impl Whitenoise {
     ) -> Result<Vec<SearchResult>> {
         Account::find_by_pubkey(pubkey, &self.database).await?;
 
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
+
         let limit_val = limit.unwrap_or(50);
-        Ok(
-            AggregatedMessage::search_messages_in_group(group_id, query, limit_val, &self.database)
-                .await?,
+        Ok(AggregatedMessage::search_messages_in_group(
+            group_id,
+            query,
+            limit_val,
+            &self.database,
+            cleared_at_ms,
         )
+        .await?)
     }
 
     /// Search messages across all groups the account belongs to.
@@ -1334,10 +1350,13 @@ mod tests {
         assert!(!needs_sync, "Cache should not need sync after syncing");
 
         // Verify we can fetch the messages from cache
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 3);
         assert!(messages[0].content.contains("Message"));
         assert!(messages[1].content.contains("Message"));
@@ -1402,10 +1421,13 @@ mod tests {
         assert_eq!(cached_count, 3);
 
         // Verify all messages are retrievable
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 3);
 
         let contents: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
@@ -1464,10 +1486,13 @@ mod tests {
         assert_eq!(cached_count, 5);
 
         // Verify messages are correct
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 5);
         let contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
         for i in 1..=5 {
@@ -1864,7 +1889,7 @@ mod tests {
 
         // Subscribe before retry so we can verify live delivery status transition.
         let mut updates = whitenoise
-            .subscribe_to_group_messages(&group.mls_group_id, None)
+            .subscribe_to_group_messages(&creator.pubkey, &group.mls_group_id, None)
             .await
             .unwrap()
             .updates;
@@ -1897,10 +1922,13 @@ mod tests {
 
         // A new message should exist in cache in a non-failure state.
         // The background publish may complete before we read, so accept Sending OR Sent.
-        let all_messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let all_messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // find_messages_by_group excludes Retried, so only the new message should appear
         let new_msg = all_messages
@@ -2153,10 +2181,13 @@ mod tests {
             .unwrap();
 
         // Verify messages were recovered
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 3, "All 3 messages should be recovered");
 
         let contents: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
@@ -2247,10 +2278,13 @@ mod tests {
         whitenoise.sync_message_cache_on_startup().await.unwrap();
 
         // Verify all messages were recovered
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 4, "All 4 messages should be recovered");
 
         let contents: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
@@ -2324,10 +2358,13 @@ mod tests {
         assert!(target.is_deleted, "Message should be marked as deleted");
 
         // Also verify via find_messages_by_group — message should have is_deleted flag
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         let target_msg = messages.iter().find(|m| m.id == target_id).unwrap();
         assert!(
             target_msg.is_deleted,
@@ -2476,10 +2513,13 @@ mod tests {
             .unwrap();
 
         // Verify message is marked as deleted
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         let target_msg = messages.iter().find(|m| m.id == target_id).unwrap();
         assert!(target_msg.is_deleted, "Message should be marked as deleted");
 
@@ -2501,10 +2541,13 @@ mod tests {
         .await;
 
         // Message should no longer be deleted after cascade
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         let target_msg = messages.iter().find(|m| m.id == target_id).unwrap();
         assert!(
             !target_msg.is_deleted,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1525,7 +1525,7 @@ mod tests {
             // Non-existent group ID
             let group_id = GroupId::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
 
-            // Fetching messages for a non-existent group should return empty list (no error)
+            // Fetching messages for a non-existent group should return GroupNotFound
             let result = whitenoise
                 .fetch_aggregated_messages_for_group(
                     &account.pubkey,
@@ -1535,12 +1535,10 @@ mod tests {
                 )
                 .await;
 
-            assert!(result.is_ok(), "Should succeed with empty list");
-            let messages = result.unwrap();
-            assert_eq!(
-                messages.len(),
-                0,
-                "Should return empty list for non-existent group"
+            assert!(
+                matches!(result, Err(error::WhitenoiseError::GroupNotFound)),
+                "Should return GroupNotFound for non-existent group, got: {:?}",
+                result
             );
         }
 
@@ -1558,6 +1556,8 @@ mod tests {
             )
             .await
             .unwrap();
+
+            setup_account_group(&test_pubkey, &group_id, &whitenoise).await;
 
             // Setup: Insert test messages into the cache
             let msg1 = message_aggregator::ChatMessage {
@@ -1608,7 +1608,7 @@ mod tests {
 
             // Test: Subscribe and verify initial messages
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&test_pubkey, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1633,6 +1633,8 @@ mod tests {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let group_id = GroupId::from_slice(&[42; 32]);
             let test_pubkey = nostr_sdk::Keys::generate().public_key();
+            setup_group(&group_id, &whitenoise).await;
+            setup_account_group(&test_pubkey, &group_id, &whitenoise).await;
 
             // First emit an update before subscribing (simulates concurrent update scenario)
             // This tests the merge logic path
@@ -1664,7 +1666,7 @@ mod tests {
             // Subscribe - the drain loop should find the channel empty (no subscriber existed)
             // This test verifies the deduplication logic path compiles and runs
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&test_pubkey, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1724,6 +1726,56 @@ mod tests {
             .unwrap();
         }
 
+        /// Create the minimal user + account + accounts_groups rows for a
+        /// raw pubkey so that `chat_cleared_at_ms` (and similar methods) can
+        /// find the account-group association.
+        async fn setup_account_group(
+            pubkey: &nostr_sdk::PublicKey,
+            group_id: &GroupId,
+            whitenoise: &Whitenoise,
+        ) {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            let hex = pubkey.to_hex();
+            // user row (FK target for accounts)
+            sqlx::query(
+                "INSERT OR IGNORE INTO users (pubkey, created_at, updated_at) \
+                 VALUES (?, ?, ?)",
+            )
+            .bind(&hex)
+            .bind(now_ms)
+            .bind(now_ms)
+            .execute(&whitenoise.database.pool)
+            .await
+            .unwrap();
+            let user_id: i64 = sqlx::query_scalar("SELECT id FROM users WHERE pubkey = ?")
+                .bind(&hex)
+                .fetch_one(&whitenoise.database.pool)
+                .await
+                .unwrap();
+            // account row (FK target for accounts_groups)
+            sqlx::query(
+                "INSERT OR IGNORE INTO accounts \
+                 (pubkey, user_id, account_type, created_at, updated_at) \
+                 VALUES (?, ?, 'local', ?, ?)",
+            )
+            .bind(&hex)
+            .bind(user_id)
+            .bind(now_ms)
+            .bind(now_ms)
+            .execute(&whitenoise.database.pool)
+            .await
+            .unwrap();
+            // accounts_groups row
+            accounts_groups::AccountGroup::find_or_create(
+                pubkey,
+                group_id,
+                None,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
+        }
+
         // ── limit parameter ───────────────────────────────────────────────────
 
         /// `limit=Some(N)` caps the initial snapshot to the N newest messages.
@@ -1733,6 +1785,7 @@ mod tests {
             let group_id = GroupId::from_slice(&[110; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
             let base: u64 = 1_710_000_000;
 
             // Insert 10 messages with distinct timestamps (seeds 1–10)
@@ -1741,7 +1794,7 @@ mod tests {
             }
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(3))
+                .subscribe_to_group_messages(&author, &group_id, Some(3))
                 .await
                 .unwrap();
 
@@ -1769,6 +1822,7 @@ mod tests {
             let group_id = GroupId::from_slice(&[111; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
             let base: u64 = 1_711_000_000;
 
             for i in 1u8..=5 {
@@ -1776,7 +1830,7 @@ mod tests {
             }
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(200))
+                .subscribe_to_group_messages(&author, &group_id, Some(200))
                 .await
                 .unwrap();
 
@@ -1795,6 +1849,7 @@ mod tests {
             let group_id = GroupId::from_slice(&[112; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
             let base: u64 = 1_712_000_000;
 
             // Insert exactly 50 messages
@@ -1803,7 +1858,7 @@ mod tests {
             }
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1822,6 +1877,7 @@ mod tests {
             let group_id = GroupId::from_slice(&[113; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
             let base: u64 = 1_713_000_000;
 
             for i in 1u8..=60 {
@@ -1829,7 +1885,7 @@ mod tests {
             }
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1857,6 +1913,7 @@ mod tests {
             let group_id = GroupId::from_slice(&[114; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
             let base: u64 = 1_714_000_000;
 
             // Insert in reverse order to confirm sorting is not dependent on insertion order
@@ -1865,7 +1922,7 @@ mod tests {
             }
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1905,12 +1962,13 @@ mod tests {
             let group_id = GroupId::from_slice(&[115; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             insert_msg_at(1, author, 1_715_000_001, &group_id, &whitenoise).await;
 
             // No updates are emitted — the drain must exit via the Empty arm immediately
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1937,12 +1995,13 @@ mod tests {
             let group_id = GroupId::from_slice(&[116; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             // Insert a message into the DB — this is the "stale" row
             insert_msg_at(1, author, 1_716_000_001, &group_id, &whitenoise).await;
 
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -1969,9 +2028,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[117; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             let mut subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -2020,12 +2080,13 @@ mod tests {
             let group_id = GroupId::from_slice(&[118; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             insert_msg_at(1, author, 1_718_000_001, &group_id, &whitenoise).await;
             insert_msg_at(2, author, 1_718_000_002, &group_id, &whitenoise).await;
 
             let mut subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -2053,9 +2114,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[119; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             let mut subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(10))
+                .subscribe_to_group_messages(&author, &group_id, Some(10))
                 .await
                 .unwrap();
 
@@ -2105,16 +2167,17 @@ mod tests {
             let group_id = GroupId::from_slice(&[120; 32]);
             setup_group(&group_id, &whitenoise).await;
             let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_id, &whitenoise).await;
 
             insert_msg_at(1, author, 1_720_000_001, &group_id, &whitenoise).await;
 
             // Two independent subscriptions
             let mut sub_a = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
             let mut sub_b = whitenoise
-                .subscribe_to_group_messages(&group_id, None)
+                .subscribe_to_group_messages(&author, &group_id, None)
                 .await
                 .unwrap();
 
@@ -2168,14 +2231,16 @@ mod tests {
             let group_b = GroupId::from_slice(&[122; 32]);
             setup_group(&group_a, &whitenoise).await;
             setup_group(&group_b, &whitenoise).await;
+            let author = nostr_sdk::Keys::generate().public_key();
+            setup_account_group(&author, &group_a, &whitenoise).await;
+            setup_account_group(&author, &group_b, &whitenoise).await;
 
             let mut sub_b = whitenoise
-                .subscribe_to_group_messages(&group_b, None)
+                .subscribe_to_group_messages(&author, &group_b, None)
                 .await
                 .unwrap();
 
             // Emit an update for group A only
-            let author = nostr_sdk::Keys::generate().public_key();
             let msg_a = message_aggregator::ChatMessage {
                 id: format!("{:0>64x}", 91u8),
                 author,
@@ -2249,6 +2314,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[130; 32]);
             setup_group(&group_id, &whitenoise).await;
             let account = create_db_account(&whitenoise).await;
+            whitenoise
+                .get_or_create_account_group(&account, &group_id, None)
+                .await
+                .unwrap();
             let author = nostr_sdk::Keys::generate().public_key();
 
             // History: 10 messages at t+1 … t+10 (oldest → newest)
@@ -2260,7 +2329,7 @@ mod tests {
             // ── Step 1: open chat ─────────────────────────────────────────────
             // Subscribe with limit=5 → snapshot contains the 5 newest (seeds 6–10).
             let mut subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(5))
+                .subscribe_to_group_messages(&account.pubkey, &group_id, Some(5))
                 .await
                 .unwrap();
 
@@ -2443,6 +2512,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[131; 32]);
             setup_group(&group_id, &whitenoise).await;
             let account = create_db_account(&whitenoise).await;
+            whitenoise
+                .get_or_create_account_group(&account, &group_id, None)
+                .await
+                .unwrap();
             let author = nostr_sdk::Keys::generate().public_key();
 
             // Exactly 10 messages, page size 5 — two full pages, then nothing
@@ -2453,7 +2526,7 @@ mod tests {
 
             // Page 1 (initial snapshot): seeds 6–10
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(5))
+                .subscribe_to_group_messages(&account.pubkey, &group_id, Some(5))
                 .await
                 .unwrap();
             assert_eq!(subscription.initial_messages.len(), 5);
@@ -2505,6 +2578,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[132; 32]);
             setup_group(&group_id, &whitenoise).await;
             let account = create_db_account(&whitenoise).await;
+            whitenoise
+                .get_or_create_account_group(&account, &group_id, None)
+                .await
+                .unwrap();
             let author = nostr_sdk::Keys::generate().public_key();
 
             let base: u64 = 1_732_000_000;
@@ -2514,7 +2591,7 @@ mod tests {
 
             // Subscribe (snapshot = seeds 11–15)
             let mut subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(5))
+                .subscribe_to_group_messages(&account.pubkey, &group_id, Some(5))
                 .await
                 .unwrap();
 
@@ -2606,6 +2683,10 @@ mod tests {
             let group_id = GroupId::from_slice(&[133; 32]);
             setup_group(&group_id, &whitenoise).await;
             let account = create_db_account(&whitenoise).await;
+            whitenoise
+                .get_or_create_account_group(&account, &group_id, None)
+                .await
+                .unwrap();
             let author = nostr_sdk::Keys::generate().public_key();
 
             // 8 messages: seeds 1–6 all at the same second (tie), seed 7 earlier, seed 8 later
@@ -2618,7 +2699,7 @@ mod tests {
 
             // Subscribe with limit=3 → snapshot is the 3 newest
             let subscription = whitenoise
-                .subscribe_to_group_messages(&group_id, Some(3))
+                .subscribe_to_group_messages(&account.pubkey, &group_id, Some(3))
                 .await
                 .unwrap();
             assert_eq!(subscription.initial_messages.len(), 3);

--- a/src/whitenoise/notification_streaming/mod.rs
+++ b/src/whitenoise/notification_streaming/mod.rs
@@ -597,6 +597,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -627,6 +629,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -672,6 +676,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -743,6 +749,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -782,6 +790,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -833,6 +843,8 @@ mod tests {
             removed_at: None,
             self_removed: false,
             muted_until: None,
+            chat_cleared_at: None,
+
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -292,7 +292,7 @@ async fn publish_push_group_message_with(
 ) -> Result<()> {
     let mdk = Account::create_mdk(account.pubkey, &config.data_dir, &config.keyring_service_id)?;
     let relay_urls = Whitenoise::ensure_group_relays(&mdk, group_id)?;
-    let event = mdk.create_message(group_id, rumor)?;
+    let event = mdk.create_message(group_id, rumor, None)?;
 
     relay_control
         .publish_event_to(event, &account.pubkey, &relay_urls)

--- a/src/whitenoise/storage/media_files.rs
+++ b/src/whitenoise/storage/media_files.rs
@@ -129,7 +129,6 @@ impl MediaFileStorage {
     }
 
     /// Returns the cache directory path
-    #[cfg(test)]
     pub(crate) fn cache_dir(&self) -> &Path {
         &self.cache_dir
     }

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast;
 use crate::perf_instrument;
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
+use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::database::aggregated_messages::PaginationOptions;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::users::User;
@@ -40,6 +41,7 @@ impl Whitenoise {
     #[perf_instrument("whitenoise")]
     pub async fn subscribe_to_group_messages(
         &self,
+        account_pubkey: &nostr_sdk::PublicKey,
         group_id: &mdk_core::prelude::GroupId,
         limit: Option<u32>,
     ) -> Result<message_streaming::GroupMessageSubscription> {
@@ -48,12 +50,16 @@ impl Whitenoise {
 
         // 2. Fetch the most-recent `limit` messages using the paginated query so the initial
         //    snapshot honours the same page size the Flutter side will use for further loads.
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(account_pubkey, group_id, &self.database).await?;
+
         let fetched_messages =
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(
                 group_id,
                 &self.database,
                 &PaginationOptions::default(),
                 limit,
+                cleared_at_ms,
             )
             .await
             .map_err(|e| {
@@ -79,6 +85,13 @@ impl Whitenoise {
         loop {
             match updates.try_recv() {
                 Ok(update) => {
+                    // Skip messages at or before the clear timestamp
+                    if let Some(cleared) = cleared_at_ms {
+                        let msg_ms = update.message.created_at.as_secs() as i64 * 1000;
+                        if msg_ms <= cleared {
+                            continue;
+                        }
+                    }
                     if update.trigger == message_streaming::UpdateTrigger::NewMessage
                         || messages_map.contains_key(&update.message.id)
                     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clear Chat and Delete Chat actions with streaming notifications for cleared/deleted chats
  * Account-aware message subscriptions (subscriptions respect per-account visibility)

* **Improvements**
  * Messages hidden at-or-before per-account cleared timestamps across lists, searches, and unread counts
  * Automatic cleanup of orphaned media files and background cleanup of cleared messages
  * Chat-cleared and Chat-deleted streaming updates; more accurate unread-count semantics

* **Chores**
  * Pinned MDK dependencies
  * Added workspace CLI install helper

* **Tests**
  * Expanded tests and fixtures for cleared/delete behavior, subscriptions, unread counts, search, and media cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->