### PR TITLE
Replace anyhow with typed error enums throughout codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,6 @@ name = "whitenoise"
 version = "0.2.1"
 dependencies = [
  "android-native-keyring-store",
- "anyhow",
  "apple-native-keyring-store",
  "async-trait",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ name = "whitenoise"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-trait = "0.1.88"
 chrono = { version = "0.4.40", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive"], optional = true }

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -150,12 +150,10 @@ fn save_keyring_sidecar(
 ) -> Result<(), WhitenoiseError> {
     let db_key_id = format!("mdk.db.key.{pubkey_hex}");
     let entry = Entry::new(KEYRING_SERVICE, &db_key_id)
-        .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("keyring entry error: {e}")))?;
+        .map_err(|e| WhitenoiseError::Internal(format!("keyring entry error: {e}")))?;
 
     let secret = entry.get_secret().map_err(|e| {
-        WhitenoiseError::Other(anyhow::anyhow!(
-            "failed to read MDK DB key from keyring: {e}"
-        ))
+        WhitenoiseError::Internal(format!("failed to read MDK DB key from keyring: {e}"))
     })?;
 
     let hex_secret = hex::encode(&secret);
@@ -175,16 +173,16 @@ fn save_keyring_sidecar(
             .mode(0o600)
             .open(&path)
             .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("failed to create keyring sidecar: {e}"))
+                WhitenoiseError::Internal(format!("failed to create keyring sidecar: {e}"))
             })?;
         file.write_all(line.as_bytes()).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("failed to write keyring sidecar: {e}"))
+            WhitenoiseError::Internal(format!("failed to write keyring sidecar: {e}"))
         })?;
     }
     #[cfg(not(unix))]
     {
         std::fs::write(&path, &line).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("failed to write keyring sidecar: {e}"))
+            WhitenoiseError::Internal(format!("failed to write keyring sidecar: {e}"))
         })?;
     }
 
@@ -208,10 +206,10 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
 
     // Re-seed the Nostr private key.
     let keys = Keys::parse(nsec)
-        .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("Invalid --seed-nsec value: {e}")))?;
+        .map_err(|e| WhitenoiseError::Internal(format!("Invalid --seed-nsec value: {e}")))?;
     SecretsStore::new(KEYRING_SERVICE)
         .store_private_key(&keys)
-        .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("Failed to re-seed Nostr key: {e}")))?;
+        .map_err(|e| WhitenoiseError::Internal(format!("Failed to re-seed Nostr key: {e}")))?;
     tracing::info!(
         "Re-seeded Nostr key for pubkey {}",
         keys.public_key().to_hex()
@@ -220,7 +218,7 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
     // Restore MDK DB encryption keys from the sidecar.
     let path = data_dir.join(KEYRING_SIDECAR);
     let content = std::fs::read_to_string(&path).map_err(|e| {
-        WhitenoiseError::Other(anyhow::anyhow!(
+        WhitenoiseError::Internal(format!(
             "Failed to read keyring sidecar {}: {} — run --login first",
             path.display(),
             e
@@ -233,18 +231,15 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
             continue;
         }
         let (key_id, hex_secret) = line.split_once(' ').ok_or_else(|| {
-            WhitenoiseError::Other(anyhow::anyhow!("Malformed keyring sidecar line: {line:?}"))
+            WhitenoiseError::Internal(format!("Malformed keyring sidecar line: {line:?}"))
         })?;
-        let secret = hex::decode(hex_secret).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Hex decode error in sidecar: {e}"))
-        })?;
+        let secret = hex::decode(hex_secret)
+            .map_err(|e| WhitenoiseError::Internal(format!("Hex decode error in sidecar: {e}")))?;
 
         let entry = Entry::new(KEYRING_SERVICE, key_id)
-            .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("keyring entry error: {e}")))?;
+            .map_err(|e| WhitenoiseError::Internal(format!("keyring entry error: {e}")))?;
         entry.set_secret(&secret).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!(
-                "Failed to restore keyring entry {key_id}: {e}"
-            ))
+            WhitenoiseError::Internal(format!("Failed to restore keyring entry {key_id}: {e}"))
         })?;
 
         tracing::info!("Restored keyring entry: {key_id}");
@@ -332,9 +327,9 @@ async fn main() -> Result<(), WhitenoiseError> {
 
     if let Some(ref trace_path) = args.chrome_trace {
         if !args.detailed {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                "--chrome-trace requires --detailed; re-run with both flags"
-            )));
+            return Err(WhitenoiseError::Internal(
+                "--chrome-trace requires --detailed; re-run with both flags".to_string(),
+            ));
         }
         write_perfetto_trace(trace_path, &results)?;
     }

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -206,7 +206,7 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
 
     // Re-seed the Nostr private key.
     let keys = Keys::parse(nsec)
-        .map_err(|e| WhitenoiseError::Internal(format!("Invalid --seed-nsec value: {e}")))?;
+        .map_err(|e| WhitenoiseError::InvalidInput(format!("Invalid --seed-nsec value: {e}")))?;
     SecretsStore::new(KEYRING_SERVICE)
         .store_private_key(&keys)
         .map_err(|e| WhitenoiseError::Internal(format!("Failed to re-seed Nostr key: {e}")))?;
@@ -327,7 +327,7 @@ async fn main() -> Result<(), WhitenoiseError> {
 
     if let Some(ref trace_path) = args.chrome_trace {
         if !args.detailed {
-            return Err(WhitenoiseError::Internal(
+            return Err(WhitenoiseError::InvalidInput(
                 "--chrome-trace requires --detailed; re-run with both flags".to_string(),
             ));
         }

--- a/src/bin/wn.rs
+++ b/src/bin/wn.rs
@@ -123,7 +123,7 @@ enum Cmd {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> whitenoise::cli::Result<()> {
     let args = Args::parse();
     let config = Config::resolve(None, None);
     let socket = args.socket.unwrap_or_else(|| config.socket_path());
@@ -150,9 +150,9 @@ async fn main() -> anyhow::Result<()> {
         Cmd::Keys(cmd) => cmd.run(&socket, args.json, args.account.as_deref()).await,
         Cmd::Reset { confirm } => {
             if !confirm {
-                anyhow::bail!(
-                    "this will delete ALL data (database, MLS state, logs). Pass --confirm to proceed."
-                );
+                return Err(whitenoise::cli::CliError::msg(
+                    "this will delete ALL data (database, MLS state, logs). Pass --confirm to proceed.",
+                ));
             }
             let resp = client::send(&socket, &Request::DeleteAllData).await?;
             output::print_and_exit(&resp, args.json)

--- a/src/bin/wnd.rs
+++ b/src/bin/wnd.rs
@@ -17,7 +17,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> whitenoise::cli::Result<()> {
     let args = Args::parse();
     let config = Config::resolve(args.data_dir.as_ref(), args.logs_dir.as_ref());
 

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::cli::client;
+use crate::cli::error::CliError;
 use crate::cli::protocol::Request;
 
 /// Resolve which account to use for a command.
@@ -10,7 +11,7 @@ use crate::cli::protocol::Request;
 /// 2. `WN_ACCOUNT` environment variable
 /// 3. If exactly one account is logged in, use it
 /// 4. Error with guidance
-pub async fn resolve_account(socket: &Path, explicit: Option<&str>) -> anyhow::Result<String> {
+pub async fn resolve_account(socket: &Path, explicit: Option<&str>) -> crate::cli::Result<String> {
     // 1. Explicit flag
     if let Some(pubkey) = explicit {
         return Ok(pubkey.to_string());
@@ -28,7 +29,7 @@ pub async fn resolve_account(socket: &Path, explicit: Option<&str>) -> anyhow::R
     let resp = client::send(socket, &Request::AllAccounts).await?;
 
     if let Some(error) = &resp.error {
-        anyhow::bail!("{}", error.message);
+        return Err(CliError::msg(error.message.clone()));
     }
 
     let pubkeys = extract_pubkeys(&resp.result);
@@ -36,20 +37,20 @@ pub async fn resolve_account(socket: &Path, explicit: Option<&str>) -> anyhow::R
 }
 
 /// Pure resolution logic over a list of pubkeys, separated for testability.
-fn resolve_from_list(pubkeys: &[String]) -> anyhow::Result<String> {
+fn resolve_from_list(pubkeys: &[String]) -> crate::cli::Result<String> {
     match pubkeys.len() {
-        0 => anyhow::bail!(
-            "no accounts logged in\n\n  Create one with: wn create-identity\n  Or log in with:  wn login"
-        ),
+        0 => Err(CliError::msg(
+            "no accounts logged in\n\n  Create one with: wn create-identity\n  Or log in with:  wn login",
+        )),
         1 => Ok(pubkeys[0].clone()),
-        _ => anyhow::bail!(
+        _ => Err(CliError::msg(format!(
             "multiple accounts logged in. Specify --account <npub> or set WN_ACCOUNT\n\n  Accounts:\n{}",
             pubkeys
                 .iter()
                 .map(|p| format!("    {p}"))
                 .collect::<Vec<_>>()
                 .join("\n")
-        ),
+        ))),
     }
 }
 

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -4,21 +4,28 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
+use super::error::CliError;
 use super::protocol::{Request, Response};
 
+fn connection_error(err: std::io::Error) -> CliError {
+    if matches!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+    ) {
+        CliError::DaemonUnavailable(
+            "daemon not running\n\n  Start it with: wn daemon start\n  Check status:  wn daemon status"
+                .to_string(),
+        )
+    } else {
+        CliError::msg(format!("failed to connect to daemon: {err}"))
+    }
+}
+
 /// Send a single request to the daemon and return a response.
-pub async fn send(socket_path: &Path, request: &Request) -> anyhow::Result<Response> {
-    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::ConnectionRefused
-            || e.kind() == std::io::ErrorKind::NotFound
-        {
-            anyhow::anyhow!(
-                "daemon not running\n\n  Start it with: wn daemon start\n  Check status:  wn daemon status"
-            )
-        } else {
-            anyhow::anyhow!("failed to connect to daemon: {e}")
-        }
-    })?;
+pub async fn send(socket_path: &Path, request: &Request) -> crate::cli::Result<Response> {
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(connection_error)?;
 
     let (reader, mut writer) = stream.into_split();
 
@@ -30,9 +37,9 @@ pub async fn send(socket_path: &Path, request: &Request) -> anyhow::Result<Respo
     let mut lines = BufReader::new(reader).lines();
     match tokio::time::timeout(Duration::from_secs(30), lines.next_line()).await {
         Ok(Ok(Some(line))) => Ok(serde_json::from_str(&line)?),
-        Ok(Ok(None)) => anyhow::bail!("daemon closed connection without responding"),
+        Ok(Ok(None)) => Err(CliError::msg("daemon closed connection without responding")),
         Ok(Err(e)) => Err(e.into()),
-        Err(_) => anyhow::bail!("daemon did not respond within 30s"),
+        Err(_) => Err(CliError::msg("daemon did not respond within 30s")),
     }
 }
 
@@ -45,18 +52,10 @@ pub async fn stream(
     socket_path: &Path,
     request: &Request,
     mut handler: impl FnMut(&Response) -> bool,
-) -> anyhow::Result<()> {
-    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::ConnectionRefused
-            || e.kind() == std::io::ErrorKind::NotFound
-        {
-            anyhow::anyhow!(
-                "daemon not running\n\n  Start it with: wn daemon start\n  Check status:  wn daemon status"
-            )
-        } else {
-            anyhow::anyhow!("failed to connect to daemon: {e}")
-        }
-    })?;
+) -> crate::cli::Result<()> {
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(connection_error)?;
 
     let (reader, mut writer) = stream.into_split();
 

--- a/src/cli/commands/accounts.rs
+++ b/src/cli/commands/accounts.rs
@@ -13,14 +13,14 @@ pub enum AccountsCmd {
 }
 
 impl AccountsCmd {
-    pub async fn run(self, socket: &Path, json: bool) -> anyhow::Result<()> {
+    pub async fn run(self, socket: &Path, json: bool) -> crate::cli::Result<()> {
         match self {
             Self::List => list(socket, json).await,
         }
     }
 }
 
-async fn list(socket: &Path, json: bool) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::AllAccounts).await?;
     output::print_and_exit(&resp, json)
 }

--- a/src/cli/commands/chats.rs
+++ b/src/cli/commands/chats.rs
@@ -54,7 +54,7 @@ impl ChatsCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List => list(socket, json, account_flag).await,
             Self::Subscribe => subscribe(socket, json, account_flag).await,
@@ -70,13 +70,17 @@ impl ChatsCmd {
     }
 }
 
-async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::ChatsList { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn subscribe(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn subscribe(
+    socket: &Path,
+    json: bool,
+    account_flag: Option<&str>,
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let req = Request::ChatsSubscribe { account: pubkey };
     let mut had_error = false;
@@ -99,7 +103,7 @@ async fn archive(
     json: bool,
     account_flag: Option<&str>,
     group_id: &str,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -117,7 +121,7 @@ async fn unarchive(
     json: bool,
     account_flag: Option<&str>,
     group_id: &str,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -134,7 +138,7 @@ async fn list_archived(
     socket: &Path,
     json: bool,
     account_flag: Option<&str>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::ArchivedChatsList { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -144,7 +148,7 @@ async fn subscribe_archived(
     socket: &Path,
     json: bool,
     account_flag: Option<&str>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let req = Request::ArchivedChatsSubscribe { account: pubkey };
     let mut had_error = false;
@@ -168,11 +172,11 @@ async fn mute(
     account_flag: Option<&str>,
     group_id: &str,
     duration: &str,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let duration = duration
         .parse::<MuteDuration>()
-        .map_err(|e| anyhow::anyhow!(e))?;
+        .map_err(crate::cli::error::CliError::msg)?;
     let resp = client::send(
         socket,
         &Request::MuteChat {
@@ -190,7 +194,7 @@ async fn unmute(
     json: bool,
     account_flag: Option<&str>,
     group_id: &str,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -1,9 +1,9 @@
 use std::process::Command;
 
-use anyhow::Context;
 use clap::Subcommand;
 
 use crate::cli::config::Config;
+use crate::cli::error::CliError;
 use crate::cli::server;
 
 #[derive(Debug, Subcommand)]
@@ -17,7 +17,7 @@ pub enum DaemonCmd {
 }
 
 impl DaemonCmd {
-    pub async fn run(self, config: &Config) -> anyhow::Result<()> {
+    pub async fn run(self, config: &Config) -> crate::cli::Result<()> {
         match self {
             Self::Start => start(config).await,
             Self::Stop => server::stop_daemon(config),
@@ -26,7 +26,7 @@ impl DaemonCmd {
     }
 }
 
-async fn start(config: &Config) -> anyhow::Result<()> {
+async fn start(config: &Config) -> crate::cli::Result<()> {
     // When invoked via `wn daemon start`, spawn `wnd` as a detached child
     // and return immediately. When invoked directly as `wnd`, this path
     // isn't used — wnd.rs calls server::run() directly.
@@ -37,12 +37,13 @@ async fn start(config: &Config) -> anyhow::Result<()> {
     cmd.stdout(std::process::Stdio::null());
     cmd.stderr(std::process::Stdio::null());
 
-    cmd.spawn().context("failed to start daemon")?;
+    cmd.spawn()
+        .map_err(|e| CliError::msg(format!("failed to start daemon: {e}")))?;
     println!("daemon started");
     Ok(())
 }
 
-fn status(config: &Config) -> anyhow::Result<()> {
+fn status(config: &Config) -> crate::cli::Result<()> {
     match server::is_daemon_running(config) {
         Some(pid) => {
             println!("daemon running (pid {pid})");
@@ -55,7 +56,7 @@ fn status(config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn which_wnd() -> anyhow::Result<std::path::PathBuf> {
+fn which_wnd() -> crate::cli::Result<std::path::PathBuf> {
     // Look next to the current executable first (cargo install puts both binaries together)
     if let Ok(current) = std::env::current_exe() {
         let sibling = current.parent().unwrap_or(current.as_ref()).join("wnd");
@@ -71,5 +72,5 @@ fn which_wnd() -> anyhow::Result<std::path::PathBuf> {
                 candidate.is_file().then_some(candidate)
             })
         })
-        .ok_or_else(|| anyhow::anyhow!("wnd not found. Ensure it's installed and on your PATH."))
+        .ok_or_else(|| CliError::msg("wnd not found. Ensure it's installed and on your PATH."))
 }

--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -37,8 +37,7 @@ async fn start(config: &Config) -> crate::cli::Result<()> {
     cmd.stdout(std::process::Stdio::null());
     cmd.stderr(std::process::Stdio::null());
 
-    cmd.spawn()
-        .map_err(|e| CliError::msg(format!("failed to start daemon: {e}")))?;
+    cmd.spawn()?;
     println!("daemon started");
     Ok(())
 }

--- a/src/cli/commands/debug.rs
+++ b/src/cli/commands/debug.rs
@@ -28,7 +28,7 @@ impl DebugCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::RelayControlState => relay_control_state(socket, json).await,
             Self::Health => health(socket, json, account_flag).await,
@@ -39,12 +39,12 @@ impl DebugCmd {
     }
 }
 
-async fn relay_control_state(socket: &Path, json: bool) -> anyhow::Result<()> {
+async fn relay_control_state(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::DebugRelayControlState).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn health(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn health(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::DebugHealth { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -55,7 +55,7 @@ async fn ratchet_tree(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/follows.rs
+++ b/src/cli/commands/follows.rs
@@ -37,7 +37,7 @@ impl FollowsCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List => list(socket, json, account_flag).await,
             Self::Add { pubkey } => add(socket, json, account_flag, pubkey).await,
@@ -47,7 +47,7 @@ impl FollowsCmd {
     }
 }
 
-async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::FollowsList { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -58,7 +58,7 @@ async fn add(
     json: bool,
     account_flag: Option<&str>,
     pubkey: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let account = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::FollowsAdd { account, pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -69,7 +69,7 @@ async fn remove(
     json: bool,
     account_flag: Option<&str>,
     pubkey: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let account = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::FollowsRemove { account, pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -80,7 +80,7 @@ async fn check(
     json: bool,
     account_flag: Option<&str>,
     pubkey: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let account = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::FollowsCheck { account, pubkey }).await?;
     output::print_and_exit(&resp, json)

--- a/src/cli/commands/groups.rs
+++ b/src/cli/commands/groups.rs
@@ -132,7 +132,7 @@ impl GroupsCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List => list(socket, json, account_flag).await,
             Self::Create {
@@ -177,7 +177,7 @@ async fn create(
     name: String,
     members: Vec<String>,
     description: Option<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -197,7 +197,7 @@ async fn show(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -216,7 +216,7 @@ async fn add_members(
     account_flag: Option<&str>,
     group_id: String,
     members: Vec<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -236,7 +236,7 @@ async fn remove_members(
     account_flag: Option<&str>,
     group_id: String,
     members: Vec<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -255,7 +255,7 @@ async fn members(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -273,7 +273,7 @@ async fn admins(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -291,7 +291,7 @@ async fn relays(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -309,7 +309,7 @@ async fn leave(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -328,7 +328,7 @@ async fn rename(
     account_flag: Option<&str>,
     group_id: String,
     name: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -342,13 +342,13 @@ async fn rename(
     output::print_and_exit(&resp, json)
 }
 
-async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::VisibleGroups { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn invites(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn invites(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::GroupInvites { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -359,7 +359,7 @@ async fn accept(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -377,7 +377,7 @@ async fn decline(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -396,7 +396,7 @@ async fn promote(
     account_flag: Option<&str>,
     group_id: String,
     pubkey: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let account = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -416,7 +416,7 @@ async fn demote(
     account_flag: Option<&str>,
     group_id: String,
     pubkey: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let account = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -435,7 +435,7 @@ async fn self_demote(
     json: bool,
     account_flag: Option<&str>,
     group_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -5,12 +5,12 @@ use crate::cli::client;
 use crate::cli::output;
 use crate::cli::protocol::{Request, Response};
 
-pub async fn create_identity(socket: &Path, json: bool) -> anyhow::Result<()> {
+pub async fn create_identity(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::CreateIdentity).await?;
     output::print_and_exit(&resp, json)
 }
 
-pub async fn login(socket: &Path, json: bool, relay: Option<String>) -> anyhow::Result<()> {
+pub async fn login(socket: &Path, json: bool, relay: Option<String>) -> crate::cli::Result<()> {
     let nsec = read_nsec()?;
     let resp = client::send(socket, &Request::LoginStart { nsec }).await?;
 
@@ -41,7 +41,9 @@ pub async fn login(socket: &Path, json: bool, relay: Option<String>) -> anyhow::
         .and_then(|v| v.get("account"))
         .and_then(|v| v.get("pubkey"))
         .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow::anyhow!("unexpected login response: missing pubkey"))?
+        .ok_or_else(|| {
+            crate::cli::error::CliError::msg("unexpected login response: missing pubkey")
+        })?
         .to_string();
 
     let relay_resp = match relay {
@@ -86,7 +88,7 @@ pub async fn login(socket: &Path, json: bool, relay: Option<String>) -> anyhow::
                 if url.is_empty() {
                     // User bailed — cancel the pending login
                     let _ = client::send(socket, &Request::LoginCancel { pubkey }).await;
-                    anyhow::bail!("login cancelled");
+                    return Err(crate::cli::error::CliError::msg("login cancelled"));
                 }
 
                 client::send(
@@ -114,7 +116,7 @@ pub async fn login(socket: &Path, json: bool, relay: Option<String>) -> anyhow::
     Ok(())
 }
 
-pub async fn logout(socket: &Path, pubkey: &str, json: bool) -> anyhow::Result<()> {
+pub async fn logout(socket: &Path, pubkey: &str, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(
         socket,
         &Request::Logout {
@@ -125,7 +127,7 @@ pub async fn logout(socket: &Path, pubkey: &str, json: bool) -> anyhow::Result<(
     output::print_and_exit(&resp, json)
 }
 
-pub async fn whoami(socket: &Path, json: bool) -> anyhow::Result<()> {
+pub async fn whoami(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::AllAccounts).await?;
     if json {
         output::print_response(&resp, true);
@@ -148,7 +150,7 @@ pub async fn whoami(socket: &Path, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn export_nsec(socket: &Path, pubkey: &str, json: bool) -> anyhow::Result<()> {
+pub async fn export_nsec(socket: &Path, pubkey: &str, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(
         socket,
         &Request::ExportNsec {
@@ -159,7 +161,7 @@ pub async fn export_nsec(socket: &Path, pubkey: &str, json: bool) -> anyhow::Res
     output::print_and_exit(&resp, json)
 }
 
-fn read_nsec() -> anyhow::Result<String> {
+fn read_nsec() -> crate::cli::Result<String> {
     let nsec = if io::stdin().is_terminal() {
         eprint!("Enter nsec: ");
         io::stderr().flush()?;
@@ -173,7 +175,7 @@ fn read_nsec() -> anyhow::Result<String> {
     };
     let nsec = nsec.trim().to_string();
     if nsec.is_empty() {
-        anyhow::bail!("no nsec provided");
+        return Err(crate::cli::error::CliError::msg("no nsec provided"));
     }
     Ok(nsec)
 }

--- a/src/cli/commands/keys.rs
+++ b/src/cli/commands/keys.rs
@@ -41,16 +41,16 @@ impl KeysCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List => list(socket, json, account_flag).await,
             Self::Publish => publish(socket, json, account_flag).await,
             Self::Delete { event_id } => delete(socket, json, account_flag, event_id).await,
             Self::DeleteAll { confirm } => {
                 if !confirm {
-                    anyhow::bail!(
-                        "this will delete ALL published key packages. Pass --confirm to proceed."
-                    );
+                    return Err(crate::cli::error::CliError::msg(
+                        "this will delete ALL published key packages. Pass --confirm to proceed.",
+                    ));
                 }
                 delete_all(socket, json, account_flag).await
             }
@@ -59,13 +59,13 @@ impl KeysCmd {
     }
 }
 
-async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::KeysList { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn publish(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn publish(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::KeysPublish { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -76,7 +76,7 @@ async fn delete(
     json: bool,
     account_flag: Option<&str>,
     event_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -89,13 +89,17 @@ async fn delete(
     output::print_and_exit(&resp, json)
 }
 
-async fn delete_all(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn delete_all(
+    socket: &Path,
+    json: bool,
+    account_flag: Option<&str>,
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::KeysDeleteAll { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn check(socket: &Path, json: bool, pubkey: &str) -> anyhow::Result<()> {
+async fn check(socket: &Path, json: bool, pubkey: &str) -> crate::cli::Result<()> {
     let resp = client::send(
         socket,
         &Request::KeysCheck {

--- a/src/cli/commands/media.rs
+++ b/src/cli/commands/media.rs
@@ -48,7 +48,7 @@ impl MediaCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::Upload {
                 group_id,
@@ -84,7 +84,7 @@ async fn upload(
     file_path: String,
     send: bool,
     message: Option<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     // --message implies --send
     let send = send || message.is_some();
@@ -102,7 +102,7 @@ async fn upload(
     output::print_and_exit(&resp, json)
 }
 
-async fn list(socket: &Path, json: bool, group_id: String) -> anyhow::Result<()> {
+async fn list(socket: &Path, json: bool, group_id: String) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::ListMedia { group_id }).await?;
     output::print_and_exit(&resp, json)
 }
@@ -113,7 +113,7 @@ async fn download(
     account_flag: Option<&str>,
     group_id: String,
     file_hash: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/messages.rs
+++ b/src/cli/commands/messages.rs
@@ -137,7 +137,7 @@ impl MessagesCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List {
                 group_id,
@@ -207,7 +207,7 @@ async fn list(
     after: Option<u64>,
     after_message_id: Option<String>,
     limit: Option<u32>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -232,7 +232,7 @@ async fn search(
     group_id: String,
     query: String,
     limit: Option<u32>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -253,7 +253,7 @@ async fn search_all(
     account_flag: Option<&str>,
     query: String,
     limit: Option<u32>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -273,7 +273,7 @@ async fn subscribe(
     account_flag: Option<&str>,
     group_id: String,
     limit: Option<u32>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let req = Request::MessagesSubscribe {
         account: pubkey,
@@ -302,7 +302,7 @@ async fn send(
     group_id: String,
     message: String,
     reply_to: Option<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -323,7 +323,7 @@ async fn delete(
     account_flag: Option<&str>,
     group_id: String,
     message_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -343,7 +343,7 @@ async fn retry(
     account_flag: Option<&str>,
     group_id: String,
     event_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -364,7 +364,7 @@ async fn react(
     group_id: String,
     message_id: String,
     emoji: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -385,7 +385,7 @@ async fn unreact(
     account_flag: Option<&str>,
     group_id: String,
     message_id: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/notifications.rs
+++ b/src/cli/commands/notifications.rs
@@ -13,14 +13,14 @@ pub enum NotificationsCmd {
 }
 
 impl NotificationsCmd {
-    pub async fn run(self, socket: &Path, json: bool) -> anyhow::Result<()> {
+    pub async fn run(self, socket: &Path, json: bool) -> crate::cli::Result<()> {
         match self {
             Self::Subscribe => subscribe(socket, json).await,
         }
     }
 }
 
-async fn subscribe(socket: &Path, json: bool) -> anyhow::Result<()> {
+async fn subscribe(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let req = Request::NotificationsSubscribe;
     let mut had_error = false;
     client::stream(socket, &req, |resp| {

--- a/src/cli/commands/profile.rs
+++ b/src/cli/commands/profile.rs
@@ -46,7 +46,7 @@ impl ProfileCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::Show => show(socket, json, account_flag).await,
             Self::Update {
@@ -74,7 +74,7 @@ impl ProfileCmd {
     }
 }
 
-async fn show(socket: &Path, json: bool, account_flag: Option<&str>) -> anyhow::Result<()> {
+async fn show(socket: &Path, json: bool, account_flag: Option<&str>) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(socket, &Request::ProfileShow { account: pubkey }).await?;
     output::print_and_exit(&resp, json)
@@ -91,7 +91,7 @@ async fn update(
     picture: Option<String>,
     nip05: Option<String>,
     lud16: Option<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/relays.rs
+++ b/src/cli/commands/relays.rs
@@ -43,7 +43,7 @@ impl RelaysCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::List { relay_type } => list(socket, json, account_flag, relay_type).await,
             Self::Add { url, relay_type } => add(socket, json, account_flag, url, relay_type).await,
@@ -59,7 +59,7 @@ async fn list(
     json: bool,
     account_flag: Option<&str>,
     relay_type: Option<String>,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -78,7 +78,7 @@ async fn add(
     account_flag: Option<&str>,
     url: String,
     relay_type: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,
@@ -98,7 +98,7 @@ async fn remove(
     account_flag: Option<&str>,
     url: String,
     relay_type: String,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let resp = client::send(
         socket,

--- a/src/cli/commands/settings.rs
+++ b/src/cli/commands/settings.rs
@@ -25,7 +25,7 @@ pub enum SettingsCmd {
 }
 
 impl SettingsCmd {
-    pub async fn run(self, socket: &Path, json: bool) -> anyhow::Result<()> {
+    pub async fn run(self, socket: &Path, json: bool) -> crate::cli::Result<()> {
         match self {
             Self::Show => show(socket, json).await,
             Self::Theme { mode } => theme(socket, json, &mode).await,
@@ -34,17 +34,17 @@ impl SettingsCmd {
     }
 }
 
-async fn show(socket: &Path, json: bool) -> anyhow::Result<()> {
+async fn show(socket: &Path, json: bool) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::SettingsShow).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn theme(socket: &Path, json: bool, mode: &str) -> anyhow::Result<()> {
+async fn theme(socket: &Path, json: bool, mode: &str) -> crate::cli::Result<()> {
     let resp = client::send(socket, &Request::SettingsTheme { theme: mode.into() }).await?;
     output::print_and_exit(&resp, json)
 }
 
-async fn language(socket: &Path, json: bool, lang: &str) -> anyhow::Result<()> {
+async fn language(socket: &Path, json: bool, lang: &str) -> crate::cli::Result<()> {
     let resp = client::send(
         socket,
         &Request::SettingsLanguage {

--- a/src/cli/commands/users.rs
+++ b/src/cli/commands/users.rs
@@ -32,7 +32,7 @@ impl UsersCmd {
         socket: &Path,
         json: bool,
         account_flag: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::cli::Result<()> {
         match self {
             Self::Show { pubkey } => show(socket, json, &pubkey).await,
             Self::Search { query, radius } => {
@@ -59,7 +59,7 @@ fn parse_radius(s: &str) -> Result<(u8, u8), String> {
     Ok((start, end))
 }
 
-async fn show(socket: &Path, json: bool, pubkey: &str) -> anyhow::Result<()> {
+async fn show(socket: &Path, json: bool, pubkey: &str) -> crate::cli::Result<()> {
     let resp = client::send(
         socket,
         &Request::UsersShow {
@@ -77,7 +77,7 @@ async fn search(
     query: &str,
     radius_start: u8,
     radius_end: u8,
-) -> anyhow::Result<()> {
+) -> crate::cli::Result<()> {
     let pubkey = account::resolve_account(socket, account_flag).await?;
     let req = Request::UsersSearch {
         account: pubkey,

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -35,7 +35,7 @@ pub enum CliError {
 
 impl CliError {
     /// Convenience constructor for ad-hoc CLI errors.
-    pub fn msg(message: impl Into<String>) -> Self {
-        Self::Message(message.into())
+    pub fn msg(message: impl ToString) -> Self {
+        Self::Message(message.to_string())
     }
 }

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,0 +1,41 @@
+//! Error type for the `wn` and `wnd` command-line binaries.
+//!
+//! CLI surfaces a small set of failure modes: IPC with the daemon,
+//! serialization, I/O, and ad-hoc operational errors (missing binaries,
+//! cancelled prompts, etc). This module centralizes them without relying
+//! on `anyhow` so the library stays free of dynamic error types.
+
+use std::io;
+
+use thiserror::Error;
+
+use crate::whitenoise::error::WhitenoiseError;
+
+pub type Result<T> = core::result::Result<T, CliError>;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("Whitenoise error: {0}")]
+    Whitenoise(#[from] WhitenoiseError),
+
+    /// The daemon is not reachable. The message is already user-facing.
+    #[error("{0}")]
+    DaemonUnavailable(String),
+
+    /// Generic CLI-level failure with a human-readable message.
+    #[error("{0}")]
+    Message(String),
+}
+
+impl CliError {
+    /// Convenience constructor for ad-hoc CLI errors.
+    pub fn msg(message: impl Into<String>) -> Self {
+        Self::Message(message.into())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,9 @@ pub mod client;
 pub mod commands;
 pub mod config;
 pub mod dispatch;
+pub mod error;
 pub mod output;
 pub mod protocol;
 pub mod server;
+
+pub use error::{CliError, Result};

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -6,7 +6,7 @@ use nostr_sdk::{PublicKey, ToBech32};
 use super::protocol::Response;
 
 /// Print a response and return a non-zero exit code on error.
-pub fn print_and_exit(response: &Response, json: bool) -> anyhow::Result<()> {
+pub fn print_and_exit(response: &Response, json: bool) -> crate::cli::Result<()> {
     print_response(response, json);
     if response.error.is_some() {
         std::process::exit(1);

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -11,6 +11,7 @@ use crate::Whitenoise;
 
 use super::config::Config;
 use super::dispatch;
+use super::error::CliError;
 use super::protocol::{Request, Response};
 
 /// Start the daemon: bind the socket, accept connections, dispatch requests.
@@ -113,7 +114,7 @@ fn clean_stale_socket(socket_path: &Path, pid_path: &Path) -> crate::cli::Result
     }
 
     if let Some(pid) = read_pid(pid_path).filter(|&p| is_process_alive(p)) {
-        return Err(crate::cli::error::CliError::msg(format!(
+        return Err(CliError::msg(format!(
             "daemon already running (pid {pid}). \
              Stop it with: wn daemon stop"
         )));
@@ -179,7 +180,6 @@ pub fn is_daemon_running(config: &Config) -> Option<u32> {
 ///
 /// Waits up to 5 seconds for the process to exit after sending the signal.
 pub fn stop_daemon(config: &Config) -> crate::cli::Result<()> {
-    use crate::cli::error::CliError;
     match is_daemon_running(config) {
         Some(pid) => {
             if !send_sigterm(pid) {

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -16,7 +16,7 @@ use super::protocol::{Request, Response};
 /// Start the daemon: bind the socket, accept connections, dispatch requests.
 ///
 /// Returns when a shutdown signal is received or the listener fails.
-pub async fn run(config: &Config) -> anyhow::Result<()> {
+pub async fn run(config: &Config) -> crate::cli::Result<()> {
     let socket_path = config.socket_path();
     let pid_path = config.pid_path();
 
@@ -107,16 +107,16 @@ async fn handle_connection(stream: tokio::net::UnixStream) {
 }
 
 /// If a socket file exists but the process that created it is dead, remove it.
-fn clean_stale_socket(socket_path: &Path, pid_path: &Path) -> anyhow::Result<()> {
+fn clean_stale_socket(socket_path: &Path, pid_path: &Path) -> crate::cli::Result<()> {
     if !socket_path.exists() {
         return Ok(());
     }
 
     if let Some(pid) = read_pid(pid_path).filter(|&p| is_process_alive(p)) {
-        anyhow::bail!(
+        return Err(crate::cli::error::CliError::msg(format!(
             "daemon already running (pid {pid}). \
              Stop it with: wn daemon stop"
-        );
+        )));
     }
 
     // Stale socket — previous process died without cleanup
@@ -126,19 +126,19 @@ fn clean_stale_socket(socket_path: &Path, pid_path: &Path) -> anyhow::Result<()>
     Ok(())
 }
 
-fn write_pid_file(path: &Path) -> anyhow::Result<()> {
+fn write_pid_file(path: &Path) -> crate::cli::Result<()> {
     fs::write(path, std::process::id().to_string())?;
     Ok(())
 }
 
 #[cfg(unix)]
-fn set_socket_permissions(path: &Path) -> anyhow::Result<()> {
+fn set_socket_permissions(path: &Path) -> crate::cli::Result<()> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn set_socket_permissions(_path: &Path) -> anyhow::Result<()> {
+fn set_socket_permissions(_path: &Path) -> crate::cli::Result<()> {
     Ok(())
 }
 
@@ -178,11 +178,14 @@ pub fn is_daemon_running(config: &Config) -> Option<u32> {
 /// Stop the daemon by sending SIGTERM to the PID in the pidfile.
 ///
 /// Waits up to 5 seconds for the process to exit after sending the signal.
-pub fn stop_daemon(config: &Config) -> anyhow::Result<()> {
+pub fn stop_daemon(config: &Config) -> crate::cli::Result<()> {
+    use crate::cli::error::CliError;
     match is_daemon_running(config) {
         Some(pid) => {
             if !send_sigterm(pid) {
-                anyhow::bail!("failed to send SIGTERM to pid {pid}");
+                return Err(CliError::msg(format!(
+                    "failed to send SIGTERM to pid {pid}"
+                )));
             }
             for _ in 0..100 {
                 if !is_process_alive(pid) {
@@ -191,11 +194,11 @@ pub fn stop_daemon(config: &Config) -> anyhow::Result<()> {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
-            anyhow::bail!("daemon (pid {pid}) did not exit within 5s after SIGTERM");
+            Err(CliError::msg(format!(
+                "daemon (pid {pid}) did not exit within 5s after SIGTERM"
+            )))
         }
-        None => {
-            anyhow::bail!("daemon not running");
-        }
+        None => Err(CliError::msg("daemon not running")),
     }
 }
 

--- a/src/integration_tests/benchmarks/scenarios/user_search.rs
+++ b/src/integration_tests/benchmarks/scenarios/user_search.rs
@@ -94,10 +94,7 @@ impl BenchmarkScenario for UserSearchBenchmark {
             .map_err(|e| WhitenoiseError::InvalidInput(format!("Invalid searcher npub: {}", e)))?;
 
         // Follow the target so their social graph becomes our radius 1
-        whitenoise
-            .follow_user(searcher, &target_pubkey)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to follow target: {}", e)))?;
+        whitenoise.follow_user(searcher, &target_pubkey).await?;
 
         // Clear perf samples accumulated during setup/follow so only
         // actual search timings appear in the breakdown.

--- a/src/integration_tests/benchmarks/scenarios/user_search.rs
+++ b/src/integration_tests/benchmarks/scenarios/user_search.rs
@@ -97,9 +97,7 @@ impl BenchmarkScenario for UserSearchBenchmark {
         whitenoise
             .follow_user(searcher, &target_pubkey)
             .await
-            .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to follow target: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to follow target: {}", e)))?;
 
         // Clear perf samples accumulated during setup/follow so only
         // actual search timings appear in the breakdown.

--- a/src/integration_tests/benchmarks/test_cases/accounts/login_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/accounts/login_benchmark.rs
@@ -44,7 +44,7 @@ impl BenchmarkTestCase for LoginBenchmark {
     ) -> Result<Duration, WhitenoiseError> {
         let iteration = context.tests_count as usize;
         if iteration >= self.prepared_keys.len() {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Login benchmark iteration {} exceeds prepared keys count ({})",
                 iteration,
                 self.prepared_keys.len()

--- a/src/integration_tests/benchmarks/test_cases/accounts/login_multistep_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/accounts/login_multistep_benchmark.rs
@@ -48,7 +48,7 @@ impl BenchmarkTestCase for LoginMultistepBenchmark {
     ) -> Result<Duration, WhitenoiseError> {
         let iteration = self.next_key.fetch_add(1, Ordering::Relaxed);
         if iteration >= self.prepared_keys.len() {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Login multistep benchmark iteration {} exceeds prepared keys count ({})",
                 iteration,
                 self.prepared_keys.len()
@@ -63,10 +63,10 @@ impl BenchmarkTestCase for LoginMultistepBenchmark {
             .whitenoise
             .login_start(keys.secret_key().to_secret_hex())
             .await
-            .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("{}", e)))?;
+            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
 
         if result.status != LoginStatus::NeedsRelayLists {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Expected LoginStatus::NeedsRelayLists but got {:?}",
                 result.status
             )));
@@ -76,12 +76,12 @@ impl BenchmarkTestCase for LoginMultistepBenchmark {
             .whitenoise
             .login_publish_default_relays(&result.account.pubkey)
             .await
-            .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("{}", e)))?;
+            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
 
         let duration = start.elapsed();
 
         if final_result.status != LoginStatus::Complete {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Expected LoginStatus::Complete after publish_default_relays but got {:?}",
                 final_result.status
             )));

--- a/src/integration_tests/benchmarks/test_cases/accounts/login_multistep_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/accounts/login_multistep_benchmark.rs
@@ -62,8 +62,7 @@ impl BenchmarkTestCase for LoginMultistepBenchmark {
         let result = context
             .whitenoise
             .login_start(keys.secret_key().to_secret_hex())
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
+            .await?;
 
         if result.status != LoginStatus::NeedsRelayLists {
             return Err(WhitenoiseError::Internal(format!(
@@ -75,8 +74,7 @@ impl BenchmarkTestCase for LoginMultistepBenchmark {
         let final_result = context
             .whitenoise
             .login_publish_default_relays(&result.account.pubkey)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
+            .await?;
 
         let duration = start.elapsed();
 

--- a/src/integration_tests/benchmarks/test_cases/accounts/login_start_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/accounts/login_start_benchmark.rs
@@ -37,7 +37,7 @@ impl BenchmarkTestCase for LoginStartBenchmark {
     ) -> Result<Duration, WhitenoiseError> {
         let iteration = context.tests_count as usize;
         if iteration >= self.prepared_keys.len() {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Login start benchmark iteration {} exceeds prepared keys count ({})",
                 iteration,
                 self.prepared_keys.len()
@@ -51,11 +51,11 @@ impl BenchmarkTestCase for LoginStartBenchmark {
             .whitenoise
             .login_start(keys.secret_key().to_secret_hex())
             .await
-            .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("{}", e)))?;
+            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
         let duration = start.elapsed();
 
         if result.status != LoginStatus::Complete {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Expected LoginStatus::Complete but got {:?}",
                 result.status
             )));

--- a/src/integration_tests/benchmarks/test_cases/accounts/login_start_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/accounts/login_start_benchmark.rs
@@ -50,8 +50,7 @@ impl BenchmarkTestCase for LoginStartBenchmark {
         let result = context
             .whitenoise
             .login_start(keys.secret_key().to_secret_hex())
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("{}", e)))?;
+            .await?;
         let duration = start.elapsed();
 
         if result.status != LoginStatus::Complete {

--- a/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
@@ -47,7 +47,7 @@ impl BenchmarkTestCase for AddMembersBenchmark {
     ) -> Result<Duration, WhitenoiseError> {
         let iteration = self.next_set.fetch_add(1, Ordering::Relaxed);
         if iteration >= self.member_sets.len() {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Add members benchmark iteration {} exceeds prepared member sets ({})",
                 iteration,
                 self.member_sets.len()

--- a/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
@@ -41,7 +41,7 @@ impl BenchmarkTestCase for CreateGroupBenchmark {
     ) -> Result<Duration, WhitenoiseError> {
         let iteration = context.tests_count as usize;
         if iteration >= self.member_sets.len() {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "Create group benchmark iteration {} exceeds prepared member sets ({})",
                 iteration,
                 self.member_sets.len()

--- a/src/integration_tests/core/retry.rs
+++ b/src/integration_tests/core/retry.rs
@@ -54,11 +54,9 @@ where
                         retry_count,
                         e
                     );
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Operation '{}' failed after {} retries: {}",
-                        description,
-                        retry_count,
-                        e
+                        description, retry_count, e
                     )));
                 }
 

--- a/src/integration_tests/test_cases/advanced_messaging/aggregate_messages.rs
+++ b/src/integration_tests/test_cases/advanced_messaging/aggregate_messages.rs
@@ -56,7 +56,7 @@ impl TestCase for AggregateMessagesTestCase {
                 if messages.len() >= self.expected_min_messages {
                     Ok(messages)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Found {} messages, need at least {}",
                         messages.len(),
                         self.expected_min_messages

--- a/src/integration_tests/test_cases/advanced_messaging/verify_reaction_deletion.rs
+++ b/src/integration_tests/test_cases/advanced_messaging/verify_reaction_deletion.rs
@@ -61,7 +61,7 @@ impl TestCase for VerifyReactionDeletionTestCase {
                     .iter()
                     .find(|msg| msg.id == *target_message_id)
                     .ok_or_else(|| {
-                        WhitenoiseError::Other(anyhow::anyhow!(
+                        WhitenoiseError::Internal(format!(
                             "Target message {} not found in aggregated messages",
                             target_message_id
                         ))
@@ -74,7 +74,7 @@ impl TestCase for VerifyReactionDeletionTestCase {
                     .any(|r| r.user == reactor_account.pubkey);
 
                 if reactor_has_reaction {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Reaction from {} still present on message {}",
                         &reactor_account.pubkey.to_hex()[..8],
                         target_message_id

--- a/src/integration_tests/test_cases/chat_list_streaming/verify_chat_list_update.rs
+++ b/src/integration_tests/test_cases/chat_list_streaming/verify_chat_list_update.rs
@@ -79,25 +79,24 @@ impl TestCase for VerifyChatListUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let mut guard = self.receiver.lock().await;
         let receiver = guard.as_mut().ok_or_else(|| {
-            WhitenoiseError::Other(anyhow::anyhow!(
+            WhitenoiseError::Internal(
                 "VerifyChatListUpdateTestCase: subscribe() must be called before run(). \
                  The scenario should first call subscribe(), then perform the action \
                  that triggers the update, then call execute()."
-            ))
+                    .to_string(),
+            )
         })?;
 
         // Wait for the update with timeout
         let update = tokio::time::timeout(tokio::time::Duration::from_secs(10), receiver.recv())
             .await
             .map_err(|_| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(format!(
                     "Timeout waiting for {:?} update",
                     self.expected_trigger
                 ))
             })?
-            .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to receive update: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to receive update: {}", e)))?;
 
         // Verify trigger type
         assert_eq!(
@@ -121,7 +120,7 @@ impl TestCase for VerifyChatListUpdateTestCase {
         // Verify last message content if expected
         if let Some(expected_content) = &self.expected_last_message_content {
             let last_msg = update.item.last_message.as_ref().ok_or_else(|| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(format!(
                     "Expected last message with content '{}' but no last message in update",
                     expected_content
                 ))

--- a/src/integration_tests/test_cases/chat_media_upload/download_chat_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/download_chat_media.rs
@@ -20,17 +20,14 @@ impl DownloadChatMediaTestCase {
 
     /// Create a temporary test image file
     fn create_test_image(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
-        let temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         // Create a distinctive 100x100 blue image for testing
         let img = ::image::RgbaImage::from_pixel(100, 100, ::image::Rgba([0u8, 0, 255, 255]));
 
         img.save_with_format(temp_file.path(), ::image::ImageFormat::Png)
-            .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to save test image: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to save test image: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -53,7 +50,7 @@ impl TestCase for DownloadChatMediaTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         // Read original file data for later comparison
         let original_file_data = tokio::fs::read(temp_path).await?;
@@ -117,7 +114,7 @@ impl TestCase for DownloadChatMediaTestCase {
         );
 
         tokio::fs::remove_file(&cached_path).await.map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to delete cached file: {}", e))
+            WhitenoiseError::Internal(format!("Failed to delete cached file: {}", e))
         })?;
 
         tracing::info!(
@@ -137,7 +134,7 @@ impl TestCase for DownloadChatMediaTestCase {
             .unwrap()
             .as_slice()
             .try_into()
-            .map_err(|_| WhitenoiseError::Other(anyhow::anyhow!("Invalid hash length")))?;
+            .map_err(|_| WhitenoiseError::Internal("Invalid hash length".to_string()))?;
 
         // Step 5: Call download_chat_media with original hash
         tracing::info!(

--- a/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
@@ -49,9 +49,8 @@ impl ReceiveMessageWithMediaTestCase {
             format!("v mip04-v2"),
         ];
 
-        Tag::parse(parts).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create imeta tag: {}", e))
-        })
+        Tag::parse(parts)
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create imeta tag: {}", e)))
     }
 }
 
@@ -151,9 +150,9 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
                     .collect();
 
                 if matching.is_empty() {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Media reference not yet created for receiver"
-                    )));
+                    return Err(WhitenoiseError::Internal(
+                        "Media reference not yet created for receiver".to_string(),
+                    ));
                 }
 
                 Ok(matching)
@@ -172,9 +171,10 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
         // Verify original_file_hash is populated (from imeta 'x' field)
         let receiver_original_hash =
             receiver_media.original_file_hash.as_ref().ok_or_else(|| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(
                     "Receiver's MediaFile should have original_file_hash from imeta 'x' field"
-                ))
+                        .to_string(),
+                )
             })?;
 
         assert_eq!(

--- a/src/integration_tests/test_cases/chat_media_upload/send_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/send_message_with_media.rs
@@ -37,7 +37,7 @@ impl SendMessageWithMediaTestCase {
             &format!("x {}", hash_hex),
             "v mip04-v1",
         ])
-        .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("Failed to create imeta tag: {}", e)))
+        .map_err(|e| WhitenoiseError::Internal(format!("Failed to create imeta tag: {}", e)))
     }
 }
 
@@ -108,14 +108,14 @@ impl TestCase for SendMessageWithMediaTestCase {
                     .await?;
 
                 if messages.is_empty() {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "No messages found yet"
-                    )));
+                    return Err(WhitenoiseError::Internal(
+                        "No messages found yet".to_string(),
+                    ));
                 }
 
                 // Verify our specific message is in the cache
                 if !messages.iter().any(|msg| msg.id == sent_message_id) {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Sent message {} not found in aggregated messages yet",
                         sent_message_id
                     )));

--- a/src/integration_tests/test_cases/chat_media_upload/upload_audio.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_audio.rs
@@ -21,9 +21,8 @@ impl UploadAudioTestCase {
     fn create_test_audio(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
         use std::io::Write;
 
-        let mut temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let mut temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         // MP3 magic bytes (ID3v2 header)
         let mp3_header: &[u8] = &[
@@ -33,13 +32,13 @@ impl UploadAudioTestCase {
             0x00, 0x00, 0x00, 0x00, // size (syncsafe integer)
         ];
 
-        temp_file.write_all(mp3_header).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to write MP3 data: {}", e))
-        })?;
+        temp_file
+            .write_all(mp3_header)
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write MP3 data: {}", e)))?;
 
-        temp_file.flush().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to flush temp file: {}", e))
-        })?;
+        temp_file
+            .flush()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -61,7 +60,7 @@ impl TestCase for UploadAudioTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         // Read the file data and compute expected hash
         let test_audio_data = tokio::fs::read(temp_path).await?;

--- a/src/integration_tests/test_cases/chat_media_upload/upload_chat_image.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_chat_image.rs
@@ -29,16 +29,13 @@ impl UploadChatImageTestCase {
 
     /// Create a temporary test image file using NamedTempFile
     fn create_test_image(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
-        let temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         let img = ::image::RgbaImage::from_pixel(100, 100, ::image::Rgba([0u8, 255, 0, 255]));
 
         img.save_with_format(temp_file.path(), ::image::ImageFormat::Png)
-            .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to save test image: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to save test image: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -61,7 +58,7 @@ impl TestCase for UploadChatImageTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         // Read the file data and compute expected hash
         let test_image_data = tokio::fs::read(temp_path).await?;

--- a/src/integration_tests/test_cases/chat_media_upload/upload_pdf.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_pdf.rs
@@ -1,7 +1,10 @@
-use crate::WhitenoiseError;
-use crate::integration_tests::core::*;
+use std::io::Write;
+
 use async_trait::async_trait;
 use nostr_sdk::Url;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::core::*;
 
 /// Test case for uploading PDF documents
 pub struct UploadPdfTestCase {
@@ -19,21 +22,13 @@ impl UploadPdfTestCase {
 
     /// Create a temporary PDF file with valid magic bytes
     fn create_test_pdf(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
-        use std::io::Write;
-
-        let mut temp_file = tempfile::NamedTempFile::new()
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
+        let mut temp_file = tempfile::NamedTempFile::new()?;
 
         // Minimal valid PDF header
         let pdf_header: &[u8] = b"%PDF-1.4\n";
 
-        temp_file
-            .write_all(pdf_header)
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write PDF data: {}", e)))?;
-
-        temp_file
-            .flush()
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
+        temp_file.write_all(pdf_header)?;
+        temp_file.flush()?;
 
         Ok(temp_file)
     }

--- a/src/integration_tests/test_cases/chat_media_upload/upload_pdf.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_pdf.rs
@@ -21,20 +21,19 @@ impl UploadPdfTestCase {
     fn create_test_pdf(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
         use std::io::Write;
 
-        let mut temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let mut temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         // Minimal valid PDF header
         let pdf_header: &[u8] = b"%PDF-1.4\n";
 
-        temp_file.write_all(pdf_header).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to write PDF data: {}", e))
-        })?;
+        temp_file
+            .write_all(pdf_header)
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write PDF data: {}", e)))?;
 
-        temp_file.flush().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to flush temp file: {}", e))
-        })?;
+        temp_file
+            .flush()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -56,7 +55,7 @@ impl TestCase for UploadPdfTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         // Read the file data and compute expected hash
         let test_pdf_data = tokio::fs::read(temp_path).await?;

--- a/src/integration_tests/test_cases/chat_media_upload/upload_unsupported_format.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_unsupported_format.rs
@@ -21,20 +21,19 @@ impl UnsupportedFormatTestCase {
     fn create_test_bmp(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
         use std::io::Write;
 
-        let mut temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let mut temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         // BMP magic bytes
         let bmp_header: &[u8] = &[0x42, 0x4D]; // 'BM'
 
-        temp_file.write_all(bmp_header).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to write BMP data: {}", e))
-        })?;
+        temp_file
+            .write_all(bmp_header)
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write BMP data: {}", e)))?;
 
-        temp_file.flush().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to flush temp file: {}", e))
-        })?;
+        temp_file
+            .flush()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -56,7 +55,7 @@ impl TestCase for UnsupportedFormatTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         let blossom_url = if cfg!(debug_assertions) {
             Some(Url::parse("http://localhost:3000").unwrap())
@@ -81,15 +80,15 @@ impl TestCase for UnsupportedFormatTestCase {
                 );
             }
             Err(e) => {
-                return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                return Err(WhitenoiseError::Internal(format!(
                     "Expected UnsupportedMediaFormat error, got: {:?}",
                     e
                 )));
             }
             Ok(_) => {
-                return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                    "Expected upload to fail for unsupported format"
-                )));
+                return Err(WhitenoiseError::Internal(
+                    "Expected upload to fail for unsupported format".to_string(),
+                ));
             }
         }
 

--- a/src/integration_tests/test_cases/chat_media_upload/upload_video.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_video.rs
@@ -21,9 +21,8 @@ impl UploadVideoTestCase {
     fn create_test_video(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
         use std::io::Write;
 
-        let mut temp_file = tempfile::NamedTempFile::new().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create temp file: {}", e))
-        })?;
+        let mut temp_file = tempfile::NamedTempFile::new()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
 
         // MP4 magic bytes (ftyp box signature)
         // This is a minimal valid MP4 file structure
@@ -38,13 +37,13 @@ impl UploadVideoTestCase {
             0x00, 0x00, 0x00, 0x00, // padding
         ];
 
-        temp_file.write_all(mp4_header).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to write MP4 data: {}", e))
-        })?;
+        temp_file
+            .write_all(mp4_header)
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write MP4 data: {}", e)))?;
 
-        temp_file.flush().map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to flush temp file: {}", e))
-        })?;
+        temp_file
+            .flush()
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
 
         Ok(temp_file)
     }
@@ -66,7 +65,7 @@ impl TestCase for UploadVideoTestCase {
         let temp_path = temp_file
             .path()
             .to_str()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid temp path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid temp path".to_string()))?;
 
         // Read the file data and compute expected hash
         let test_video_data = tokio::fs::read(temp_path).await?;

--- a/src/integration_tests/test_cases/chat_media_upload/upload_video.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/upload_video.rs
@@ -1,7 +1,10 @@
-use crate::WhitenoiseError;
-use crate::integration_tests::core::*;
+use std::io::Write;
+
 use async_trait::async_trait;
 use nostr_sdk::Url;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::core::*;
 
 /// Test case for uploading video files (MP4)
 pub struct UploadVideoTestCase {
@@ -19,10 +22,7 @@ impl UploadVideoTestCase {
 
     /// Create a temporary MP4 video file with valid magic bytes
     fn create_test_video(&self) -> Result<tempfile::NamedTempFile, WhitenoiseError> {
-        use std::io::Write;
-
-        let mut temp_file = tempfile::NamedTempFile::new()
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to create temp file: {}", e)))?;
+        let mut temp_file = tempfile::NamedTempFile::new()?;
 
         // MP4 magic bytes (ftyp box signature)
         // This is a minimal valid MP4 file structure
@@ -37,13 +37,8 @@ impl UploadVideoTestCase {
             0x00, 0x00, 0x00, 0x00, // padding
         ];
 
-        temp_file
-            .write_all(mp4_header)
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to write MP4 data: {}", e)))?;
-
-        temp_file
-            .flush()
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to flush temp file: {}", e)))?;
+        temp_file.write_all(mp4_header)?;
+        temp_file.flush()?;
 
         Ok(temp_file)
     }

--- a/src/integration_tests/test_cases/follow_management/follow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/follow_user.rs
@@ -46,9 +46,9 @@ impl TestCase for FollowUserTestCase {
                 if is_following {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Follow relationship not yet established"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "Follow relationship not yet established".to_string(),
+                    ))
                 }
             },
             &format!(

--- a/src/integration_tests/test_cases/follow_management/unfollow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/unfollow_user.rs
@@ -46,9 +46,9 @@ impl TestCase for UnfollowUserTestCase {
                 if !is_following {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Follow relationship still exists after unfollow"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "Follow relationship still exists after unfollow".to_string(),
+                    ))
                 }
             },
             &format!(

--- a/src/integration_tests/test_cases/group_membership/add_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/add_group_members.rs
@@ -63,7 +63,7 @@ impl TestCase for AddGroupMembersTestCase {
         if self.expect_failure {
             match add_result {
                 Ok(_) => {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Expected adding {} members to fail, but it succeeded",
                         self.new_member_pubkeys.len()
                     )));
@@ -97,7 +97,7 @@ impl TestCase for AddGroupMembersTestCase {
                     // Verify each new member is in the group
                     for pubkey in &self.new_member_pubkeys {
                         if !members.contains(pubkey) {
-                            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                            return Err(WhitenoiseError::Internal(format!(
                                 "New member {} not yet in group",
                                 &pubkey.to_hex()[..8]
                             )));
@@ -105,7 +105,7 @@ impl TestCase for AddGroupMembersTestCase {
                     }
                     Ok(members)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Expected {} members, found {}",
                         expected_count,
                         members.len()

--- a/src/integration_tests/test_cases/group_membership/remove_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/remove_group_members.rs
@@ -98,7 +98,7 @@ impl TestCase for RemoveGroupMembersTestCase {
                     // Verify each removed member is no longer in the group
                     for pubkey in &self.member_pubkeys_to_remove {
                         if members.contains(pubkey) {
-                            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                            return Err(WhitenoiseError::Internal(format!(
                                 "Removed member {} still in group",
                                 &pubkey.to_hex()[..8]
                             )));
@@ -106,7 +106,7 @@ impl TestCase for RemoveGroupMembersTestCase {
                     }
                     Ok(members)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Expected {} members, found {}",
                         expected_count,
                         members.len()

--- a/src/integration_tests/test_cases/login_flow/register_external_signer_recovers_subscriptions.rs
+++ b/src/integration_tests/test_cases/login_flow/register_external_signer_recovers_subscriptions.rs
@@ -40,9 +40,9 @@ impl TestCase for RegisterExternalSignerRecoversSubscriptionsTestCase {
                 {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "External account subscriptions are not yet operational"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "External account subscriptions are not yet operational".to_string(),
+                    ))
                 }
             },
             "wait initial external account subscriptions to become operational",
@@ -84,9 +84,10 @@ impl TestCase for RegisterExternalSignerRecoversSubscriptionsTestCase {
                 {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(
                         "register_external_signer did not recover account subscriptions"
-                    )))
+                            .to_string(),
+                    ))
                 }
             },
             "wait account subscriptions to recover after signer re-registration",

--- a/src/integration_tests/test_cases/message_streaming/verify_initial_messages.rs
+++ b/src/integration_tests/test_cases/message_streaming/verify_initial_messages.rs
@@ -94,7 +94,7 @@ impl TestCase for VerifyInitialMessagesTestCase {
                 .iter()
                 .find(|m| &m.id == msg_id)
                 .ok_or_else(|| {
-                    WhitenoiseError::Other(anyhow::anyhow!(
+                    WhitenoiseError::Internal(format!(
                         "Message '{}' not found for reaction check",
                         key
                     ))
@@ -120,7 +120,7 @@ impl TestCase for VerifyInitialMessagesTestCase {
                 .iter()
                 .find(|m| &m.id == msg_id)
                 .ok_or_else(|| {
-                    WhitenoiseError::Other(anyhow::anyhow!(
+                    WhitenoiseError::Internal(format!(
                         "Message '{}' not found for no-reaction check",
                         key
                     ))

--- a/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
+++ b/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
@@ -85,11 +85,12 @@ impl TestCase for VerifyStreamUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let mut guard = self.receiver.lock().await;
         let receiver = guard.as_mut().ok_or_else(|| {
-            WhitenoiseError::Other(anyhow::anyhow!(
+            WhitenoiseError::Internal(
                 "VerifyStreamUpdateTestCase: subscribe() must be called before run(). \
                  The scenario should first call subscribe(), then perform the action \
                  that triggers the update, then call execute()."
-            ))
+                    .to_string(),
+            )
         })?;
 
         // Pre-resolve the expected message ID to avoid borrow issues in async block
@@ -130,12 +131,12 @@ impl TestCase for VerifyStreamUpdateTestCase {
         })
         .await
         .map_err(|_| {
-            WhitenoiseError::Other(anyhow::anyhow!(
+            WhitenoiseError::Internal(format!(
                 "Timeout waiting for {:?} update",
                 self.expected_trigger
             ))
         })?
-        .map_err(|e| WhitenoiseError::Other(anyhow::anyhow!("Failed to receive update: {}", e)))?;
+        .map_err(|e| WhitenoiseError::Internal(format!("Failed to receive update: {}", e)))?;
 
         // Verify trigger type
         assert_eq!(

--- a/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
+++ b/src/integration_tests/test_cases/message_streaming/verify_stream_update.rs
@@ -85,7 +85,7 @@ impl TestCase for VerifyStreamUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let mut guard = self.receiver.lock().await;
         let receiver = guard.as_mut().ok_or_else(|| {
-            WhitenoiseError::Internal(
+            WhitenoiseError::InvalidInput(
                 "VerifyStreamUpdateTestCase: subscribe() must be called before run(). \
                  The scenario should first call subscribe(), then perform the action \
                  that triggers the update, then call execute()."

--- a/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
+++ b/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
@@ -1,8 +1,9 @@
+use async_trait::async_trait;
+use tokio::sync::{Mutex, broadcast};
+
 use crate::WhitenoiseError;
 use crate::integration_tests::core::*;
 use crate::whitenoise::notification_streaming::{NotificationTrigger, NotificationUpdate};
-use async_trait::async_trait;
-use tokio::sync::{Mutex, broadcast};
 
 /// Test case that verifies a real-time notification update is received correctly.
 ///

--- a/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
+++ b/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
@@ -79,7 +79,7 @@ impl VerifyNotificationUpdateTestCase {
         let mut guard = self
             .receiver
             .try_lock()
-            .map_err(|_| WhitenoiseError::Other(anyhow::anyhow!("Failed to acquire lock")))?;
+            .map_err(|_| WhitenoiseError::Internal("Failed to acquire lock".to_string()))?;
         *guard = Some(subscription.updates);
 
         tracing::info!(
@@ -95,24 +95,25 @@ impl TestCase for VerifyNotificationUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let mut guard = self.receiver.lock().await;
         let receiver = guard.as_mut().ok_or_else(|| {
-            WhitenoiseError::Other(anyhow::anyhow!(
+            WhitenoiseError::Internal(
                 "VerifyNotificationUpdateTestCase: subscribe() must be called before run(). \
                  The scenario should first call subscribe(), then perform the action \
                  that triggers the notification, then call execute()."
-            ))
+                    .to_string(),
+            )
         })?;
 
         // Wait for the update with timeout
         let update = tokio::time::timeout(tokio::time::Duration::from_secs(10), receiver.recv())
             .await
             .map_err(|_| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(format!(
                     "Timeout waiting for {:?} notification",
                     self.expected_trigger
                 ))
             })?
             .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to receive notification: {}", e))
+                WhitenoiseError::Internal(format!("Failed to receive notification: {}", e))
             })?;
 
         // Verify trigger type

--- a/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
+++ b/src/integration_tests/test_cases/notification_streaming/verify_notification_update.rs
@@ -95,7 +95,7 @@ impl TestCase for VerifyNotificationUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let mut guard = self.receiver.lock().await;
         let receiver = guard.as_mut().ok_or_else(|| {
-            WhitenoiseError::Internal(
+            WhitenoiseError::InvalidInput(
                 "VerifyNotificationUpdateTestCase: subscribe() must be called before run(). \
                  The scenario should first call subscribe(), then perform the action \
                  that triggers the notification, then call execute()."

--- a/src/integration_tests/test_cases/scheduler/key_package_lifecycle.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_lifecycle.rs
@@ -107,9 +107,9 @@ impl TestCase for KeyPackageLifecycleTestCase {
 
                     match pkg {
                         Some(p) if p.consumed_at.is_some() => Ok(()),
-                        _ => Err(WhitenoiseError::Other(anyhow::anyhow!(
-                            "KP not yet marked as consumed"
-                        ))),
+                        _ => Err(WhitenoiseError::Internal(
+                            "KP not yet marked as consumed".to_string(),
+                        )),
                     }
                 }
             },

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -197,7 +197,7 @@ where
                 if predicate(&key_packages) {
                     Ok(key_packages)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Observed {} key package(s) while waiting for {}",
                         key_packages.len(),
                         description,
@@ -225,7 +225,8 @@ async fn publish_backdated_key_package(
 
     // Get the account's secret key via public API
     let nsec = context.whitenoise.export_account_nsec(account).await?;
-    let secret_key = SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Other(e.into()))?;
+    let secret_key =
+        SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
     let keys = Keys::new(secret_key);
 
     // Calculate the backdated timestamp
@@ -236,7 +237,7 @@ async fn publish_backdated_key_package(
         .tags(key_package_data.tags_443.to_vec())
         .custom_created_at(backdated)
         .sign_with_keys(&keys)
-        .map_err(|e| WhitenoiseError::Other(e.into()))?;
+        .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
 
     let event_id = event.id;
 

--- a/src/integration_tests/test_cases/shared/create_accounts.rs
+++ b/src/integration_tests/test_cases/shared/create_accounts.rs
@@ -45,7 +45,7 @@ impl TestCase for CreateAccountsTestCase {
                         .await?;
 
                     if key_packages.is_empty() {
-                        return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        return Err(WhitenoiseError::Internal(format!(
                             "Key package not yet published for account '{}' ({})",
                             name,
                             account.pubkey.to_hex()

--- a/src/integration_tests/test_cases/shared/delete_message.rs
+++ b/src/integration_tests/test_cases/shared/delete_message.rs
@@ -34,9 +34,10 @@ impl TestCase for DeleteMessageTestCase {
         let target_message_id = context.get_message_id(&self.target_message_id_key)?;
 
         // Create delete tags targeting the specific message
-        let delete_tags = vec![Tag::parse(vec!["e", target_message_id]).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to create e-tag: {}", e))
-        })?];
+        let delete_tags =
+            vec![Tag::parse(vec!["e", target_message_id]).map_err(|e| {
+                WhitenoiseError::Internal(format!("Failed to create e-tag: {}", e))
+            })?];
 
         // Send delete message (kind 5 with empty content)
         let delete_result = context

--- a/src/integration_tests/test_cases/shared/verify_self_update.rs
+++ b/src/integration_tests/test_cases/shared/verify_self_update.rs
@@ -81,12 +81,10 @@ impl TestCase for VerifySelfUpdateTestCase {
                         if current_group.epoch >= min_epoch {
                             Ok(current_group.epoch)
                         } else {
-                            Err(WhitenoiseError::Other(anyhow::anyhow!(
+                            Err(WhitenoiseError::Internal(format!(
                                 "{} epoch is {} but expected >= {} \
                                  (self-update not yet applied)",
-                                account_name,
-                                current_group.epoch,
-                                min_epoch
+                                account_name, current_group.epoch, min_epoch
                             )))
                         }
                     }

--- a/src/integration_tests/test_cases/shared/wait_for_welcome.rs
+++ b/src/integration_tests/test_cases/shared/wait_for_welcome.rs
@@ -53,7 +53,7 @@ impl TestCase for WaitForWelcomeTestCase {
                         if groups.iter().any(|g| g.mls_group_id == group_id) {
                             Ok(())
                         } else {
-                            Err(WhitenoiseError::Other(anyhow::anyhow!(
+                            Err(WhitenoiseError::Internal(format!(
                                 "{} has not yet processed the welcome for the group",
                                 account_name
                             )))

--- a/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
+++ b/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
@@ -197,9 +197,10 @@ impl PublishSubscriptionUpdateTestCase {
                     {
                         Ok(())
                     } else {
-                        Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        Err(WhitenoiseError::Internal(
                             "Account subscription-driven metadata update not yet applied"
-                        )))
+                                .to_string(),
+                        ))
                     }
                 },
                 "account subscription metadata update",
@@ -222,9 +223,10 @@ impl PublishSubscriptionUpdateTestCase {
                     {
                         Ok(())
                     } else {
-                        Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        Err(WhitenoiseError::Internal(
                             "External user subscription-driven metadata update not yet applied"
-                        )))
+                                .to_string(),
+                        ))
                     }
                 },
                 &format!(
@@ -271,11 +273,9 @@ impl PublishSubscriptionUpdateTestCase {
                     if has_new_relay {
                         Ok(())
                     } else {
-                        Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        Err(WhitenoiseError::Internal(format!(
                             "{} NIP-65 relays missing subscription-updated relay: {}, got: {:?}",
-                            user_type,
-                            expected_relay_url,
-                            nip65_relays
+                            user_type, expected_relay_url, nip65_relays
                         )))
                     }
                 },
@@ -300,11 +300,9 @@ impl PublishSubscriptionUpdateTestCase {
                     if has_new_relay {
                         Ok(())
                     } else {
-                        Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        Err(WhitenoiseError::Internal(format!(
                             "{} NIP-65 relays missing subscription-updated relay: {}, got: {:?}",
-                            user_type,
-                            expected_relay_url,
-                            nip65_relays
+                            user_type, expected_relay_url, nip65_relays
                         )))
                     }
                 },
@@ -347,7 +345,7 @@ impl PublishSubscriptionUpdateTestCase {
                 if actual == expected {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Account follows do not match expected follows. Missing: {:?}, Extra: {:?}",
                         expected.difference(&actual).collect::<Vec<_>>(),
                         actual.difference(&expected).collect::<Vec<_>>()

--- a/src/integration_tests/test_cases/subscription_processing/verify_last_synced_timestamp.rs
+++ b/src/integration_tests/test_cases/subscription_processing/verify_last_synced_timestamp.rs
@@ -52,9 +52,9 @@ impl VerifyLastSyncedTimestampTestCase {
                 match (before, account.last_synced_at) {
                     (None, Some(_)) => Ok(()),
                     (Some(before_time), Some(after_time)) if after_time > before_time => Ok(()),
-                    _ => Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "last_synced_at not advanced yet"
-                    ))),
+                    _ => Err(WhitenoiseError::Internal(
+                        "last_synced_at not advanced yet".to_string(),
+                    )),
                 }
             },
             description,
@@ -77,9 +77,9 @@ impl VerifyLastSyncedTimestampTestCase {
                 if account.last_synced_at == before {
                     Ok(())
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "last_synced_at advanced on global-only event"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "last_synced_at advanced on global-only event".to_string(),
+                    ))
                 }
             },
             description,
@@ -104,7 +104,7 @@ impl VerifyLastSyncedTimestampTestCase {
             .tags(tags)
             .custom_created_at(event_timestamp)
             .sign_with_keys(&keys)
-            .map_err(|e| WhitenoiseError::Other(e.into()))?;
+            .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
 
         client.send_event(&event).await?;
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
@@ -127,7 +127,7 @@ impl VerifyLastSyncedTimestampTestCase {
         let event = EventBuilder::metadata(&metadata)
             .custom_created_at(event_timestamp)
             .sign_with_keys(&keys)
-            .map_err(|e| WhitenoiseError::Other(e.into()))?;
+            .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
 
         client.send_event(&event).await?;
         tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;

--- a/src/integration_tests/test_cases/user_discovery/helpers.rs
+++ b/src/integration_tests/test_cases/user_discovery/helpers.rs
@@ -23,7 +23,7 @@ pub async fn wait_for_relay_list_indexed(
             if events.iter().next().is_some() {
                 Ok(())
             } else {
-                Err(WhitenoiseError::Other(anyhow::anyhow!(
+                Err(WhitenoiseError::Internal(format!(
                     "Relay-list event is not yet queryable for {}",
                     pubkey
                 )))
@@ -57,7 +57,7 @@ pub async fn wait_for_latest_metadata_event(
             if events.iter().any(|event| event.id == expected_event_id) {
                 Ok(())
             } else {
-                Err(WhitenoiseError::Other(anyhow::anyhow!(
+                Err(WhitenoiseError::Internal(format!(
                     "Latest metadata query does not yet return expected event {}",
                     expected_event_id.to_hex()
                 )))

--- a/src/integration_tests/test_cases/user_discovery/resolve_user.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user.rs
@@ -102,9 +102,9 @@ impl TestCase for ResolveUserTestCase {
                 if u.metadata != nostr_sdk::Metadata::default() {
                     Ok(u)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Background metadata fetch not yet complete"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "Background metadata fetch not yet complete".to_string(),
+                    ))
                 }
             },
             &format!(

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_blocking.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_blocking.rs
@@ -76,7 +76,7 @@ impl ResolveUserBlockingTestCase {
         let metadata = self
             .test_metadata
             .as_ref()
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Missing test metadata")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Missing test metadata".to_string()))?;
         tracing::info!(target: LOG_TARGET, "Publishing test metadata for test pubkey");
         let event_id = *test_client
             .send_event_builder(nostr_sdk::EventBuilder::metadata(metadata))

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_known_metadata_no_refresh.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_known_metadata_no_refresh.rs
@@ -68,9 +68,9 @@ impl TestCase for ResolveUserKnownMetadataNoRefreshTestCase {
                 if user.metadata.name == self.initial_metadata.name {
                     Ok(user)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Initial metadata has not been resolved yet"
-                    )))
+                    Err(WhitenoiseError::Internal(
+                        "Initial metadata has not been resolved yet".to_string(),
+                    ))
                 }
             },
             &format!(

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_preserves_newer_processed_metadata.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_preserves_newer_processed_metadata.rs
@@ -83,7 +83,7 @@ impl TestCase for ResolveUserPreservesNewerProcessedMetadataTestCase {
                 if user.metadata.name == self.newer_metadata.name {
                     Ok(user)
                 } else {
-                    Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    Err(WhitenoiseError::Internal(format!(
                         "Expected newer metadata to be processed first, got {:?}",
                         user.metadata.name
                     )))

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use crate::{
 use mdk_core::prelude::*;
 use nostr_sdk::prelude::*;
 use serde::Serialize;
+use thiserror::Error;
 
 /// Retry information for failed event processing
 #[derive(Debug, Clone)]
@@ -210,6 +211,34 @@ impl MessageWithTokens {
     }
 }
 
+/// Errors returned by [`ImageType`] detection and MIME type parsing.
+#[derive(Debug, Error)]
+pub enum ImageTypeError {
+    /// The `image` crate failed to detect a valid format from the raw bytes.
+    #[error("Failed to detect image format: {source}. Supported formats: {supported}")]
+    DetectFailed {
+        #[source]
+        source: ::image::ImageError,
+        supported: String,
+    },
+    /// The detected format is not one of the supported image types.
+    #[error("Unsupported image format: {format}. Supported formats: {supported}")]
+    UnsupportedFormat { format: String, supported: String },
+    /// The image bytes could not be decoded as the detected format.
+    #[error("Invalid or corrupted {mime_type} image: {source}")]
+    InvalidImage {
+        mime_type: &'static str,
+        #[source]
+        source: ::image::ImageError,
+    },
+    /// The provided MIME type is not one of the supported image types.
+    #[error("Unsupported image MIME type: {mime_type}. Supported types: {supported}")]
+    UnsupportedMimeType {
+        mime_type: String,
+        supported: String,
+    },
+}
+
 /// Supported image types for group images
 ///
 /// This enum represents the allowed image formats that can be uploaded
@@ -255,7 +284,7 @@ impl ImageType {
     ///
     /// # Returns
     /// * `Ok(ImageType)` - The detected and validated image type
-    /// * `Err(anyhow::Error)` - If the format is unsupported, unrecognized, or invalid
+    /// * `Err(ImageTypeError)` - If the format is unsupported, unrecognized, or invalid
     ///
     /// # Example
     /// ```ignore
@@ -263,18 +292,11 @@ impl ImageType {
     /// let image_type = ImageType::detect(&image_data)?;
     /// assert_eq!(image_type, ImageType::Jpeg);
     /// ```
-    pub fn detect(data: &[u8]) -> Result<Self, anyhow::Error> {
+    pub fn detect(data: &[u8]) -> Result<Self, ImageTypeError> {
         // Use the image crate to detect format - it's more reliable than magic bytes
-        let format = ::image::guess_format(data).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to detect image format: {}. Supported formats: {}",
-                e,
-                Self::all()
-                    .iter()
-                    .map(|t| t.mime_type())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
+        let format = ::image::guess_format(data).map_err(|e| ImageTypeError::DetectFailed {
+            source: e,
+            supported: Self::supported_mime_types(),
         })?;
 
         // Map the detected format to our ImageType enum
@@ -284,28 +306,30 @@ impl ImageType {
             ::image::ImageFormat::Gif => ImageType::Gif,
             ::image::ImageFormat::WebP => ImageType::Webp,
             other => {
-                return Err(anyhow::anyhow!(
-                    "Unsupported image format: {:?}. Supported formats: {}",
-                    other,
-                    Self::all()
-                        .iter()
-                        .map(|t| t.mime_type())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
+                return Err(ImageTypeError::UnsupportedFormat {
+                    format: format!("{other:?}"),
+                    supported: Self::supported_mime_types(),
+                });
             }
         };
 
         // Validate the image can actually be decoded
         ::image::load_from_memory_with_format(data, format).map_err(|e| {
-            anyhow::anyhow!(
-                "Invalid or corrupted {} image: {}",
-                image_type.mime_type(),
-                e
-            )
+            ImageTypeError::InvalidImage {
+                mime_type: image_type.mime_type(),
+                source: e,
+            }
         })?;
 
         Ok(image_type)
+    }
+
+    fn supported_mime_types() -> String {
+        Self::all()
+            .iter()
+            .map(|t| t.mime_type())
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     /// All supported image types as a slice
@@ -326,7 +350,7 @@ impl From<ImageType> for String {
 }
 
 impl TryFrom<String> for ImageType {
-    type Error = anyhow::Error;
+    type Error = ImageTypeError;
 
     fn try_from(mime_type: String) -> Result<Self, Self::Error> {
         Self::try_from(mime_type.as_str())
@@ -334,7 +358,7 @@ impl TryFrom<String> for ImageType {
 }
 
 impl TryFrom<&str> for ImageType {
-    type Error = anyhow::Error;
+    type Error = ImageTypeError;
 
     fn try_from(mime_type: &str) -> Result<Self, Self::Error> {
         match mime_type {
@@ -342,15 +366,10 @@ impl TryFrom<&str> for ImageType {
             "image/png" => Ok(ImageType::Png),
             "image/gif" => Ok(ImageType::Gif),
             "image/webp" => Ok(ImageType::Webp),
-            _ => Err(anyhow::anyhow!(
-                "Unsupported image MIME type: {}. Supported types: {}",
-                mime_type,
-                ImageType::all()
-                    .iter()
-                    .map(|t| t.mime_type())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )),
+            _ => Err(ImageTypeError::UnsupportedMimeType {
+                mime_type: mime_type.to_string(),
+                supported: ImageType::supported_mime_types(),
+            }),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,12 @@
-use crate::{
-    nostr_manager::parser::SerializableToken, relay_control::SubscriptionContext,
-    whitenoise::error::WhitenoiseError,
-};
 use mdk_core::prelude::*;
 use nostr_sdk::prelude::*;
 use serde::Serialize;
 use thiserror::Error;
+
+use crate::{
+    nostr_manager::parser::SerializableToken, relay_control::SubscriptionContext,
+    whitenoise::error::WhitenoiseError,
+};
 
 /// Retry information for failed event processing
 #[derive(Debug, Clone)]
@@ -368,7 +369,7 @@ impl TryFrom<&str> for ImageType {
             "image/webp" => Ok(ImageType::Webp),
             _ => Err(ImageTypeError::UnsupportedMimeType {
                 mime_type: mime_type.to_string(),
-                supported: ImageType::supported_mime_types(),
+                supported: Self::supported_mime_types(),
             }),
         }
     }

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -392,10 +392,10 @@ impl Whitenoise {
         signer: &impl NostrSigner,
     ) -> crate::whitenoise::error::Result<()> {
         let signer_pubkey = signer.get_public_key().await.map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to get signer pubkey: {}", e))
+            WhitenoiseError::Internal(format!("Failed to get signer pubkey: {}", e))
         })?;
         if signer_pubkey != *expected_pubkey {
-            return Err(WhitenoiseError::Other(anyhow::anyhow!(
+            return Err(WhitenoiseError::Internal(format!(
                 "External signer pubkey mismatch: expected {}, got {}",
                 expected_pubkey.to_hex(),
                 signer_pubkey.to_hex()

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -540,12 +540,12 @@ impl Account {
         let descriptor = tokio::time::timeout(Whitenoise::BLOSSOM_TIMEOUT, upload_future)
             .await
             .map_err(|_| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(format!(
                     "Upload timed out after {} seconds",
                     Whitenoise::BLOSSOM_TIMEOUT.as_secs()
                 ))
             })?
-            .map_err(|err| WhitenoiseError::Other(anyhow::anyhow!(err)))?;
+            .map_err(|err| WhitenoiseError::Internal(err.to_string()))?;
 
         Whitenoise::require_https(&descriptor.url)?;
 

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -18,6 +18,7 @@ use crate::nostr_manager::NostrManagerError;
 use crate::perf_instrument;
 use crate::types::ImageType;
 use crate::whitenoise::error::Result;
+use crate::whitenoise::groups::blossom_error::BlossomError;
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::secrets_store::SecretsStoreError;
 use crate::whitenoise::user_streaming::{UserUpdate, UserUpdateTrigger};
@@ -539,13 +540,8 @@ impl Account {
 
         let descriptor = tokio::time::timeout(Whitenoise::BLOSSOM_TIMEOUT, upload_future)
             .await
-            .map_err(|_| {
-                WhitenoiseError::Internal(format!(
-                    "Upload timed out after {} seconds",
-                    Whitenoise::BLOSSOM_TIMEOUT.as_secs()
-                ))
-            })?
-            .map_err(|err| WhitenoiseError::Internal(err.to_string()))?;
+            .map_err(|_| BlossomError::Timeout(Whitenoise::BLOSSOM_TIMEOUT))?
+            .map_err(BlossomError::client)?;
 
         Whitenoise::require_https(&descriptor.url)?;
 

--- a/src/whitenoise/database/users.rs
+++ b/src/whitenoise/database/users.rs
@@ -96,8 +96,7 @@ impl User {
 
         for (pubkey_hex, relay_url) in rows {
             if current_pubkey.as_ref() != Some(&pubkey_hex) {
-                let pk =
-                    PublicKey::parse(&pubkey_hex).map_err(|e| WhitenoiseError::Other(e.into()))?;
+                let pk = PublicKey::parse(&pubkey_hex).map_err(WhitenoiseError::from)?;
                 result.push((pk, Vec::new()));
                 current_pubkey = Some(pubkey_hex);
             }
@@ -126,9 +125,7 @@ impl User {
         .map_err(DatabaseError::Sqlx)?;
 
         rows.into_iter()
-            .map(|pubkey_hex| {
-                PublicKey::parse(&pubkey_hex).map_err(|error| WhitenoiseError::Other(error.into()))
-            })
+            .map(|pubkey_hex| PublicKey::parse(&pubkey_hex).map_err(WhitenoiseError::from))
             .collect()
     }
 

--- a/src/whitenoise/discovery_sync_worker.rs
+++ b/src/whitenoise/discovery_sync_worker.rs
@@ -35,9 +35,9 @@ impl DiscoverySyncWorker {
         let current = *rx.borrow_and_update();
         self.notify.notify_one();
         rx.wait_for(|g| *g > current).await.map_err(|_| {
-            crate::whitenoise::error::WhitenoiseError::Other(anyhow::anyhow!(
-                "Discovery sync worker stopped"
-            ))
+            crate::whitenoise::error::WhitenoiseError::Internal(
+                "Discovery sync worker stopped".to_string(),
+            )
         })?;
         Ok(())
     }
@@ -289,8 +289,8 @@ mod tests {
                         let call = c.fetch_add(1, Ordering::SeqCst);
                         if call == 0 {
                             // First call fails
-                            Err(crate::whitenoise::error::WhitenoiseError::Other(
-                                anyhow::anyhow!("simulated failure"),
+                            Err(crate::whitenoise::error::WhitenoiseError::Internal(
+                                "simulated failure".to_string(),
                             ))
                         } else {
                             Ok(())

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -6,8 +6,10 @@ use crate::{
     whitenoise::{
         accounts::{AccountError, LoginError},
         database::DatabaseError,
+        groups::blossom_error::BlossomError,
         message_aggregator::ProcessingError,
         secrets_store::SecretsStoreError,
+        streaming_error::StreamingError,
     },
 };
 
@@ -143,6 +145,18 @@ pub enum WhitenoiseError {
 
     #[error("Message aggregation error: {0}")]
     MessageAggregation(#[from] ProcessingError),
+
+    #[error("Streaming error: {0}")]
+    Streaming(#[from] StreamingError),
+
+    #[error("Blossom error: {0}")]
+    Blossom(#[from] BlossomError),
+
+    #[error("MDK group image error: {0}")]
+    MdkGroupImage(#[from] mdk_core::extension::GroupImageError),
+
+    #[error("MDK encrypted media error: {0}")]
+    MdkEncryptedMedia(#[from] mdk_core::encrypted_media::EncryptedMediaError),
 
     #[error("Internal error: {0}")]
     Internal(String),

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -144,8 +144,8 @@ pub enum WhitenoiseError {
     #[error("Message aggregation error: {0}")]
     MessageAggregation(#[from] ProcessingError),
 
-    #[error("Other error: {0}")]
-    Other(#[from] anyhow::Error),
+    #[error("Internal error: {0}")]
+    Internal(String),
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
@@ -221,7 +221,7 @@ pub enum WhitenoiseError {
 
 impl From<Box<dyn std::error::Error + Send + Sync>> for WhitenoiseError {
     fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        WhitenoiseError::Other(anyhow::anyhow!(err.to_string()))
+        WhitenoiseError::Internal(err.to_string())
     }
 }
 
@@ -240,10 +240,10 @@ mod tests {
     }
 
     #[test]
-    fn boxed_errors_map_to_other_variant() {
+    fn boxed_errors_map_to_internal_variant() {
         let boxed: Box<dyn std::error::Error + Send + Sync> = std::io::Error::other("boom").into();
         let err = WhitenoiseError::from(boxed);
-        assert!(matches!(err, WhitenoiseError::Other(_)));
+        assert!(matches!(err, WhitenoiseError::Internal(_)));
         assert!(format!("{err}").contains("boom"));
     }
 

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -235,7 +235,7 @@ pub enum WhitenoiseError {
 
 impl From<Box<dyn std::error::Error + Send + Sync>> for WhitenoiseError {
     fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        WhitenoiseError::Internal(err.to_string())
+        Self::Internal(err.to_string())
     }
 }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -748,7 +748,7 @@ impl Whitenoise {
         tags.iter()
             .find(|tag| tag.kind() == nostr_sdk::TagKind::e())
             .and_then(|tag| tag.content().map(|s| s.to_string()))
-            .ok_or_else(|| WhitenoiseError::Internal("Reaction missing e-tag".to_string()))
+            .ok_or_else(|| WhitenoiseError::InvalidEvent("Reaction missing e-tag".to_string()))
     }
 
     pub(crate) fn extract_deletion_target_ids(tags: &Tags) -> Vec<String> {

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -748,7 +748,7 @@ impl Whitenoise {
         tags.iter()
             .find(|tag| tag.kind() == nostr_sdk::TagKind::e())
             .and_then(|tag| tag.content().map(|s| s.to_string()))
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Reaction missing e-tag")))
+            .ok_or_else(|| WhitenoiseError::Internal("Reaction missing e-tag".to_string()))
     }
 
     pub(crate) fn extract_deletion_target_ids(tags: &Tags) -> Vec<String> {

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -20,6 +20,7 @@ use crate::{
     },
 };
 
+pub mod blossom_error;
 mod media;
 mod membership;
 mod publish;

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -125,9 +125,9 @@ impl Whitenoise {
         key_package_events: &[Event],
     ) -> Result<Vec<(UnsignedEvent, User, PublicKey)>> {
         if welcome_rumors.len() != members.len() {
-            return Err(WhitenoiseError::Other(anyhow::Error::msg(
-                "Welcome rumours are missing for some of the members",
-            )));
+            return Err(WhitenoiseError::Internal(
+                "Welcome rumours are missing for some of the members".to_string(),
+            ));
         }
 
         let kp_pubkey_by_event_id: HashMap<EventId, PublicKey> = key_package_events
@@ -143,18 +143,18 @@ impl Whitenoise {
         welcome_rumors
             .into_iter()
             .map(|rumor| {
-                let kp_event_id = rumor.tags.event_ids().next().ok_or(WhitenoiseError::Other(
-                    anyhow::anyhow!("No event ID found in welcome rumor"),
-                ))?;
+                let kp_event_id = rumor.tags.event_ids().next().ok_or_else(|| {
+                    WhitenoiseError::Internal("No event ID found in welcome rumor".to_string())
+                })?;
                 let member_pubkey = kp_pubkey_by_event_id.get(kp_event_id).copied().ok_or(
-                    WhitenoiseError::Other(anyhow::anyhow!(
-                        "No public key found in key package event"
-                    )),
+                    WhitenoiseError::Internal(
+                        "No public key found in key package event".to_string(),
+                    ),
                 )?;
                 let member =
                     members_by_pubkey
                         .remove(&member_pubkey)
-                        .ok_or(WhitenoiseError::Other(anyhow::anyhow!(
+                        .ok_or(WhitenoiseError::Internal(format!(
                             "No member record found for welcome target {}",
                             member_pubkey
                         )))?;
@@ -645,9 +645,9 @@ impl Whitenoise {
         };
 
         if welcome_rumors.len() != users.len() {
-            return Err(WhitenoiseError::Other(anyhow::Error::msg(
-                "Welcome rumours are missing for some of the members",
-            )));
+            return Err(WhitenoiseError::Internal(
+                "Welcome rumours are missing for some of the members".to_string(),
+            ));
         }
 
         self.publish_and_merge_commit(evolution_event, &account.pubkey, group_id, &relay_urls)
@@ -662,17 +662,17 @@ impl Whitenoise {
                     .tags
                     .event_ids()
                     .next()
-                    .ok_or(WhitenoiseError::Other(anyhow::anyhow!(
-                        "No event ID found in welcome rumor"
-                    )))?;
+                    .ok_or(WhitenoiseError::Internal(
+                        "No event ID found in welcome rumor".to_string(),
+                    ))?;
 
             let member_pubkey = key_package_events
                 .iter()
                 .find(|event| event.id == *key_package_event_id)
                 .map(|event| event.pubkey)
-                .ok_or(WhitenoiseError::Other(anyhow::anyhow!(
-                    "No public key found in key package event"
-                )))?;
+                .ok_or(WhitenoiseError::Internal(
+                    "No public key found in key package event".to_string(),
+                ))?;
 
             // Create a timestamp 1 month in the future
             let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);

--- a/src/whitenoise/groups/blossom_error.rs
+++ b/src/whitenoise/groups/blossom_error.rs
@@ -1,0 +1,81 @@
+//! Errors raised by Blossom upload/download flows.
+//!
+//! These cover every failure mode specific to talking to a Blossom
+//! server: URL parsing, HTTP transport, non-success responses,
+//! request timeouts, and Nostr auth event signing for BUD-01.
+//! Errors from the `nostr-blossom` crate's high-level client are
+//! carried through as [`BlossomError::Client`].
+
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BlossomError {
+    /// Invalid Blossom server or endpoint URL.
+    #[error("Failed to build Blossom URL: {0}")]
+    Url(#[from] nostr_sdk::types::url::ParseError),
+
+    /// Transport-level HTTP error from reqwest.
+    #[error("Blossom HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Blossom server returned a non-success HTTP status.
+    #[error("Blossom upload failed with status {0}")]
+    UploadStatus(StatusCode),
+
+    /// Failed to parse the Blossom server's JSON response.
+    #[error("Failed to parse Blossom upload response: {0}")]
+    ResponseBody(#[source] reqwest::Error),
+
+    /// Upload exceeded the configured timeout.
+    #[error("Blossom upload timed out after {}s", .0.as_secs())]
+    Timeout(Duration),
+
+    /// Signing the Nostr auth event for BUD-01 failed.
+    #[error("Failed to sign Blossom auth event: {0}")]
+    AuthSign(#[from] nostr_sdk::event::builder::Error),
+
+    /// Error surfaced by the `nostr-blossom` high-level client.
+    #[error("Blossom client error: {0}")]
+    Client(String),
+}
+
+impl BlossomError {
+    /// Construct a [`BlossomError::Client`] from the opaque
+    /// `nostr_blossom::error::Error`, which does not implement `Display`
+    /// cleanly across versions but does implement `std::error::Error`.
+    pub fn client<E>(err: E) -> Self
+    where
+        E: std::error::Error,
+    {
+        Self::Client(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_message_includes_seconds() {
+        let err = BlossomError::Timeout(Duration::from_secs(30));
+        assert_eq!(err.to_string(), "Blossom upload timed out after 30s");
+    }
+
+    #[test]
+    fn upload_status_message_includes_code() {
+        let err = BlossomError::UploadStatus(StatusCode::BAD_REQUEST);
+        assert!(err.to_string().contains("400"));
+    }
+
+    #[test]
+    fn url_error_conversion() {
+        let parse_err = "ht!tp://bad"
+            .parse::<nostr_sdk::types::url::Url>()
+            .unwrap_err();
+        let err: BlossomError = parse_err.into();
+        assert!(matches!(err, BlossomError::Url(_)));
+    }
+}

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -245,7 +245,7 @@ impl Whitenoise {
                 &options.unwrap_or_default(),
             )
             .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to prepare group image: {}", e))
+                WhitenoiseError::Internal(format!("Failed to prepare group image: {}", e))
             })?;
 
         let blossom_server_url = blossom_server_url.unwrap_or(Self::default_blossom_url());
@@ -319,7 +319,7 @@ impl Whitenoise {
         let original_filename = std::path::Path::new(file_path)
             .file_name()
             .and_then(|n| n.to_str())
-            .ok_or_else(|| WhitenoiseError::Other(anyhow::anyhow!("Invalid file path")))?;
+            .ok_or_else(|| WhitenoiseError::Internal("Invalid file path".to_string()))?;
 
         let prepared = {
             let mdk = self.create_mdk_for_account(account.pubkey)?;
@@ -333,7 +333,7 @@ impl Whitenoise {
                     &options.unwrap_or_default(),
                 )
                 .map_err(|e| {
-                    WhitenoiseError::Other(anyhow::anyhow!("Failed to encrypt chat media: {}", e))
+                    WhitenoiseError::Internal(format!("Failed to encrypt chat media: {}", e))
                 })?
         };
 
@@ -702,7 +702,7 @@ impl Whitenoise {
 
         let secret_key = Secret::new(*image_key);
         let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to derive upload keypair: {}", e))
+            WhitenoiseError::Internal(format!("Failed to derive upload keypair: {}", e))
         })?;
 
         let upload = MediaFileUpload {
@@ -930,7 +930,7 @@ impl Whitenoise {
         let decrypted = media_manager
             .decrypt_from_download(&encrypted_data, &reference)
             .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to decrypt chat media: {}", e))
+                WhitenoiseError::Internal(format!("Failed to decrypt chat media: {}", e))
             })?;
 
         // MIP-04 requires an explicit SHA-256 check on the plaintext after decryption.
@@ -964,7 +964,7 @@ impl Whitenoise {
         let hash_hex = hex::encode(image_hash);
         let filename = format!("{}.{}", hash_hex, image_type.extension());
         let blossom_url = blossom_server.join(&hash_hex).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to construct Blossom URL: {}", e))
+            WhitenoiseError::Internal(format!("Failed to construct Blossom URL: {}", e))
         })?;
 
         let mut hasher = Sha256::new();
@@ -973,7 +973,7 @@ impl Whitenoise {
 
         let secret_key = Secret::new(*image_key);
         let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to derive upload keypair: {}", e))
+            WhitenoiseError::Internal(format!("Failed to derive upload keypair: {}", e))
         })?;
 
         let upload = MediaFileUpload {
@@ -1021,14 +1021,14 @@ impl Whitenoise {
             .sign(upload_keypair)
             .await
             .map_err(|e| {
-                WhitenoiseError::Other(anyhow::anyhow!("Failed to sign Blossom auth event: {}", e))
+                WhitenoiseError::Internal(format!("Failed to sign Blossom auth event: {}", e))
             })?;
         let auth_json = auth_event.as_json();
         let auth_header_value = format!("Nostr {}", Base64::encode_string(auth_json.as_bytes()));
 
-        let upload_url = blossom_server_url.join("upload").map_err(|e| {
-            WhitenoiseError::Other(anyhow::anyhow!("Failed to build upload URL: {}", e))
-        })?;
+        let upload_url = blossom_server_url
+            .join("upload")
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to build upload URL: {}", e)))?;
 
         let upload_future = async {
             let response = BLOSSOM_HTTP_CLIENT
@@ -1039,11 +1039,11 @@ impl Whitenoise {
                 .send()
                 .await
                 .map_err(|e| {
-                    WhitenoiseError::Other(anyhow::anyhow!("Upload HTTP request failed: {}", e))
+                    WhitenoiseError::Internal(format!("Upload HTTP request failed: {}", e))
                 })?;
 
             if !response.status().is_success() {
-                return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                return Err(WhitenoiseError::Internal(format!(
                     "Upload failed with status {}",
                     response.status()
                 )));
@@ -1053,17 +1053,14 @@ impl Whitenoise {
                 .json::<nostr_blossom::bud02::BlobDescriptor>()
                 .await
                 .map_err(|e| {
-                    WhitenoiseError::Other(anyhow::anyhow!(
-                        "Failed to parse upload response: {}",
-                        e
-                    ))
+                    WhitenoiseError::Internal(format!("Failed to parse upload response: {}", e))
                 })
         };
 
         let descriptor = tokio::time::timeout(Self::BLOSSOM_TIMEOUT, upload_future)
             .await
             .map_err(|_| {
-                WhitenoiseError::Other(anyhow::anyhow!(
+                WhitenoiseError::Internal(format!(
                     "Upload timed out after {} seconds",
                     Self::BLOSSOM_TIMEOUT.as_secs()
                 ))

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -25,6 +25,7 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::database::media_files::{FileMetadata, MediaFile};
 use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::groups::blossom_error::BlossomError;
 use crate::whitenoise::media_files::MediaFileUpload;
 
 /// Shared HTTP client for Blossom blob downloads.
@@ -243,10 +244,7 @@ impl Whitenoise {
                 &image_data,
                 image_type.mime_type(),
                 &options.unwrap_or_default(),
-            )
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to prepare group image: {}", e))
-            })?;
+            )?;
 
         let blossom_server_url = blossom_server_url.unwrap_or(Self::default_blossom_url());
         let descriptor = Self::upload_encrypted_blob_to_blossom(
@@ -325,16 +323,12 @@ impl Whitenoise {
             let mdk = self.create_mdk_for_account(account.pubkey)?;
             let media_manager = mdk.media_manager(group_id.clone());
 
-            media_manager
-                .encrypt_for_upload_with_options(
-                    &file_data,
-                    media_detection.mime_type(),
-                    original_filename,
-                    &options.unwrap_or_default(),
-                )
-                .map_err(|e| {
-                    WhitenoiseError::Internal(format!("Failed to encrypt chat media: {}", e))
-                })?
+            media_manager.encrypt_for_upload_with_options(
+                &file_data,
+                media_detection.mime_type(),
+                original_filename,
+                &options.unwrap_or_default(),
+            )?
         };
 
         let blossom_server_url = blossom_server_url.unwrap_or_else(Self::default_blossom_url);
@@ -701,9 +695,7 @@ impl Whitenoise {
         let original_hash: [u8; 32] = hasher.finalize().into();
 
         let secret_key = Secret::new(*image_key);
-        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to derive upload keypair: {}", e))
-        })?;
+        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2)?;
 
         let upload = MediaFileUpload {
             data: &[],
@@ -927,11 +919,7 @@ impl Whitenoise {
             nonce,
         };
 
-        let decrypted = media_manager
-            .decrypt_from_download(&encrypted_data, &reference)
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to decrypt chat media: {}", e))
-            })?;
+        let decrypted = media_manager.decrypt_from_download(&encrypted_data, &reference)?;
 
         // MIP-04 requires an explicit SHA-256 check on the plaintext after decryption.
         // ChaCha20-Poly1305 authenticates the ciphertext, but does not guarantee the
@@ -963,18 +951,14 @@ impl Whitenoise {
     ) -> Result<MediaFile> {
         let hash_hex = hex::encode(image_hash);
         let filename = format!("{}.{}", hash_hex, image_type.extension());
-        let blossom_url = blossom_server.join(&hash_hex).map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to construct Blossom URL: {}", e))
-        })?;
+        let blossom_url = blossom_server.join(&hash_hex).map_err(BlossomError::from)?;
 
         let mut hasher = Sha256::new();
         hasher.update(decrypted_data);
         let original_hash: [u8; 32] = hasher.finalize().into();
 
         let secret_key = Secret::new(*image_key);
-        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2).map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to derive upload keypair: {}", e))
-        })?;
+        let upload_keypair = group_image::derive_upload_keypair(&secret_key, 2)?;
 
         let upload = MediaFileUpload {
             data: decrypted_data,
@@ -1020,15 +1004,13 @@ impl Whitenoise {
         let auth_event = EventBuilder::blossom_auth(auth)
             .sign(upload_keypair)
             .await
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to sign Blossom auth event: {}", e))
-            })?;
+            .map_err(BlossomError::from)?;
         let auth_json = auth_event.as_json();
         let auth_header_value = format!("Nostr {}", Base64::encode_string(auth_json.as_bytes()));
 
         let upload_url = blossom_server_url
             .join("upload")
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to build upload URL: {}", e)))?;
+            .map_err(BlossomError::from)?;
 
         let upload_future = async {
             let response = BLOSSOM_HTTP_CLIENT
@@ -1038,33 +1020,21 @@ impl Whitenoise {
                 .body(encrypted_data)
                 .send()
                 .await
-                .map_err(|e| {
-                    WhitenoiseError::Internal(format!("Upload HTTP request failed: {}", e))
-                })?;
+                .map_err(BlossomError::from)?;
 
             if !response.status().is_success() {
-                return Err(WhitenoiseError::Internal(format!(
-                    "Upload failed with status {}",
-                    response.status()
-                )));
+                return Err(BlossomError::UploadStatus(response.status()).into());
             }
 
             response
                 .json::<nostr_blossom::bud02::BlobDescriptor>()
                 .await
-                .map_err(|e| {
-                    WhitenoiseError::Internal(format!("Failed to parse upload response: {}", e))
-                })
+                .map_err(|e| WhitenoiseError::from(BlossomError::ResponseBody(e)))
         };
 
         let descriptor = tokio::time::timeout(Self::BLOSSOM_TIMEOUT, upload_future)
             .await
-            .map_err(|_| {
-                WhitenoiseError::Internal(format!(
-                    "Upload timed out after {} seconds",
-                    Self::BLOSSOM_TIMEOUT.as_secs()
-                ))
-            })??;
+            .map_err(|_| BlossomError::Timeout(Self::BLOSSOM_TIMEOUT))??;
 
         Self::require_https(&descriptor.url)?;
 

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -1019,7 +1019,7 @@ impl Whitenoise {
     ) -> Result<Option<PublishedKeyPackage>> {
         PublishedKeyPackage::find_by_event_id(account_pubkey, event_id, &self.database)
             .await
-            .map_err(|e| WhitenoiseError::Other(e.into()))
+            .map_err(WhitenoiseError::from)
     }
 
     /// Records a published key package in the lifecycle tracking table.
@@ -1036,7 +1036,7 @@ impl Whitenoise {
     ) -> Result<()> {
         PublishedKeyPackage::create(account_pubkey, hash_ref, event_id, &self.database)
             .await
-            .map_err(|e| WhitenoiseError::Other(e.into()))
+            .map_err(WhitenoiseError::from)
     }
 
     /// Backdates the `consumed_at` timestamp for a published key package.

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -95,7 +95,7 @@ impl Whitenoise {
                     .await?;
             }
             other => {
-                return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                return Err(WhitenoiseError::Internal(format!(
                     "Unsupported outgoing event kind: {other}"
                 )));
             }
@@ -191,15 +191,11 @@ impl Whitenoise {
                 msg.delivery_status = Some(DeliveryStatus::Sending);
                 msg
             })
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to process message: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to process message: {}", e)))?;
 
         AggregatedMessage::insert_message(&chat_message, group_id, &self.database)
             .await
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to cache message: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache message: {}", e)))?;
 
         // Emit NewMessage so the UI shows it immediately (optimistic)
         self.message_stream_manager.emit(
@@ -227,9 +223,7 @@ impl Whitenoise {
         // Insert the reaction event row
         AggregatedMessage::insert_reaction(mdk_message, group_id, &self.database)
             .await
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to cache reaction: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache reaction: {}", e)))?;
 
         // Track delivery status for the reaction event (direct insert, not full
         // update_delivery_status which opens a transaction that can contend with
@@ -242,10 +236,7 @@ impl Whitenoise {
         )
         .await
         .map_err(|e| {
-            WhitenoiseError::from(anyhow::anyhow!(
-                "Failed to set reaction delivery status: {}",
-                e,
-            ))
+            WhitenoiseError::Internal(format!("Failed to set reaction delivery status: {}", e,))
         })?;
 
         // Apply reaction to the target kind-9 message (if e-tag is present and target cached)
@@ -257,7 +248,7 @@ impl Whitenoise {
                 &mdk_message.content,
                 self.message_aggregator.config().normalize_emoji,
             )
-            .map_err(|e| WhitenoiseError::from(anyhow::anyhow!("Invalid reaction emoji: {}", e)))?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Invalid reaction emoji: {}", e)))?;
 
             reaction_handler::add_reaction_to_message(
                 &mut target,
@@ -301,9 +292,7 @@ impl Whitenoise {
         // Insert the deletion event row
         AggregatedMessage::insert_deletion(mdk_message, group_id, &self.database)
             .await
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to cache deletion: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache deletion: {}", e)))?;
 
         // Track delivery status for the deletion event (direct insert, not full
         // update_delivery_status which opens a transaction that can contend with
@@ -316,10 +305,7 @@ impl Whitenoise {
         )
         .await
         .map_err(|e| {
-            WhitenoiseError::from(anyhow::anyhow!(
-                "Failed to set deletion delivery status: {}",
-                e,
-            ))
+            WhitenoiseError::Internal(format!("Failed to set deletion delivery status: {}", e,))
         })?;
 
         // Capture the last message ID *before* applying deletions so we can
@@ -559,22 +545,21 @@ impl Whitenoise {
                     cached
                 }
                 Ok(Some(cached)) => {
-                    return Err(WhitenoiseError::from(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Can only retry messages with Failed delivery status, got {:?}",
                         cached.delivery_status
                     )));
                 }
                 Ok(None) => {
-                    return Err(WhitenoiseError::from(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Cannot retry message {}: not found in cache for group",
                         event_id_str
                     )));
                 }
                 Err(e) => {
-                    return Err(WhitenoiseError::from(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Cannot retry message {}: failed to query cache: {}",
-                        event_id_str,
-                        e
+                        event_id_str, e
                     )));
                 }
             };
@@ -690,7 +675,7 @@ impl Whitenoise {
                 WhitenoiseError::InvalidCursor { reason }
             }
             other => {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to read cached messages: {}", other))
+                WhitenoiseError::Internal(format!("Failed to read cached messages: {}", other))
             }
         })
     }
@@ -755,9 +740,7 @@ impl Whitenoise {
 
         AggregatedMessage::find_by_id(message_id, group_id, &self.database)
             .await
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to read cached message: {}", e))
-            })
+            .map_err(|e| WhitenoiseError::Internal(format!("Failed to read cached message: {}", e)))
     }
 
     /// Search messages within a group by content.
@@ -894,7 +877,7 @@ impl Whitenoise {
         let cached_count = AggregatedMessage::count_by_group(group_id, &self.database)
             .await
             .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to count cached events: {}", e))
+                WhitenoiseError::Internal(format!("Failed to count cached events: {}", e))
             })?;
 
         if mdk_messages.len() != cached_count {
@@ -928,7 +911,7 @@ impl Whitenoise {
         let cached_ids = AggregatedMessage::get_all_event_ids_by_group(group_id, &self.database)
             .await
             .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to get cached event IDs: {}", e))
+                WhitenoiseError::Internal(format!("Failed to get cached event IDs: {}", e))
             })?;
 
         let new_events: Vec<Message> = mdk_messages
@@ -966,14 +949,12 @@ impl Whitenoise {
                 media_files,
             )
             .await
-            .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Message aggregation failed: {}", e))
-            })?;
+            .map_err(|e| WhitenoiseError::Internal(format!("Message aggregation failed: {}", e)))?;
 
         AggregatedMessage::save_events(new_events, processed_messages, group_id, &self.database)
             .await
             .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to save events to cache: {}", e))
+                WhitenoiseError::Internal(format!("Failed to save events to cache: {}", e))
             })?;
 
         tracing::debug!(

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -190,12 +190,9 @@ impl Whitenoise {
             .map(|mut msg| {
                 msg.delivery_status = Some(DeliveryStatus::Sending);
                 msg
-            })
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to process message: {}", e)))?;
+            })?;
 
-        AggregatedMessage::insert_message(&chat_message, group_id, &self.database)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache message: {}", e)))?;
+        AggregatedMessage::insert_message(&chat_message, group_id, &self.database).await?;
 
         // Emit NewMessage so the UI shows it immediately (optimistic)
         self.message_stream_manager.emit(
@@ -221,9 +218,7 @@ impl Whitenoise {
         group_id: &GroupId,
     ) -> Result<()> {
         // Insert the reaction event row
-        AggregatedMessage::insert_reaction(mdk_message, group_id, &self.database)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache reaction: {}", e)))?;
+        AggregatedMessage::insert_reaction(mdk_message, group_id, &self.database).await?;
 
         // Track delivery status for the reaction event (direct insert, not full
         // update_delivery_status which opens a transaction that can contend with
@@ -234,10 +229,7 @@ impl Whitenoise {
             &DeliveryStatus::Sending,
             &self.database,
         )
-        .await
-        .map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to set reaction delivery status: {}", e,))
-        })?;
+        .await?;
 
         // Apply reaction to the target kind-9 message (if e-tag is present and target cached)
         if let Ok(target_id) = Self::extract_reaction_target_id(&mdk_message.tags)
@@ -247,8 +239,7 @@ impl Whitenoise {
             let emoji = emoji_utils::validate_and_normalize_reaction(
                 &mdk_message.content,
                 self.message_aggregator.config().normalize_emoji,
-            )
-            .map_err(|e| WhitenoiseError::Internal(format!("Invalid reaction emoji: {}", e)))?;
+            )?;
 
             reaction_handler::add_reaction_to_message(
                 &mut target,
@@ -290,9 +281,7 @@ impl Whitenoise {
         group_id: &GroupId,
     ) -> Result<()> {
         // Insert the deletion event row
-        AggregatedMessage::insert_deletion(mdk_message, group_id, &self.database)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to cache deletion: {}", e)))?;
+        AggregatedMessage::insert_deletion(mdk_message, group_id, &self.database).await?;
 
         // Track delivery status for the deletion event (direct insert, not full
         // update_delivery_status which opens a transaction that can contend with
@@ -303,10 +292,7 @@ impl Whitenoise {
             &DeliveryStatus::Sending,
             &self.database,
         )
-        .await
-        .map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to set deletion delivery status: {}", e,))
-        })?;
+        .await?;
 
         // Capture the last message ID *before* applying deletions so we can
         // detect if the deletion removed it and emit a chat-list update.
@@ -537,32 +523,22 @@ impl Whitenoise {
     ) -> Result<()> {
         // Guard: only retry messages that are in Failed state to prevent duplicate publishes
         let event_id_str = event_id.to_string();
-        let original =
-            match AggregatedMessage::find_by_id(&event_id_str, group_id, &self.database).await {
-                Ok(Some(cached))
-                    if matches!(cached.delivery_status, Some(DeliveryStatus::Failed(_))) =>
-                {
-                    cached
-                }
-                Ok(Some(cached)) => {
-                    return Err(WhitenoiseError::Internal(format!(
-                        "Can only retry messages with Failed delivery status, got {:?}",
-                        cached.delivery_status
-                    )));
-                }
-                Ok(None) => {
-                    return Err(WhitenoiseError::Internal(format!(
-                        "Cannot retry message {}: not found in cache for group",
-                        event_id_str
-                    )));
-                }
-                Err(e) => {
-                    return Err(WhitenoiseError::Internal(format!(
-                        "Cannot retry message {}: failed to query cache: {}",
-                        event_id_str, e
-                    )));
-                }
-            };
+        let original = match AggregatedMessage::find_by_id(&event_id_str, group_id, &self.database)
+            .await?
+        {
+            Some(cached) if matches!(cached.delivery_status, Some(DeliveryStatus::Failed(_))) => {
+                cached
+            }
+            Some(cached) => {
+                return Err(WhitenoiseError::Internal(format!(
+                    "Can only retry messages with Failed delivery status, got {:?}",
+                    cached.delivery_status
+                )));
+            }
+            None => {
+                return Err(WhitenoiseError::MessageNotFound);
+            }
+        };
 
         // Create the new message FIRST — if this fails, the original stays visible as Failed
         // rather than being hidden with no replacement.
@@ -738,9 +714,7 @@ impl Whitenoise {
     ) -> Result<Option<ChatMessage>> {
         Account::find_by_pubkey(pubkey, &self.database).await?;
 
-        AggregatedMessage::find_by_id(message_id, group_id, &self.database)
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Failed to read cached message: {}", e)))
+        Ok(AggregatedMessage::find_by_id(message_id, group_id, &self.database).await?)
     }
 
     /// Search messages within a group by content.
@@ -874,11 +848,7 @@ impl Whitenoise {
             return Ok(false);
         }
 
-        let cached_count = AggregatedMessage::count_by_group(group_id, &self.database)
-            .await
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to count cached events: {}", e))
-            })?;
+        let cached_count = AggregatedMessage::count_by_group(group_id, &self.database).await?;
 
         if mdk_messages.len() != cached_count {
             tracing::debug!(
@@ -908,11 +878,8 @@ impl Whitenoise {
             return Ok(());
         }
 
-        let cached_ids = AggregatedMessage::get_all_event_ids_by_group(group_id, &self.database)
-            .await
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to get cached event IDs: {}", e))
-            })?;
+        let cached_ids =
+            AggregatedMessage::get_all_event_ids_by_group(group_id, &self.database).await?;
 
         let new_events: Vec<Message> = mdk_messages
             .into_iter()
@@ -948,14 +915,10 @@ impl Whitenoise {
                 &self.content_parser,
                 media_files,
             )
-            .await
-            .map_err(|e| WhitenoiseError::Internal(format!("Message aggregation failed: {}", e)))?;
+            .await?;
 
         AggregatedMessage::save_events(new_events, processed_messages, group_id, &self.database)
-            .await
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to save events to cache: {}", e))
-            })?;
+            .await?;
 
         tracing::debug!(
             target: "whitenoise::cache",

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -1762,11 +1762,10 @@ mod tests {
             "Should reject retry for uncached message"
         );
 
-        let err_msg = retry_result.unwrap_err().to_string();
+        let err = retry_result.unwrap_err();
         assert!(
-            err_msg.contains("not found in cache"),
-            "Error should mention message not found, got: {}",
-            err_msg
+            matches!(err, WhitenoiseError::MessageNotFound),
+            "Expected MessageNotFound for uncached retry, got: {err:?}"
         );
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -445,12 +445,24 @@ impl Whitenoise {
         let data_dir = &config.data_dir;
         let logs_dir = &config.logs_dir;
 
-        // Setup directories
-        std::fs::create_dir_all(data_dir).map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to create data directory: {data_dir:?}: {e}"))
+        // Setup directories. Path context is preserved via tracing; the
+        // io::Error itself flows through `WhitenoiseError::Filesystem` so
+        // callers can distinguish filesystem failures.
+        std::fs::create_dir_all(data_dir).inspect_err(|e| {
+            tracing::error!(
+                target: "whitenoise::initialize_whitenoise",
+                ?data_dir,
+                error = %e,
+                "Failed to create data directory"
+            );
         })?;
-        std::fs::create_dir_all(logs_dir).map_err(|e| {
-            WhitenoiseError::Internal(format!("Failed to create logs directory: {logs_dir:?}: {e}"))
+        std::fs::create_dir_all(logs_dir).inspect_err(|e| {
+            tracing::error!(
+                target: "whitenoise::initialize_whitenoise",
+                ?logs_dir,
+                error = %e,
+                "Failed to create logs directory"
+            );
         })?;
 
         // Only initialize tracing once

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -46,6 +46,7 @@ pub mod secrets_store;
 mod signer;
 pub mod storage;
 mod streaming;
+pub mod streaming_error;
 mod subscriptions;
 pub mod user_search;
 pub mod user_streaming;

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, OnceLock};
 
 use ::rand::RngCore;
 
-use anyhow::Context;
 use dashmap::DashMap;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::NostrSigner;
@@ -446,12 +445,12 @@ impl Whitenoise {
         let logs_dir = &config.logs_dir;
 
         // Setup directories
-        std::fs::create_dir_all(data_dir)
-            .with_context(|| format!("Failed to create data directory: {:?}", data_dir))
-            .map_err(WhitenoiseError::from)?;
-        std::fs::create_dir_all(logs_dir)
-            .with_context(|| format!("Failed to create logs directory: {:?}", logs_dir))
-            .map_err(WhitenoiseError::from)?;
+        std::fs::create_dir_all(data_dir).map_err(|e| {
+            WhitenoiseError::Internal(format!("Failed to create data directory: {data_dir:?}: {e}"))
+        })?;
+        std::fs::create_dir_all(logs_dir).map_err(|e| {
+            WhitenoiseError::Internal(format!("Failed to create logs directory: {logs_dir:?}: {e}"))
+        })?;
 
         // Only initialize tracing once
         init_tracing(logs_dir);

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -436,7 +436,7 @@ mod tests {
 
         let nsec = whitenoise.export_account_nsec(account).await?;
         let secret_key =
-            SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Other(e.into()))?;
+            SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
         let keys = Keys::new(secret_key);
 
         // Filter out the encoding tag to simulate an outdated key package
@@ -449,7 +449,7 @@ mod tests {
         let event = EventBuilder::new(Kind::MlsKeyPackage, &key_package_data.content)
             .tags(tags_without_encoding)
             .sign_with_keys(&keys)
-            .map_err(|e| WhitenoiseError::Other(e.into()))?;
+            .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
 
         let event_id = event.id;
 

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -63,7 +63,7 @@ impl Whitenoise {
             )
             .await
             .map_err(|e| {
-                WhitenoiseError::from(anyhow::anyhow!("Failed to read cached messages: {}", e))
+                WhitenoiseError::Internal(format!("Failed to read cached messages: {}", e))
             })?;
 
         // 3. Build a map keyed by message ID for deduplication.
@@ -104,16 +104,16 @@ impl Whitenoise {
                         target: "whitenoise::mod",
                         "subscription drain lagged by {n} messages, snapshot may be incomplete"
                     );
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(format!(
                         "Message stream lagged by {} messages during subscription initialization, retry needed",
                         n
                     )));
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
                     // Channel closed unexpectedly — unreachable while we hold a receiver.
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Message stream closed unexpectedly during subscription"
-                    )));
+                    return Err(WhitenoiseError::Internal(
+                        "Message stream closed unexpectedly during subscription".to_string(),
+                    ));
                 }
             }
         }
@@ -174,9 +174,9 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "User stream closed unexpectedly during subscription"
-                    )));
+                    return Err(WhitenoiseError::Internal(
+                        "User stream closed unexpectedly during subscription".to_string(),
+                    ));
                 }
             }
         }
@@ -223,9 +223,9 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
-                        "Chat list stream closed unexpectedly during subscription"
-                    )));
+                    return Err(WhitenoiseError::Internal(
+                        "Chat list stream closed unexpectedly during subscription".to_string(),
+                    ));
                 }
             }
         }
@@ -277,9 +277,10 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                    return Err(WhitenoiseError::Internal(
                         "Archived chat list stream closed unexpectedly during subscription"
-                    )));
+                            .to_string(),
+                    ));
                 }
             }
         }

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -8,7 +8,8 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::database::aggregated_messages::PaginationOptions;
-use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::error::Result;
+use crate::whitenoise::streaming_error::{StreamKind, StreamingError};
 use crate::whitenoise::users::User;
 use crate::whitenoise::{
     aggregated_message, chat_list, chat_list_streaming, media_files, message_aggregator,
@@ -61,10 +62,7 @@ impl Whitenoise {
                 limit,
                 cleared_at_ms,
             )
-            .await
-            .map_err(|e| {
-                WhitenoiseError::Internal(format!("Failed to read cached messages: {}", e))
-            })?;
+            .await?;
 
         // 3. Build a map keyed by message ID for deduplication.
         let mut messages_map: HashMap<String, message_aggregator::ChatMessage> = fetched_messages
@@ -104,16 +102,18 @@ impl Whitenoise {
                         target: "whitenoise::mod",
                         "subscription drain lagged by {n} messages, snapshot may be incomplete"
                     );
-                    return Err(WhitenoiseError::Internal(format!(
-                        "Message stream lagged by {} messages during subscription initialization, retry needed",
-                        n
-                    )));
+                    return Err(StreamingError::Lagged {
+                        stream: StreamKind::Message,
+                        missed: n,
+                    }
+                    .into());
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
                     // Channel closed unexpectedly — unreachable while we hold a receiver.
-                    return Err(WhitenoiseError::Internal(
-                        "Message stream closed unexpectedly during subscription".to_string(),
-                    ));
+                    return Err(StreamingError::Closed {
+                        stream: StreamKind::Message,
+                    }
+                    .into());
                 }
             }
         }
@@ -174,9 +174,10 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Internal(
-                        "User stream closed unexpectedly during subscription".to_string(),
-                    ));
+                    return Err(StreamingError::Closed {
+                        stream: StreamKind::User,
+                    }
+                    .into());
                 }
             }
         }
@@ -223,9 +224,10 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Internal(
-                        "Chat list stream closed unexpectedly during subscription".to_string(),
-                    ));
+                    return Err(StreamingError::Closed {
+                        stream: StreamKind::ChatList,
+                    }
+                    .into());
                 }
             }
         }
@@ -277,10 +279,10 @@ impl Whitenoise {
                     continue;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
-                    return Err(WhitenoiseError::Internal(
-                        "Archived chat list stream closed unexpectedly during subscription"
-                            .to_string(),
-                    ));
+                    return Err(StreamingError::Closed {
+                        stream: StreamKind::ArchivedChatList,
+                    }
+                    .into());
                 }
             }
         }

--- a/src/whitenoise/streaming_error.rs
+++ b/src/whitenoise/streaming_error.rs
@@ -1,0 +1,84 @@
+//! Errors raised while initializing a streaming subscription.
+//!
+//! These originate from `tokio::sync::broadcast` receivers used by the
+//! streaming layer (messages, users, chat list, archived chat list,
+//! notifications). The receiver variants we surface are:
+//! - `Lagged(n)` — the subscription missed `n` messages before we could
+//!   drain them, so the initial snapshot is incomplete and the caller
+//!   should retry.
+//! - `Closed` — the sender was dropped, which is unreachable while we
+//!   hold a receiver. Reported defensively so callers see the problem
+//!   instead of silently exiting.
+
+use thiserror::Error;
+
+/// Identifies which stream raised a streaming error. Used purely for
+/// diagnostic messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamKind {
+    Message,
+    User,
+    ChatList,
+    ArchivedChatList,
+}
+
+impl StreamKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Message => "Message",
+            Self::User => "User",
+            Self::ChatList => "Chat list",
+            Self::ArchivedChatList => "Archived chat list",
+        }
+    }
+}
+
+impl std::fmt::Display for StreamKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum StreamingError {
+    /// The broadcast channel lagged during snapshot initialization; the
+    /// subscription drained less than was published, so the initial
+    /// snapshot would be incomplete. Caller should retry.
+    #[error(
+        "{stream} stream lagged by {missed} messages during subscription initialization, retry needed"
+    )]
+    Lagged { stream: StreamKind, missed: u64 },
+
+    /// The broadcast sender was dropped while a receiver was still held;
+    /// this is unreachable under normal operation.
+    #[error("{stream} stream closed unexpectedly during subscription")]
+    Closed { stream: StreamKind },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lagged_message_includes_stream_and_count() {
+        let err = StreamingError::Lagged {
+            stream: StreamKind::Message,
+            missed: 42,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Message"));
+        assert!(msg.contains("42"));
+        assert!(msg.contains("retry needed"));
+    }
+
+    #[test]
+    fn closed_message_includes_stream() {
+        let err = StreamingError::Closed {
+            stream: StreamKind::ChatList,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Chat list stream closed unexpectedly during subscription"
+        );
+    }
+}


### PR DESCRIPTION
This PR eliminates the use of `anyhow::Error` across the codebase by introducing properly typed error enums with `thiserror`, improving error handling clarity and type safety.

## Summary
Removes the `anyhow` dependency and replaces all dynamic error handling with concrete, typed error enums. This provides better compile-time error information, clearer error semantics, and improved maintainability.

## Key Changes

- **New error types introduced:**
  - `StreamingError` - for broadcast channel subscription failures (lagged/closed)
  - `BlossomError` - for Blossom server upload/download operations (URL, HTTP, auth, timeout)
  - `ImageTypeError` - for image format detection and validation
  - `CliError` - for CLI-specific failures (daemon IPC, serialization, I/O)

- **Error handling improvements:**
  - Replaced `WhitenoiseError::Other(anyhow::anyhow!(...))` with `WhitenoiseError::Internal(String)` throughout
  - Removed verbose `.map_err(|e| WhitenoiseError::from(anyhow::anyhow!(...)))` chains with simple `?` operator
  - Updated `ImageType::detect()` to return `ImageTypeError` instead of `anyhow::Error`
  - CLI commands now return `crate::cli::Result<T>` instead of `anyhow::Result<T>`

- **Error enum updates:**
  - `WhitenoiseError` now includes variants for `Streaming`, `Blossom`, and `MdkGroupImage` errors
  - Removed catch-all `Other(anyhow::Error)` variant
  - Added `Internal(String)` for internal/unexpected errors

- **Code cleanup:**
  - Removed `anyhow::Context` imports
  - Simplified error propagation by removing unnecessary error wrapping
  - Updated all integration tests and CLI commands to use new error types

## Implementation Details

The migration maintains backward compatibility at the API level while providing better error semantics. Errors that were previously wrapped in `anyhow::Error` are now properly categorized, making it easier for callers to handle specific failure modes. The `Internal` variant serves as a catch-all for unexpected errors that don't fit other categories.

https://claude.ai/code/session_01SjtLyCgEj6SRXbCW41oibN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI and daemon now emit consistent, user-facing error types and exit codes for clearer feedback.
  * Streaming diagnostics show distinct, human-readable reasons (lagged/closed) with actionable guidance.
  * Media and group upload flows produce more specific upload/auth/timeouts messages to aid troubleshooting.
  * Image handling reports typed, actionable errors for unsupported/invalid formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->