### PR TITLE
Add disappearing messages support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -664,7 +664,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
 dependencies = [
  "base64",
  "blurhash",
@@ -2580,12 +2580,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
 dependencies = [
  "nostr",
  "openmls",
@@ -3408,7 +3408,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3876,7 +3876,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3933,7 +3933,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4254,7 +4254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4537,7 +4537,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5385,7 +5385,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5489,15 +5489,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5529,28 +5520,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5566,12 +5540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,12 +5550,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5602,22 +5564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5632,12 +5582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5648,12 +5592,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5668,12 +5606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,12 +5616,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
+source = "git+https://github.com/marmot-protocol/mdk?rev=e589c8488c7a8bbc7992fbc72ce0e4b8a297170c#e589c8488c7a8bbc7992fbc72ce0e4b8a297170c"
 dependencies = [
  "base64",
  "blurhash",
@@ -2580,12 +2580,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
+source = "git+https://github.com/marmot-protocol/mdk?rev=e589c8488c7a8bbc7992fbc72ce0e4b8a297170c#e589c8488c7a8bbc7992fbc72ce0e4b8a297170c"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
+source = "git+https://github.com/marmot-protocol/mdk?rev=e589c8488c7a8bbc7992fbc72ce0e4b8a297170c#e589c8488c7a8bbc7992fbc72ce0e4b8a297170c"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=00be14876ea534145155f70b904b1fd758426430#00be14876ea534145155f70b904b1fd758426430"
+source = "git+https://github.com/marmot-protocol/mdk?rev=e589c8488c7a8bbc7992fbc72ce0e4b8a297170c#e589c8488c7a8bbc7992fbc72ce0e4b8a297170c"
 dependencies = [
  "nostr",
  "openmls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ infer = "0.19"
 keyring-core = "0.7"
 lightning-invoice = "0.33.1"
 
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "e589c8488c7a8bbc7992fbc72ce0e4b8a297170c", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "e589c8488c7a8bbc7992fbc72ce0e4b8a297170c" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "e589c8488c7a8bbc7992fbc72ce0e4b8a297170c" }
 
 nwc = "0.44"
 nostr-blossom = "0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ infer = "0.19"
 keyring-core = "0.7"
 lightning-invoice = "0.33.1"
 
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "00be14876ea534145155f70b904b1fd758426430" }
 
 nwc = "0.44"
 nostr-blossom = "0.44"

--- a/db_migrations/0046_add_expires_at_to_aggregated_messages.sql
+++ b/db_migrations/0046_add_expires_at_to_aggregated_messages.sql
@@ -1,0 +1,14 @@
+-- Migration 0044: Add expires_at column to aggregated_messages
+--
+-- Supports disappearing messages: when a group has a disappearing message
+-- duration configured, new messages are stored with an expires_at timestamp.
+-- A scheduled cleanup task periodically deletes rows past their expiry.
+--
+-- NULL means the message does not expire. Only non-NULL rows are indexed
+-- so the cleanup query stays efficient regardless of how many permanent
+-- messages exist.
+
+ALTER TABLE aggregated_messages ADD COLUMN expires_at INTEGER;
+
+CREATE INDEX idx_aggregated_messages_expires_at
+    ON aggregated_messages(expires_at) WHERE expires_at IS NOT NULL;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -943,6 +943,7 @@ async fn create_group(
         None, // image_nonce
         cli_group_relay_urls(),
         vec![account.pubkey], // admins — creator only
+        None,                 // disappearing_message_duration_secs
     );
 
     let group = wn

--- a/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
@@ -81,6 +81,7 @@ impl BenchmarkScenario for AddMembersPerformanceBenchmark {
             None,
             context.test_relays(),
             vec![admin.pubkey],
+            None, // disappearing_message_duration_secs
         );
 
         let group = context

--- a/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
@@ -64,6 +64,7 @@ impl BenchmarkTestCase for CreateGroupBenchmark {
             None,
             context.test_relays(),
             admin_pubkeys,
+            None, // disappearing_message_duration_secs
         );
 
         // Time only the create_group call

--- a/src/integration_tests/test_cases/chat_list/create_dm.rs
+++ b/src/integration_tests/test_cases/chat_list/create_dm.rs
@@ -52,6 +52,7 @@ impl TestCase for CreateDmTestCase {
                     None,
                     context.test_relays(),
                     vec![creator.pubkey, other.pubkey],
+                    None, // disappearing_message_duration_secs
                 ),
                 None,
             )

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -218,7 +218,7 @@ async fn publish_backdated_key_package(
     days_old: u64,
 ) -> Result<EventId, WhitenoiseError> {
     // Get the encoded key package and tags
-    let (encoded_key_package, tags, hash_ref) = context
+    let kp_data = context
         .whitenoise
         .encoded_key_package(account, relays)
         .await?;
@@ -232,8 +232,8 @@ async fn publish_backdated_key_package(
     let backdated = Timestamp::now() - Duration::from_secs(days_old * 24 * 60 * 60);
 
     // Build and sign the event with custom timestamp
-    let event = EventBuilder::new(Kind::MlsKeyPackage, &encoded_key_package)
-        .tags(tags.to_vec())
+    let event = EventBuilder::new(Kind::MlsKeyPackage, &kp_data.content)
+        .tags(kp_data.tags_443.to_vec())
         .custom_created_at(backdated)
         .sign_with_keys(&keys)
         .map_err(|e| WhitenoiseError::Other(e.into()))?;
@@ -248,7 +248,11 @@ async fn publish_backdated_key_package(
 
     context
         .whitenoise
-        .track_published_key_package_for_testing(&account.pubkey, &hash_ref, &event_id.to_hex())
+        .track_published_key_package_for_testing(
+            &account.pubkey,
+            &kp_data.hash_ref,
+            &event_id.to_hex(),
+        )
         .await?;
 
     tracing::debug!(

--- a/src/integration_tests/test_cases/shared/create_group.rs
+++ b/src/integration_tests/test_cases/shared/create_group.rs
@@ -59,6 +59,7 @@ impl TestCase for CreateGroupTestCase {
                     None, // image_nonce
                     context.test_relays(),
                     admin_pubkeys,
+                    None, // disappearing_message_duration_secs
                 ),
                 None,
             )

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1192,6 +1192,7 @@ mod tests {
             None,
             vec![relay1.clone(), relay2.clone()],
             vec![creator_account.pubkey],
+            None, // disappearing_message_duration_secs
         );
 
         let group = whitenoise
@@ -1490,6 +1491,7 @@ mod tests {
             None,
             vec![relay_url.clone()],
             vec![creator_account.pubkey],
+            None, // disappearing_message_duration_secs
         );
 
         whitenoise
@@ -1524,6 +1526,7 @@ mod tests {
             None,
             vec![relay_url.clone()],
             vec![creator_account.pubkey],
+            None, // disappearing_message_duration_secs
         );
 
         whitenoise

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -1027,6 +1027,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg1, &group1.mls_group_id, &whitenoise.database)
             .await
@@ -1046,6 +1047,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg2, &group2.mls_group_id, &whitenoise.database)
             .await
@@ -1210,6 +1212,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
             .await
@@ -1272,6 +1275,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg, &group1.mls_group_id, &whitenoise.database)
             .await
@@ -1361,6 +1365,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
             .await
@@ -1653,6 +1658,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
                 .await

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -1087,6 +1087,27 @@ impl AggregatedMessage {
         Ok(())
     }
 
+    /// Find all kind-9 messages whose `expires_at` timestamp has passed.
+    ///
+    /// Returns `(message_id_hex, mls_group_id)` pairs so callers can emit
+    /// per-message stream updates before the rows are deleted.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn find_expired(now_ms: i64, database: &Database) -> Result<Vec<(String, GroupId)>> {
+        let rows: Vec<(String, Vec<u8>)> = sqlx::query_as(
+            "SELECT message_id, mls_group_id
+             FROM aggregated_messages
+             WHERE expires_at IS NOT NULL AND expires_at <= ? AND kind = 9",
+        )
+        .bind(now_ms)
+        .fetch_all(&database.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, group)| (id, GroupId::from_slice(&group)))
+            .collect())
+    }
+
     /// Delete all messages whose `expires_at` timestamp has passed.
     ///
     /// Returns the set of group IDs that had messages removed so callers

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -57,6 +57,9 @@ struct AggregatedMessageRow {
     pub reactions: ReactionSummary,
     pub media_attachments: Vec<MediaFile>,
     pub delivery_status: Option<DeliveryStatus>,
+    /// Expiration timestamp (Unix milliseconds).  `None` means the message
+    /// does not expire.  Set when the group has disappearing messages enabled.
+    pub expires_at: Option<DateTime<Utc>>,
     /// Position of this message within the group (0 = newest).
     /// Only populated by search queries that include a ROW_NUMBER window.
     pub position: Option<i64>,
@@ -169,6 +172,23 @@ where
                 Err(e) => return Err(e),
             };
 
+        // Optional expires_at column — only present when the migration has been
+        // applied and the column was included in the SELECT.
+        let expires_at: Option<DateTime<Utc>> = match row.try_get::<Option<i64>, _>("expires_at") {
+            Ok(Some(ms)) => {
+                let dt = DateTime::from_timestamp_millis(ms).ok_or_else(|| {
+                    sqlx::Error::ColumnDecode {
+                        index: "expires_at".to_string(),
+                        source: "timestamp out of range".into(),
+                    }
+                })?;
+                Some(dt)
+            }
+            Ok(None) => None,
+            Err(sqlx::Error::ColumnNotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+
         // Optional position column — only present in search queries that use
         // a ROW_NUMBER window function.
         let position: Option<i64> = match row.try_get::<Option<i64>, _>("position") {
@@ -192,6 +212,7 @@ where
             reactions,
             media_attachments,
             delivery_status,
+            expires_at,
             position,
         })
     }
@@ -717,11 +738,13 @@ impl AggregatedMessage {
 
         let mut tx = database.pool.begin().await?;
 
+        let expires_at_ms = message.expires_at.map(|ts| ts.as_secs() as i64 * 1000);
+
         sqlx::query(
             "INSERT INTO aggregated_messages
              (message_id, mls_group_id, author, created_at, kind, content, content_normalized,
-              tags, reply_to_id, content_tokens, reactions, media_attachments)
-             VALUES (?, ?, ?, ?, 9, ?, ?, ?, ?, ?, ?, ?)
+              tags, reply_to_id, content_tokens, reactions, media_attachments, expires_at)
+             VALUES (?, ?, ?, ?, 9, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(message_id, mls_group_id) DO UPDATE SET
                content = excluded.content,
                content_normalized = excluded.content_normalized,
@@ -729,7 +752,8 @@ impl AggregatedMessage {
                reply_to_id = excluded.reply_to_id,
                content_tokens = excluded.content_tokens,
                reactions = excluded.reactions,
-               media_attachments = excluded.media_attachments",
+               media_attachments = excluded.media_attachments,
+               expires_at = excluded.expires_at",
         )
         .bind(&message.id)
         .bind(group_id.as_slice())
@@ -744,6 +768,7 @@ impl AggregatedMessage {
         .bind(serde_json::to_string(&message.content_tokens)?)
         .bind(serde_json::to_string(&message.reactions)?)
         .bind(serde_json::to_string(&message.media_attachments)?)
+        .bind(expires_at_ms)
         .execute(&mut *tx)
         .await?;
 
@@ -1060,6 +1085,47 @@ impl AggregatedMessage {
             .execute(&database.pool)
             .await?;
         Ok(())
+    }
+
+    /// Delete all messages whose `expires_at` timestamp has passed.
+    ///
+    /// Returns the set of group IDs that had messages removed so callers
+    /// can emit stream updates for those groups.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn delete_expired(now_ms: i64, database: &Database) -> Result<Vec<GroupId>> {
+        // First collect the distinct groups that have expired messages
+        let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
+            "SELECT DISTINCT mls_group_id
+             FROM aggregated_messages
+             WHERE expires_at IS NOT NULL AND expires_at <= ?",
+        )
+        .bind(now_ms)
+        .fetch_all(&database.pool)
+        .await?;
+
+        let affected_groups: Vec<GroupId> = rows
+            .into_iter()
+            .map(|(bytes,)| GroupId::from_slice(&bytes))
+            .collect();
+
+        if !affected_groups.is_empty() {
+            let deleted = sqlx::query(
+                "DELETE FROM aggregated_messages
+                 WHERE expires_at IS NOT NULL AND expires_at <= ?",
+            )
+            .bind(now_ms)
+            .execute(&database.pool)
+            .await?;
+
+            tracing::info!(
+                target: "whitenoise::disappearing_messages",
+                "Deleted {} expired message(s) across {} group(s)",
+                deleted.rows_affected(),
+                affected_groups.len(),
+            );
+        }
+
+        Ok(affected_groups)
     }
 
     /// Find a cached message by ID (for updating with reactions/deletions)
@@ -1404,6 +1470,10 @@ impl AggregatedMessage {
         // Convert DateTime<Utc> to Timestamp (seconds)
         let created_at = Timestamp::from(row.created_at.timestamp() as u64);
 
+        let expires_at = row
+            .expires_at
+            .map(|dt| Timestamp::from(dt.timestamp() as u64));
+
         Ok(ChatMessage {
             id: row.message_id.to_string(),
             author: row.author,
@@ -1418,6 +1488,7 @@ impl AggregatedMessage {
             kind: row.kind.as_u16(),
             media_attachments: row.media_attachments,
             delivery_status: row.delivery_status,
+            expires_at,
         })
     }
 
@@ -1492,6 +1563,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         }
     }
 
@@ -2720,6 +2792,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&msg, group_id, database)
             .await
@@ -4050,6 +4123,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: Some(DeliveryStatus::Retried),
+            expires_at: None,
         };
         AggregatedMessage::insert_message(&retried_msg, &group_id, &whitenoise.database)
             .await
@@ -4096,6 +4170,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         }
     }
 
@@ -4274,6 +4349,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
                 .await
@@ -4301,5 +4377,267 @@ mod tests {
         assert_eq!(results[0].position, 0);
         assert_eq!(results[1].position, 1);
         assert_eq!(results[2].position, 2);
+    }
+
+    // ======================== Disappearing messages ========================
+
+    #[tokio::test]
+    async fn test_insert_message_with_expires_at_round_trips() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[0xDA; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let mut message = create_test_chat_message(1, author);
+        let expires_at_secs = message.created_at.as_secs() + 3600; // 1 hour
+        message.expires_at = Some(Timestamp::from(expires_at_secs));
+
+        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let retrieved = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
+            .await
+            .unwrap()
+            .expect("message should exist");
+
+        assert_eq!(
+            retrieved.expires_at.map(|t| t.as_secs()),
+            Some(expires_at_secs),
+            "expires_at should round-trip through the database"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_message_without_expires_at() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[0xDB; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let message = create_test_chat_message(1, author);
+        assert!(message.expires_at.is_none(), "precondition: no expires_at");
+
+        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let retrieved = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
+            .await
+            .unwrap()
+            .expect("message should exist");
+
+        assert_eq!(
+            retrieved.expires_at, None,
+            "permanent message should have no expires_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_removes_only_expired_messages() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[0xDC; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let now_secs = Timestamp::now().as_secs();
+
+        // Message 1: already expired (1 hour ago)
+        let mut expired_msg = create_test_chat_message(1, author);
+        expired_msg.expires_at = Some(Timestamp::from(now_secs - 3600));
+        AggregatedMessage::insert_message(&expired_msg, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Message 2: expires in the future (1 hour from now)
+        let mut future_msg = create_test_chat_message(2, author);
+        future_msg.expires_at = Some(Timestamp::from(now_secs + 3600));
+        AggregatedMessage::insert_message(&future_msg, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Message 3: permanent (no expires_at)
+        let permanent_msg = create_test_chat_message(3, author);
+        AggregatedMessage::insert_message(&permanent_msg, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Verify all 3 exist
+        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(count, 3);
+
+        // Run cleanup
+        let now_ms = now_secs as i64 * 1000;
+        let affected = AggregatedMessage::delete_expired(now_ms, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Only 1 group should be affected
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0].as_slice(), group_id.as_slice());
+
+        // Only 2 messages remain (future + permanent)
+        let remaining = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(remaining, 2, "only the expired message should be deleted");
+
+        // Verify which messages survive
+        let expired_lookup =
+            AggregatedMessage::find_by_id(&expired_msg.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        assert!(expired_lookup.is_none(), "expired message should be gone");
+
+        let future_lookup =
+            AggregatedMessage::find_by_id(&future_msg.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        assert!(future_lookup.is_some(), "future message should survive");
+
+        let permanent_lookup =
+            AggregatedMessage::find_by_id(&permanent_msg.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        assert!(
+            permanent_lookup.is_some(),
+            "permanent message should survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_returns_all_affected_groups() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_a = GroupId::from_slice(&[0xA0; 32]);
+        let group_b = GroupId::from_slice(&[0xB0; 32]);
+        let group_c = GroupId::from_slice(&[0xC0; 32]);
+        setup_group(&group_a, &whitenoise.database).await;
+        setup_group(&group_b, &whitenoise.database).await;
+        setup_group(&group_c, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let now_secs = Timestamp::now().as_secs();
+
+        // Group A: has an expired message
+        let mut msg_a = create_test_chat_message(1, author);
+        msg_a.expires_at = Some(Timestamp::from(now_secs - 100));
+        AggregatedMessage::insert_message(&msg_a, &group_a, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Group B: has an expired message
+        let mut msg_b = create_test_chat_message(2, author);
+        msg_b.expires_at = Some(Timestamp::from(now_secs - 200));
+        AggregatedMessage::insert_message(&msg_b, &group_b, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Group C: only has a permanent message (no expiry)
+        let msg_c = create_test_chat_message(3, author);
+        AggregatedMessage::insert_message(&msg_c, &group_c, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let now_ms = now_secs as i64 * 1000;
+        let mut affected = AggregatedMessage::delete_expired(now_ms, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Sort for deterministic comparison
+        affected.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+
+        assert_eq!(
+            affected.len(),
+            2,
+            "only groups A and B have expired messages"
+        );
+
+        let mut expected = vec![group_a.as_slice().to_vec(), group_b.as_slice().to_vec()];
+        expected.sort();
+        let actual: Vec<Vec<u8>> = affected.iter().map(|g| g.as_slice().to_vec()).collect();
+        assert_eq!(actual, expected);
+
+        // Group C's message should still exist
+        let c_count = AggregatedMessage::count_by_group(&group_c, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(c_count, 1, "group C's permanent message should survive");
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_with_no_expired_messages() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[0xDD; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+
+        // Only permanent messages
+        let msg = create_test_chat_message(1, author);
+        AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let now_ms = Timestamp::now().as_secs() as i64 * 1000;
+        let affected = AggregatedMessage::delete_expired(now_ms, &whitenoise.database)
+            .await
+            .unwrap();
+
+        assert!(affected.is_empty(), "no groups should be affected");
+
+        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "permanent message should not be deleted");
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_on_empty_table() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let now_ms = Timestamp::now().as_secs() as i64 * 1000;
+        let affected = AggregatedMessage::delete_expired(now_ms, &whitenoise.database)
+            .await
+            .unwrap();
+
+        assert!(affected.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_insert_message_upsert_preserves_expires_at() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[0xDE; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let now_secs = Timestamp::now().as_secs();
+
+        // Insert with an expiry
+        let mut message = create_test_chat_message(1, author);
+        message.expires_at = Some(Timestamp::from(now_secs + 3600));
+        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Upsert the same message with updated content but same expiry
+        let mut updated = message.clone();
+        updated.content = "Updated content".to_string();
+        AggregatedMessage::insert_message(&updated, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let retrieved = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
+            .await
+            .unwrap()
+            .expect("message should exist");
+
+        assert_eq!(retrieved.content, "Updated content");
+        assert_eq!(
+            retrieved.expires_at.map(|t| t.as_secs()),
+            Some(now_secs + 3600),
+            "expires_at should be preserved through upsert"
+        );
     }
 }

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -494,7 +494,7 @@ mod tests {
             "shared group relay event".to_string(),
         );
         inner.ensure_id();
-        let event = admin_mdk.create_message(&group_id, inner).unwrap();
+        let event = admin_mdk.create_message(&group_id, inner, None).unwrap();
         let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
 
         for account in [&admin_account, &member_account] {

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -154,9 +154,17 @@ impl Whitenoise {
             .store_parsed_media_references(&group_id, &account.pubkey, parsed_references)
             .await?;
 
+        let disappearing_duration_secs = mdk
+            .get_group(&group_id)
+            .ok()
+            .flatten()
+            .and_then(|g| g.disappearing_message_duration_secs);
+
         match message.kind {
             Kind::ChatMessage => {
-                let msg = self.cache_chat_message(&group_id, &message).await?;
+                let msg = self
+                    .cache_chat_message(&group_id, &message, disappearing_duration_secs)
+                    .await?;
                 let group_name = mdk.get_group(&group_id).ok().flatten().map(|g| g.name);
                 Whitenoise::spawn_new_message_notification_if_enabled(
                     account, &group_id, &msg, group_name,
@@ -426,11 +434,15 @@ impl Whitenoise {
     ///
     /// Processes the message through the aggregator, inserts into database,
     /// and applies any orphaned reactions/deletions that arrived before this message.
+    ///
+    /// `disappearing_duration_secs` is the group's configured disappearing message
+    /// TTL. When `Some(n)`, `expires_at` is set to `created_at + n` on the message.
     #[perf_instrument("event_handlers")]
     async fn cache_chat_message(
         &self,
         group_id: &GroupId,
         message: &Message,
+        disappearing_duration_secs: Option<u64>,
     ) -> Result<ChatMessage> {
         let media_files = MediaFile::find_by_group(&self.database, group_id).await?;
 
@@ -438,6 +450,12 @@ impl Whitenoise {
             .message_aggregator
             .process_single_message(message, &self.content_parser, media_files)
             .await?;
+
+        // Set expiration based on the group's disappearing message setting
+        if let Some(duration) = disappearing_duration_secs {
+            let expires_at_secs = chat_message.created_at.as_secs() + duration;
+            chat_message.expires_at = Some(Timestamp::from(expires_at_secs));
+        }
 
         // Preserve existing delivery status for relay echoes of locally-sent messages.
         // This keeps stream payloads aligned with the latest DB state instead of
@@ -869,7 +887,7 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        let message_event = mdk.create_message(group_id, inner).unwrap();
+        let message_event = mdk.create_message(group_id, inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -892,7 +910,7 @@ mod tests {
             "👍".to_string(),
         );
         reaction_inner.ensure_id();
-        let reaction_event = mdk.create_message(group_id, reaction_inner).unwrap();
+        let reaction_event = mdk.create_message(group_id, reaction_inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -919,7 +937,7 @@ mod tests {
             String::new(),
         );
         deletion_inner.ensure_id();
-        let deletion_event = mdk.create_message(group_id, deletion_inner).unwrap();
+        let deletion_event = mdk.create_message(group_id, deletion_inner, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, deletion_event)
@@ -967,7 +985,8 @@ mod tests {
         );
         inner.ensure_id();
         let message_id = inner.id.unwrap();
-        mdk.create_message(&group.mls_group_id, inner).unwrap();
+        mdk.create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         let message = mdk
             .get_message(&group.mls_group_id, &message_id)
@@ -976,7 +995,7 @@ mod tests {
 
         // Initial cache pass creates the row without delivery status.
         let first = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&group.mls_group_id, &message, None)
             .await
             .unwrap();
         assert_eq!(first.delivery_status, None);
@@ -993,7 +1012,7 @@ mod tests {
 
         // Relay echo reprocess should preserve the existing status.
         let second = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&group.mls_group_id, &message, None)
             .await
             .unwrap();
         assert_eq!(second.delivery_status, Some(DeliveryStatus::Sent(1)));
@@ -1040,7 +1059,9 @@ mod tests {
             "Valid message".to_string(),
         );
         inner.ensure_id();
-        let valid_event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let valid_event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // Corrupt the event by changing its kind (MLS processing should fail)
         let mut bad_event = valid_event;
@@ -1094,7 +1115,9 @@ mod tests {
             "+".to_string(), // Use simple emoji that won't be normalized
         );
         orphaned_reaction.ensure_id();
-        let reaction_event = mdk.create_message(group_id, orphaned_reaction).unwrap();
+        let reaction_event = mdk
+            .create_message(group_id, orphaned_reaction, None)
+            .unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, reaction_event)
@@ -1124,7 +1147,7 @@ mod tests {
             "Late message".to_string(),
         );
         actual_message.id = Some(future_message_id);
-        let message_event = mdk.create_message(group_id, actual_message).unwrap();
+        let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -1194,7 +1217,7 @@ mod tests {
             "👍".to_string(),
         );
         valid_reaction.ensure_id();
-        let valid_event = mdk.create_message(group_id, valid_reaction).unwrap();
+        let valid_event = mdk.create_message(group_id, valid_reaction, None).unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, valid_event)
@@ -1210,7 +1233,9 @@ mod tests {
             "".to_string(), // Empty content is invalid
         );
         invalid_reaction.ensure_id();
-        let invalid_event = mdk.create_message(group_id, invalid_reaction).unwrap();
+        let invalid_event = mdk
+            .create_message(group_id, invalid_reaction, None)
+            .unwrap();
 
         whitenoise
             .handle_mls_message(&creator_account, invalid_event)
@@ -1226,7 +1251,7 @@ mod tests {
             "Target message".to_string(),
         );
         actual_message.id = Some(future_message_id);
-        let message_event = mdk.create_message(group_id, actual_message).unwrap();
+        let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
             .handle_mls_message(&creator_account, message_event)
@@ -1373,7 +1398,9 @@ mod tests {
                 format!("Message {}", i),
             );
             inner.ensure_id();
-            let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+            let event = mdk
+                .create_message(&group.mls_group_id, inner, None)
+                .unwrap();
 
             whitenoise
                 .handle_mls_message(&creator_account, event)
@@ -1427,7 +1454,7 @@ mod tests {
             vec![token_tag.clone()],
         )
         .unwrap();
-        let event = admin_mdk.create_message(&group_id, request).unwrap();
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1495,7 +1522,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let event = admin_mdk.create_message(&group_id, response).unwrap();
+        let event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1559,7 +1586,7 @@ mod tests {
         .unwrap();
 
         let removal = build_token_removal_rumor(admin_account.pubkey, Timestamp::now());
-        let event = admin_mdk.create_message(&group_id, removal).unwrap();
+        let event = admin_mdk.create_message(&group_id, removal, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1602,7 +1629,7 @@ mod tests {
             build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![token_tag])
                 .unwrap();
         let request_event_id = request.id.expect("447 rumor must have an event id");
-        let event = admin_mdk.create_message(&group_id, request).unwrap();
+        let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, event)
@@ -1647,7 +1674,7 @@ mod tests {
         )
         .unwrap();
         let request_event_id = request.id.expect("447 rumor must have an event id");
-        let request_event = admin_mdk.create_message(&group_id, request).unwrap();
+        let request_event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, request_event)
@@ -1670,7 +1697,7 @@ mod tests {
             }],
         )
         .unwrap();
-        let response_event = admin_mdk.create_message(&group_id, response).unwrap();
+        let response_event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
             .handle_mls_message(&member_account, response_event)
@@ -1844,7 +1871,9 @@ mod tests {
             "Test message".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
 
         // First processing: should succeed
         let first = whitenoise
@@ -1917,7 +1946,9 @@ mod tests {
             "Unprocessable test".to_string(),
         );
         inner.ensure_id();
-        let event = mdk.create_message(&group.mls_group_id, inner).unwrap();
+        let event = mdk
+            .create_message(&group.mls_group_id, inner, None)
+            .unwrap();
         let event_id = event.id;
 
         // Build a relay-plane source context for this account.
@@ -2013,7 +2044,7 @@ mod tests {
         );
         inner.ensure_id();
 
-        let message_event = admin_mdk.create_message(&group_id, inner);
+        let message_event = admin_mdk.create_message(&group_id, inner, None);
         assert!(
             message_event.is_ok(),
             "Admin should be able to create messages after auto-committed removal: {:?}",

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -781,6 +781,41 @@ impl Whitenoise {
         Ok(())
     }
 
+    /// Updates the disappearing message duration for a group.
+    ///
+    /// Only group admins can change this setting. The change is distributed
+    /// to all group members via an MLS commit (group data update).
+    ///
+    /// # Arguments
+    /// * `account` - The account performing the update (must be group admin)
+    /// * `group_id` - The MLS group ID
+    /// * `duration_secs` - `Some(n)` to enable (messages expire after `n` seconds),
+    ///   `None` to disable (messages persist forever). `Some(0)` is rejected.
+    #[perf_instrument("groups")]
+    pub async fn set_disappearing_messages(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+        duration_secs: Option<u64>,
+    ) -> Result<()> {
+        let update = NostrGroupDataUpdate::new().disappearing_message_duration_secs(duration_secs);
+        self.update_group_data(account, group_id, update).await
+    }
+
+    /// Returns the disappearing message duration for a group.
+    ///
+    /// Returns `None` when disappearing messages are disabled (messages persist
+    /// forever), or `Some(seconds)` when enabled.
+    #[perf_instrument("groups")]
+    pub async fn get_disappearing_message_duration(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<Option<u64>> {
+        let group = self.group(account, group_id).await?;
+        Ok(group.disappearing_message_duration_secs)
+    }
+
     /// Removes the caller from the group's `admin_pubkeys` list.
     ///
     /// This is a prerequisite for `leave_group()` — the MIP-03 protocol requires
@@ -1320,6 +1355,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
 
         let update_result = whitenoise
@@ -1384,6 +1420,7 @@ mod tests {
             admins: Some(vec![new_admin_pubkey]),
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
         whitenoise
             .update_group_data(
@@ -1437,6 +1474,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
         let update_result = whitenoise
             .update_group_data(&creator_account, &group.mls_group_id, update)
@@ -2069,6 +2107,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
 
         let update_result = whitenoise
@@ -2209,6 +2248,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
 
         whitenoise
@@ -2454,6 +2494,7 @@ mod tests {
             admins: None,
             relays: Some(unreachable_urls),
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
         whitenoise
             .update_group_data(&creator, &group.mls_group_id, relay_swap)
@@ -2552,6 +2593,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
         let result = whitenoise
             .update_group_data(&creator, group_id, new_data)

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use base64ct::{Base64, Encoding};
 use nostr_sdk::prelude::*;
 
+use mdk_core::key_packages::KeyPackageEventData;
+
 use crate::perf_instrument;
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
@@ -155,14 +157,15 @@ pub(crate) fn filter_key_package_events_for_account(
 impl Whitenoise {
     /// Helper method to create and encode a key package for the given account.
     ///
-    /// Returns `(encoded_content, tags, hash_ref_bytes)` where `hash_ref_bytes`
-    /// is the serialized hash_ref of the key package for lifecycle tracking.
+    /// Returns a [`KeyPackageEventData`] containing the encoded content, tags for
+    /// both kind:30443 and kind:443 events, the hash_ref for lifecycle tracking,
+    /// and the `d` tag value for NIP-33 addressable replacement.
     #[perf_instrument("key_packages")]
     pub(crate) async fn encoded_key_package(
         &self,
         account: &Account,
         key_package_relays: &[Relay],
-    ) -> Result<(String, Vec<Tag>, Vec<u8>)> {
+    ) -> Result<KeyPackageEventData> {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
 
         let key_package_relay_urls = Relay::urls(key_package_relays);
@@ -188,8 +191,7 @@ impl Whitenoise {
         }
 
         // Create the key package once — retries below only re-publish the same payload
-        let (encoded_key_package, tags, hash_ref) =
-            self.encoded_key_package(account, &relays).await?;
+        let kp_data = self.encoded_key_package(account, &relays).await?;
         let relay_urls = Relay::urls(&relays);
         let signer = self.get_signer_for_account(account)?;
 
@@ -210,15 +212,15 @@ impl Whitenoise {
 
             match self
                 .publish_key_package_to_relays(
-                    &encoded_key_package,
+                    &kp_data.content,
                     &relay_urls,
-                    &tags,
+                    &kp_data.tags_443,
                     signer.clone(),
                 )
                 .await
             {
                 Ok(event_id) => {
-                    self.track_published_key_package(account, &hash_ref, &event_id)
+                    self.track_published_key_package(account, &kp_data.hash_ref, &event_id)
                         .await;
                     return Ok(());
                 }
@@ -257,18 +259,17 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
-        let (encoded_key_package, tags, hash_ref) =
-            self.encoded_key_package(account, &relays).await?;
+        let kp_data = self.encoded_key_package(account, &relays).await?;
         let relay_urls = Relay::urls(&relays);
         let event_id = self
             .publish_key_package_to_relays(
-                &encoded_key_package,
+                &kp_data.content,
                 &relay_urls,
-                &tags,
+                &kp_data.tags_443,
                 std::sync::Arc::new(signer),
             )
             .await?;
-        self.track_published_key_package(account, &hash_ref, &event_id)
+        self.track_published_key_package(account, &kp_data.hash_ref, &event_id)
             .await;
         Ok(())
     }
@@ -284,14 +285,13 @@ impl Whitenoise {
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
-        let (encoded_key_package, tags, hash_ref) =
-            self.encoded_key_package(account, relays).await?;
+        let kp_data = self.encoded_key_package(account, relays).await?;
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
         let event_id = self
-            .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+            .publish_key_package_to_relays(&kp_data.content, &relay_urls, &kp_data.tags_443, signer)
             .await?;
-        self.track_published_key_package(account, &hash_ref, &event_id)
+        self.track_published_key_package(account, &kp_data.hash_ref, &event_id)
             .await;
         Ok(())
     }
@@ -311,8 +311,7 @@ impl Whitenoise {
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
-        let (encoded_key_package, tags, hash_ref) =
-            self.encoded_key_package(account, relays).await?;
+        let kp_data = self.encoded_key_package(account, relays).await?;
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
 
@@ -331,11 +330,16 @@ impl Whitenoise {
                     }
                 };
                 match wn
-                    .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+                    .publish_key_package_to_relays(
+                        &kp_data.content,
+                        &relay_urls,
+                        &kp_data.tags_443,
+                        signer,
+                    )
                     .await
                 {
                     Ok(event_id) => {
-                        wn.track_published_key_package(&account, &hash_ref, &event_id)
+                        wn.track_published_key_package(&account, &kp_data.hash_ref, &event_id)
                             .await;
                     }
                     Err(e) => {
@@ -350,11 +354,16 @@ impl Whitenoise {
         } else {
             // Synchronous fallback (unit tests or pre-initialization).
             match self
-                .publish_key_package_to_relays(&encoded_key_package, &relay_urls, &tags, signer)
+                .publish_key_package_to_relays(
+                    &kp_data.content,
+                    &relay_urls,
+                    &kp_data.tags_443,
+                    signer,
+                )
                 .await
             {
                 Ok(event_id) => {
-                    self.track_published_key_package(account, &hash_ref, &event_id)
+                    self.track_published_key_package(account, &kp_data.hash_ref, &event_id)
                         .await;
                 }
                 Err(e) => {

--- a/src/whitenoise/message_aggregator/processor.rs
+++ b/src/whitenoise/message_aggregator/processor.rs
@@ -168,6 +168,7 @@ pub(crate) async fn process_regular_message(
         kind: u16::from(message.kind),
         media_attachments,
         delivery_status: None,
+        expires_at: None,
     })
 }
 
@@ -585,6 +586,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             },
         );
 

--- a/src/whitenoise/message_aggregator/reaction_handler.rs
+++ b/src/whitenoise/message_aggregator/reaction_handler.rs
@@ -183,6 +183,7 @@ mod tests {
             kind: 9, // Default to MLS group chat
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         }
     }
 

--- a/src/whitenoise/message_aggregator/tests.rs
+++ b/src/whitenoise/message_aggregator/tests.rs
@@ -230,6 +230,7 @@ mod integration_tests {
             kind: 9, // Default to MLS group chat
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
 
         // Test serialization
@@ -260,6 +261,7 @@ mod integration_tests {
             kind: 9, // Default to MLS group chat
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         };
 
         let message2 = message1.clone();
@@ -306,5 +308,70 @@ mod integration_tests {
         let target_ids = super::super::processor::extract_deletion_target_ids(&tags);
         assert_eq!(target_ids.len(), 1);
         assert_eq!(target_ids[0], "test_id");
+    }
+
+    #[test]
+    fn test_chat_message_expires_at_serialization() {
+        let keys = Keys::generate();
+        let expires = Timestamp::from(1_700_000_000u64);
+
+        let chat_message = ChatMessage {
+            id: "expiring_msg".to_string(),
+            author: keys.public_key(),
+            content: "This will disappear".to_string(),
+            created_at: Timestamp::from(1_699_996_400u64),
+            tags: Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: false,
+            content_tokens: vec![],
+            reactions: ReactionSummary::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+            expires_at: Some(expires),
+        };
+
+        let json = serde_json::to_string(&chat_message).unwrap();
+        let deserialized: ChatMessage = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            deserialized.expires_at,
+            Some(expires),
+            "expires_at should survive JSON round-trip"
+        );
+
+        // Also verify None round-trips
+        let mut permanent = chat_message.clone();
+        permanent.expires_at = None;
+        let json2 = serde_json::to_string(&permanent).unwrap();
+        let deserialized2: ChatMessage = serde_json::from_str(&json2).unwrap();
+        assert_eq!(deserialized2.expires_at, None);
+    }
+
+    #[test]
+    fn test_chat_message_equality_considers_expires_at() {
+        let keys = Keys::generate();
+        let base = ChatMessage {
+            id: "eq_test".to_string(),
+            author: keys.public_key(),
+            content: "same".to_string(),
+            created_at: Timestamp::from(1000),
+            tags: Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: false,
+            content_tokens: vec![],
+            reactions: ReactionSummary::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+            expires_at: None,
+        };
+
+        let mut with_expiry = base.clone();
+        with_expiry.expires_at = Some(Timestamp::from(2000));
+
+        assert_ne!(base, with_expiry, "different expires_at should be unequal");
     }
 }

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -73,6 +73,34 @@ pub struct ChatMessage {
     pub expires_at: Option<Timestamp>,
 }
 
+impl ChatMessage {
+    /// Build a minimal placeholder used when emitting `MessageExpired` updates.
+    ///
+    /// The message row has already been deleted, so only the `id` field is
+    /// meaningful — subscribers use it to remove the message from the UI.
+    pub fn expired_placeholder(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            author: PublicKey::from_hex(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .expect("hardcoded placeholder pubkey is valid"),
+            content: String::new(),
+            created_at: Timestamp::from(0),
+            tags: Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: true,
+            content_tokens: vec![],
+            reactions: ReactionSummary::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+            expires_at: None,
+        }
+    }
+}
+
 /// A search result wrapping a matched message with token highlight spans.
 ///
 /// Each entry in `highlight_spans` is a `[start, end]` pair of **char indices**

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -67,6 +67,10 @@ pub struct ChatMessage {
     /// Delivery status for outgoing messages.
     /// `None` for incoming messages, `Some(status)` for messages sent by the current user.
     pub delivery_status: Option<DeliveryStatus>,
+
+    /// Expiration timestamp in Unix milliseconds, set when the group has
+    /// disappearing messages enabled.  `None` means the message persists forever.
+    pub expires_at: Option<Timestamp>,
 }
 
 /// A search result wrapping a matched message with token highlight spans.

--- a/src/whitenoise/message_streaming/manager.rs
+++ b/src/whitenoise/message_streaming/manager.rs
@@ -82,6 +82,7 @@ mod tests {
             kind: 9,
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         }
     }
 

--- a/src/whitenoise/message_streaming/types.rs
+++ b/src/whitenoise/message_streaming/types.rs
@@ -29,6 +29,11 @@ pub enum UpdateTrigger {
     /// The delivery status of an outgoing message changed (e.g. Sending → Sent or Failed).
     /// The message stays in its current position in the chat.
     DeliveryStatusChanged,
+
+    /// The message expired due to the group's disappearing-messages setting.
+    /// The message has been deleted from the database — only the `id` field
+    /// in the accompanying [`MessageUpdate`] is meaningful.
+    MessageExpired,
 }
 
 /// Represents a single update to be sent to subscribers.
@@ -80,6 +85,7 @@ mod tests {
             UpdateTrigger::ReactionRemoved,
             UpdateTrigger::MessageDeleted,
             UpdateTrigger::DeliveryStatusChanged,
+            UpdateTrigger::MessageExpired,
         ];
 
         for trigger in triggers {

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -64,8 +64,23 @@ impl Whitenoise {
             return Err(WhitenoiseError::GroupMissingRelays);
         }
 
+        // Look up the group's disappearing message setting before creating the
+        // MLS message so we can attach a NIP-40 expiration tag to the outer event.
+        let disappearing_duration_secs = mdk
+            .get_group(group_id)
+            .ok()
+            .flatten()
+            .and_then(|g| g.disappearing_message_duration_secs);
+
+        let outer_tags = disappearing_duration_secs.map(|duration| {
+            let expires_at_secs = Timestamp::now().as_secs() + duration;
+            vec![mdk_core::messages::EventTag::expiration(Timestamp::from(
+                expires_at_secs,
+            ))]
+        });
+
         let _mls_span = perf_span!("messages::mls_create_message");
-        let message_event = mdk.create_message(group_id, inner_event)?;
+        let message_event = mdk.create_message(group_id, inner_event, outer_tags)?;
         let mdk_message =
             mdk.get_message(group_id, &event_id)?
                 .ok_or(WhitenoiseError::MdkCoreError(
@@ -77,13 +92,14 @@ impl Whitenoise {
         let tokens = self.content_parser.parse(&mdk_message.content);
         drop(_parse_span);
 
-        // Proactive caching + delivery tracking for all outgoing event kinds.
-        // Kind 9 (chat): full message processing + NewMessage emission
-        // Kind 7/5 (reaction/deletion): insert event + apply aggregated effect on parent
         match kind {
             9 => {
-                self.process_and_emit_outgoing_message(&mdk_message, group_id)
-                    .await?;
+                self.process_and_emit_outgoing_message(
+                    &mdk_message,
+                    group_id,
+                    disappearing_duration_secs,
+                )
+                .await?;
             }
             7 => {
                 self.cache_and_apply_outgoing_reaction(&mdk_message, group_id)
@@ -177,6 +193,7 @@ impl Whitenoise {
         &self,
         mdk_message: &Message,
         group_id: &GroupId,
+        disappearing_duration_secs: Option<u64>,
     ) -> Result<()> {
         let chat_message = self
             .message_aggregator
@@ -188,6 +205,10 @@ impl Whitenoise {
             .await
             .map(|mut msg| {
                 msg.delivery_status = Some(DeliveryStatus::Sending);
+                if let Some(duration) = disappearing_duration_secs {
+                    let expires_at_secs = msg.created_at.as_secs() + duration;
+                    msg.expires_at = Some(Timestamp::from(expires_at_secs));
+                }
                 msg
             })
             .map_err(|e| {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -555,6 +555,7 @@ impl Whitenoise {
             Arc::new(scheduled_tasks::RelayListMaintenance),
             Arc::new(scheduled_tasks::SubscriptionHealthCheck),
             Arc::new(scheduled_tasks::MuteExpiryCleanup),
+            Arc::new(scheduled_tasks::DisappearingMessageCleanup),
         ];
         let scheduler_handles = scheduled_tasks::start_scheduled_tasks(
             whitenoise_ref,
@@ -1047,6 +1048,7 @@ pub mod test_utils {
             Some([2u8; 12]), // 12-byte nonce
             vec![RelayUrl::parse("ws://localhost:8080/").unwrap()],
             admins,
+            None, // disappearing_message_duration_secs
         )
     }
 
@@ -1574,6 +1576,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             let msg2 = message_aggregator::ChatMessage {
                 id: format!("{:0>64x}", 2),
@@ -1589,6 +1592,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
 
             aggregated_message::AggregatedMessage::insert_message(
@@ -1650,6 +1654,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
 
             // Emit an update (will be caught by subscriber during drain phase)
@@ -1702,6 +1707,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             aggregated_message::AggregatedMessage::insert_message(
                 &msg,
@@ -1990,6 +1996,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             whitenoise.message_stream_manager.emit(
                 &group_id,
@@ -2079,6 +2086,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             whitenoise.message_stream_manager.emit(
                 &group_id,
@@ -2137,6 +2145,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             whitenoise.message_stream_manager.emit(
                 &group_id,
@@ -2190,6 +2199,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             whitenoise.message_stream_manager.emit(
                 &group_a,
@@ -2366,6 +2376,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             let new_msg_b = message_aggregator::ChatMessage {
                 id: format!("{:0>64x}", 202u8),
@@ -2381,6 +2392,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
 
             whitenoise.message_stream_manager.emit(
@@ -2566,6 +2578,7 @@ mod tests {
                 kind: 9,
                 media_attachments: vec![],
                 delivery_status: None,
+                expires_at: None,
             };
             whitenoise.message_stream_manager.emit(
                 &group_id,
@@ -3172,6 +3185,7 @@ mod tests {
                     kind: 9,
                     media_attachments: vec![],
                     delivery_status: None,
+                    expires_at: None,
                 };
                 aggregated_message::AggregatedMessage::insert_message(
                     &msg,

--- a/src/whitenoise/notification_streaming/mod.rs
+++ b/src/whitenoise/notification_streaming/mod.rs
@@ -288,6 +288,7 @@ mod tests {
             kind: 9, // MLS message kind
             media_attachments: vec![],
             delivery_status: None,
+            expires_at: None,
         }
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -292,7 +292,7 @@ async fn publish_push_group_message_with(
 ) -> Result<()> {
     let mdk = Account::create_mdk(account.pubkey, &config.data_dir, &config.keyring_service_id)?;
     let relay_urls = Whitenoise::ensure_group_relays(&mdk, group_id)?;
-    let event = mdk.create_message(group_id, rumor)?;
+    let event = mdk.create_message(group_id, rumor, None)?;
 
     relay_control
         .publish_event_to(event, &account.pubkey, &relay_urls)
@@ -2609,6 +2609,7 @@ mod tests {
                 RelayUrl::parse("ws://localhost:2").unwrap(),
             ]),
             nostr_group_id: None,
+            disappearing_message_duration_secs: None,
         };
         whitenoise
             .update_group_data(&admin_account, &group_id, relay_swap)

--- a/src/whitenoise/scheduled_tasks/mod.rs
+++ b/src/whitenoise/scheduled_tasks/mod.rs
@@ -13,6 +13,7 @@ mod tasks;
 
 pub(crate) use self::tasks::CachedGraphUserCleanup;
 pub(crate) use self::tasks::ConsumedKeyPackageCleanup;
+pub(crate) use self::tasks::DisappearingMessageCleanup;
 pub(crate) use self::tasks::KeyPackageMaintenance;
 pub(crate) use self::tasks::MuteExpiryCleanup;
 pub(crate) use self::tasks::RelayListMaintenance;

--- a/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
@@ -1,12 +1,15 @@
 //! Scheduled task to delete expired disappearing messages.
 
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use nostr_sdk::{EventId, PublicKey};
 
 use crate::perf_instrument;
 use crate::whitenoise::Whitenoise;
+use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::aggregated_message::AggregatedMessage;
 use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
 use crate::whitenoise::error::WhitenoiseError;
@@ -41,16 +44,83 @@ impl Task for DisappearingMessageCleanup {
     async fn execute(&self, whitenoise: &'static Whitenoise) -> Result<(), WhitenoiseError> {
         let now_ms = Utc::now().timestamp_millis();
 
-        // Collect expired message IDs before deletion so we can notify subscribers.
+        // Collect expired message IDs before deletion so we can notify subscribers
+        // and delete them from each member's MDK storage.
         let expired_messages =
             AggregatedMessage::find_expired(now_ms, &whitenoise.database).await?;
 
-        let affected_groups =
-            AggregatedMessage::delete_expired(now_ms, &whitenoise.database).await?;
-
-        if affected_groups.is_empty() {
+        if expired_messages.is_empty() {
             return Ok(());
         }
+
+        // Resolve which accounts hold MDK storage for each affected group. A
+        // group is typically joined by one local account, but the codebase
+        // supports multiple accounts on the same device, so we union them.
+        let mut group_members: HashMap<Vec<u8>, HashSet<PublicKey>> = HashMap::new();
+        for (_, group_id) in &expired_messages {
+            let key = group_id.as_slice().to_vec();
+            if group_members.contains_key(&key) {
+                continue;
+            }
+            let account_groups =
+                AccountGroup::find_by_group(group_id, &whitenoise.database).await?;
+            let members: HashSet<PublicKey> = account_groups
+                .into_iter()
+                .map(|ag| ag.account_pubkey)
+                .collect();
+            group_members.insert(key, members);
+        }
+
+        // Delete each expired message from every member account's MDK
+        // storage. We do this before the aggregated-messages DELETE so that a
+        // crash mid-cleanup leaves the DB consistent with MDK (the task will
+        // retry next tick). Failures are logged but do not abort the pass —
+        // one bad account shouldn't hold the whole cleanup hostage.
+        for (message_id_hex, group_id) in &expired_messages {
+            let event_id = match EventId::from_hex(message_id_hex) {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::disappearing_messages",
+                        "Skipping expired message with unparseable id {}: {}",
+                        message_id_hex,
+                        e,
+                    );
+                    continue;
+                }
+            };
+
+            let Some(members) = group_members.get(group_id.as_slice()) else {
+                continue;
+            };
+
+            for account_pubkey in members {
+                let mdk = match whitenoise.create_mdk_for_account(*account_pubkey) {
+                    Ok(mdk) => mdk,
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "whitenoise::disappearing_messages",
+                            "Failed to open MDK for account {} while cleaning group: {}",
+                            account_pubkey.to_hex(),
+                            e,
+                        );
+                        continue;
+                    }
+                };
+
+                if let Err(e) = mdk.delete_message(group_id, &event_id) {
+                    tracing::warn!(
+                        target: "whitenoise::disappearing_messages",
+                        "MDK delete_message failed for {} in group: {}",
+                        message_id_hex,
+                        e,
+                    );
+                }
+            }
+        }
+
+        let affected_groups =
+            AggregatedMessage::delete_expired(now_ms, &whitenoise.database).await?;
 
         // Emit per-message updates so open conversation views can remove them.
         for (message_id, group_id) in &expired_messages {

--- a/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
@@ -1,0 +1,79 @@
+//! Scheduled task to delete expired disappearing messages.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use crate::perf_instrument;
+use crate::whitenoise::Whitenoise;
+use crate::whitenoise::aggregated_message::AggregatedMessage;
+use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
+use crate::whitenoise::error::WhitenoiseError;
+use crate::whitenoise::scheduled_tasks::Task;
+
+/// Scheduled task that periodically deletes messages whose `expires_at`
+/// timestamp has passed.
+///
+/// When a group has disappearing messages enabled, every incoming and
+/// outgoing message is stored with an `expires_at` value derived from the
+/// group's configured duration. This task scans for rows past their expiry,
+/// deletes them, and emits chat-list updates so the UI refreshes.
+///
+/// Runs every 30 seconds. This is a local-only operation — no deletion
+/// events are published to relays (the outer kind:445 events already carry
+/// NIP-40 expiration tags for relay-side cleanup).
+pub(crate) struct DisappearingMessageCleanup;
+
+#[async_trait]
+impl Task for DisappearingMessageCleanup {
+    fn name(&self) -> &'static str {
+        "disappearing_message_cleanup"
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_secs(30)
+    }
+
+    #[perf_instrument("scheduled::disappearing_message_cleanup")]
+    async fn execute(&self, whitenoise: &'static Whitenoise) -> Result<(), WhitenoiseError> {
+        let now_ms = Utc::now().timestamp_millis();
+
+        let affected_groups =
+            AggregatedMessage::delete_expired(now_ms, &whitenoise.database).await?;
+
+        if affected_groups.is_empty() {
+            return Ok(());
+        }
+
+        // Emit chat-list updates for each affected group so the UI refreshes
+        // the last-message preview and message list.
+        for group_id in &affected_groups {
+            whitenoise
+                .emit_chat_list_update_for_group(
+                    group_id,
+                    ChatListUpdateTrigger::LastMessageDeleted,
+                )
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_has_correct_name() {
+        let task = DisappearingMessageCleanup;
+        assert_eq!(task.name(), "disappearing_message_cleanup");
+    }
+
+    #[test]
+    fn task_has_thirty_second_interval() {
+        let task = DisappearingMessageCleanup;
+        assert_eq!(task.interval(), Duration::from_secs(30));
+    }
+}

--- a/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/disappearing_message_cleanup.rs
@@ -10,6 +10,8 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::aggregated_message::AggregatedMessage;
 use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
 use crate::whitenoise::error::WhitenoiseError;
+use crate::whitenoise::message_aggregator::ChatMessage;
+use crate::whitenoise::message_streaming::{MessageUpdate, UpdateTrigger};
 use crate::whitenoise::scheduled_tasks::Task;
 
 /// Scheduled task that periodically deletes messages whose `expires_at`
@@ -39,6 +41,10 @@ impl Task for DisappearingMessageCleanup {
     async fn execute(&self, whitenoise: &'static Whitenoise) -> Result<(), WhitenoiseError> {
         let now_ms = Utc::now().timestamp_millis();
 
+        // Collect expired message IDs before deletion so we can notify subscribers.
+        let expired_messages =
+            AggregatedMessage::find_expired(now_ms, &whitenoise.database).await?;
+
         let affected_groups =
             AggregatedMessage::delete_expired(now_ms, &whitenoise.database).await?;
 
@@ -46,8 +52,19 @@ impl Task for DisappearingMessageCleanup {
             return Ok(());
         }
 
+        // Emit per-message updates so open conversation views can remove them.
+        for (message_id, group_id) in &expired_messages {
+            whitenoise.message_stream_manager.emit(
+                group_id,
+                MessageUpdate {
+                    trigger: UpdateTrigger::MessageExpired,
+                    message: ChatMessage::expired_placeholder(message_id),
+                },
+            );
+        }
+
         // Emit chat-list updates for each affected group so the UI refreshes
-        // the last-message preview and message list.
+        // the last-message preview.
         for group_id in &affected_groups {
             whitenoise
                 .emit_chat_list_update_for_group(

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -432,8 +432,7 @@ mod tests {
         account: &crate::whitenoise::accounts::Account,
         relays: &[Relay],
     ) -> Result<EventId, crate::whitenoise::error::WhitenoiseError> {
-        let (encoded_key_package, tags, _hash_ref) =
-            whitenoise.encoded_key_package(account, relays).await?;
+        let kp_data = whitenoise.encoded_key_package(account, relays).await?;
 
         let nsec = whitenoise.export_account_nsec(account).await?;
         let secret_key =
@@ -441,12 +440,13 @@ mod tests {
         let keys = Keys::new(secret_key);
 
         // Filter out the encoding tag to simulate an outdated key package
-        let tags_without_encoding: Vec<Tag> = tags
+        let tags_without_encoding: Vec<Tag> = kp_data
+            .tags_443
             .into_iter()
             .filter(|tag| tag.kind() != TagKind::Custom("encoding".into()))
             .collect();
 
-        let event = EventBuilder::new(Kind::MlsKeyPackage, &encoded_key_package)
+        let event = EventBuilder::new(Kind::MlsKeyPackage, &kp_data.content)
             .tags(tags_without_encoding)
             .sign_with_keys(&keys)
             .map_err(|e| WhitenoiseError::Other(e.into()))?;

--- a/src/whitenoise/scheduled_tasks/tasks/mod.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/mod.rs
@@ -1,5 +1,6 @@
 mod cached_graph_user_cleanup;
 mod consumed_key_package_cleanup;
+mod disappearing_message_cleanup;
 mod key_package_maintenance;
 mod mute_expiry_cleanup;
 mod relay_list_maintenance;
@@ -7,6 +8,7 @@ mod subscription_health_check;
 
 pub(crate) use cached_graph_user_cleanup::CachedGraphUserCleanup;
 pub(crate) use consumed_key_package_cleanup::ConsumedKeyPackageCleanup;
+pub(crate) use disappearing_message_cleanup::DisappearingMessageCleanup;
 pub(crate) use key_package_maintenance::KeyPackageMaintenance;
 pub(crate) use mute_expiry_cleanup::MuteExpiryCleanup;
 pub(crate) use relay_list_maintenance::RelayListMaintenance;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/7041d0ad1d4b08a24e3c3f7649fd5257d9facc2fea8b7982c6523cb27614f051.jpg)

Needs: https://github.com/marmot-protocol/mdk/pull/253

## Summary

Adds group-level disappearing messages, closing #278. Admins set a TTL (in seconds) on a group; every message stored after that gets an `expires_at` timestamp. A background task sweeps expired rows every 30 seconds and notifies the UI.

This marmot learned to build hourglasses into the burrow walls. Messages that overstay their welcome get politely escorted out.

## What changed

**mdk-core bump** (commit `00be148`): picks up the new `disappearing_message_duration_secs` field on `NostrGroupDataExtension` v3, the `EventTag` type for NIP-40 expiration, and the `KeyPackageEventData` struct replacing the old tuple return.

**Database** (`0046_add_expires_at_to_aggregated_messages.sql`): adds a nullable `expires_at INTEGER` column to `aggregated_messages` with a partial index on non-NULL rows so cleanup queries stay fast regardless of how many permanent messages exist.

**Message lifecycle**: both incoming (`cache_chat_message`) and outgoing (`process_and_emit_outgoing_message`) paths now read the group's disappearing duration and compute `expires_at = created_at + duration`. Outgoing messages also get a NIP-40 `expiration` tag on the outer kind:445 wrapper so relays can discard stale ciphertext.

**Scheduled task** (`DisappearingMessageCleanup`): runs every 30s, deletes rows where `expires_at <= now`, and emits `LastMessageDeleted` chat-list updates for affected groups.

**Public API** on `Whitenoise`:
- `set_disappearing_messages(account, group_id, duration_secs)` (admin-gated via `ensure_account_is_group_admin`)
- `get_disappearing_message_duration(account, group_id)` returns `Option<u64>`

**`ChatMessage.expires_at`**: new field visible to frontends so they can show countdown indicators or "this message will disappear" UI.

## Design decisions

- **No retroactive expiry.** Changing the duration only affects new messages. Existing messages keep their original `expires_at` (or lack thereof). This matches Signal/WhatsApp behavior.
- **Local-only deletion.** The cleanup task does not publish kind:5 deletion events. Relay-side cleanup relies on NIP-40 expiration tags on the outer encrypted wrapper. The inner plaintext is never visible to relays anyway.
- **30-second sweep interval.** Fast enough that users see messages disappear promptly, cheap enough that it does not tax SQLite on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-group disappearing-message setting with set/get APIs; messages may have optional per-message expiry and expired-placeholder updates.
  * Background cleanup task removes expired messages and triggers chat-list refreshes and MessageExpired stream updates.
* **Database**
  * Migration adds expires_at column and partial index to support expiring messages.
* **Chores**
  * Updated pinned external dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->