### PR TITLE
Reuse single MDK connection per push notification operation

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -138,7 +138,7 @@ impl Whitenoise {
     ) -> Result<()> {
         if is_push_group_message_kind(message.kind) {
             if let Err(error) = self
-                .handle_push_application_message(account, outcome, &message)
+                .handle_push_application_message(mdk, account, outcome, &message)
                 .await
             {
                 tracing::warn!(
@@ -160,11 +160,13 @@ impl Whitenoise {
 
     async fn handle_push_application_message(
         &self,
+        mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         account: &Account,
         outcome: &MessageProcessingOutcome,
         message: &Message,
     ) -> Result<()> {
         self.handle_received_push_group_message(
+            mdk,
             account,
             message,
             outcome.context.sender_leaf_index,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -185,25 +185,15 @@ impl PendingTokenResponseContext {
             &self.config.data_dir,
             &self.config.keyring_service_id,
         )?;
-        let token_tags = group_push_token_tags_for_response_with(
-            &account.pubkey,
-            group_id,
-            &self.database,
+        respond_to_token_request_with(
             &mdk,
-        )
-        .await?;
-
-        if token_tags.is_empty() {
-            return Ok(());
-        }
-
-        let rumor = build_token_list_response_rumor(
-            account.pubkey,
-            nostr_sdk::Timestamp::now(),
+            &self.database,
+            &self.relay_control,
+            account,
+            group_id,
             request_event_id,
-            token_tags,
-        )?;
-        publish_push_group_message_with(&mdk, &self.relay_control, account, group_id, rumor).await
+        )
+        .await
     }
 }
 
@@ -298,6 +288,31 @@ async fn publish_push_group_message_with(
         .publish_event_to(event, &account.pubkey, &relay_urls)
         .await?;
     Ok(())
+}
+
+#[perf_instrument("push_notifications")]
+async fn respond_to_token_request_with(
+    mdk: &MDK<MdkSqliteStorage>,
+    database: &Database,
+    relay_control: &RelayControlPlane,
+    account: &Account,
+    group_id: &GroupId,
+    request_event_id: EventId,
+) -> Result<()> {
+    let token_tags =
+        group_push_token_tags_for_response_with(&account.pubkey, group_id, database, mdk).await?;
+
+    if token_tags.is_empty() {
+        return Ok(());
+    }
+
+    let rumor = build_token_list_response_rumor(
+        account.pubkey,
+        nostr_sdk::Timestamp::now(),
+        request_event_id,
+        token_tags,
+    )?;
+    publish_push_group_message_with(mdk, relay_control, account, group_id, rumor).await
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -711,6 +726,7 @@ impl Whitenoise {
     #[perf_instrument("push_notifications")]
     pub(crate) async fn handle_received_push_group_message(
         &self,
+        mdk: &MDK<MdkSqliteStorage>,
         account: &Account,
         message: &mdk_core::prelude::message_types::Message,
         sender_leaf_index: Option<u32>,
@@ -748,7 +764,7 @@ impl Whitenoise {
             }
             Mip05GroupMessage::TokenListResponse(response) => {
                 let request_event_id = response.request_event_id;
-                self.merge_token_list_response(account, &message.mls_group_id, response)
+                self.merge_token_list_response(mdk, account, &message.mls_group_id, response)
                     .await?;
                 self.clear_pending_token_response(
                     &account.pubkey,
@@ -1199,13 +1215,12 @@ impl Whitenoise {
     #[perf_instrument("push_notifications")]
     async fn merge_token_list_response(
         &self,
+        mdk: &MDK<MdkSqliteStorage>,
         account: &Account,
         mls_group_id: &GroupId,
         response: mdk_core::mip05::TokenListResponse,
     ) -> Result<()> {
-        let active_leaf_map = self
-            .create_mdk_for_account(account.pubkey)?
-            .group_leaf_map(mls_group_id)?;
+        let active_leaf_map = mdk.group_leaf_map(mls_group_id)?;
 
         GroupPushToken::upsert_active_token_list_response(
             &account.pubkey,
@@ -1227,25 +1242,15 @@ impl Whitenoise {
         request_event_id: EventId,
     ) -> Result<()> {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let token_tags = group_push_token_tags_for_response_with(
-            &account.pubkey,
-            group_id,
-            &self.database,
+        respond_to_token_request_with(
             &mdk,
-        )
-        .await?;
-
-        if token_tags.is_empty() {
-            return Ok(());
-        }
-
-        let rumor = build_token_list_response_rumor(
-            account.pubkey,
-            nostr_sdk::Timestamp::now(),
+            &self.database,
+            &self.relay_control,
+            account,
+            group_id,
             request_event_id,
-            token_tags,
-        )?;
-        publish_push_group_message_with(&mdk, &self.relay_control, account, group_id, rumor).await
+        )
+        .await
     }
 
     #[perf_instrument("push_notifications")]

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -207,6 +207,7 @@ impl PendingTokenResponseContext {
     }
 }
 
+#[perf_instrument("push_notifications")]
 async fn group_push_token_tags_for_response_with(
     account_pubkey: &PublicKey,
     group_id: &GroupId,
@@ -282,6 +283,7 @@ async fn group_push_token_tags_for_response_with(
     Ok(response_tokens)
 }
 
+#[perf_instrument("push_notifications")]
 async fn publish_push_group_message_with(
     mdk: &MDK<MdkSqliteStorage>,
     relay_control: &RelayControlPlane,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -15,7 +15,7 @@ use mdk_core::mip05::{
     TokenTag, build_notification_batches, build_token_list_response_rumor,
     build_token_removal_rumor, build_token_request_rumor, encrypt_push_token, parse_group_message,
 };
-use mdk_core::prelude::{GroupId, group_types::GroupState};
+use mdk_core::prelude::{GroupId, MDK, group_types::GroupState};
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::{EventId, Kind, PublicKey, RelayUrl};
 use serde::{Deserialize, Serialize};
@@ -203,8 +203,7 @@ impl PendingTokenResponseContext {
             request_event_id,
             token_tags,
         )?;
-        publish_push_group_message_with(&self.config, &self.relay_control, account, group_id, rumor)
-            .await
+        publish_push_group_message_with(&mdk, &self.relay_control, account, group_id, rumor).await
     }
 }
 
@@ -212,7 +211,7 @@ async fn group_push_token_tags_for_response_with(
     account_pubkey: &PublicKey,
     group_id: &GroupId,
     database: &Database,
-    mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
+    mdk: &MDK<MdkSqliteStorage>,
 ) -> Result<Vec<LeafTokenTag>> {
     let tokens =
         GroupPushToken::find_by_account_and_group(account_pubkey, group_id, database).await?;
@@ -284,14 +283,13 @@ async fn group_push_token_tags_for_response_with(
 }
 
 async fn publish_push_group_message_with(
-    config: &WhitenoiseConfig,
+    mdk: &MDK<MdkSqliteStorage>,
     relay_control: &RelayControlPlane,
     account: &Account,
     group_id: &GroupId,
     rumor: nostr_sdk::UnsignedEvent,
 ) -> Result<()> {
-    let mdk = Account::create_mdk(account.pubkey, &config.data_dir, &config.keyring_service_id)?;
-    let relay_urls = Whitenoise::ensure_group_relays(&mdk, group_id)?;
+    let relay_urls = Whitenoise::ensure_group_relays(mdk, group_id)?;
     let event = mdk.create_message(group_id, rumor, None)?;
 
     relay_control
@@ -903,9 +901,14 @@ impl Whitenoise {
                 nostr_sdk::Timestamp::now(),
                 vec![token_tag.clone()],
             )?;
-            if let Err(error) = self
-                .publish_push_group_message(account, &group.mls_group_id, rumor)
-                .await
+            if let Err(error) = publish_push_group_message_with(
+                &mdk,
+                &self.relay_control,
+                account,
+                &group.mls_group_id,
+                rumor,
+            )
+            .await
             {
                 publish_failures.push(format!(
                     "{}: {error}",
@@ -915,7 +918,12 @@ impl Whitenoise {
             }
 
             if let Err(error) = self
-                .sync_local_group_push_token_cache(account, &group.mls_group_id, Some(token_tag))
+                .sync_local_group_push_token_cache(
+                    &mdk,
+                    account,
+                    &group.mls_group_id,
+                    Some(token_tag),
+                )
                 .await
             {
                 publish_failures.push(format!(
@@ -1012,6 +1020,7 @@ impl Whitenoise {
     #[perf_instrument("push_notifications")]
     async fn share_push_token_to_group(
         &self,
+        mdk: &MDK<MdkSqliteStorage>,
         account: &Account,
         group_id: &GroupId,
         token_tag: &TokenTag,
@@ -1021,9 +1030,8 @@ impl Whitenoise {
             nostr_sdk::Timestamp::now(),
             vec![token_tag.clone()],
         )?;
-        self.publish_push_group_message(account, group_id, rumor)
-            .await?;
-        self.sync_local_group_push_token_cache(account, group_id, Some(token_tag))
+        publish_push_group_message_with(mdk, &self.relay_control, account, group_id, rumor).await?;
+        self.sync_local_group_push_token_cache(mdk, account, group_id, Some(token_tag))
             .await
     }
 
@@ -1056,7 +1064,7 @@ impl Whitenoise {
             return Ok(());
         };
 
-        self.share_push_token_to_group(account, group_id, &token_tag)
+        self.share_push_token_to_group(&mdk, account, group_id, &token_tag)
             .await
     }
 
@@ -1075,9 +1083,14 @@ impl Whitenoise {
             }
 
             let rumor = build_token_removal_rumor(account.pubkey, nostr_sdk::Timestamp::now());
-            if let Err(error) = self
-                .publish_push_group_message(account, &group.mls_group_id, rumor)
-                .await
+            if let Err(error) = publish_push_group_message_with(
+                &mdk,
+                &self.relay_control,
+                account,
+                &group.mls_group_id,
+                rumor,
+            )
+            .await
             {
                 publish_failures.push(format!(
                     "{}: {error}",
@@ -1086,7 +1099,7 @@ impl Whitenoise {
             }
 
             if let Err(error) = self
-                .sync_local_group_push_token_cache(account, &group.mls_group_id, None)
+                .sync_local_group_push_token_cache(&mdk, account, &group.mls_group_id, None)
                 .await
             {
                 publish_failures.push(format!(
@@ -1134,9 +1147,9 @@ impl Whitenoise {
         }
 
         let rumor = build_token_removal_rumor(account.pubkey, nostr_sdk::Timestamp::now());
-        if let Err(error) = self
-            .publish_push_group_message(account, group_id, rumor)
-            .await
+        if let Err(error) =
+            publish_push_group_message_with(&mdk, &self.relay_control, account, group_id, rumor)
+                .await
         {
             tracing::warn!(
                 target: "whitenoise::push_notifications",
@@ -1147,7 +1160,7 @@ impl Whitenoise {
             );
         }
 
-        self.sync_local_group_push_token_cache(account, group_id, None)
+        self.sync_local_group_push_token_cache(&mdk, account, group_id, None)
             .await
     }
 
@@ -1211,9 +1224,14 @@ impl Whitenoise {
         group_id: &GroupId,
         request_event_id: EventId,
     ) -> Result<()> {
-        let token_tags = self
-            .group_push_token_tags_for_response(account, group_id)
-            .await?;
+        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let token_tags = group_push_token_tags_for_response_with(
+            &account.pubkey,
+            group_id,
+            &self.database,
+            &mdk,
+        )
+        .await?;
 
         if token_tags.is_empty() {
             return Ok(());
@@ -1225,29 +1243,17 @@ impl Whitenoise {
             request_event_id,
             token_tags,
         )?;
-        self.publish_push_group_message(account, group_id, rumor)
-            .await
-    }
-
-    #[perf_instrument("push_notifications")]
-    async fn group_push_token_tags_for_response(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-    ) -> Result<Vec<LeafTokenTag>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        group_push_token_tags_for_response_with(&account.pubkey, group_id, &self.database, &mdk)
-            .await
+        publish_push_group_message_with(&mdk, &self.relay_control, account, group_id, rumor).await
     }
 
     #[perf_instrument("push_notifications")]
     async fn sync_local_group_push_token_cache(
         &self,
+        mdk: &MDK<MdkSqliteStorage>,
         account: &Account,
         group_id: &GroupId,
         token_tag: Option<&TokenTag>,
     ) -> Result<()> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
         let leaf_index = mdk.own_leaf_index(group_id)?;
 
         match token_tag {
@@ -1280,17 +1286,6 @@ impl Whitenoise {
         };
 
         registration.token_tag()
-    }
-
-    #[perf_instrument("push_notifications")]
-    async fn publish_push_group_message(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-        rumor: nostr_sdk::UnsignedEvent,
-    ) -> Result<()> {
-        publish_push_group_message_with(&self.config, &self.relay_control, account, group_id, rumor)
-            .await
     }
 }
 


### PR DESCRIPTION
Fixes #707.

## Summary
- Refactored `publish_push_group_message_with` and `sync_local_group_push_token_cache` to accept `&MDK<MdkSqliteStorage>` instead of calling `Account::create_mdk` internally
- Each top-level operation (`share_push_token_to_joined_groups`, `remove_push_token_from_joined_groups`, etc.) now creates a single MDK instance and threads it through all helpers
- Removed the now-redundant `publish_push_group_message` and `group_push_token_tags_for_response` wrapper methods

## Test plan
- [x] `just precommit-quick` passes
- [x] Integration tests pass with Docker (`just precommit`)
- [ ] Verify push token share/remove flows work on device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Push-notification flows now reuse a shared account context to reduce redundant setup and improve reliability.
  * Token publishing and local cache synchronization for group push tokens are streamlined for more consistent, efficient delivery.
  * Added performance instrumentation across push-notification paths to improve observability and tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->