### PR TITLE
Remove 5 unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,16 +327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
-dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,42 +362,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
-name = "bitcoin"
-version = "0.32.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
-dependencies = [
- "base58ck",
- "bech32",
- "bitcoin-internals",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
- "hex_lit",
- "secp256k1",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-
-[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
-name = "bitcoin-units"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
-dependencies = [
- "bitcoin-internals",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1573,12 +1531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,26 +2385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightning-invoice"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
-dependencies = [
- "bech32",
- "bitcoin",
- "lightning-types",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin",
-]
-
-[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,17 +2849,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "nwc"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f651e3c28dd9da0873151233e804a92b6240a1db1260f3c9d727950adb8e9036"
-dependencies = [
- "nostr",
- "nostr-relay-pool",
- "tracing",
 ]
 
 [[package]]
@@ -4030,7 +3951,6 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -5317,13 +5237,10 @@ dependencies = [
  "apple-native-keyring-store",
  "async-trait",
  "base64ct",
- "blurhash",
- "chacha20poly1305",
  "chrono",
  "clap",
  "dashmap",
  "dirs",
- "dotenvy",
  "futures",
  "hex",
  "image",
@@ -5331,7 +5248,6 @@ dependencies = [
  "indicatif",
  "infer",
  "keyring-core",
- "lightning-invoice",
  "linux-keyutils-keyring-store",
  "mdk-core",
  "mdk-sqlite-storage",
@@ -5339,7 +5255,6 @@ dependencies = [
  "mockito",
  "nostr-blossom",
  "nostr-sdk",
- "nwc",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-trait = "0.1.88"
-blurhash = "0.2.3"
-chacha20poly1305 = "0.10"
 chrono = { version = "0.4.40", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive"], optional = true }
 dashmap = "6.1"
@@ -28,8 +26,6 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "0.7"
-lightning-invoice = "0.33.1"
-
 mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a", features = [
     "mip04",
     "mip05",
@@ -37,7 +33,6 @@ mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", 
 mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
 mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
 
-nwc = "0.44"
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [
     "nip04",
@@ -51,7 +46,6 @@ nostr-sdk = { version = "0.44", features = [
 # mdk-sqlite-storage = { version = "0.7.1", path="../mdk/crates/mdk-sqlite-storage" }
 
 # LOCAL RUST_NOSTR FOR DEVELOPMENT
-# nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }
 # nostr-blossom = { version = "0.43", path="../rust-nostr/rfs/nostr-blossom" }
 # nostr-sdk = { version = "0.43", path="../rust-nostr/crates/nostr-sdk", features = [
 #     "lmdb",
@@ -94,7 +88,6 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64ct = "=1.7.3"
-dotenvy = "0.15"
 whitenoise-macros = { path = "crates/whitenoise-macros" }
 tempfile = "3.19.1"
 dirs = { version = "6", optional = true }


### PR DESCRIPTION
![marmot](https://blossom.primal.net/8b54e115374e8ce66c21ee8c3e79d3cbf2ce373871c84dd426802597bbf2f736.jpg)

Audit of all 42 declared dependencies against actual source code usage found 5 crates with zero imports or references anywhere in the codebase:

- **blurhash**: blurhash generation is handled internally by mdk-core
- **chacha20poly1305**: encryption/decryption is handled internally by mdk-core EncryptedMediaManager
- **lightning-invoice**: leftover from planned Lightning/Zap support that was never implemented
- **nwc**: leftover from planned Nostr Wallet Connect support that was never implemented
- **dotenvy**: no .env file loading exists in the codebase

This marmot swept out the dusty crates nobody was using. The burrow is 92 lines lighter across Cargo.toml and Cargo.lock.

All checks pass (fmt, clippy, docs, dead_code, unit tests). The 4 test failures in login_multistep are pre-existing relay-connection timeouts that require Docker services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined dependencies by removing unused packages, reducing build overhead and project complexity while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->