### PR TITLE
fix: add sleeps between follow mutations to avoid relay timestamp collisions

### DIFF
--- a/src/integration_tests/scenarios/follow_management.rs
+++ b/src/integration_tests/scenarios/follow_management.rs
@@ -1,10 +1,13 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nostr_sdk::Keys;
+
 use crate::integration_tests::{
     core::*,
     test_cases::{follow_management::*, shared::*},
 };
 use crate::{Whitenoise, WhitenoiseError};
-use async_trait::async_trait;
-use nostr_sdk::Keys;
 
 pub struct FollowManagementScenario {
     context: ScenarioContext,
@@ -39,10 +42,18 @@ impl Scenario for FollowManagementScenario {
             .execute(&mut self.context)
             .await?;
 
+        // Allow background ContactList publish to reach relay before next mutation.
+        // Without this, rapid follow/unfollow can produce ContactList events with
+        // identical second-precision timestamps, causing the relay to reject the
+        // newer event ("replaced: have newer event") and leaving stale state.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
         // Test following a second user
         FollowUserTestCase::new("follow_mgmt_follower", test_contact2)
             .execute(&mut self.context)
             .await?;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         // Test unfollowing the first user
         UnfollowUserTestCase::new("follow_mgmt_follower", test_contact1)


### PR DESCRIPTION
## Changes

Add 2-second delays between follow/unfollow operations in the follow management integration test scenario.

## Why

Rapid consecutive follow/unfollow mutations can produce ContactList events with identical second-precision timestamps. When these events are sent to the relay in quick succession, the relay rejects newer events with "replaced: have newer event" errors, leaving the state inconsistent.

The delays ensure each ContactList event has a distinct timestamp, preventing relay rejection and maintaining correct state throughout the test scenario.

## Files Changed

- `src/integration_tests/scenarios/follow_management.rs`: Added `tokio::time::sleep` calls and necessary imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test timing to allow proper propagation of background processes in follow management scenarios.

**Note:** This release contains only internal test infrastructure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->