### PR TITLE
Fixing silent discards all MIP-05 tokens beyond the first

### DIFF
--- a/db_migrations/0044_group_push_tokens_per_server.sql
+++ b/db_migrations/0044_group_push_tokens_per_server.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_group_push_tokens_account_group_leaf;
+
+CREATE UNIQUE INDEX idx_group_push_tokens_account_group_leaf_server
+    ON group_push_tokens(account_pubkey, mls_group_id, leaf_index, server_pubkey);

--- a/src/whitenoise/database/group_push_tokens.rs
+++ b/src/whitenoise/database/group_push_tokens.rs
@@ -151,9 +151,8 @@ impl GroupPushToken {
                  updated_at
              )
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(account_pubkey, mls_group_id, leaf_index) DO UPDATE SET
+             ON CONFLICT(account_pubkey, mls_group_id, leaf_index, server_pubkey) DO UPDATE SET
                  member_pubkey = excluded.member_pubkey,
-                 server_pubkey = excluded.server_pubkey,
                  relay_hint = excluded.relay_hint,
                  encrypted_token = excluded.encrypted_token,
                  updated_at = excluded.updated_at
@@ -284,9 +283,8 @@ impl GroupPushToken {
                      updated_at
                  )
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 ON CONFLICT(account_pubkey, mls_group_id, leaf_index) DO UPDATE SET
+                 ON CONFLICT(account_pubkey, mls_group_id, leaf_index, server_pubkey) DO UPDATE SET
                      member_pubkey = excluded.member_pubkey,
-                     server_pubkey = excluded.server_pubkey,
                      relay_hint = excluded.relay_hint,
                      encrypted_token = excluded.encrypted_token,
                      updated_at = excluded.updated_at",
@@ -324,12 +322,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_group_push_tokens_insert_replace_delete() {
+    async fn test_group_push_tokens_insert_update_delete() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let mls_group_id = make_group_id(1);
-        let first_server = Keys::generate().public_key();
-        let second_server = Keys::generate().public_key();
+        let server_pubkey = Keys::generate().public_key();
         let member_pubkey = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://server.example.com/").unwrap();
 
@@ -338,7 +335,7 @@ mod tests {
             &mls_group_id,
             &member_pubkey,
             7,
-            &first_server,
+            &server_pubkey,
             Some(&relay_hint),
             "ciphertext-one",
             &whitenoise.database,
@@ -346,26 +343,26 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(created.leaf_index, 7);
-        assert_eq!(created.server_pubkey, first_server);
+        assert_eq!(created.server_pubkey, server_pubkey);
         assert_eq!(created.encrypted_token, "ciphertext-one");
 
-        let replaced = GroupPushToken::upsert(
+        let updated = GroupPushToken::upsert(
             &account.pubkey,
             &mls_group_id,
             &member_pubkey,
             7,
-            &second_server,
+            &server_pubkey,
             None,
             "ciphertext-two",
             &whitenoise.database,
         )
         .await
         .unwrap();
-        assert_eq!(replaced.leaf_index, 7);
-        assert_eq!(replaced.server_pubkey, second_server);
-        assert_eq!(replaced.relay_hint, None);
-        assert_eq!(replaced.encrypted_token, "ciphertext-two");
-        assert!(replaced.updated_at >= created.updated_at);
+        assert_eq!(updated.leaf_index, 7);
+        assert_eq!(updated.server_pubkey, server_pubkey);
+        assert_eq!(updated.relay_hint, None);
+        assert_eq!(updated.encrypted_token, "ciphertext-two");
+        assert!(updated.updated_at >= created.updated_at);
 
         let stored = GroupPushToken::find_by_account_and_group(
             &account.pubkey,
@@ -374,7 +371,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(stored, vec![replaced.clone()]);
+        assert_eq!(stored, vec![updated.clone()]);
 
         let deleted =
             GroupPushToken::delete(&account.pubkey, &mls_group_id, 7, &whitenoise.database)
@@ -438,6 +435,56 @@ mod tests {
         assert_eq!(second_leaf.server_pubkey, second_server);
         assert!(stored.iter().any(|token| token.leaf_index == 3));
         assert!(stored.iter().any(|token| token == &second_leaf));
+    }
+
+    #[tokio::test]
+    async fn test_group_push_tokens_upsert_allows_multiple_servers_for_same_leaf() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let mls_group_id = make_group_id(8);
+        let member_pubkey = Keys::generate().public_key();
+        let first_server = Keys::generate().public_key();
+        let second_server = Keys::generate().public_key();
+
+        GroupPushToken::upsert(
+            &account.pubkey,
+            &mls_group_id,
+            &member_pubkey,
+            3,
+            &first_server,
+            None,
+            "ciphertext-one",
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        let second_server_token = GroupPushToken::upsert(
+            &account.pubkey,
+            &mls_group_id,
+            &member_pubkey,
+            3,
+            &second_server,
+            None,
+            "ciphertext-two",
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let stored = GroupPushToken::find_by_account_and_group(
+            &account.pubkey,
+            &mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(stored.len(), 2);
+        assert!(
+            stored
+                .iter()
+                .any(|token| token.server_pubkey == first_server)
+        );
+        assert!(stored.iter().any(|token| token == &second_server_token));
     }
 
     #[tokio::test]
@@ -583,8 +630,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let mls_group_id = make_group_id(33);
-        let first_server = Keys::generate().public_key();
-        let second_server = Keys::generate().public_key();
+        let server_pubkey = Keys::generate().public_key();
         let member_pubkey = Keys::generate().public_key();
 
         GroupPushToken::upsert(
@@ -592,7 +638,7 @@ mod tests {
             &mls_group_id,
             &member_pubkey,
             4,
-            &first_server,
+            &server_pubkey,
             None,
             "ciphertext-one",
             &whitenoise.database,
@@ -621,7 +667,7 @@ mod tests {
             &mls_group_id,
             &member_pubkey,
             4,
-            &second_server,
+            &server_pubkey,
             None,
             "ciphertext-two",
             &whitenoise.database,
@@ -630,7 +676,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(updated.created_at, expected_created_at);
-        assert_eq!(updated.server_pubkey, second_server);
+        assert_eq!(updated.server_pubkey, server_pubkey);
         assert_eq!(updated.encrypted_token, "ciphertext-two");
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1160,23 +1160,25 @@ impl Whitenoise {
         leaf_index: u32,
         request: mdk_core::mip05::TokenRequest,
     ) -> Result<()> {
-        let Some(token) = request.tokens.into_iter().next() else {
+        if request.tokens.is_empty() {
             return Err(WhitenoiseError::InvalidEvent(
                 "MIP-05 token request must include at least one token".to_string(),
             ));
-        };
+        }
 
-        GroupPushToken::upsert(
-            &account.pubkey,
-            mls_group_id,
-            &member_pubkey,
-            leaf_index,
-            &token.server_pubkey,
-            Some(&token.relay_hint),
-            &token.encrypted_token.to_base64(),
-            &self.database,
-        )
-        .await?;
+        for token in request.tokens {
+            GroupPushToken::upsert(
+                &account.pubkey,
+                mls_group_id,
+                &member_pubkey,
+                leaf_index,
+                &token.server_pubkey,
+                Some(&token.relay_hint),
+                &token.encrypted_token.to_base64(),
+                &self.database,
+            )
+            .await?;
+        }
 
         Ok(())
     }
@@ -1879,6 +1881,64 @@ mod tests {
         .await
         .unwrap();
         assert!(cached_tokens.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_merge_token_request_upserts_all_tokens() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[11; 32]);
+        let member_pubkey = Keys::generate().public_key();
+        let first_server = Keys::generate().public_key();
+        let second_server = Keys::generate().public_key();
+        let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
+        let first_token = encrypt_push_token(
+            &first_server,
+            &PushTokenPlaintext::new(NotificationPlatform::Fcm, b"device-a".to_vec()).unwrap(),
+        )
+        .unwrap();
+        let second_token = encrypt_push_token(
+            &second_server,
+            &PushTokenPlaintext::new(NotificationPlatform::Apns, vec![7; 32]).unwrap(),
+        )
+        .unwrap();
+        let request = mdk_core::mip05::TokenRequest {
+            tokens: vec![
+                TokenTag {
+                    encrypted_token: first_token,
+                    server_pubkey: first_server,
+                    relay_hint: relay_hint.clone(),
+                },
+                TokenTag {
+                    encrypted_token: second_token,
+                    server_pubkey: second_server,
+                    relay_hint,
+                },
+            ],
+        };
+
+        whitenoise
+            .merge_token_request(&account, &group_id, member_pubkey, 5, request)
+            .await
+            .unwrap();
+
+        let cached_tokens = GroupPushToken::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        let cached_servers: std::collections::HashSet<PublicKey> = cached_tokens
+            .iter()
+            .map(|token| token.server_pubkey)
+            .collect();
+
+        assert_eq!(cached_tokens.len(), 2);
+        assert_eq!(
+            cached_servers,
+            std::collections::HashSet::from([first_server, second_server])
+        );
     }
 
     #[tokio::test]
@@ -2615,12 +2675,10 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::pause();
         let settings = whitenoise
             .update_notifications_enabled(&admin_account, false)
             .await
             .unwrap();
-        tokio::time::resume();
         assert!(!settings.notifications_enabled);
 
         let cached_after_disable = GroupPushToken::find_by_account_and_group(


### PR DESCRIPTION
Should close #705 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed push notification token handling to process all provided tokens instead of only the first one
* Enhanced support for handling push tokens from multiple notification servers for the same group member

<!-- end of auto-generated comment: release notes by coderabbit.ai -->