### PR TITLE
Re-export mdk-core types via whitenoise::mdk module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod relay_control;
 // Crate-private because the macro expands to `crate::perf_span!(...)` which
 // only resolves inside this crate.
 pub(crate) use whitenoise_macros::perf_instrument;
+pub mod mdk;
 mod types;
 pub mod whitenoise;
 

--- a/src/mdk.rs
+++ b/src/mdk.rs
@@ -1,0 +1,14 @@
+//! Re-exports of [`mdk_core`] types used by the whitenoise public API.
+//!
+//! Consumers should depend only on `whitenoise` and access MLS protocol types
+//! through this module, avoiding a direct `mdk-core` dependency and the
+//! version-drift risk that comes with it.
+
+// The fundamental group identifier used throughout the crate's public types.
+pub use mdk_core::prelude::GroupId;
+
+// MLS group model and state enum (fields of `GroupWithMembership`, etc.).
+pub use mdk_core::prelude::group_types::{Group, GroupState};
+
+// Configuration types required to create and update MLS groups.
+pub use mdk_core::prelude::{NostrGroupConfigData, NostrGroupDataUpdate};


### PR DESCRIPTION
![marmot](https://blossom.primal.net/92acdf99d1e2de597a1e4531d31316cd6553cda94a9f5f2f19cea206ed3d5528.jpg)

Adds a `whitenoise::mdk` module that re-exports the five `mdk-core` types the Flutter bridge layer uses: `GroupId`, `Group`, `GroupState`, `NostrGroupConfigData`, and `NostrGroupDataUpdate`.

The Flutter app currently depends on both `whitenoise` and `mdk-core` directly. When the two crates pin different revisions, the compiler sees them as distinct types, and builds break. This re-export module lets the Flutter app drop its direct `mdk-core` dependency and import everything through `whitenoise::mdk`, keeping versions locked to a single source of truth.

## What changed

- **`src/mdk.rs`** (new): Re-export module with the five types.
- **`src/lib.rs`**: Added `pub mod mdk;`.

## What the Flutter app does next (separate PR)

1. Remove `mdk-core` from `rust/Cargo.toml`.
2. Replace `use mdk_core::prelude::GroupId` with `use whitenoise::mdk::GroupId` (and the same for the other four types).

Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public API now includes MLS protocol types for group management, configuration, and state tracking, enabling unified access to protocol functionality without requiring external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->