### PR TITLE
feat: add cross-group message search

### DIFF
--- a/src/cli/commands/messages.rs
+++ b/src/cli/commands/messages.rs
@@ -87,6 +87,16 @@ pub enum MessagesCmd {
         limit: Option<u32>,
     },
 
+    /// Search messages across all groups
+    SearchAll {
+        /// Search query (forward-order substring matching)
+        query: String,
+
+        /// Maximum number of results (default: 50, max: 200)
+        #[arg(long)]
+        limit: Option<u32>,
+    },
+
     /// Subscribe to live messages in a group
     Subscribe {
         /// MLS group ID (hex)
@@ -160,6 +170,9 @@ impl MessagesCmd {
                 query,
                 limit,
             } => search(socket, json, account_flag, group_id, query, limit).await,
+            Self::SearchAll { query, limit } => {
+                search_all(socket, json, account_flag, query, limit).await
+            }
             Self::Subscribe { group_id, limit } => {
                 subscribe(socket, json, account_flag, group_id, limit).await
             }
@@ -226,6 +239,26 @@ async fn search(
         &Request::SearchMessages {
             account: pubkey,
             group_id,
+            query,
+            limit,
+        },
+    )
+    .await?;
+    output::print_and_exit(&resp, json)
+}
+
+async fn search_all(
+    socket: &Path,
+    json: bool,
+    account_flag: Option<&str>,
+    query: String,
+    limit: Option<u32>,
+) -> anyhow::Result<()> {
+    let pubkey = account::resolve_account(socket, account_flag).await?;
+    let resp = client::send(
+        socket,
+        &Request::SearchAllMessages {
+            account: pubkey,
             query,
             limit,
         },

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -435,6 +435,15 @@ pub async fn dispatch(req: Request) -> Response {
             Err(resp) => resp,
         },
 
+        Request::SearchAllMessages {
+            account,
+            query,
+            limit,
+        } => match search_all_messages(wn, &account, &query, limit).await {
+            Ok(resp) => resp,
+            Err(resp) => resp,
+        },
+
         Request::SendMessage {
             account,
             group_id,
@@ -1708,6 +1717,38 @@ async fn search_messages(
         .iter()
         .filter_map(|r| {
             let mut msg = format_chat_message(&r.message, &display_names)?;
+            msg["highlight_spans"] = serde_json::to_value(&r.highlight_spans)
+                .unwrap_or(serde_json::Value::Array(vec![]));
+            msg["position"] = serde_json::Value::Number(r.position.into());
+            Some(msg)
+        })
+        .collect();
+
+    Ok(to_response(&clean))
+}
+
+#[perf_instrument("dispatch")]
+async fn search_all_messages(
+    wn: &Whitenoise,
+    account_str: &str,
+    query: &str,
+    limit: Option<u32>,
+) -> Result<Response, Response> {
+    let account = find_account(wn, account_str).await?;
+    let results = wn
+        .search_messages(&account.pubkey, query, limit)
+        .await
+        .map_err(|e| Response::err(e.to_string()))?;
+
+    let messages: Vec<crate::whitenoise::message_aggregator::ChatMessage> =
+        results.iter().map(|r| r.message.clone()).collect();
+    let display_names = resolve_chat_display_names(wn, &messages).await;
+
+    let clean: Vec<serde_json::Value> = results
+        .iter()
+        .filter_map(|r| {
+            let mut msg = format_chat_message(&r.message, &display_names)?;
+            msg["mls_group_id"] = serde_json::Value::String(hex::encode(r.mls_group_id.as_slice()));
             msg["highlight_spans"] = serde_json::to_value(&r.highlight_spans)
                 .unwrap_or(serde_json::Value::Array(vec![]));
             msg["position"] = serde_json::Value::Number(r.position.into());

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1713,6 +1713,10 @@ async fn search_messages(
         results.iter().map(|r| r.message.clone()).collect();
     let display_names = resolve_chat_display_names(wn, &messages).await;
 
+    // Note: mls_group_id is intentionally omitted from the per-group response.
+    // The caller already knows the group (they passed group_id in the request).
+    // The cross-group search_all_messages handler includes it because the caller
+    // needs to know which group each result belongs to.
     let clean: Vec<serde_json::Value> = results
         .iter()
         .filter_map(|r| {

--- a/src/cli/protocol.rs
+++ b/src/cli/protocol.rs
@@ -243,6 +243,14 @@ pub enum Request {
         limit: Option<u32>,
     },
 
+    #[serde(rename = "search_all_messages")]
+    SearchAllMessages {
+        account: String,
+        query: String,
+        #[serde(default)]
+        limit: Option<u32>,
+    },
+
     // Media
     #[serde(rename = "upload_media")]
     UploadMedia {
@@ -1482,6 +1490,51 @@ mod tests {
         assert!(matches!(
             parsed_wire,
             Request::SearchMessages { limit, .. }
+            if limit.is_none()
+        ));
+    }
+
+    #[test]
+    fn search_all_messages_roundtrip_with_limit() {
+        let req = Request::SearchAllMessages {
+            account: "npub1abc".to_string(),
+            query: "hello world".to_string(),
+            limit: Some(25),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""method":"search_all_messages""#));
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            Request::SearchAllMessages { account, query, limit }
+            if account == "npub1abc"
+                && query == "hello world"
+                && limit == Some(25)
+        ));
+    }
+
+    #[test]
+    fn search_all_messages_roundtrip_limit_omitted() {
+        let req = Request::SearchAllMessages {
+            account: "npub1abc".to_string(),
+            query: "marmot".to_string(),
+            limit: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            Request::SearchAllMessages { limit, .. }
+            if limit.is_none()
+        ));
+
+        // Wire format with field omitted
+        let wire =
+            r#"{"method":"search_all_messages","params":{"account":"npub1abc","query":"marmot"}}"#;
+        let parsed_wire: Request = serde_json::from_str(wire).unwrap();
+        assert!(matches!(
+            parsed_wire,
+            Request::SearchAllMessages { limit, .. }
             if limit.is_none()
         ));
     }

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -595,11 +595,86 @@ impl AggregatedMessage {
                         message_id: row.message_id.to_string(),
                     }
                 })?;
+                let mls_group_id = row.mls_group_id.clone();
                 let message = Self::row_to_chat_message(row)?;
                 let highlight_spans =
                     super::content_search::find_highlight_spans(&message.content, query);
                 Ok(SearchResult {
                     message,
+                    mls_group_id,
+                    highlight_spans,
+                    position,
+                })
+            })
+            .collect()
+    }
+
+    /// Search messages across **all** groups belonging to an account.
+    ///
+    /// Behaves identically to [`search_messages_in_group`](Self::search_messages_in_group)
+    /// except that it removes the single-group filter and scopes results to groups
+    /// the account is a member of (via `accounts_groups`). Each result carries its
+    /// `mls_group_id` so Flutter can group them by conversation.
+    ///
+    /// `position` is computed per-group via `PARTITION BY mls_group_id` so the
+    /// frontend can still jump to the correct page within each conversation.
+    pub async fn search_messages(
+        pubkey: &PublicKey,
+        query: &str,
+        limit: u32,
+        database: &Database,
+    ) -> Result<Vec<SearchResult>> {
+        let limit_val = i64::from(limit.min(200));
+        let like_pattern = super::content_search::query_to_like_pattern(query);
+
+        let rows: Vec<AggregatedMessageRow> = sqlx::query_as(
+            "WITH ranked AS (
+               SELECT am.*,
+                      mds.status AS delivery_status,
+                      (ROW_NUMBER() OVER (
+                         PARTITION BY am.mls_group_id
+                         ORDER BY am.created_at DESC, am.message_id DESC
+                      )) - 1 AS position
+               FROM aggregated_messages am
+               JOIN accounts_groups ag
+                 ON ag.mls_group_id = am.mls_group_id
+               LEFT JOIN message_delivery_status mds
+                 ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+               WHERE am.kind = 9
+                 AND ag.account_pubkey = ?1
+                 AND (mds.status IS NULL OR mds.status != '\"Retried\"')
+             )
+             SELECT * FROM ranked
+             WHERE deletion_event_id IS NULL
+               AND content_normalized LIKE ?2
+             ORDER BY created_at DESC, message_id DESC
+             LIMIT ?3",
+        )
+        .bind(pubkey.to_hex())
+        .bind(&like_pattern)
+        .bind(limit_val)
+        .fetch_all(&database.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let position_i64 =
+                    row.position
+                        .ok_or_else(|| DatabaseError::MissingSearchPosition {
+                            message_id: row.message_id.to_string(),
+                        })?;
+                let position = u64::try_from(position_i64).map_err(|_| {
+                    DatabaseError::MissingSearchPosition {
+                        message_id: row.message_id.to_string(),
+                    }
+                })?;
+                let mls_group_id = row.mls_group_id.clone();
+                let message = Self::row_to_chat_message(row)?;
+                let highlight_spans =
+                    super::content_search::find_highlight_spans(&message.content, query);
+                Ok(SearchResult {
+                    message,
+                    mls_group_id,
                     highlight_spans,
                     position,
                 })

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -583,41 +583,34 @@ impl AggregatedMessage {
         .fetch_all(&database.pool)
         .await?;
 
-        rows.into_iter()
-            .map(|row| {
-                let position_i64 =
-                    row.position
-                        .ok_or_else(|| DatabaseError::MissingSearchPosition {
-                            message_id: row.message_id.to_string(),
-                        })?;
-                let position = u64::try_from(position_i64).map_err(|_| {
-                    DatabaseError::MissingSearchPosition {
-                        message_id: row.message_id.to_string(),
-                    }
-                })?;
-                let mls_group_id = row.mls_group_id.clone();
-                let message = Self::row_to_chat_message(row)?;
-                let highlight_spans =
-                    super::content_search::find_highlight_spans(&message.content, query);
-                Ok(SearchResult {
-                    message,
-                    mls_group_id,
-                    highlight_spans,
-                    position,
-                })
-            })
-            .collect()
+        Self::rows_to_search_results(rows, query)
     }
 
-    /// Search messages across **all** groups belonging to an account.
+    /// Search messages across **all visible** groups belonging to an account.
     ///
     /// Behaves identically to [`search_messages_in_group`](Self::search_messages_in_group)
     /// except that it removes the single-group filter and scopes results to groups
-    /// the account is a member of (via `accounts_groups`). Each result carries its
-    /// `mls_group_id` so Flutter can group them by conversation.
+    /// the account is a member of (via `accounts_groups`). Declined groups
+    /// (`user_confirmation = 0`) are excluded to match the visibility semantics
+    /// of `find_visible_for_account`. Each result carries its `mls_group_id` so
+    /// Flutter can group them by conversation.
+    ///
+    /// # Position semantics
     ///
     /// `position` is computed per-group via `PARTITION BY mls_group_id` so the
     /// frontend can still jump to the correct page within each conversation.
+    /// The window intentionally includes deleted tombstones so that positions
+    /// match the pagination ordering used by `find_messages_by_group_paginated`;
+    /// the `deletion_event_id IS NULL` filter is applied in the outer SELECT
+    /// instead. Do not push deletion filtering into the CTE or positions will
+    /// silently drift from pagination offsets.
+    ///
+    /// # Performance
+    ///
+    /// Unlike the single-group variant, the window evaluation here is
+    /// O(sum of all group sizes) rather than O(single_group_size). The covering
+    /// index from migration 0043 still drives each per-partition scan, but users
+    /// with many large groups will pay proportionally more.
     pub async fn search_messages(
         pubkey: &PublicKey,
         query: &str,
@@ -642,6 +635,7 @@ impl AggregatedMessage {
                  ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
                WHERE am.kind = 9
                  AND ag.account_pubkey = ?1
+                 AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)
                  AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              )
              SELECT * FROM ranked
@@ -656,6 +650,19 @@ impl AggregatedMessage {
         .fetch_all(&database.pool)
         .await?;
 
+        Self::rows_to_search_results(rows, query)
+    }
+
+    /// Convert search query rows into [`SearchResult`]s with highlight spans
+    /// and validated positions.
+    ///
+    /// Shared by both [`search_messages_in_group`](Self::search_messages_in_group)
+    /// and [`search_messages`](Self::search_messages) to avoid drift between the
+    /// two row-mapping paths.
+    fn rows_to_search_results(
+        rows: Vec<AggregatedMessageRow>,
+        query: &str,
+    ) -> Result<Vec<SearchResult>> {
         rows.into_iter()
             .map(|row| {
                 let position_i64 =
@@ -4376,5 +4383,153 @@ mod tests {
         assert_eq!(results[0].position, 0);
         assert_eq!(results[1].position, 1);
         assert_eq!(results[2].position, 2);
+    }
+
+    /// Test cross-group search: finds messages across multiple groups,
+    /// returns per-group positions, and excludes declined groups.
+    #[tokio::test]
+    async fn test_search_messages_cross_group() {
+        use crate::whitenoise::accounts_groups::AccountGroup;
+        use chrono::Utc;
+
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let pubkey = account.pubkey;
+
+        // Set up three groups with messages
+        let group_a = GroupId::from_slice(&[10; 32]);
+        let group_b = GroupId::from_slice(&[11; 32]);
+        let group_declined = GroupId::from_slice(&[12; 32]);
+
+        for gid in [&group_a, &group_b, &group_declined] {
+            setup_group(gid, &whitenoise.database).await;
+        }
+
+        // Link account to groups: A = accepted, B = pending (null), C = declined
+        let now = Utc::now();
+        for (gid, confirmation) in [
+            (&group_a, Some(true)),
+            (&group_b, None),
+            (&group_declined, Some(false)),
+        ] {
+            let ag = AccountGroup {
+                id: None,
+                account_pubkey: pubkey,
+                mls_group_id: gid.clone(),
+                user_confirmation: confirmation,
+                welcomer_pubkey: None,
+                last_read_message_id: None,
+                pin_order: None,
+                dm_peer_pubkey: None,
+                archived_at: None,
+                removed_at: None,
+                self_removed: false,
+                muted_until: None,
+                created_at: now,
+                updated_at: now,
+            };
+            ag.save(&whitenoise.database).await.unwrap();
+        }
+
+        let author = Keys::generate().public_key();
+
+        // Insert messages: "marmot" in all three groups
+        let msg_a = create_test_chat_message_with_content(1, author, "marmot in group A");
+        AggregatedMessage::insert_message(&msg_a, &group_a, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let msg_b = create_test_chat_message_with_content(2, author, "marmot in group B");
+        AggregatedMessage::insert_message(&msg_b, &group_b, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let msg_declined =
+            create_test_chat_message_with_content(3, author, "marmot in declined group");
+        AggregatedMessage::insert_message(&msg_declined, &group_declined, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Also add a second message in group A to verify per-group positions
+        let msg_a2 = create_test_chat_message_with_content(4, author, "another marmot in group A");
+        AggregatedMessage::insert_message(&msg_a2, &group_a, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Cross-group search for "marmot"
+        let results =
+            AggregatedMessage::search_messages(&pubkey, "marmot", 50, &whitenoise.database)
+                .await
+                .unwrap();
+
+        // Should find 3 results (groups A and B), NOT the declined group
+        assert_eq!(
+            results.len(),
+            3,
+            "declined group messages must be excluded from cross-group search"
+        );
+
+        // Verify no result comes from the declined group
+        for r in &results {
+            assert_ne!(
+                r.mls_group_id, group_declined,
+                "declined group must not appear in results"
+            );
+        }
+
+        // Verify mls_group_id is populated correctly on each result
+        let group_ids: Vec<&GroupId> = results.iter().map(|r| &r.mls_group_id).collect();
+        assert!(group_ids.contains(&&group_a));
+        assert!(group_ids.contains(&&group_b));
+
+        // Verify per-group positions: group A has 2 messages, newest (seed 4) = position 0
+        let group_a_results: Vec<_> = results
+            .iter()
+            .filter(|r| r.mls_group_id == group_a)
+            .collect();
+        assert_eq!(group_a_results.len(), 2);
+        // Newest message (seed 4, ts 1_700_000_004) should have position 0
+        let newest = group_a_results
+            .iter()
+            .find(|r| r.message.content == "another marmot in group A")
+            .expect("should find second group A message");
+        assert_eq!(newest.position, 0);
+        // Older message (seed 1, ts 1_700_000_001) should have position 1
+        let older = group_a_results
+            .iter()
+            .find(|r| r.message.content == "marmot in group A")
+            .expect("should find first group A message");
+        assert_eq!(older.position, 1);
+
+        // Group B has 1 message, position 0
+        let group_b_result = results
+            .iter()
+            .find(|r| r.mls_group_id == group_b)
+            .expect("should find group B result");
+        assert_eq!(group_b_result.position, 0);
+
+        // Empty query returns all non-declined messages
+        let all_results = AggregatedMessage::search_messages(&pubkey, "", 50, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(
+            all_results.len(),
+            3,
+            "empty query should match all visible messages"
+        );
+
+        // Limit is respected
+        let limited =
+            AggregatedMessage::search_messages(&pubkey, "marmot", 1, &whitenoise.database)
+                .await
+                .unwrap();
+        assert_eq!(limited.len(), 1, "limit should cap results");
+
+        // No match returns empty
+        let no_match =
+            AggregatedMessage::search_messages(&pubkey, "nonexistent", 50, &whitenoise.database)
+                .await
+                .unwrap();
+        assert!(no_match.is_empty(), "no match should return empty");
     }
 }

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -82,11 +82,15 @@ pub struct SearchResult {
     /// The matched message, identical to what regular list queries return.
     pub message: ChatMessage,
 
+    /// The MLS group this message belongs to.
+    /// Allows callers (e.g. Flutter) to group cross-group search results by conversation.
+    pub mls_group_id: GroupId,
+
     /// Char-index spans `[start, end]` (half-open) for each matched query token,
     /// in the order they appear in `message.content`.
     pub highlight_spans: Vec<[usize; 2]>,
 
-    /// 0-based position of the message within the group (0 = newest),
+    /// 0-based position of the message within its group (0 = newest),
     /// matching the `created_at DESC, message_id DESC` ordering used by pagination.
     /// The frontend can compute `page = position / page_size` to jump to this message.
     pub position: u64,

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -773,6 +773,23 @@ impl Whitenoise {
         )
     }
 
+    /// Search messages across all groups the account belongs to.
+    ///
+    /// Like [`search_messages_in_group`](Self::search_messages_in_group) but without
+    /// a group filter. Each result includes `mls_group_id` so callers can group
+    /// results by conversation.
+    pub async fn search_messages(
+        &self,
+        pubkey: &PublicKey,
+        query: &str,
+        limit: Option<u32>,
+    ) -> Result<Vec<SearchResult>> {
+        Account::find_by_pubkey(pubkey, &self.database).await?;
+
+        let limit_val = limit.unwrap_or(50);
+        Ok(AggregatedMessage::search_messages(pubkey, query, limit_val, &self.database).await?)
+    }
+
     /// Creates an unsigned nostr event with the given parameters
     fn create_unsigned_nostr_event(
         &self,


### PR DESCRIPTION
![marmot](https://blossom.primal.net/2ffbdcfde87d9b21d0a77ed8ba4bb19cbba46883fa047de536f1485770f9f950.jpg)

Add `search_messages(pubkey, query, limit)` for cross-group message search.

The existing `search_messages_in_group` requires a group ID. This new function drops that filter and searches across all groups the account belongs to, scoped via an `accounts_groups` JOIN.

**What changed:**

- `SearchResult` now carries `mls_group_id` so Flutter can group results by conversation
- `position` uses `PARTITION BY mls_group_id` to stay correct within each group (the frontend can still compute jump-to-message offsets)
- New `search_all_messages` CLI protocol variant, dispatch handler, and `wn messages search-all` subcommand
- Round-trip serde tests for the new wire format

**SQL approach:** mirrors `search_messages_in_group` but replaces `am.mls_group_id = ?1` with `JOIN accounts_groups ag ON ag.mls_group_id = am.mls_group_id WHERE ag.account_pubkey = ?1`. The covering index from migration 0043 still applies to the per-group window scan.

This is needed for https://github.com/marmot-protocol/whitenoise/issues/350 (https://github.com/marmot-protocol/whitenoise/pull/557)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global message search across all conversations, with each result showing its conversation ID and in-conversation position.
  * CLI: new "search all" command with an optional --limit to control results returned.

* **Tests**
  * Added unit and serialization tests covering cross-group search behavior, limits, and wire-format round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->