### PR TITLE
Fix message delivery status scoping by account pubkey

### DIFF
--- a/db_migrations/0045_message_delivery_status_add_account_pubkey.sql
+++ b/db_migrations/0045_message_delivery_status_add_account_pubkey.sql
@@ -1,0 +1,35 @@
+-- Add account_pubkey to message_delivery_status primary key.
+--
+-- The old table keyed by (message_id, mls_group_id) allows delivery state to
+-- collide when two local accounts belong to the same group.  Adding
+-- account_pubkey scopes the status per-account.
+
+-- 1. Create the new table with the expanded primary key.
+CREATE TABLE message_delivery_status_v2 (
+    account_pubkey TEXT    NOT NULL,
+    message_id     TEXT    NOT NULL,
+    mls_group_id   BLOB   NOT NULL,
+    status         TEXT    NOT NULL,
+    PRIMARY KEY (account_pubkey, message_id, mls_group_id),
+    FOREIGN KEY (message_id, mls_group_id)
+        REFERENCES aggregated_messages(message_id, mls_group_id)
+        ON DELETE CASCADE
+);
+
+-- 2. Copy existing rows, filling account_pubkey from accounts_groups.
+--    If multiple local accounts belong to the same group the row is duplicated
+--    once per account (the status applies to whoever sent it, but we cannot
+--    know which account that was from the old schema alone, so we conservatively
+--    copy to all).
+INSERT INTO message_delivery_status_v2 (account_pubkey, message_id, mls_group_id, status)
+SELECT DISTINCT ag.account_pubkey, mds.message_id, mds.mls_group_id, mds.status
+FROM message_delivery_status mds
+JOIN accounts_groups ag ON ag.mls_group_id = mds.mls_group_id;
+
+-- 3. Replace old table.
+DROP TABLE message_delivery_status;
+ALTER TABLE message_delivery_status_v2 RENAME TO message_delivery_status;
+
+-- 4. Recreate index for queries that filter by (account_pubkey, mls_group_id, status).
+CREATE INDEX idx_mds_account_group_status
+    ON message_delivery_status (account_pubkey, mls_group_id, status);

--- a/db_migrations/0045_message_delivery_status_add_account_pubkey.sql
+++ b/db_migrations/0045_message_delivery_status_add_account_pubkey.sql
@@ -16,15 +16,17 @@ CREATE TABLE message_delivery_status_v2 (
         ON DELETE CASCADE
 );
 
--- 2. Copy existing rows, filling account_pubkey from accounts_groups.
---    If multiple local accounts belong to the same group the row is duplicated
---    once per account (the status applies to whoever sent it, but we cannot
---    know which account that was from the old schema alone, so we conservatively
---    copy to all).
+-- 2. Copy existing rows, filling account_pubkey from the message author.
+--    Delivery status is only created for outgoing messages, so the author in
+--    aggregated_messages is the local account that sent it.  The INNER JOIN on
+--    accounts ensures we only copy rows whose author is actually a local account
+--    (filtering out any hypothetical stale rows whose author was removed).
 INSERT INTO message_delivery_status_v2 (account_pubkey, message_id, mls_group_id, status)
-SELECT DISTINCT ag.account_pubkey, mds.message_id, mds.mls_group_id, mds.status
+SELECT am.author, mds.message_id, mds.mls_group_id, mds.status
 FROM message_delivery_status mds
-JOIN accounts_groups ag ON ag.mls_group_id = mds.mls_group_id;
+JOIN aggregated_messages am
+  ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+INNER JOIN accounts a ON a.pubkey = am.author;
 
 -- 3. Replace old table.
 DROP TABLE message_delivery_status;

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -700,6 +700,7 @@ impl EphemeralPlane {
         {
             Ok(updated_msg) => {
                 stream_manager.emit(
+                    account_pubkey,
                     group_id,
                     MessageUpdate {
                         trigger: UpdateTrigger::DeliveryStatusChanged,

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -567,6 +567,7 @@ impl EphemeralPlane {
                     let status =
                         DeliveryStatus::Failed("No relay accepted the message".to_string());
                     Self::update_and_emit_delivery_status(
+                        account_pubkey,
                         event_id,
                         group_id,
                         &status,
@@ -579,6 +580,7 @@ impl EphemeralPlane {
 
                 let status = DeliveryStatus::Sent(output.success.len());
                 Self::update_and_emit_delivery_status(
+                    account_pubkey,
                     event_id,
                     group_id,
                     &status,
@@ -607,6 +609,7 @@ impl EphemeralPlane {
                 };
                 let status = DeliveryStatus::Failed(failure_message);
                 Self::update_and_emit_delivery_status(
+                    account_pubkey,
                     event_id,
                     group_id,
                     &status,
@@ -679,6 +682,7 @@ impl EphemeralPlane {
 
     #[perf_instrument("relay")]
     async fn update_and_emit_delivery_status(
+        account_pubkey: &PublicKey,
         event_id: &str,
         group_id: &GroupId,
         status: &DeliveryStatus,
@@ -686,7 +690,11 @@ impl EphemeralPlane {
         stream_manager: &MessageStreamManager,
     ) {
         match AggregatedMessage::update_delivery_status_with_retry(
-            event_id, group_id, status, database,
+            account_pubkey,
+            event_id,
+            group_id,
+            status,
+            database,
         )
         .await
         {

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -1046,9 +1046,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg1, &group1.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &creator.pubkey,
+            &msg1,
+            &group1.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let msg2 = ChatMessage {
             id: format!("{:0>64}", "2"),
@@ -1065,9 +1070,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg2, &group2.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &creator.pubkey,
+            &msg2,
+            &group2.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1229,9 +1239,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &creator.pubkey,
+            &msg,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1291,9 +1306,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group1.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &creator.pubkey,
+            &msg,
+            &group1.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1380,9 +1400,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &creator.pubkey,
+            &msg,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let result = whitenoise
             .build_chat_list_item(&creator, &group.mls_group_id)
@@ -1672,9 +1697,14 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &creator.pubkey,
+                &msg,
+                &group.mls_group_id,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
         }
 
         // Order should be stable when timestamps are identical

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -1174,7 +1174,7 @@ impl AggregatedMessage {
         Ok(())
     }
 
-    /// Check whether an event has a delivery status row (i.e. was sent by us).
+    /// Check whether an event has a delivery status row for a specific account.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn has_delivery_status(
         account_pubkey: &PublicKey,
@@ -1187,6 +1187,30 @@ impl AggregatedMessage {
              WHERE account_pubkey = ? AND message_id = ? AND mls_group_id = ?)",
         )
         .bind(account_pubkey.to_hex())
+        .bind(message_id)
+        .bind(group_id.as_slice())
+        .fetch_one(&database.pool)
+        .await?;
+
+        Ok(exists)
+    }
+
+    /// Check whether an event has a delivery status row for **any** local account.
+    ///
+    /// Used for echo detection in the event processor: when a relay echo arrives
+    /// for an event that was sent locally (by any account on this device), the
+    /// optimistic cache update has already been applied and reprocessing must be
+    /// skipped regardless of which account is currently handling the echo.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn has_delivery_status_any_account(
+        message_id: &str,
+        group_id: &GroupId,
+        database: &Database,
+    ) -> Result<bool> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM message_delivery_status
+             WHERE message_id = ? AND mls_group_id = ?)",
+        )
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_one(&database.pool)

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -2695,6 +2695,78 @@ mod tests {
         assert!(!ids.contains(&msg_retried.id.as_str()));
     }
 
+    /// Verify that delivery status is fully isolated per account: a status
+    /// inserted for one account must not be visible when querying as another.
+    #[tokio::test]
+    async fn test_delivery_status_isolated_per_account() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[240; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let author = Keys::generate().public_key();
+        let other_account = Keys::generate().public_key();
+
+        // Insert a message authored by `author`
+        let message = create_test_chat_message(240, author);
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Insert delivery status scoped to `author`
+        AggregatedMessage::insert_delivery_status(
+            &author,
+            &message.id,
+            &group_id,
+            &DeliveryStatus::Sending,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        // Author should see the delivery status
+        assert!(
+            AggregatedMessage::has_delivery_status(
+                &author,
+                &message.id,
+                &group_id,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap()
+        );
+        let found_by_author =
+            AggregatedMessage::find_by_id(&author, &message.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            found_by_author.delivery_status,
+            Some(DeliveryStatus::Sending)
+        );
+
+        // Other account should NOT see the delivery status
+        assert!(
+            !AggregatedMessage::has_delivery_status(
+                &other_account,
+                &message.id,
+                &group_id,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap()
+        );
+        let found_by_other = AggregatedMessage::find_by_id(
+            &other_account,
+            &message.id,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(found_by_other.delivery_status, None);
+    }
+
     #[tokio::test]
     async fn test_count_unread_for_groups_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -258,6 +258,7 @@ impl AggregatedMessage {
     /// Query uses covering index: idx_aggregated_messages_kind_group(kind, mls_group_id, created_at)
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_by_group(
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         chat_cleared_at_ms: Option<i64>,
         database: &Database,
@@ -266,12 +267,15 @@ impl AggregatedMessage {
             "SELECT am.*, mds.status AS delivery_status
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
-               ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+               ON am.message_id = mds.message_id
+              AND am.mls_group_id = mds.mls_group_id
+              AND mds.account_pubkey = ?
              WHERE am.kind = 9 AND am.mls_group_id = ?
                AND am.created_at > COALESCE(?, 0)
                AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              ORDER BY am.created_at",
         )
+        .bind(account_pubkey.to_hex())
         .bind(group_id.as_slice())
         .bind(chat_cleared_at_ms)
         .fetch_all(&database.pool)
@@ -306,6 +310,7 @@ impl AggregatedMessage {
     /// Query uses covering index: idx_aggregated_messages_kind_group(kind, mls_group_id, created_at)
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_by_group_paginated(
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         database: &Database,
         options: &PaginationOptions,
@@ -391,13 +396,17 @@ impl AggregatedMessage {
             },
         };
 
+        let account_hex = account_pubkey.to_hex();
+
         let rows: Vec<AggregatedMessageRow> = match direction {
             Direction::Before => {
                 sqlx::query_as(
                     "SELECT am.*, mds.status AS delivery_status
                      FROM aggregated_messages am
                      LEFT JOIN message_delivery_status mds
-                       ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                       ON am.message_id = mds.message_id
+                      AND am.mls_group_id = mds.mls_group_id
+                      AND mds.account_pubkey = ?
                      WHERE am.kind = 9 AND am.mls_group_id = ?
                        AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at < ? OR (am.created_at = ? AND am.message_id < ?))
@@ -405,6 +414,7 @@ impl AggregatedMessage {
                      ORDER BY am.created_at DESC, am.message_id DESC
                      LIMIT ?",
                 )
+                .bind(&account_hex)
                 .bind(group_id.as_slice())
                 .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
@@ -419,7 +429,9 @@ impl AggregatedMessage {
                     "SELECT am.*, mds.status AS delivery_status
                      FROM aggregated_messages am
                      LEFT JOIN message_delivery_status mds
-                       ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                       ON am.message_id = mds.message_id
+                      AND am.mls_group_id = mds.mls_group_id
+                      AND mds.account_pubkey = ?
                      WHERE am.kind = 9 AND am.mls_group_id = ?
                        AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at > ? OR (am.created_at = ? AND am.message_id > ?))
@@ -427,6 +439,7 @@ impl AggregatedMessage {
                      ORDER BY am.created_at ASC, am.message_id ASC
                      LIMIT ?",
                 )
+                .bind(&account_hex)
                 .bind(group_id.as_slice())
                 .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
@@ -470,6 +483,7 @@ impl AggregatedMessage {
     /// Messages in oldest-first order (same as `find_messages_by_group_paginated`).
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_with_unread_minimum(
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         read_marker: Option<&EventId>,
         minimum: u32,
@@ -493,6 +507,7 @@ impl AggregatedMessage {
         // render "message deleted" placeholders — matching the tombstone contract
         // in `find_messages_by_group_paginated`.
         let marker_hex = read_marker.map(EventId::to_hex);
+        let account_hex = account_pubkey.to_hex();
 
         let rows: Vec<AggregatedMessageRow> = sqlx::query_as(
             "WITH unread_count AS (
@@ -501,6 +516,7 @@ impl AggregatedMessage {
                LEFT JOIN message_delivery_status mds
                  ON am.message_id = mds.message_id
                 AND am.mls_group_id = mds.mls_group_id
+                AND mds.account_pubkey = ?
                WHERE am.mls_group_id = ?
                  AND am.kind = 9
                  AND am.deletion_event_id IS NULL
@@ -517,6 +533,7 @@ impl AggregatedMessage {
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id
               AND am.mls_group_id = mds.mls_group_id
+              AND mds.account_pubkey = ?
              WHERE am.kind = 9
                AND am.mls_group_id = ?
                AND am.created_at > COALESCE(?, 0)
@@ -524,10 +541,12 @@ impl AggregatedMessage {
              ORDER BY am.created_at DESC, am.message_id DESC
              LIMIT MAX((SELECT cnt FROM unread_count), ?)",
         )
+        .bind(&account_hex) // unread CTE: account_pubkey for mds join
         .bind(group_id.as_slice()) // unread CTE: mls_group_id
         .bind(marker_hex.as_deref()) // unread CTE: read marker message_id (NULL = no marker)
         .bind(group_id.as_slice()) // unread CTE: mls_group_id for marker lookup
         .bind(chat_cleared_at_ms) // unread CTE: chat_cleared_at floor
+        .bind(&account_hex) // outer SELECT: account_pubkey for mds join
         .bind(group_id.as_slice()) // outer SELECT: mls_group_id
         .bind(chat_cleared_at_ms) // outer SELECT: chat_cleared_at floor
         .bind(minimum_val) // MAX(cnt, minimum)
@@ -564,6 +583,7 @@ impl AggregatedMessage {
     /// `(kind, mls_group_id, deletion_event_id, created_at DESC, message_id DESC)`
     /// so the window scan uses an index walk instead of a temp B-tree sort.
     pub async fn search_messages_in_group(
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         query: &str,
         limit: u32,
@@ -580,18 +600,21 @@ impl AggregatedMessage {
                       (ROW_NUMBER() OVER (ORDER BY am.created_at DESC, am.message_id DESC)) - 1 AS position
                FROM aggregated_messages am
                LEFT JOIN message_delivery_status mds
-                 ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                 ON am.message_id = mds.message_id
+                AND am.mls_group_id = mds.mls_group_id
+                AND mds.account_pubkey = ?1
                WHERE am.kind = 9
-                 AND am.mls_group_id = ?1
-                 AND am.created_at > COALESCE(?2, 0)
+                 AND am.mls_group_id = ?2
+                 AND am.created_at > COALESCE(?3, 0)
                  AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              )
              SELECT * FROM ranked
              WHERE deletion_event_id IS NULL
-               AND content_normalized LIKE ?3
+               AND content_normalized LIKE ?4
              ORDER BY created_at DESC, message_id DESC
-             LIMIT ?4",
+             LIMIT ?5",
         )
+        .bind(account_pubkey.to_hex())
         .bind(group_id.as_slice())
         .bind(chat_cleared_at_ms)
         .bind(&like_pattern)
@@ -648,7 +671,9 @@ impl AggregatedMessage {
                JOIN accounts_groups ag
                  ON ag.mls_group_id = am.mls_group_id
                LEFT JOIN message_delivery_status mds
-                 ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                 ON am.message_id = mds.message_id
+                AND am.mls_group_id = mds.mls_group_id
+                AND mds.account_pubkey = ?1
                WHERE am.kind = 9
                  AND ag.account_pubkey = ?1
                  AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)
@@ -803,6 +828,7 @@ impl AggregatedMessage {
     /// Used by event processor for real-time caching
     #[perf_instrument("db::aggregated_messages")]
     pub async fn insert_message(
+        account_pubkey: &PublicKey,
         message: &ChatMessage,
         group_id: &GroupId,
         database: &Database,
@@ -847,10 +873,13 @@ impl AggregatedMessage {
 
         if let Some(status) = &message.delivery_status {
             sqlx::query(
-                "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-                 VALUES (?, ?, ?)
-                 ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+                "INSERT INTO message_delivery_status
+                   (account_pubkey, message_id, mls_group_id, status)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(account_pubkey, message_id, mls_group_id)
+                   DO UPDATE SET status = excluded.status",
             )
+            .bind(account_pubkey.to_hex())
             .bind(&message.id)
             .bind(group_id.as_slice())
             .bind(serde_json::to_string(status)?)
@@ -1015,6 +1044,7 @@ impl AggregatedMessage {
     /// Returns an error if no matching message was found.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn update_delivery_status(
+        account_pubkey: &PublicKey,
         message_id: &str,
         group_id: &GroupId,
         status: &DeliveryStatus,
@@ -1038,10 +1068,13 @@ impl AggregatedMessage {
 
         // Upsert delivery status
         sqlx::query(
-            "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-             VALUES (?, ?, ?)
-             ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+            "INSERT INTO message_delivery_status
+               (account_pubkey, message_id, mls_group_id, status)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(account_pubkey, message_id, mls_group_id)
+               DO UPDATE SET status = excluded.status",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .bind(serde_json::to_string(status)?)
@@ -1053,9 +1086,12 @@ impl AggregatedMessage {
             "SELECT am.*, mds.status AS delivery_status
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
-               ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+               ON am.message_id = mds.message_id
+              AND am.mls_group_id = mds.mls_group_id
+              AND mds.account_pubkey = ?
              WHERE am.message_id = ? AND am.mls_group_id = ?",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_optional(&mut *tx)
@@ -1071,6 +1107,7 @@ impl AggregatedMessage {
 
     #[perf_instrument("db::aggregated_messages")]
     pub async fn update_delivery_status_with_retry(
+        account_pubkey: &PublicKey,
         message_id: &str,
         group_id: &GroupId,
         status: &DeliveryStatus,
@@ -1081,7 +1118,15 @@ impl AggregatedMessage {
             .copied()
             .enumerate()
         {
-            match Self::update_delivery_status(message_id, group_id, status, database).await {
+            match Self::update_delivery_status(
+                account_pubkey,
+                message_id,
+                group_id,
+                status,
+                database,
+            )
+            .await
+            {
                 Ok(message) => return Ok(message),
                 Err(error) if Self::is_database_lock_error(&error) => {
                     tracing::debug!(
@@ -1096,7 +1141,7 @@ impl AggregatedMessage {
             }
         }
 
-        Self::update_delivery_status(message_id, group_id, status, database).await
+        Self::update_delivery_status(account_pubkey, message_id, group_id, status, database).await
     }
 
     /// Insert an initial delivery status row for an outgoing event.
@@ -1106,16 +1151,20 @@ impl AggregatedMessage {
     /// Only suitable when the parent `aggregated_messages` row was just inserted.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn insert_delivery_status(
+        account_pubkey: &PublicKey,
         message_id: &str,
         group_id: &GroupId,
         status: &DeliveryStatus,
         database: &Database,
     ) -> Result<()> {
         sqlx::query(
-            "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-             VALUES (?, ?, ?)
-             ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+            "INSERT INTO message_delivery_status
+               (account_pubkey, message_id, mls_group_id, status)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(account_pubkey, message_id, mls_group_id)
+               DO UPDATE SET status = excluded.status",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .bind(serde_json::to_string(status)?)
@@ -1128,14 +1177,16 @@ impl AggregatedMessage {
     /// Check whether an event has a delivery status row (i.e. was sent by us).
     #[perf_instrument("db::aggregated_messages")]
     pub async fn has_delivery_status(
+        account_pubkey: &PublicKey,
         message_id: &str,
         group_id: &GroupId,
         database: &Database,
     ) -> Result<bool> {
         let exists: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM message_delivery_status
-             WHERE message_id = ? AND mls_group_id = ?)",
+             WHERE account_pubkey = ? AND message_id = ? AND mls_group_id = ?)",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_one(&database.pool)
@@ -1163,6 +1214,7 @@ impl AggregatedMessage {
     /// Find a cached message by ID (for updating with reactions/deletions)
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_by_id(
+        account_pubkey: &PublicKey,
         message_id: &str,
         group_id: &GroupId,
         database: &Database,
@@ -1171,9 +1223,12 @@ impl AggregatedMessage {
             "SELECT am.*, mds.status AS delivery_status
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
-               ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+               ON am.message_id = mds.message_id
+              AND am.mls_group_id = mds.mls_group_id
+              AND mds.account_pubkey = ?
              WHERE am.message_id = ? AND am.mls_group_id = ? AND am.kind = 9",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_optional(&database.pool)
@@ -1653,11 +1708,16 @@ mod tests {
     async fn test_find_messages_by_group_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
+        let test_pubkey = Keys::generate().public_key();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &test_pubkey,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(messages.is_empty());
     }
 
@@ -1672,7 +1732,8 @@ mod tests {
 
         // Insert message
         let result =
-            AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database).await;
+            AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
+                .await;
         assert!(result.is_ok());
 
         // Verify it was inserted
@@ -1682,10 +1743,14 @@ mod tests {
         assert_eq!(count, 1);
 
         // Verify we can retrieve it
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, message.id);
         assert_eq!(messages[0].content, message.content);
@@ -1704,7 +1769,7 @@ mod tests {
         for i in 1..=3 {
             let message = create_test_chat_message(i, author);
             message_ids.push(message.id.clone());
-            AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -1716,10 +1781,14 @@ mod tests {
         assert_eq!(count, 3);
 
         // Verify we can retrieve all messages
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 3);
 
         // Verify event IDs
@@ -1743,7 +1812,7 @@ mod tests {
 
         // Insert a message
         let message = create_test_chat_message(10, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1770,10 +1839,14 @@ mod tests {
         assert_eq!(count_after, 1);
 
         // But the message should have deletion_event_id set
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_deleted);
     }
@@ -1788,17 +1861,17 @@ mod tests {
 
         // Insert multiple messages
         let message1 = create_test_chat_message(20, author);
-        AggregatedMessage::insert_message(&message1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message1, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         let message2 = create_test_chat_message(21, author);
-        AggregatedMessage::insert_message(&message2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message2, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         let message3 = create_test_chat_message(22, author);
-        AggregatedMessage::insert_message(&message3, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message3, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1820,10 +1893,14 @@ mod tests {
         assert_eq!(count_after, 0);
 
         // No messages should be found
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(messages.is_empty());
 
         // No event IDs should be found
@@ -1846,13 +1923,13 @@ mod tests {
 
         // Insert message in group 1
         let message1 = create_test_chat_message(30, author);
-        AggregatedMessage::insert_message(&message1, &group_id_1, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message1, &group_id_1, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert message in group 2
         let message2 = create_test_chat_message(31, author);
-        AggregatedMessage::insert_message(&message2, &group_id_2, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message2, &group_id_2, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1884,7 +1961,7 @@ mod tests {
 
         // Insert a message with empty reactions
         let message = create_test_chat_message(40, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1909,10 +1986,14 @@ mod tests {
         .unwrap();
 
         // Verify reactions were updated
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].reactions.by_emoji.len(), 1);
         assert!(messages[0].reactions.by_emoji.contains_key("👍"));
@@ -1988,31 +2069,51 @@ mod tests {
                 created_at: chrono::Utc::now(),
             },
         ];
-        AggregatedMessage::insert_message(&msg_with_media, &group_with_media, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &author,
+            &msg_with_media,
+            &group_with_media,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Group 2: Message without media
         let mut msg_no_media = create_test_chat_message(51, author);
         msg_no_media.content = "Message without media".to_string();
-        AggregatedMessage::insert_message(&msg_no_media, &group_no_media, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &author,
+            &msg_no_media,
+            &group_no_media,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Group 3: Has deleted newest message, should return older one
         let mut msg_older = create_test_chat_message(52, author);
         msg_older.content = "Older non-deleted".to_string();
         msg_older.created_at = Timestamp::from(1000);
-        AggregatedMessage::insert_message(&msg_older, &group_with_deletion, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &author,
+            &msg_older,
+            &group_with_deletion,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let mut msg_deleted = create_test_chat_message(53, author);
         msg_deleted.content = "Deleted message".to_string();
         msg_deleted.created_at = Timestamp::from(2000);
-        AggregatedMessage::insert_message(&msg_deleted, &group_with_deletion, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &author,
+            &msg_deleted,
+            &group_with_deletion,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         AggregatedMessage::mark_deleted(
             &msg_deleted.id,
             &group_with_deletion,
@@ -2029,6 +2130,7 @@ mod tests {
         msg_first.content = "First message".to_string();
         msg_first.created_at = Timestamp::from(1000);
         AggregatedMessage::insert_message(
+            &author,
             &msg_first,
             &group_multiple_messages,
             &whitenoise.database,
@@ -2040,6 +2142,7 @@ mod tests {
         msg_last.content = "Last message".to_string();
         msg_last.created_at = Timestamp::from(2000);
         AggregatedMessage::insert_message(
+            &author,
             &msg_last,
             &group_multiple_messages,
             &whitenoise.database,
@@ -2099,7 +2202,7 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(70, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2135,7 +2238,7 @@ mod tests {
         let author = Keys::generate().public_key();
         for i in 1..=3 {
             let msg = create_test_chat_message(80 + i, author);
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2159,7 +2262,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(90 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
             messages.push(msg);
@@ -2188,10 +2291,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(100, author);
         let msg2 = create_test_chat_message(101, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg1, &group_id, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg2, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2241,7 +2344,7 @@ mod tests {
         // Group 1: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(110 + i, author);
-            AggregatedMessage::insert_message(&msg, &group1, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group1, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2249,7 +2352,7 @@ mod tests {
         // Group 2: 5 messages
         for i in 1..=5 {
             let msg = create_test_chat_message(120 + i, author);
-            AggregatedMessage::insert_message(&msg, &group2, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group2, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2290,7 +2393,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(130 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group1, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group1, &whitenoise.database)
                 .await
                 .unwrap();
             group1_messages.push(msg);
@@ -2302,7 +2405,7 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(140 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group2, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group2, &whitenoise.database)
                 .await
                 .unwrap();
             group2_messages.push(msg);
@@ -2342,9 +2445,14 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(150 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group_with_marker, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &author,
+                &msg,
+                &group_with_marker,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
             messages.push(msg);
         }
         let marker = EventId::from_hex(&messages[1].id).unwrap();
@@ -2352,9 +2460,14 @@ mod tests {
         // Group without marker: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(160 + i, author);
-            AggregatedMessage::insert_message(&msg, &group_without_marker, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &author,
+                &msg,
+                &group_without_marker,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
         }
 
         let input = vec![
@@ -2384,19 +2497,21 @@ mod tests {
         // Insert a message with Sending status
         let mut message = create_test_chat_message(200, author);
         message.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Verify initial Sending status via find_by_id
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&author, &message.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
 
         // Update to Sent(3) — returned message should have the updated status
         let updated = AggregatedMessage::update_delivery_status(
+            &author,
             &message.id,
             &group_id,
             &DeliveryStatus::Sent(3),
@@ -2407,14 +2522,16 @@ mod tests {
         assert_eq!(updated.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Verify via find_by_id as well
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&author, &message.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Update to Failed
         let updated = AggregatedMessage::update_delivery_status(
+            &author,
             &message.id,
             &group_id,
             &DeliveryStatus::Failed("timeout".to_string()),
@@ -2432,10 +2549,16 @@ mod tests {
     async fn test_find_by_id_returns_none_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[201; 32]);
+        let test_pubkey = Keys::generate().public_key();
 
-        let found = AggregatedMessage::find_by_id("nonexistent", &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let found = AggregatedMessage::find_by_id(
+            &test_pubkey,
+            "nonexistent",
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(found.is_none());
     }
 
@@ -2450,14 +2573,15 @@ mod tests {
         // delivery_status is None (incoming message)
         assert!(message.delivery_status.is_none());
 
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &message, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&author, &message.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, None);
     }
 
@@ -2471,21 +2595,25 @@ mod tests {
 
         // Insert incoming message (no delivery status)
         let msg_incoming = create_test_chat_message(203, author);
-        AggregatedMessage::insert_message(&msg_incoming, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_incoming, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert outgoing message with Sent status
         let mut msg_outgoing = create_test_chat_message(204, author);
         msg_outgoing.delivery_status = Some(DeliveryStatus::Sent(2));
-        AggregatedMessage::insert_message(&msg_outgoing, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_outgoing, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 2);
 
         let statuses: Vec<_> = messages.iter().map(|m| &m.delivery_status).collect();
@@ -2498,9 +2626,11 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[205; 32]);
         setup_group(&group_id, &whitenoise.database).await;
+        let test_pubkey = Keys::generate().public_key();
 
         // Try to update delivery status for a message that doesn't exist
         let result = AggregatedMessage::update_delivery_status(
+            &test_pubkey,
             &format!("{:0>64}", "ff"),
             &group_id,
             &DeliveryStatus::Sent(1),
@@ -2530,28 +2660,32 @@ mod tests {
 
         // Insert a normal message
         let msg_normal = create_test_chat_message(206, author);
-        AggregatedMessage::insert_message(&msg_normal, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_normal, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert a message with Retried status (simulating a retried failed message)
         let mut msg_retried = create_test_chat_message(207, author);
         msg_retried.delivery_status = Some(DeliveryStatus::Retried);
-        AggregatedMessage::insert_message(&msg_retried, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_retried, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert a message with Failed status (should still be visible)
         let mut msg_failed = create_test_chat_message(208, author);
         msg_failed.delivery_status = Some(DeliveryStatus::Failed("error".to_string()));
-        AggregatedMessage::insert_message(&msg_failed, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_failed, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Only normal and failed messages should appear, not retried
         assert_eq!(messages.len(), 2);
@@ -2574,7 +2708,7 @@ mod tests {
         let msg3 = create_test_chat_message(172, author);
 
         for msg in [&msg1, &msg2, &msg3] {
-            AggregatedMessage::insert_message(msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2605,18 +2739,24 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(180, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Before inserting, has_delivery_status should return false
-        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            &author,
+            &msg.id,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(!has, "No delivery status should exist yet");
 
         // Insert delivery status
         AggregatedMessage::insert_delivery_status(
+            &author,
             &msg.id,
             &group_id,
             &DeliveryStatus::Sending,
@@ -2626,16 +2766,22 @@ mod tests {
         .unwrap();
 
         // Now has_delivery_status should return true
-        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            &author,
+            &msg.id,
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(has, "Delivery status should exist after insert");
 
         // Verify it shows up in find_by_id
-        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&author, &msg.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
     }
 
@@ -2647,12 +2793,13 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(181, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert Sending
         AggregatedMessage::insert_delivery_status(
+            &author,
             &msg.id,
             &group_id,
             &DeliveryStatus::Sending,
@@ -2663,6 +2810,7 @@ mod tests {
 
         // Upsert to Sent — ON CONFLICT should update
         AggregatedMessage::insert_delivery_status(
+            &author,
             &msg.id,
             &group_id,
             &DeliveryStatus::Sent(2),
@@ -2671,10 +2819,11 @@ mod tests {
         .await
         .unwrap();
 
-        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&author, &msg.id, &group_id, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(2)));
     }
 
@@ -2687,10 +2836,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(182, author);
         let msg2 = create_test_chat_message(183, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg1, &group_id, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg2, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2705,10 +2854,14 @@ mod tests {
             .unwrap();
 
         // Both should have is_deleted=true
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(
             messages.iter().all(|m| m.is_deleted),
             "All messages should be marked as deleted"
@@ -2719,10 +2872,14 @@ mod tests {
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 2, "Both messages should still be present");
         assert!(
             messages.iter().all(|m| !m.is_deleted),
@@ -2739,10 +2896,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(184, author);
         let msg2 = create_test_chat_message(185, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg1, &group_id, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg2, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2761,10 +2918,14 @@ mod tests {
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &author,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         let not_deleted: Vec<_> = messages.iter().filter(|m| !m.is_deleted).collect();
         assert_eq!(not_deleted.len(), 1, "Only msg1 should be un-deleted");
         assert_eq!(not_deleted[0].id, msg1.id);
@@ -2831,11 +2992,16 @@ mod tests {
     async fn test_has_delivery_status_returns_false_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[188; 32]);
+        let test_pubkey = Keys::generate().public_key();
 
-        let has =
-            AggregatedMessage::has_delivery_status("nonexistent", &group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            &test_pubkey,
+            "nonexistent",
+            &group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(!has);
     }
 
@@ -2865,7 +3031,7 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, group_id, database)
+        AggregatedMessage::insert_message(&author, &msg, group_id, database)
             .await
             .unwrap();
         msg
@@ -2875,8 +3041,10 @@ mod tests {
     async fn test_paginated_empty_group_returns_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[200; 32]);
+        let test_pubkey = Keys::generate().public_key();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -2911,6 +3079,7 @@ mod tests {
 
         // Default (no cursor) should return the 50 newest
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -2969,6 +3138,7 @@ mod tests {
         let cursor_ts = Timestamp::from(base_ts + 3);
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3012,6 +3182,7 @@ mod tests {
         }
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3057,6 +3228,7 @@ mod tests {
 
         // Requesting u32::MAX should be capped to 200
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3092,6 +3264,7 @@ mod tests {
 
         // Page 1: newest 5 (seeds 6–10)
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3106,6 +3279,7 @@ mod tests {
         let cursor_ts = page1[0].created_at;
         let cursor_id = page1[0].id.as_str();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3134,6 +3308,7 @@ mod tests {
         let cursor_ts2 = page2[0].created_at;
         let cursor_id2 = page2[0].id.as_str();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3176,6 +3351,7 @@ mod tests {
         // Total 8 messages. Page size 3 — three pages needed.
         // Page 1: newest 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3190,6 +3366,7 @@ mod tests {
         let c1_ts = page1[0].created_at;
         let c1_id = page1[0].id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3208,6 +3385,7 @@ mod tests {
         let c2_ts = page2[0].created_at;
         let c2_id = page2[0].id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3230,6 +3408,7 @@ mod tests {
         let c3_ts = page3[0].created_at;
         let c3_id = page3[0].id.clone();
         let page4 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3277,9 +3456,11 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[207; 32]);
         let ts = Timestamp::from(1_700_000_000u64);
+        let test_pubkey = Keys::generate().public_key();
 
         // before=Some, before_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3298,6 +3479,7 @@ mod tests {
 
         // before=None, before_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3322,9 +3504,11 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[208; 32]);
         let ts = Timestamp::from(1_700_000_000u64);
+        let test_pubkey = Keys::generate().public_key();
 
         // Non-hex string → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3344,6 +3528,7 @@ mod tests {
 
         // Valid hex but wrong length (32 chars instead of 64) → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3389,6 +3574,7 @@ mod tests {
         let cursor_ts = Timestamp::from(base_ts + 2);
         let cursor_id = format!("{:0>64}", format!("{:x}", 2u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3436,6 +3622,7 @@ mod tests {
         let cursor_ts = Timestamp::from(base_ts + 3);
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3482,6 +3669,7 @@ mod tests {
 
         // Page through with limit 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3499,6 +3687,7 @@ mod tests {
         let c1_ts = page1.last().unwrap().created_at;
         let c1_id = page1.last().unwrap().id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3516,6 +3705,7 @@ mod tests {
         let c2_ts = page2.last().unwrap().created_at;
         let c2_id = page2.last().unwrap().id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3562,8 +3752,10 @@ mod tests {
         let group_id = GroupId::from_slice(&[223; 32]);
         let ts = Timestamp::from(1_710_300_000u64);
         let id = "0000000000000000000000000000000000000000000000000000000000000001";
+        let test_pubkey = Keys::generate().public_key();
 
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3588,9 +3780,11 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[224; 32]);
         let ts = Timestamp::from(1_710_400_000u64);
+        let test_pubkey = Keys::generate().public_key();
 
         // after=Some, after_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3609,6 +3803,7 @@ mod tests {
 
         // after=None, after_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
+            &test_pubkey,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3652,6 +3847,7 @@ mod tests {
         let cursor_ts = Timestamp::from(base_ts + 100);
         let cursor_id = format!("{:0>64}", format!("{:x}", 0xffu8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3708,6 +3904,7 @@ mod tests {
         }
 
         let results_a = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_a,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3717,6 +3914,7 @@ mod tests {
         .await
         .unwrap();
         let results_b = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_b,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3769,6 +3967,7 @@ mod tests {
             .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3829,6 +4028,7 @@ mod tests {
         // No read marker → all non-deleted messages are unread (cnt=2), minimum=3
         // LIMIT = MAX(2, 3) = 3, so all 3 rows (including the tombstone) are returned.
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
+            &author,
             &group_id,
             None,
             3,
@@ -3893,6 +4093,7 @@ mod tests {
         .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3945,6 +4146,7 @@ mod tests {
 
         // Should not error — uppercase is valid hex and gets canonicalized internally
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -3982,6 +4184,7 @@ mod tests {
         let msg = insert_message_at(1, author, ts, &group_id, &whitenoise.database).await;
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -3999,6 +4202,7 @@ mod tests {
 
         // Cursor from the only message → next page is empty
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -4040,6 +4244,7 @@ mod tests {
         }
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -4056,6 +4261,7 @@ mod tests {
 
         // Cursor from the oldest (page1[0]) → no older messages exist
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -4111,6 +4317,7 @@ mod tests {
             };
 
             let page = AggregatedMessage::find_messages_by_group_paginated(
+                &author,
                 &group_id,
                 &whitenoise.database,
                 &opts,
@@ -4171,6 +4378,7 @@ mod tests {
 
         // Full first page
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -4184,6 +4392,7 @@ mod tests {
         // Use the oldest message (page1[0]) as the cursor
         let oldest = &page1[0];
         let next_page = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions {
@@ -4233,11 +4442,12 @@ mod tests {
             media_attachments: vec![],
             delivery_status: Some(DeliveryStatus::Retried),
         };
-        AggregatedMessage::insert_message(&retried_msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &retried_msg, &group_id, &whitenoise.database)
             .await
             .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -4304,13 +4514,14 @@ mod tests {
         ];
 
         for msg in &messages {
-            AggregatedMessage::insert_message(msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
 
         // Basic single-word search
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "hello",
             50,
@@ -4326,6 +4537,7 @@ mod tests {
 
         // Forward-order multi-word search
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "big plans",
             50,
@@ -4344,6 +4556,7 @@ mod tests {
 
         // Substring matching ("big" matches "bigger")
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "big",
             50,
@@ -4356,6 +4569,7 @@ mod tests {
 
         // Case insensitive
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "MARMOT",
             50,
@@ -4369,6 +4583,7 @@ mod tests {
 
         // CJK search
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "日本語",
             50,
@@ -4382,6 +4597,7 @@ mod tests {
 
         // Cyrillic search
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "привет",
             50,
@@ -4394,6 +4610,7 @@ mod tests {
 
         // Devanagari search (with combining marks)
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "नमस्ते",
             50,
@@ -4407,6 +4624,7 @@ mod tests {
 
         // No match
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "nonexistent",
             50,
@@ -4419,6 +4637,7 @@ mod tests {
 
         // Empty query matches all — positions are sequential newest-first
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "",
             50,
@@ -4433,6 +4652,7 @@ mod tests {
 
         // Limit is respected
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "",
             2,
@@ -4480,13 +4700,14 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
 
         // Search for all three: "same-ts" matches every message
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "same-ts",
             50,
@@ -4560,24 +4781,29 @@ mod tests {
 
         // Insert messages: "marmot" in all three groups
         let msg_a = create_test_chat_message_with_content(1, author, "marmot in group A");
-        AggregatedMessage::insert_message(&msg_a, &group_a, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_a, &group_a, &whitenoise.database)
             .await
             .unwrap();
 
         let msg_b = create_test_chat_message_with_content(2, author, "marmot in group B");
-        AggregatedMessage::insert_message(&msg_b, &group_b, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_b, &group_b, &whitenoise.database)
             .await
             .unwrap();
 
         let msg_declined =
             create_test_chat_message_with_content(3, author, "marmot in declined group");
-        AggregatedMessage::insert_message(&msg_declined, &group_declined, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &author,
+            &msg_declined,
+            &group_declined,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Also add a second message in group A to verify per-group positions
         let msg_a2 = create_test_chat_message_with_content(4, author, "another marmot in group A");
-        AggregatedMessage::insert_message(&msg_a2, &group_a, &whitenoise.database)
+        AggregatedMessage::insert_message(&author, &msg_a2, &group_a, &whitenoise.database)
             .await
             .unwrap();
 
@@ -4686,6 +4912,7 @@ mod tests {
 
         // find_messages_by_group
         let messages = AggregatedMessage::find_messages_by_group(
+            &author,
             &group_id,
             Some(cleared_at_ms),
             &whitenoise.database,
@@ -4698,6 +4925,7 @@ mod tests {
 
         // find_messages_by_group_paginated
         let messages = AggregatedMessage::find_messages_by_group_paginated(
+            &author,
             &group_id,
             &whitenoise.database,
             &PaginationOptions::default(),
@@ -4710,6 +4938,7 @@ mod tests {
 
         // find_messages_with_unread_minimum
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
+            &author,
             &group_id,
             None,
             50,
@@ -4804,7 +5033,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&author, &msg, &group_id, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -4813,6 +5042,7 @@ mod tests {
         let cleared_at_ms = (base_ts + 2) as i64 * 1000;
 
         let results = AggregatedMessage::search_messages_in_group(
+            &author,
             &group_id,
             "hello",
             50,

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -548,24 +548,57 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Option<ChatMessage>> {
-        // If this reaction already has a delivery status, it was sent by us and already
-        // applied to the parent — skip re-applying to avoid unnecessary DB writes and
-        // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(
-            account_pubkey,
+        // Check if this reaction was sent locally (by any account on this device).
+        // The sending account already applied it optimistically to the shared
+        // aggregated_messages table and emitted to its own stream.
+        let sent_locally = AggregatedMessage::has_delivery_status_any_account(
             &message.id.to_string(),
             group_id,
             &self.database,
         )
-        .await?
-        {
+        .await?;
+
+        if sent_locally {
+            // The sending account already applied this reaction to the DB.
+            // Skip DB writes but still return the current target message state
+            // so the caller can emit to THIS account's stream (which didn't
+            // receive the original optimistic emit).
+            if AggregatedMessage::has_delivery_status(
+                account_pubkey,
+                &message.id.to_string(),
+                group_id,
+                &self.database,
+            )
+            .await?
+            {
+                // This IS the sending account's echo — fully skip (already emitted).
+                tracing::debug!(
+                    target: "whitenoise::cache",
+                    "Skipping echo of own reaction {} in group {}",
+                    message.id,
+                    hex::encode(group_id.as_slice())
+                );
+                return Ok(None);
+            }
+
+            // Another local account sent this reaction — skip DB writes but
+            // return the target message so the caller emits to this account.
             tracing::debug!(
                 target: "whitenoise::cache",
-                "Skipping echo of outgoing reaction {} in group {}",
+                "Re-emitting locally-sent reaction {} to account {} in group {}",
                 message.id,
+                account_pubkey.to_hex(),
                 hex::encode(group_id.as_slice())
             );
-            return Ok(None);
+            let target_id = Self::extract_reaction_target_id(&message.tags)?;
+            return AggregatedMessage::find_by_id(
+                account_pubkey,
+                &target_id,
+                group_id,
+                &self.database,
+            )
+            .await
+            .map_err(Into::into);
         }
 
         AggregatedMessage::insert_reaction(message, group_id, &self.database).await?;
@@ -646,24 +679,73 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
-        // If this deletion already has a delivery status, it was sent by us and already
-        // applied to targets — skip re-applying to avoid unnecessary DB writes and
-        // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(
-            account_pubkey,
+        // Check if this deletion was sent locally (by any account on this device).
+        let sent_locally = AggregatedMessage::has_delivery_status_any_account(
             &message.id.to_string(),
             group_id,
             &self.database,
         )
-        .await?
-        {
+        .await?;
+
+        if sent_locally {
+            if AggregatedMessage::has_delivery_status(
+                account_pubkey,
+                &message.id.to_string(),
+                group_id,
+                &self.database,
+            )
+            .await?
+            {
+                // This IS the sending account's echo — fully skip.
+                tracing::debug!(
+                    target: "whitenoise::cache",
+                    "Skipping echo of own deletion {} in group {}",
+                    message.id,
+                    hex::encode(group_id.as_slice())
+                );
+                return Ok(Vec::new());
+            }
+
+            // Another local account sent this deletion — skip DB writes but
+            // return the affected messages so the caller emits to this account.
             tracing::debug!(
                 target: "whitenoise::cache",
-                "Skipping echo of outgoing deletion {} in group {}",
+                "Re-emitting locally-sent deletion {} to account {} in group {}",
                 message.id,
+                account_pubkey.to_hex(),
                 hex::encode(group_id.as_slice())
             );
-            return Ok(Vec::new());
+            let target_ids = Self::extract_deletion_target_ids(&message.tags);
+            let mut updates = Vec::with_capacity(target_ids.len());
+            for target_id in target_ids {
+                // Check if target is a reaction — if so, find its parent message
+                if let Some(reaction) =
+                    AggregatedMessage::find_reaction_by_id(&target_id, group_id, &self.database)
+                        .await?
+                {
+                    if let Ok(parent_id) = Self::extract_reaction_target_id(&reaction.tags)
+                        && let Some(parent) = AggregatedMessage::find_by_id(
+                            account_pubkey,
+                            &parent_id,
+                            group_id,
+                            &self.database,
+                        )
+                        .await?
+                    {
+                        updates.push((UpdateTrigger::ReactionRemoved, parent));
+                    }
+                } else if let Some(msg) = AggregatedMessage::find_by_id(
+                    account_pubkey,
+                    &target_id,
+                    group_id,
+                    &self.database,
+                )
+                .await?
+                {
+                    updates.push((UpdateTrigger::MessageDeleted, msg));
+                }
+            }
+            return Ok(updates);
         }
 
         AggregatedMessage::insert_deletion(message, group_id, &self.database).await?;

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -203,7 +203,12 @@ impl Whitenoise {
                 Whitenoise::spawn_new_message_notification_if_enabled(
                     account, &group_id, &msg, group_name,
                 );
-                self.emit_message_update(&group_id, UpdateTrigger::NewMessage, msg);
+                self.emit_message_update(
+                    &account.pubkey,
+                    &group_id,
+                    UpdateTrigger::NewMessage,
+                    msg,
+                );
                 self.emit_chat_list_update(
                     account,
                     &group_id,
@@ -216,7 +221,12 @@ impl Whitenoise {
                     .cache_reaction(&account.pubkey, &group_id, &message)
                     .await?
                 {
-                    self.emit_message_update(&group_id, UpdateTrigger::ReactionAdded, target);
+                    self.emit_message_update(
+                        &account.pubkey,
+                        &group_id,
+                        UpdateTrigger::ReactionAdded,
+                        target,
+                    );
                 }
             }
             Kind::EventDeletion => {
@@ -243,7 +253,7 @@ impl Whitenoise {
             .cache_deletion(account_pubkey, group_id, message)
             .await?
         {
-            self.emit_message_update(group_id, trigger, msg);
+            self.emit_message_update(account_pubkey, group_id, trigger, msg);
         }
 
         // Check if the deleted message was the last message.
@@ -454,12 +464,16 @@ impl Whitenoise {
     /// Emit a message update to all subscribers of a group.
     fn emit_message_update(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         trigger: UpdateTrigger,
         message: ChatMessage,
     ) {
-        self.message_stream_manager
-            .emit(group_id, MessageUpdate { trigger, message });
+        self.message_stream_manager.emit(
+            account_pubkey,
+            group_id,
+            MessageUpdate { trigger, message },
+        );
     }
 
     /// Gets the ID of the last message in a group (if any).

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1561,15 +1561,15 @@ mod tests {
             token_tag.encrypted_token.to_base64()
         );
 
-        let cached_messages = AggregatedMessage::find_messages_by_group(
-            &admin_account.pubkey,
+        let receiver_cached_messages = AggregatedMessage::find_messages_by_group(
+            &member_account.pubkey,
             &group_id,
             None,
             &whitenoise.database,
         )
         .await
         .unwrap();
-        assert!(cached_messages.is_empty());
+        assert!(receiver_cached_messages.is_empty());
     }
 
     #[tokio::test]

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -196,7 +196,9 @@ impl Whitenoise {
 
         match message.kind {
             Kind::ChatMessage => {
-                let msg = self.cache_chat_message(&group_id, &message).await?;
+                let msg = self
+                    .cache_chat_message(&account.pubkey, &group_id, &message)
+                    .await?;
                 let group_name = mdk.get_group(&group_id).ok().flatten().map(|g| g.name);
                 Whitenoise::spawn_new_message_notification_if_enabled(
                     account, &group_id, &msg, group_name,
@@ -210,12 +212,15 @@ impl Whitenoise {
                 .await;
             }
             Kind::Reaction => {
-                if let Some(target) = self.cache_reaction(&group_id, &message).await? {
+                if let Some(target) = self
+                    .cache_reaction(&account.pubkey, &group_id, &message)
+                    .await?
+                {
                     self.emit_message_update(&group_id, UpdateTrigger::ReactionAdded, target);
                 }
             }
             Kind::EventDeletion => {
-                self.handle_deletion_application_message(&group_id, &message)
+                self.handle_deletion_application_message(&account.pubkey, &group_id, &message)
                     .await?;
             }
             _ => {
@@ -228,12 +233,16 @@ impl Whitenoise {
 
     async fn handle_deletion_application_message(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<()> {
         let last_message_id = self.get_last_message_id(group_id).await;
 
-        for (trigger, msg) in self.cache_deletion(group_id, message).await? {
+        for (trigger, msg) in self
+            .cache_deletion(account_pubkey, group_id, message)
+            .await?
+        {
             self.emit_message_update(group_id, trigger, msg);
         }
 
@@ -469,6 +478,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_chat_message(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<ChatMessage> {
@@ -482,18 +492,24 @@ impl Whitenoise {
         // Preserve existing delivery status for relay echoes of locally-sent messages.
         // This keeps stream payloads aligned with the latest DB state instead of
         // regressing to `None` on reprocessing.
-        if let Some(existing_message) =
-            AggregatedMessage::find_by_id(&chat_message.id, group_id, &self.database).await?
+        if let Some(existing_message) = AggregatedMessage::find_by_id(
+            account_pubkey,
+            &chat_message.id,
+            group_id,
+            &self.database,
+        )
+        .await?
             && existing_message.delivery_status.is_some()
         {
             chat_message.delivery_status = existing_message.delivery_status;
         }
 
-        AggregatedMessage::insert_message(&chat_message, group_id, &self.database).await?;
+        AggregatedMessage::insert_message(account_pubkey, &chat_message, group_id, &self.database)
+            .await?;
 
         // Apply orphaned reactions/deletions - modifies in-place and returns final state
         let final_message = self
-            .apply_orphaned_reactions_and_deletions(chat_message, group_id)
+            .apply_orphaned_reactions_and_deletions(account_pubkey, chat_message, group_id)
             .await?;
 
         tracing::debug!(
@@ -514,14 +530,20 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_reaction(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Option<ChatMessage>> {
         // If this reaction already has a delivery status, it was sent by us and already
         // applied to the parent — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(&message.id.to_string(), group_id, &self.database)
-            .await?
+        if AggregatedMessage::has_delivery_status(
+            account_pubkey,
+            &message.id.to_string(),
+            group_id,
+            &self.database,
+        )
+        .await?
         {
             tracing::debug!(
                 target: "whitenoise::cache",
@@ -534,7 +556,9 @@ impl Whitenoise {
 
         AggregatedMessage::insert_reaction(message, group_id, &self.database).await?;
 
-        let result = self.apply_reaction_to_target(message, group_id).await?;
+        let result = self
+            .apply_reaction_to_target(account_pubkey, message, group_id)
+            .await?;
 
         if result.is_none() {
             tracing::debug!(
@@ -560,13 +584,15 @@ impl Whitenoise {
     /// Returns `Err` for real failures (malformed tags, invalid emoji, DB errors).
     async fn apply_reaction_to_target(
         &self,
+        account_pubkey: &PublicKey,
         reaction: &Message,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
         let target_id = Self::extract_reaction_target_id(&reaction.tags)?;
 
         let Some(mut target) =
-            AggregatedMessage::find_by_id(&target_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(account_pubkey, &target_id, group_id, &self.database)
+                .await?
         else {
             return Ok(None); // True orphan: target not yet cached
         };
@@ -602,14 +628,20 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_deletion(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
         // If this deletion already has a delivery status, it was sent by us and already
         // applied to targets — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(&message.id.to_string(), group_id, &self.database)
-            .await?
+        if AggregatedMessage::has_delivery_status(
+            account_pubkey,
+            &message.id.to_string(),
+            group_id,
+            &self.database,
+        )
+        .await?
         {
             tracing::debug!(
                 target: "whitenoise::cache",
@@ -622,7 +654,9 @@ impl Whitenoise {
 
         AggregatedMessage::insert_deletion(message, group_id, &self.database).await?;
 
-        let updates = self.apply_deletions_to_targets(message, group_id).await?;
+        let updates = self
+            .apply_deletions_to_targets(account_pubkey, message, group_id)
+            .await?;
 
         tracing::debug!(
             target: "whitenoise::cache",
@@ -638,6 +672,7 @@ impl Whitenoise {
     /// Apply deletion to all targets and collect updates to emit.
     async fn apply_deletions_to_targets(
         &self,
+        account_pubkey: &PublicKey,
         deletion: &Message,
         group_id: &GroupId,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
@@ -646,7 +681,7 @@ impl Whitenoise {
 
         for target_id in target_ids {
             if let Some(update) = self
-                .apply_single_deletion(&target_id, &deletion.id, group_id)
+                .apply_single_deletion(account_pubkey, &target_id, &deletion.id, group_id)
                 .await?
             {
                 updates.push(update);
@@ -659,6 +694,7 @@ impl Whitenoise {
     /// Apply deletion to a single target, returning the appropriate update.
     async fn apply_single_deletion(
         &self,
+        account_pubkey: &PublicKey,
         target_id: &str,
         deletion_event_id: &EventId,
         group_id: &GroupId,
@@ -668,7 +704,7 @@ impl Whitenoise {
             AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.database).await?
         {
             let parent_update = self
-                .remove_reaction_from_parent(&reaction, group_id)
+                .remove_reaction_from_parent(account_pubkey, &reaction, group_id)
                 .await?;
             AggregatedMessage::mark_deleted(
                 target_id,
@@ -682,7 +718,8 @@ impl Whitenoise {
 
         // Check if target is a message
         if let Some(mut msg) =
-            AggregatedMessage::find_by_id(target_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(account_pubkey, target_id, group_id, &self.database)
+                .await?
         {
             msg.is_deleted = true;
             AggregatedMessage::mark_deleted(
@@ -709,6 +746,7 @@ impl Whitenoise {
     /// Remove a reaction from its parent message and return the updated parent.
     async fn remove_reaction_from_parent(
         &self,
+        account_pubkey: &PublicKey,
         reaction: &AggregatedMessage,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
@@ -717,7 +755,8 @@ impl Whitenoise {
         };
 
         let Some(mut parent) =
-            AggregatedMessage::find_by_id(&parent_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(account_pubkey, &parent_id, group_id, &self.database)
+                .await?
         else {
             return Ok(None);
         };
@@ -764,6 +803,7 @@ impl Whitenoise {
     /// This avoids re-fetching from the database after applying orphans.
     async fn apply_orphaned_reactions_and_deletions(
         &self,
+        _account_pubkey: &PublicKey,
         mut message: ChatMessage,
         group_id: &GroupId,
     ) -> Result<ChatMessage> {
@@ -918,10 +958,14 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle regular message");
 
         // Verify message was cached
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
+            &message_id.to_string(),
+            group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_msg.is_some(), "Message should be cached");
 
         // Test 2: Reaction message (Kind 7)
@@ -941,11 +985,15 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle reaction");
 
         // Verify reaction was applied to cached message
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
+            &message_id.to_string(),
+            group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             !cached_msg.reactions.by_emoji.is_empty(),
             "Reaction should be applied"
@@ -968,11 +1016,15 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle deletion");
 
         // Verify message was marked as deleted
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
+            &message_id.to_string(),
+            group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(cached_msg.is_deleted, "Message should be marked as deleted");
     }
 
@@ -1018,13 +1070,14 @@ mod tests {
 
         // Initial cache pass creates the row without delivery status.
         let first = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&creator_account.pubkey, &group.mls_group_id, &message)
             .await
             .unwrap();
         assert_eq!(first.delivery_status, None);
 
         // Simulate background publish completion updating delivery status.
         AggregatedMessage::update_delivery_status(
+            &creator_account.pubkey,
             &message_id.to_string(),
             &group.mls_group_id,
             &DeliveryStatus::Sent(1),
@@ -1035,12 +1088,13 @@ mod tests {
 
         // Relay echo reprocess should preserve the existing status.
         let second = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&creator_account.pubkey, &group.mls_group_id, &message)
             .await
             .unwrap();
         assert_eq!(second.delivery_status, Some(DeliveryStatus::Sent(1)));
 
         let persisted = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
             &message_id.to_string(),
             &group.mls_group_id,
             &whitenoise.database,
@@ -1182,6 +1236,7 @@ mod tests {
 
         // Verify the orphaned reaction was applied
         let cached_msg = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
             &future_message_id.to_string(),
             group_id,
             &whitenoise.database,
@@ -1288,6 +1343,7 @@ mod tests {
 
         // Verify only the valid reaction was applied
         let cached_msg = AggregatedMessage::find_by_id(
+            &creator_account.pubkey,
             &future_message_id.to_string(),
             group_id,
             &whitenoise.database,
@@ -1433,6 +1489,7 @@ mod tests {
 
         // Verify all messages are in cache
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator_account.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -1504,10 +1561,14 @@ mod tests {
             token_tag.encrypted_token.to_base64()
         );
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &admin_account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 
@@ -1575,10 +1636,14 @@ mod tests {
             leaf_one.encrypted_token.to_base64()
         );
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &member_account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 
@@ -1628,10 +1693,14 @@ mod tests {
         .unwrap();
         assert!(stored.is_empty());
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &member_account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 

--- a/src/whitenoise/message_streaming/manager.rs
+++ b/src/whitenoise/message_streaming/manager.rs
@@ -1,10 +1,14 @@
-//! Message stream manager for per-group broadcast channels.
+//! Message stream manager for per-account, per-group broadcast channels.
 //!
 //! Manages broadcast channels for real-time message updates, with lazy stream
 //! creation and automatic cleanup when all receivers are dropped.
+//!
+//! Streams are keyed by `(PublicKey, GroupId)` so delivery-status updates
+//! (which differ per account) are never leaked across accounts.
 
 use dashmap::DashMap;
 use mdk_core::prelude::GroupId;
+use nostr_sdk::PublicKey;
 use tokio::sync::broadcast;
 
 use super::types::MessageUpdate;
@@ -12,7 +16,7 @@ use super::types::MessageUpdate;
 const BUFFER_SIZE: usize = 100;
 
 pub struct MessageStreamManager {
-    streams: DashMap<GroupId, broadcast::Sender<MessageUpdate>>,
+    streams: DashMap<(PublicKey, GroupId), broadcast::Sender<MessageUpdate>>,
 }
 
 impl MessageStreamManager {
@@ -22,27 +26,33 @@ impl MessageStreamManager {
         }
     }
 
-    pub fn subscribe(&self, group_id: &GroupId) -> broadcast::Receiver<MessageUpdate> {
+    pub fn subscribe(
+        &self,
+        account_pubkey: &PublicKey,
+        group_id: &GroupId,
+    ) -> broadcast::Receiver<MessageUpdate> {
         self.streams
-            .entry(group_id.clone())
+            .entry((*account_pubkey, group_id.clone()))
             .or_insert_with(|| broadcast::channel(BUFFER_SIZE).0)
             .subscribe()
     }
 
-    pub fn emit(&self, group_id: &GroupId, update: MessageUpdate) {
-        if let Some(sender) = self.streams.get(group_id)
+    pub fn emit(&self, account_pubkey: &PublicKey, group_id: &GroupId, update: MessageUpdate) {
+        let key = (*account_pubkey, group_id.clone());
+        if let Some(sender) = self.streams.get(&key)
             && sender.send(update).is_err()
         {
             drop(sender);
             // Atomically check and remove to avoid race with concurrent subscribe()
             if self
                 .streams
-                .remove_if(group_id, |_, s| s.receiver_count() == 0)
+                .remove_if(&key, |_, s| s.receiver_count() == 0)
                 .is_some()
             {
                 tracing::debug!(
                     target: "whitenoise::message_streaming",
-                    "Cleaned up stream for group {} (no active receivers)",
+                    "Cleaned up stream for account {} group {} (no active receivers)",
+                    account_pubkey.to_hex(),
                     hex::encode(group_id.as_slice()),
                 );
             }
@@ -65,6 +75,10 @@ mod tests {
 
     fn make_test_group_id(seed: u8) -> GroupId {
         GroupId::from_slice(&[seed; 32])
+    }
+
+    fn make_test_pubkey() -> PublicKey {
+        Keys::generate().public_key()
     }
 
     fn make_test_message(id: &str) -> ChatMessage {
@@ -95,42 +109,43 @@ mod tests {
     #[test]
     fn subscribe_creates_new_stream() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group_id = make_test_group_id(1);
 
-        // Stream should not exist before subscribe
-        assert!(!manager.streams.contains_key(&group_id));
+        assert!(!manager.streams.contains_key(&(pubkey, group_id.clone())));
 
-        let _rx = manager.subscribe(&group_id);
+        let _rx = manager.subscribe(&pubkey, &group_id);
 
-        // Stream should exist after subscribe
-        assert!(manager.streams.contains_key(&group_id));
+        assert!(manager.streams.contains_key(&(pubkey, group_id)));
     }
 
     #[test]
     fn multiple_subscribes_share_sender() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group_id = make_test_group_id(2);
 
-        let _rx1 = manager.subscribe(&group_id);
-        let _rx2 = manager.subscribe(&group_id);
+        let _rx1 = manager.subscribe(&pubkey, &group_id);
+        let _rx2 = manager.subscribe(&pubkey, &group_id);
 
         // Should still only have one entry
         assert_eq!(manager.streams.len(), 1);
 
         // Both should receive from same sender (receiver_count should be 2)
-        let sender = manager.streams.get(&group_id).unwrap();
+        let sender = manager.streams.get(&(pubkey, group_id)).unwrap();
         assert_eq!(sender.receiver_count(), 2);
     }
 
     #[tokio::test]
     async fn emit_delivers_to_receivers() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group_id = make_test_group_id(3);
 
-        let mut rx = manager.subscribe(&group_id);
+        let mut rx = manager.subscribe(&pubkey, &group_id);
 
         let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg1");
-        manager.emit(&group_id, update.clone());
+        manager.emit(&pubkey, &group_id, update.clone());
 
         let received = rx.try_recv().expect("should receive update");
         assert_eq!(received.message.id, "msg1");
@@ -139,48 +154,66 @@ mod tests {
     #[test]
     fn emit_without_subscribers_is_noop() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group_id = make_test_group_id(4);
 
         // No stream exists, emit should not panic
         let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg2");
-        manager.emit(&group_id, update);
+        manager.emit(&pubkey, &group_id, update);
 
         // No stream should be created
-        assert!(!manager.streams.contains_key(&group_id));
+        assert!(!manager.streams.contains_key(&(pubkey, group_id)));
     }
 
     #[test]
     fn emit_cleans_up_when_all_receivers_dropped() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group_id = make_test_group_id(5);
 
         // Subscribe then drop the receiver
-        let rx = manager.subscribe(&group_id);
+        let rx = manager.subscribe(&pubkey, &group_id);
         drop(rx);
 
         // Stream still exists (cleanup happens on emit)
-        assert!(manager.streams.contains_key(&group_id));
+        assert!(manager.streams.contains_key(&(pubkey, group_id.clone())));
 
         // Emit triggers cleanup since receiver was dropped
         let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg3");
-        manager.emit(&group_id, update);
+        manager.emit(&pubkey, &group_id, update);
 
         // Stream should be cleaned up
-        assert!(!manager.streams.contains_key(&group_id));
+        assert!(!manager.streams.contains_key(&(pubkey, group_id)));
     }
 
     #[test]
     fn different_groups_have_separate_streams() {
         let manager = MessageStreamManager::new();
+        let pubkey = make_test_pubkey();
         let group1 = make_test_group_id(6);
         let group2 = make_test_group_id(7);
 
-        let _rx1 = manager.subscribe(&group1);
-        let _rx2 = manager.subscribe(&group2);
+        let _rx1 = manager.subscribe(&pubkey, &group1);
+        let _rx2 = manager.subscribe(&pubkey, &group2);
 
         assert_eq!(manager.streams.len(), 2);
-        assert!(manager.streams.contains_key(&group1));
-        assert!(manager.streams.contains_key(&group2));
+        assert!(manager.streams.contains_key(&(pubkey, group1)));
+        assert!(manager.streams.contains_key(&(pubkey, group2)));
+    }
+
+    #[test]
+    fn different_accounts_have_separate_streams() {
+        let manager = MessageStreamManager::new();
+        let pubkey1 = make_test_pubkey();
+        let pubkey2 = make_test_pubkey();
+        let group_id = make_test_group_id(8);
+
+        let _rx1 = manager.subscribe(&pubkey1, &group_id);
+        let _rx2 = manager.subscribe(&pubkey2, &group_id);
+
+        assert_eq!(manager.streams.len(), 2);
+        assert!(manager.streams.contains_key(&(pubkey1, group_id.clone())));
+        assert!(manager.streams.contains_key(&(pubkey2, group_id)));
     }
 
     #[test]
@@ -192,18 +225,44 @@ mod tests {
     #[tokio::test]
     async fn emit_delivers_to_all_subscribers() {
         let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(8);
+        let pubkey = make_test_pubkey();
+        let group_id = make_test_group_id(9);
 
-        let mut rx1 = manager.subscribe(&group_id);
-        let mut rx2 = manager.subscribe(&group_id);
+        let mut rx1 = manager.subscribe(&pubkey, &group_id);
+        let mut rx2 = manager.subscribe(&pubkey, &group_id);
 
         let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg_broadcast");
-        manager.emit(&group_id, update);
+        manager.emit(&pubkey, &group_id, update);
 
         let received1 = rx1.try_recv().expect("rx1 should receive update");
         let received2 = rx2.try_recv().expect("rx2 should receive update");
 
         assert_eq!(received1.message.id, "msg_broadcast");
         assert_eq!(received2.message.id, "msg_broadcast");
+    }
+
+    #[tokio::test]
+    async fn emit_does_not_leak_across_accounts() {
+        let manager = MessageStreamManager::new();
+        let account_a = make_test_pubkey();
+        let account_b = make_test_pubkey();
+        let group_id = make_test_group_id(10);
+
+        let mut rx_a = manager.subscribe(&account_a, &group_id);
+        let mut rx_b = manager.subscribe(&account_b, &group_id);
+
+        // Emit only to account A
+        let update = make_test_update(
+            super::super::UpdateTrigger::DeliveryStatusChanged,
+            "msg_a_only",
+        );
+        manager.emit(&account_a, &group_id, update);
+
+        // Account A should receive
+        let received = rx_a.try_recv().expect("account A should receive");
+        assert_eq!(received.message.id, "msg_a_only");
+
+        // Account B should NOT receive
+        assert!(rx_b.try_recv().is_err(), "account B should not receive");
     }
 }

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -199,6 +199,7 @@ impl Whitenoise {
 
         // Emit NewMessage so the UI shows it immediately (optimistic)
         self.message_stream_manager.emit(
+            account_pubkey,
             group_id,
             MessageUpdate {
                 trigger: UpdateTrigger::NewMessage,
@@ -264,6 +265,7 @@ impl Whitenoise {
             .await?;
 
             self.message_stream_manager.emit(
+                account_pubkey,
                 group_id,
                 MessageUpdate {
                     trigger: UpdateTrigger::ReactionAdded,
@@ -341,6 +343,7 @@ impl Whitenoise {
                     .await?;
 
                     self.message_stream_manager.emit(
+                        account_pubkey,
                         group_id,
                         MessageUpdate {
                             trigger: UpdateTrigger::ReactionRemoved,
@@ -374,6 +377,7 @@ impl Whitenoise {
             {
                 msg.is_deleted = true;
                 self.message_stream_manager.emit(
+                    account_pubkey,
                     group_id,
                     MessageUpdate {
                         trigger: UpdateTrigger::MessageDeleted,
@@ -461,6 +465,7 @@ impl Whitenoise {
                 match result {
                     Ok(Some(parent)) => {
                         stream_manager.emit(
+                            account_pubkey,
                             group_id,
                             MessageUpdate {
                                 trigger: UpdateTrigger::ReactionRemoved,
@@ -512,6 +517,7 @@ impl Whitenoise {
                     .await
                     {
                         stream_manager.emit(
+                            account_pubkey,
                             group_id,
                             MessageUpdate {
                                 trigger: UpdateTrigger::DeliveryStatusChanged,
@@ -597,6 +603,7 @@ impl Whitenoise {
         {
             Ok(updated_original) => {
                 self.message_stream_manager.emit(
+                    &account.pubkey,
                     group_id,
                     MessageUpdate {
                         trigger: UpdateTrigger::DeliveryStatusChanged,

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -83,15 +83,15 @@ impl Whitenoise {
         // Kind 7/5 (reaction/deletion): insert event + apply aggregated effect on parent
         match kind {
             9 => {
-                self.process_and_emit_outgoing_message(&mdk_message, group_id)
+                self.process_and_emit_outgoing_message(&account.pubkey, &mdk_message, group_id)
                     .await?;
             }
             7 => {
-                self.cache_and_apply_outgoing_reaction(&mdk_message, group_id)
+                self.cache_and_apply_outgoing_reaction(&account.pubkey, &mdk_message, group_id)
                     .await?;
             }
             5 => {
-                self.cache_and_apply_outgoing_deletion(&mdk_message, group_id)
+                self.cache_and_apply_outgoing_deletion(&account.pubkey, &mdk_message, group_id)
                     .await?;
             }
             other => {
@@ -152,6 +152,7 @@ impl Whitenoise {
             // On failure, reverse optimistic aggregated effects for reactions/deletions
             if !publish_result.succeeded() {
                 Whitenoise::cascade_delivery_failure(
+                    &account_pubkey,
                     kind,
                     &event_id_str,
                     &tags_clone,
@@ -176,6 +177,7 @@ impl Whitenoise {
     #[perf_instrument("messages")]
     async fn process_and_emit_outgoing_message(
         &self,
+        account_pubkey: &PublicKey,
         mdk_message: &Message,
         group_id: &GroupId,
     ) -> Result<()> {
@@ -192,7 +194,8 @@ impl Whitenoise {
                 msg
             })?;
 
-        AggregatedMessage::insert_message(&chat_message, group_id, &self.database).await?;
+        AggregatedMessage::insert_message(account_pubkey, &chat_message, group_id, &self.database)
+            .await?;
 
         // Emit NewMessage so the UI shows it immediately (optimistic)
         self.message_stream_manager.emit(
@@ -214,6 +217,7 @@ impl Whitenoise {
     #[perf_instrument("messages")]
     async fn cache_and_apply_outgoing_reaction(
         &self,
+        account_pubkey: &PublicKey,
         mdk_message: &Message,
         group_id: &GroupId,
     ) -> Result<()> {
@@ -224,6 +228,7 @@ impl Whitenoise {
         // update_delivery_status which opens a transaction that can contend with
         // background publish_with_retries)
         AggregatedMessage::insert_delivery_status(
+            account_pubkey,
             &mdk_message.id.to_string(),
             group_id,
             &DeliveryStatus::Sending,
@@ -234,7 +239,8 @@ impl Whitenoise {
         // Apply reaction to the target kind-9 message (if e-tag is present and target cached)
         if let Ok(target_id) = Self::extract_reaction_target_id(&mdk_message.tags)
             && let Some(mut target) =
-                AggregatedMessage::find_by_id(&target_id, group_id, &self.database).await?
+                AggregatedMessage::find_by_id(account_pubkey, &target_id, group_id, &self.database)
+                    .await?
         {
             let emoji = emoji_utils::validate_and_normalize_reaction(
                 &mdk_message.content,
@@ -277,6 +283,7 @@ impl Whitenoise {
     #[perf_instrument("messages")]
     async fn cache_and_apply_outgoing_deletion(
         &self,
+        account_pubkey: &PublicKey,
         mdk_message: &Message,
         group_id: &GroupId,
     ) -> Result<()> {
@@ -287,6 +294,7 @@ impl Whitenoise {
         // update_delivery_status which opens a transaction that can contend with
         // background publish_with_retries)
         AggregatedMessage::insert_delivery_status(
+            account_pubkey,
             &mdk_message.id.to_string(),
             group_id,
             &DeliveryStatus::Sending,
@@ -315,8 +323,13 @@ impl Whitenoise {
             {
                 // Remove reaction from parent message's summary
                 if let Ok(parent_id) = Self::extract_reaction_target_id(&reaction.tags)
-                    && let Some(mut parent) =
-                        AggregatedMessage::find_by_id(&parent_id, group_id, &self.database).await?
+                    && let Some(mut parent) = AggregatedMessage::find_by_id(
+                        account_pubkey,
+                        &parent_id,
+                        group_id,
+                        &self.database,
+                    )
+                    .await?
                     && reaction_handler::remove_reaction_from_message(&mut parent, &reaction.author)
                 {
                     AggregatedMessage::update_reactions(
@@ -356,7 +369,8 @@ impl Whitenoise {
             .await?;
 
             if let Some(mut msg) =
-                AggregatedMessage::find_by_id(target_id, group_id, &self.database).await?
+                AggregatedMessage::find_by_id(account_pubkey, target_id, group_id, &self.database)
+                    .await?
             {
                 msg.is_deleted = true;
                 self.message_stream_manager.emit(
@@ -389,8 +403,10 @@ impl Whitenoise {
     /// - **Kind 7 (reaction)**: Remove the reaction from the parent message's summary.
     /// - **Kind 5 (deletion)**: Clear `deletion_event_id` on targets so they reappear.
     /// - **Kind 9 / other**: No cascade needed — the message already shows Failed status.
+    #[allow(clippy::too_many_arguments)]
     #[perf_instrument("messages")]
     async fn cascade_delivery_failure(
+        account_pubkey: &PublicKey,
         kind: u16,
         event_id: &str,
         tags: &Tags,
@@ -415,8 +431,13 @@ impl Whitenoise {
                 };
 
                 let result = retry_on_lock(|| async {
-                    let Some(mut parent) =
-                        AggregatedMessage::find_by_id(&target_id, group_id, database).await?
+                    let Some(mut parent) = AggregatedMessage::find_by_id(
+                        account_pubkey,
+                        &target_id,
+                        group_id,
+                        database,
+                    )
+                    .await?
                     else {
                         return Ok(None);
                     };
@@ -482,8 +503,13 @@ impl Whitenoise {
                 // them as not deleted
                 let target_ids = Self::extract_deletion_target_ids(tags);
                 for target_id in target_ids {
-                    if let Ok(Some(msg)) =
-                        AggregatedMessage::find_by_id(&target_id, group_id, database).await
+                    if let Ok(Some(msg)) = AggregatedMessage::find_by_id(
+                        account_pubkey,
+                        &target_id,
+                        group_id,
+                        database,
+                    )
+                    .await
                     {
                         stream_manager.emit(
                             group_id,
@@ -523,8 +549,13 @@ impl Whitenoise {
     ) -> Result<()> {
         // Guard: only retry messages that are in Failed state to prevent duplicate publishes
         let event_id_str = event_id.to_string();
-        let original = match AggregatedMessage::find_by_id(&event_id_str, group_id, &self.database)
-            .await?
+        let original = match AggregatedMessage::find_by_id(
+            &account.pubkey,
+            &event_id_str,
+            group_id,
+            &self.database,
+        )
+        .await?
         {
             Some(cached) if matches!(cached.delivery_status, Some(DeliveryStatus::Failed(_))) => {
                 cached
@@ -556,6 +587,7 @@ impl Whitenoise {
         // This is best-effort: if it fails, the user sees a duplicate (original Failed +
         // new Sending) which is harmless and self-corrects on next app restart.
         match AggregatedMessage::update_delivery_status_with_retry(
+            &account.pubkey,
             &event_id_str,
             group_id,
             &DeliveryStatus::Retried,
@@ -639,6 +671,7 @@ impl Whitenoise {
             AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
 
         AggregatedMessage::find_messages_by_group_paginated(
+            pubkey,
             group_id,
             &self.database,
             options,
@@ -688,6 +721,7 @@ impl Whitenoise {
         let minimum_val = minimum.unwrap_or(50);
 
         Ok(AggregatedMessage::find_messages_with_unread_minimum(
+            pubkey,
             group_id,
             read_marker.as_ref(),
             minimum_val,
@@ -714,7 +748,7 @@ impl Whitenoise {
     ) -> Result<Option<ChatMessage>> {
         Account::find_by_pubkey(pubkey, &self.database).await?;
 
-        Ok(AggregatedMessage::find_by_id(message_id, group_id, &self.database).await?)
+        Ok(AggregatedMessage::find_by_id(pubkey, message_id, group_id, &self.database).await?)
     }
 
     /// Search messages within a group by content.
@@ -737,6 +771,7 @@ impl Whitenoise {
 
         let limit_val = limit.unwrap_or(50);
         Ok(AggregatedMessage::search_messages_in_group(
+            pubkey,
             group_id,
             query,
             limit_val,
@@ -1295,6 +1330,7 @@ mod tests {
 
         // Verify we can fetch the messages from cache
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -1366,6 +1402,7 @@ mod tests {
 
         // Verify all messages are retrievable
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -1431,6 +1468,7 @@ mod tests {
 
         // Verify messages are correct
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -1662,6 +1700,7 @@ mod tests {
 
         // The reaction should have been applied to the parent message
         let parent = AggregatedMessage::find_by_id(
+            &creator.pubkey,
             &chat_result.message.id.to_string(),
             &group.mls_group_id,
             &whitenoise.database,
@@ -1708,6 +1747,7 @@ mod tests {
 
         // Verify status is Sending
         let msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
             &event_id.to_string(),
             &group.mls_group_id,
             &whitenoise.database,
@@ -1808,6 +1848,7 @@ mod tests {
         // Manually mark the message as Failed (simulating exhausted retries).
         // Done after the sleep so background publish_with_retries doesn't overwrite it.
         AggregatedMessage::update_delivery_status(
+            &creator.pubkey,
             &original_event_id.to_string(),
             &group.mls_group_id,
             &DeliveryStatus::Failed("simulated failure".to_string()),
@@ -1818,6 +1859,7 @@ mod tests {
 
         // Verify status is Failed
         let msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
             &original_event_id.to_string(),
             &group.mls_group_id,
             &whitenoise.database,
@@ -1849,6 +1891,7 @@ mod tests {
 
         // Original message should now be marked as Retried
         let original_msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
             &original_event_id.to_string(),
             &group.mls_group_id,
             &whitenoise.database,
@@ -1866,6 +1909,7 @@ mod tests {
         // A new message should exist in cache in a non-failure state.
         // The background publish may complete before we read, so accept Sending OR Sent.
         let all_messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -1939,11 +1983,15 @@ mod tests {
         let event_id = result.message.id.to_string();
 
         // Verify initial status is Sending
-        let msg =
-            AggregatedMessage::find_by_id(&event_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &event_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(msg.delivery_status, Some(DeliveryStatus::Sending));
 
         // Build a test event for bounded relay-control publish
@@ -1984,11 +2032,15 @@ mod tests {
             .await;
 
         // Verify status transitioned to Failed
-        let msg =
-            AggregatedMessage::find_by_id(&event_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &event_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             matches!(msg.delivery_status, Some(DeliveryStatus::Failed(_))),
             "Expected Failed status after exhausting retries, got {:?}",
@@ -2125,6 +2177,7 @@ mod tests {
 
         // Verify messages were recovered
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -2222,6 +2275,7 @@ mod tests {
 
         // Verify all messages were recovered
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -2293,15 +2347,20 @@ mod tests {
         );
 
         // find_by_id should return the message but with is_deleted=true
-        let target =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let target = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &target_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(target.is_deleted, "Message should be marked as deleted");
 
         // Also verify via find_messages_by_group — message should have is_deleted flag
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -2317,6 +2376,7 @@ mod tests {
         // The deletion event (kind 5) should have delivery status
         let del_event_id = del_result.unwrap().message.id.to_string();
         let has_status = AggregatedMessage::has_delivery_status(
+            &creator.pubkey,
             &del_event_id,
             &group.mls_group_id,
             &whitenoise.database,
@@ -2371,11 +2431,15 @@ mod tests {
             .unwrap();
 
         // Verify reaction was applied to parent
-        let parent =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let parent = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &target_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             !parent.reactions.by_emoji.is_empty(),
             "Parent should have reaction applied"
@@ -2387,6 +2451,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         Whitenoise::cascade_delivery_failure(
+            &creator.pubkey,
             7,
             &reaction_event_id,
             &tags,
@@ -2399,11 +2464,15 @@ mod tests {
         .await;
 
         // Parent should no longer have the reaction
-        let parent =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let parent = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &target_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             parent.reactions.by_emoji.is_empty(),
             "Reaction should be removed after cascade failure"
@@ -2457,6 +2526,7 @@ mod tests {
 
         // Verify message is marked as deleted
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -2472,6 +2542,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         Whitenoise::cascade_delivery_failure(
+            &creator.pubkey,
             5,
             &del_event_id,
             &tags,
@@ -2485,6 +2556,7 @@ mod tests {
 
         // Message should no longer be deleted after cascade
         let messages = AggregatedMessage::find_messages_by_group(
+            &creator.pubkey,
             &group.mls_group_id,
             None,
             &whitenoise.database,
@@ -2508,6 +2580,7 @@ mod tests {
 
         // Should not panic or error — just a no-op
         Whitenoise::cascade_delivery_failure(
+            &author,
             9,
             "some_event_id",
             &Tags::from_list(vec![]),
@@ -2569,6 +2642,7 @@ mod tests {
 
         // Should return cleanly without panic — parent not found is handled
         Whitenoise::cascade_delivery_failure(
+            &author,
             7,
             "some_reaction_id",
             &tags,
@@ -2592,6 +2666,7 @@ mod tests {
 
         // Empty tags — no e-tag to extract
         Whitenoise::cascade_delivery_failure(
+            &author,
             7,
             "some_reaction_id",
             &Tags::new(),
@@ -2664,11 +2739,15 @@ mod tests {
         assert!(del_result.is_ok(), "Deletion should succeed");
 
         // The second message should be marked deleted
-        let msg =
-            AggregatedMessage::find_by_id(&last_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &creator.pubkey,
+            &last_id,
+            &group.mls_group_id,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(msg.is_deleted, "Last message should be marked deleted");
     }
 
@@ -2686,6 +2765,7 @@ mod tests {
         whitenoise.database.pool.close().await;
 
         Whitenoise::cascade_delivery_failure(
+            &author,
             7,
             "reaction_event_id",
             &tags,
@@ -2712,11 +2792,13 @@ mod tests {
         // Close the pool to force DB errors on unmark_deleted
         whitenoise.database.pool.close().await;
 
+        let deletion_author = Keys::generate().public_key();
         Whitenoise::cascade_delivery_failure(
+            &deletion_author,
             5,
             "deletion_event_id",
             &tags,
-            &Keys::generate().public_key(),
+            &deletion_author,
             "",
             &group_id,
             &whitenoise.database,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1670,6 +1670,7 @@ mod tests {
 
             // Emit an update (will be caught by subscriber during drain phase)
             whitenoise.message_stream_manager.emit(
+                &test_pubkey,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2067,6 +2068,7 @@ mod tests {
                 delivery_status: None,
             };
             whitenoise.message_stream_manager.emit(
+                &author,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2158,6 +2160,7 @@ mod tests {
                 delivery_status: None,
             };
             whitenoise.message_stream_manager.emit(
+                &author,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2217,6 +2220,7 @@ mod tests {
                 delivery_status: None,
             };
             whitenoise.message_stream_manager.emit(
+                &author,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2272,6 +2276,7 @@ mod tests {
                 delivery_status: None,
             };
             whitenoise.message_stream_manager.emit(
+                &author,
                 &group_a,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2468,6 +2473,7 @@ mod tests {
             };
 
             whitenoise.message_stream_manager.emit(
+                &account.pubkey,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2475,6 +2481,7 @@ mod tests {
                 },
             );
             whitenoise.message_stream_manager.emit(
+                &account.pubkey,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2660,6 +2667,7 @@ mod tests {
                 delivery_status: None,
             };
             whitenoise.message_stream_manager.emit(
+                &account.pubkey,
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1604,6 +1604,7 @@ mod tests {
             };
 
             aggregated_message::AggregatedMessage::insert_message(
+                &test_pubkey,
                 &msg1,
                 &group_id,
                 &whitenoise.database,
@@ -1611,6 +1612,7 @@ mod tests {
             .await
             .unwrap();
             aggregated_message::AggregatedMessage::insert_message(
+                &test_pubkey,
                 &msg2,
                 &group_id,
                 &whitenoise.database,
@@ -1718,6 +1720,7 @@ mod tests {
                 delivery_status: None,
             };
             aggregated_message::AggregatedMessage::insert_message(
+                &author,
                 &msg,
                 group_id,
                 &whitenoise.database,
@@ -3267,6 +3270,7 @@ mod tests {
                     delivery_status: None,
                 };
                 aggregated_message::AggregatedMessage::insert_message(
+                    &creator.pubkey,
                     &msg,
                     &group.mls_group_id,
                     &whitenoise.database,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1490,12 +1490,14 @@ mod tests {
 
     async fn wait_for_message_sent_status(
         whitenoise: &Whitenoise,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message_id: &EventId,
     ) {
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 let message = AggregatedMessage::find_by_id(
+                    account_pubkey,
                     &message_id.to_string(),
                     group_id,
                     &whitenoise.database,
@@ -2032,7 +2034,13 @@ mod tests {
             )
             .await
             .unwrap();
-        wait_for_message_sent_status(&whitenoise, &group_id, &chat_result.message.id).await;
+        wait_for_message_sent_status(
+            &whitenoise,
+            &admin_account.pubkey,
+            &group_id,
+            &chat_result.message.id,
+        )
+        .await;
 
         let admin_mdk = whitenoise
             .create_mdk_for_account(admin_account.pubkey)
@@ -2193,7 +2201,13 @@ mod tests {
             .await
             .unwrap();
 
-        wait_for_message_sent_status(&whitenoise, &group_id, &send_result.message.id).await;
+        wait_for_message_sent_status(
+            &whitenoise,
+            &creator.pubkey,
+            &group_id,
+            &send_result.message.id,
+        )
+        .await;
 
         let creator_mdk = whitenoise.create_mdk_for_account(creator.pubkey).unwrap();
         let active_leaf_map = creator_mdk.group_leaf_map(&group_id).unwrap();
@@ -2231,6 +2245,7 @@ mod tests {
         .unwrap();
 
         let cached_message = AggregatedMessage::find_by_id(
+            &creator.pubkey,
             &send_result.message.id.to_string(),
             &group_id,
             &whitenoise.database,

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -47,7 +47,9 @@ impl Whitenoise {
         limit: Option<u32>,
     ) -> Result<message_streaming::GroupMessageSubscription> {
         // 1. Subscribe FIRST to capture any concurrent updates that arrive during the fetch.
-        let mut updates = self.message_stream_manager.subscribe(group_id);
+        let mut updates = self
+            .message_stream_manager
+            .subscribe(account_pubkey, group_id);
 
         // 2. Fetch the most-recent `limit` messages using the paginated query so the initial
         //    snapshot honours the same page size the Flutter side will use for further loads.

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -56,6 +56,7 @@ impl Whitenoise {
 
         let fetched_messages =
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(
+                account_pubkey,
                 group_id,
                 &self.database,
                 &PaginationOptions::default(),


### PR DESCRIPTION
## Changes

Scopes `message_delivery_status` by `account_pubkey` to prevent cross-account data leakage.

### Details
- Added database migration to include `account_pubkey` in message delivery status tracking
- Updated MLS message handling to properly scope delivery status queries
- Refactored aggregated messages database layer with improved filtering logic
- Enhanced chat list and streaming functionality with account-aware filtering
- Updated push notification handling to respect account boundaries
- Improved ephemeral relay control logic

### Files Modified
- Database: Migration for message delivery status schema
- Core messaging: MLS message handlers and aggregation logic
- Chat operations: List and streaming endpoints
- Notifications: Push notification delivery filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delivery status, message streams, and message snapshots are now scoped per account so UI views and real-time feeds are account-specific.

* **Bug Fixes**
  * Prevents delivery-status, unread counts, and notification indicators from leaking across accounts; reactions/deletions no longer echo incorrectly between accounts.

* **Chores**
  * Optimistic send, retry, caching, and emit/subscribe flows updated to consistently include account context; tests adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->