### PR TITLE
Add AccountSession and AccountManager scaffolding

### DIFF
--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -195,13 +195,10 @@ impl Whitenoise {
                 Vec::new()
             });
 
-        self.account_manager.remove_session(pubkey);
-
-        // Cancel any running background tasks (contact list user fetches, etc.)
-        // before tearing down subscriptions and relay connections.
-        if let Some((_, cancel_tx)) = self.background_task_cancellation.remove(pubkey) {
-            let _ = cancel_tx.send(true);
+        if let Some(session) = self.account_manager.get_session(pubkey) {
+            let _ = session.cancellation.send(true);
         }
+        self.account_manager.remove_session(pubkey);
 
         // Unsubscribe from account-specific subscriptions before logout
         self.relay_control
@@ -562,34 +559,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_identity_creates_cancellation_channel() {
+    async fn test_create_identity_creates_session() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let account = whitenoise.create_identity().await.unwrap();
 
         assert!(
             whitenoise
-                .background_task_cancellation
-                .contains_key(&account.pubkey),
-            "activate_account should create a cancellation channel"
+                .account_manager
+                .get_session(&account.pubkey)
+                .is_some(),
+            "activate_account should create a session"
         );
     }
 
     #[tokio::test]
-    async fn test_logout_signals_and_removes_cancellation_channel() {
+    async fn test_logout_signals_cancellation_and_removes_session() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let account = whitenoise.create_identity().await.unwrap();
 
-        // Subscribe to the cancellation channel before logout
         let cancel_rx = whitenoise
-            .background_task_cancellation
-            .get(&account.pubkey)
-            .expect("cancellation channel should exist after login")
-            .value()
+            .account_manager
+            .get_session(&account.pubkey)
+            .expect("session should exist after login")
+            .cancellation
             .subscribe();
 
-        // Initially not cancelled
         assert!(
             !*cancel_rx.borrow(),
             "should not be cancelled before logout"
@@ -597,18 +593,17 @@ mod tests {
 
         whitenoise.logout(&account.pubkey).await.unwrap();
 
-        // After logout, the channel should have been signalled
         assert!(
             *cancel_rx.borrow(),
             "logout should signal cancellation to running background tasks"
         );
 
-        // And the entry should be removed from the map
         assert!(
-            !whitenoise
-                .background_task_cancellation
-                .contains_key(&account.pubkey),
-            "logout should remove the cancellation channel entry"
+            whitenoise
+                .account_manager
+                .get_session(&account.pubkey)
+                .is_none(),
+            "logout should remove the session"
         );
     }
 

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -195,6 +195,8 @@ impl Whitenoise {
                 Vec::new()
             });
 
+        self.account_manager.remove_session(pubkey);
+
         // Cancel any running background tasks (contact list user fetches, etc.)
         // before tearing down subscriptions and relay connections.
         if let Some((_, cancel_tx)) = self.background_task_cancellation.remove(pubkey) {

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -195,11 +195,14 @@ impl Whitenoise {
                 Vec::new()
             });
 
+        // Signal cancellation first so in-flight handlers (e.g. contact-list
+        // guard) see the flag, but keep the session visible until subscription
+        // teardown completes — handlers that check get_session() during teardown
+        // need the entry to exist.
         if let Some(session) = self.account_manager.get_session(pubkey) {
-            let _ = session.cancellation.send(true);
+            session.cancel();
         }
 
-        // Unsubscribe from account-specific subscriptions before logout
         self.relay_control
             .deactivate_account_subscriptions(pubkey)
             .await;
@@ -584,8 +587,7 @@ mod tests {
             .account_manager
             .get_session(&account.pubkey)
             .expect("session should exist after login")
-            .cancellation
-            .subscribe();
+            .subscribe_cancellation();
 
         assert!(
             !*cancel_rx.borrow(),

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -198,12 +198,13 @@ impl Whitenoise {
         if let Some(session) = self.account_manager.get_session(pubkey) {
             let _ = session.cancellation.send(true);
         }
-        self.account_manager.remove_session(pubkey);
 
         // Unsubscribe from account-specific subscriptions before logout
         self.relay_control
             .deactivate_account_subscriptions(pubkey)
             .await;
+
+        self.account_manager.remove_session(pubkey);
 
         if !ephemeral_warm_relays.is_empty()
             && let Err(error) = self

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -77,7 +77,9 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.pending_logins.insert(pubkey, discovered);
+            self.account_manager
+                .pending_logins
+                .insert(pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,
@@ -98,6 +100,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
     ) -> core::result::Result<LoginResult, LoginError> {
         let discovered = self
+            .account_manager
             .pending_logins
             .get(pubkey)
             .ok_or(LoginError::NoLoginInProgress)?
@@ -178,7 +181,7 @@ impl Whitenoise {
         )
         .await?;
 
-        self.pending_logins.remove(pubkey);
+        self.account_manager.pending_logins.remove(pubkey);
         tracing::info!(
             target: "whitenoise::accounts",
             "Login complete for {}",
@@ -197,7 +200,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
         relay_url: RelayUrl,
     ) -> core::result::Result<LoginResult, LoginError> {
-        if !self.pending_logins.contains_key(pubkey) {
+        if !self.account_manager.pending_logins.contains_key(pubkey) {
             return Err(LoginError::NoLoginInProgress);
         }
 
@@ -230,7 +233,7 @@ impl Whitenoise {
             self.sync_discovered_relay_lists(&account, &merged).await?;
             self.complete_external_signer_login(&account, merged.relays(RelayType::Inbox), signer)
                 .await?;
-            self.pending_logins.remove(pubkey);
+            self.account_manager.pending_logins.remove(pubkey);
             tracing::info!(
                 target: "whitenoise::accounts",
                 "Login complete for {} (found lists on {})",

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -77,7 +77,8 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.account_manager.stash_pending_login(pubkey, discovered);
+            self.account_manager
+                .stash_pending_login(&pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -77,9 +77,7 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.account_manager
-                .pending_logins
-                .insert(pubkey, discovered);
+            self.account_manager.stash_pending_login(pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,
@@ -101,10 +99,8 @@ impl Whitenoise {
     ) -> core::result::Result<LoginResult, LoginError> {
         let discovered = self
             .account_manager
-            .pending_logins
-            .get(pubkey)
-            .ok_or(LoginError::NoLoginInProgress)?
-            .clone();
+            .get_pending_login(pubkey)
+            .ok_or(LoginError::NoLoginInProgress)?;
 
         let signer = self
             .get_external_signer(pubkey)
@@ -181,7 +177,7 @@ impl Whitenoise {
         )
         .await?;
 
-        self.account_manager.pending_logins.remove(pubkey);
+        self.account_manager.take_pending_login(pubkey);
         tracing::info!(
             target: "whitenoise::accounts",
             "Login complete for {}",
@@ -200,7 +196,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
         relay_url: RelayUrl,
     ) -> core::result::Result<LoginResult, LoginError> {
-        if !self.account_manager.pending_logins.contains_key(pubkey) {
+        if !self.account_manager.has_pending_login(pubkey) {
             return Err(LoginError::NoLoginInProgress);
         }
 
@@ -233,7 +229,7 @@ impl Whitenoise {
             self.sync_discovered_relay_lists(&account, &merged).await?;
             self.complete_external_signer_login(&account, merged.relays(RelayType::Inbox), signer)
                 .await?;
-            self.account_manager.pending_logins.remove(pubkey);
+            self.account_manager.take_pending_login(pubkey);
             tracing::info!(
                 target: "whitenoise::accounts",
                 "Login complete for {} (found lists on {})",

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -119,7 +119,8 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.account_manager.stash_pending_login(pubkey, discovered);
+            self.account_manager
+                .stash_pending_login(&pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,
@@ -637,7 +638,7 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .stash_pending_login(keys.public_key(), discovered);
+            .stash_pending_login(&keys.public_key(), discovered);
     }
 
     /// Create an external-signer account, register its signer, and insert a
@@ -658,7 +659,7 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .stash_pending_login(pubkey, discovered);
+            .stash_pending_login(&pubkey, discovered);
     }
 
     /// Like `setup_partial_pending_login` but also writes relay associations to
@@ -686,7 +687,7 @@ mod tests {
         }
         whitenoise
             .account_manager
-            .stash_pending_login(keys.public_key(), discovered);
+            .stash_pending_login(&keys.public_key(), discovered);
     }
 
     /// Like `setup_partial_pending_login_external_signer` but also writes relay
@@ -716,7 +717,7 @@ mod tests {
         }
         whitenoise
             .account_manager
-            .stash_pending_login(pubkey, discovered);
+            .stash_pending_login(&pubkey, discovered);
     }
 
     // -----------------------------------------------------------------------
@@ -1499,7 +1500,7 @@ mod tests {
             .await
             .unwrap();
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay.clone()]),
                 inbox: None,
@@ -1508,7 +1509,7 @@ mod tests {
         );
 
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -1551,7 +1552,7 @@ mod tests {
             .await
             .unwrap();
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -1583,7 +1584,7 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -1627,7 +1628,7 @@ mod tests {
             .await
             .unwrap();
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -1654,7 +1655,7 @@ mod tests {
             .await
             .unwrap();
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay]),
                 inbox: None,
@@ -2596,7 +2597,7 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -2708,7 +2709,7 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -3109,7 +3110,7 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         whitenoise.account_manager.stash_pending_login(
-            pubkey,
+            &pubkey,
             DiscoveredRelayLists {
                 nip65: None,
                 inbox: None,
@@ -3291,7 +3292,7 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .stash_pending_login(pubkey, partial);
+            .stash_pending_login(&pubkey, partial);
 
         assert!(
             whitenoise.account_manager.has_pending_login(&pubkey),

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -60,7 +60,7 @@ impl Whitenoise {
         //    by a first call that hasn't finished activation yet and return
         //    Complete prematurely.
         if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await
-            && !self.account_manager.pending_logins.contains_key(&pubkey)
+            && !self.account_manager.has_pending_login(&pubkey)
             && self.account_manager.get_session(&pubkey).is_some()
         {
             tracing::debug!(
@@ -119,9 +119,7 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.account_manager
-                .pending_logins
-                .insert(pubkey, discovered);
+            self.account_manager.stash_pending_login(pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,
@@ -143,10 +141,8 @@ impl Whitenoise {
     ) -> core::result::Result<LoginResult, LoginError> {
         let discovered = self
             .account_manager
-            .pending_logins
-            .get(pubkey)
-            .ok_or(LoginError::NoLoginInProgress)?
-            .clone();
+            .get_pending_login(pubkey)
+            .ok_or(LoginError::NoLoginInProgress)?;
 
         tracing::debug!(
             target: "whitenoise::accounts",
@@ -271,7 +267,7 @@ impl Whitenoise {
         )
         .await?;
 
-        self.account_manager.pending_logins.remove(pubkey);
+        self.account_manager.take_pending_login(pubkey);
         tracing::info!(
             target: "whitenoise::accounts",
             "Login complete for {}",
@@ -299,7 +295,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
         relay_url: RelayUrl,
     ) -> core::result::Result<LoginResult, LoginError> {
-        if !self.account_manager.pending_logins.contains_key(pubkey) {
+        if !self.account_manager.has_pending_login(pubkey) {
             return Err(LoginError::NoLoginInProgress);
         }
         tracing::debug!(
@@ -342,7 +338,7 @@ impl Whitenoise {
                 merged.relays(RelayType::KeyPackage),
             )
             .await?;
-            self.account_manager.pending_logins.remove(pubkey);
+            self.account_manager.take_pending_login(pubkey);
             tracing::info!(
                 target: "whitenoise::accounts",
                 "Login complete for {} (found lists on {})",
@@ -377,7 +373,7 @@ impl Whitenoise {
     /// login is pending this is a no-op and returns `Ok(())`.
     pub async fn login_cancel(&self, pubkey: &PublicKey) -> core::result::Result<(), LoginError> {
         // Only clean up if there was actually a pending login for this pubkey.
-        if self.account_manager.pending_logins.remove(pubkey).is_none() {
+        if self.account_manager.take_pending_login(pubkey).is_none() {
             tracing::debug!(
                 target: "whitenoise::accounts",
                 "No pending login for {}, nothing to cancel",
@@ -502,22 +498,15 @@ impl Whitenoise {
     }
 
     /// Merge newly-discovered relay lists into the pending-login stash and
-    /// return a snapshot.  The DashMap lock is released before returning so
-    /// the caller is free to do async work with the result.
+    /// return a snapshot.
     pub(super) fn merge_into_stash(
         &self,
         pubkey: &PublicKey,
         discovered: DiscoveredRelayLists,
     ) -> core::result::Result<DiscoveredRelayLists, LoginError> {
-        let mut stash = self
-            .account_manager
-            .pending_logins
-            .get_mut(pubkey)
-            .ok_or(LoginError::NoLoginInProgress)?;
-        stash.merge(discovered);
-        let snapshot = stash.clone();
-        drop(stash);
-        Ok(snapshot)
+        self.account_manager
+            .merge_pending_login(pubkey, discovered)
+            .ok_or(LoginError::NoLoginInProgress)
     }
 
     pub(super) async fn sync_discovered_relay_lists(
@@ -648,8 +637,7 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .pending_logins
-            .insert(keys.public_key(), discovered);
+            .stash_pending_login(keys.public_key(), discovered);
     }
 
     /// Create an external-signer account, register its signer, and insert a
@@ -670,8 +658,7 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .pending_logins
-            .insert(pubkey, discovered);
+            .stash_pending_login(pubkey, discovered);
     }
 
     /// Like `setup_partial_pending_login` but also writes relay associations to
@@ -699,8 +686,7 @@ mod tests {
         }
         whitenoise
             .account_manager
-            .pending_logins
-            .insert(keys.public_key(), discovered);
+            .stash_pending_login(keys.public_key(), discovered);
     }
 
     /// Like `setup_partial_pending_login_external_signer` but also writes relay
@@ -730,8 +716,7 @@ mod tests {
         }
         whitenoise
             .account_manager
-            .pending_logins
-            .insert(pubkey, discovered);
+            .stash_pending_login(pubkey, discovered);
     }
 
     // -----------------------------------------------------------------------
@@ -1323,8 +1308,7 @@ mod tests {
         assert!(
             !whitenoise
                 .account_manager
-                .pending_logins
-                .contains_key(&original.pubkey),
+                .has_pending_login(&original.pubkey),
             "Should not create a pending login for an already-active account"
         );
     }
@@ -1346,12 +1330,7 @@ mod tests {
                 .await
                 .is_ok()
         );
-        assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
         assert!(whitenoise.account_manager.get_session(&pubkey).is_none());
 
         let result = whitenoise
@@ -1365,10 +1344,7 @@ mod tests {
             "DB row without active session must not short-circuit to Complete"
         );
         assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            whitenoise.account_manager.has_pending_login(&pubkey),
             "Relay discovery path must stash a pending login"
         );
 
@@ -1387,12 +1363,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(whitenoise.account_manager.has_pending_login(&pubkey));
 
         let result2 = whitenoise
             .login_start(keys.secret_key().to_secret_hex())
@@ -1434,12 +1405,7 @@ mod tests {
             Ok(login_result) => {
                 assert_eq!(login_result.status, LoginStatus::NeedsRelayLists);
                 assert_eq!(login_result.account.pubkey, pubkey);
-                assert!(
-                    whitenoise
-                        .account_manager
-                        .pending_logins
-                        .contains_key(&pubkey)
-                );
+                assert!(whitenoise.account_manager.has_pending_login(&pubkey));
                 let _ = whitenoise.login_cancel(&pubkey).await;
             }
             Err(e) => {
@@ -1468,12 +1434,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(whitenoise.account_manager.has_pending_login(&pubkey));
 
         // Now publish default relays to complete the login.
         let result = whitenoise
@@ -1483,12 +1444,7 @@ mod tests {
 
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(result.account.pubkey, pubkey);
-        assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
 
         // Verify all three relay types are stored.
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
@@ -1542,7 +1498,7 @@ mod tests {
             .find_or_create_relay_by_url(&RelayUrl::parse("wss://first-run.example.com").unwrap())
             .await
             .unwrap();
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay.clone()]),
@@ -1551,7 +1507,7 @@ mod tests {
             },
         );
 
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1562,14 +1518,12 @@ mod tests {
 
         let stash = whitenoise
             .account_manager
-            .pending_logins
-            .get(&pubkey)
+            .get_pending_login(&pubkey)
             .unwrap();
         assert!(
             stash.nip65.is_none(),
             "Second insert must overwrite the first stash"
         );
-        drop(stash);
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -1596,7 +1550,7 @@ mod tests {
             .create_base_account_with_private_key(&keys)
             .await
             .unwrap();
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1618,10 +1572,7 @@ mod tests {
             "Account should be deleted after cancel"
         );
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "Pending login should be removed after cancel"
         );
     }
@@ -1631,7 +1582,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1642,12 +1593,7 @@ mod tests {
 
         let result = whitenoise.login_cancel(&pubkey).await;
         assert!(result.is_ok());
-        assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
     }
 
     #[tokio::test]
@@ -1680,7 +1626,7 @@ mod tests {
             .create_base_account_with_private_key(&keys)
             .await
             .unwrap();
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1707,7 +1653,7 @@ mod tests {
             .find_or_create_relay_by_url(&RelayUrl::parse("wss://r.example.com").unwrap())
             .await
             .unwrap();
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay]),
@@ -1717,12 +1663,7 @@ mod tests {
         );
 
         whitenoise.login_cancel(&pubkey).await.unwrap();
-        assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
         assert!(whitenoise.find_account_by_pubkey(&pubkey).await.is_err());
     }
 
@@ -1765,12 +1706,7 @@ mod tests {
         whitenoise.login_cancel(&pubkey).await.unwrap();
 
         assert!(whitenoise.find_account_by_pubkey(&pubkey).await.is_err());
-        assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
 
         let nip65_after = user
             .relays(RelayType::Nip65, &whitenoise.database)
@@ -1855,10 +1791,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "pending_logins must be cleared after successful publish"
         );
     }
@@ -1900,10 +1833,7 @@ mod tests {
             .unwrap();
         assert_eq!(complete.status, LoginStatus::Complete);
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "Stash must be removed after login_publish_default_relays"
         );
     }
@@ -2315,8 +2245,7 @@ mod tests {
         );
         let stash = whitenoise
             .account_manager
-            .pending_logins
-            .get(&pubkey)
+            .get_pending_login(&pubkey)
             .unwrap();
         assert_eq!(
             stash.nip65.as_ref().map_or(0, |v| v.len()),
@@ -2325,7 +2254,6 @@ mod tests {
         );
         assert!(stash.inbox.is_none());
         assert!(stash.key_package.is_none());
-        drop(stash);
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -2371,10 +2299,7 @@ mod tests {
             "Stash already complete → must complete login"
         );
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "pending_logins must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -2404,10 +2329,7 @@ mod tests {
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
         assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            whitenoise.account_manager.has_pending_login(&pubkey),
             "Stash must persist when still incomplete"
         );
 
@@ -2509,10 +2431,7 @@ mod tests {
             "login_with_custom_relay must return Complete when merged stash is complete"
         );
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "pending_logins must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -2566,19 +2485,18 @@ mod tests {
         )
         .await;
 
-        {
-            let mut stash = whitenoise
-                .account_manager
-                .pending_logins
-                .get_mut(&pubkey)
-                .unwrap();
-            stash.merge(DiscoveredRelayLists {
-                nip65: None,
-                inbox: Some(vec![inbox_relay.clone()]),
-                key_package: Some(vec![kp_relay.clone()]),
-            });
-            assert!(stash.is_complete(), "Stash must be complete after merge");
-        }
+        let merged = whitenoise
+            .account_manager
+            .merge_pending_login(
+                &pubkey,
+                DiscoveredRelayLists {
+                    nip65: None,
+                    inbox: Some(vec![inbox_relay.clone()]),
+                    key_package: Some(vec![kp_relay.clone()]),
+                },
+            )
+            .unwrap();
+        assert!(merged.is_complete(), "Stash must be complete after merge");
 
         let account = Account::find_by_pubkey(&pubkey, &whitenoise.database)
             .await
@@ -2634,12 +2552,7 @@ mod tests {
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
         assert_eq!(result.account.pubkey, pubkey);
         assert_eq!(result.account.account_type, AccountType::External);
-        assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(whitenoise.account_manager.has_pending_login(&pubkey));
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -2682,7 +2595,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -2706,7 +2619,7 @@ mod tests {
             other => panic!("Expected LoginError::Internal, got: {:?}", other),
         }
 
-        whitenoise.account_manager.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.take_pending_login(&pubkey);
     }
 
     #[tokio::test]
@@ -2770,10 +2683,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "pending_logins must be cleared after external signer publish"
         );
     }
@@ -2797,7 +2707,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -2815,7 +2725,7 @@ mod tests {
             "Must error when signer is missing from the registry"
         );
 
-        whitenoise.account_manager.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.take_pending_login(&pubkey);
     }
 
     #[tokio::test]
@@ -3198,7 +3108,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.account_manager.pending_logins.insert(
+        whitenoise.account_manager.stash_pending_login(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -3223,7 +3133,7 @@ mod tests {
             other => panic!("Expected LoginError::Internal, got: {:?}", other),
         }
 
-        whitenoise.account_manager.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.take_pending_login(&pubkey);
     }
 
     #[tokio::test]
@@ -3258,8 +3168,7 @@ mod tests {
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
         let stash = whitenoise
             .account_manager
-            .pending_logins
-            .get(&pubkey)
+            .get_pending_login(&pubkey)
             .unwrap();
         assert_eq!(
             stash.nip65.as_ref().map_or(0, |v| v.len()),
@@ -3268,7 +3177,6 @@ mod tests {
         );
         assert!(stash.inbox.is_none());
         assert!(stash.key_package.is_none());
-        drop(stash);
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -3314,10 +3222,7 @@ mod tests {
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(result.account.account_type, AccountType::External);
         assert!(
-            !whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            !whitenoise.account_manager.has_pending_login(&pubkey),
             "Stash must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -3349,12 +3254,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey)
-        );
+        assert!(whitenoise.account_manager.has_pending_login(&pubkey));
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -3391,14 +3291,10 @@ mod tests {
             .unwrap();
         whitenoise
             .account_manager
-            .pending_logins
-            .insert(pubkey, partial);
+            .stash_pending_login(pubkey, partial);
 
         assert!(
-            whitenoise
-                .account_manager
-                .pending_logins
-                .contains_key(&pubkey),
+            whitenoise.account_manager.has_pending_login(&pubkey),
             "User with only 10002 must be held in pending state"
         );
 

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -60,7 +60,7 @@ impl Whitenoise {
         //    call could see the DB row created by a first call that hasn't
         //    finished activation yet and return Complete prematurely.
         if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await
-            && !self.pending_logins.contains_key(&pubkey)
+            && !self.account_manager.pending_logins.contains_key(&pubkey)
             && self.background_task_cancellation.contains_key(&pubkey)
         {
             tracing::debug!(
@@ -119,7 +119,9 @@ impl Whitenoise {
                 discovered.found(RelayType::Inbox),
                 discovered.found(RelayType::KeyPackage),
             );
-            self.pending_logins.insert(pubkey, discovered);
+            self.account_manager
+                .pending_logins
+                .insert(pubkey, discovered);
             Ok(LoginResult {
                 account,
                 status: LoginStatus::NeedsRelayLists,
@@ -140,6 +142,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
     ) -> core::result::Result<LoginResult, LoginError> {
         let discovered = self
+            .account_manager
             .pending_logins
             .get(pubkey)
             .ok_or(LoginError::NoLoginInProgress)?
@@ -268,7 +271,7 @@ impl Whitenoise {
         )
         .await?;
 
-        self.pending_logins.remove(pubkey);
+        self.account_manager.pending_logins.remove(pubkey);
         tracing::info!(
             target: "whitenoise::accounts",
             "Login complete for {}",
@@ -296,7 +299,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
         relay_url: RelayUrl,
     ) -> core::result::Result<LoginResult, LoginError> {
-        if !self.pending_logins.contains_key(pubkey) {
+        if !self.account_manager.pending_logins.contains_key(pubkey) {
             return Err(LoginError::NoLoginInProgress);
         }
         tracing::debug!(
@@ -339,7 +342,7 @@ impl Whitenoise {
                 merged.relays(RelayType::KeyPackage),
             )
             .await?;
-            self.pending_logins.remove(pubkey);
+            self.account_manager.pending_logins.remove(pubkey);
             tracing::info!(
                 target: "whitenoise::accounts",
                 "Login complete for {} (found lists on {})",
@@ -374,7 +377,7 @@ impl Whitenoise {
     /// login is pending this is a no-op and returns `Ok(())`.
     pub async fn login_cancel(&self, pubkey: &PublicKey) -> core::result::Result<(), LoginError> {
         // Only clean up if there was actually a pending login for this pubkey.
-        if self.pending_logins.remove(pubkey).is_none() {
+        if self.account_manager.pending_logins.remove(pubkey).is_none() {
             tracing::debug!(
                 target: "whitenoise::accounts",
                 "No pending login for {}, nothing to cancel",
@@ -507,6 +510,7 @@ impl Whitenoise {
         discovered: DiscoveredRelayLists,
     ) -> core::result::Result<DiscoveredRelayLists, LoginError> {
         let mut stash = self
+            .account_manager
             .pending_logins
             .get_mut(pubkey)
             .ok_or(LoginError::NoLoginInProgress)?;
@@ -643,6 +647,7 @@ mod tests {
             .await
             .unwrap();
         whitenoise
+            .account_manager
             .pending_logins
             .insert(keys.public_key(), discovered);
     }
@@ -663,7 +668,10 @@ mod tests {
             .insert_external_signer(pubkey, keys.clone())
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(pubkey, discovered);
+        whitenoise
+            .account_manager
+            .pending_logins
+            .insert(pubkey, discovered);
     }
 
     /// Like `setup_partial_pending_login` but also writes relay associations to
@@ -690,6 +698,7 @@ mod tests {
             }
         }
         whitenoise
+            .account_manager
             .pending_logins
             .insert(keys.public_key(), discovered);
     }
@@ -719,7 +728,10 @@ mod tests {
                     .unwrap();
             }
         }
-        whitenoise.pending_logins.insert(pubkey, discovered);
+        whitenoise
+            .account_manager
+            .pending_logins
+            .insert(pubkey, discovered);
     }
 
     // -----------------------------------------------------------------------
@@ -1309,7 +1321,10 @@ mod tests {
         );
 
         assert!(
-            !whitenoise.pending_logins.contains_key(&original.pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&original.pubkey),
             "Should not create a pending login for an already-active account"
         );
     }
@@ -1331,7 +1346,12 @@ mod tests {
                 .await
                 .is_ok()
         );
-        assert!(!whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
         assert!(
             !whitenoise
                 .background_task_cancellation
@@ -1349,7 +1369,10 @@ mod tests {
             "DB row without active session must not short-circuit to Complete"
         );
         assert!(
-            whitenoise.pending_logins.contains_key(&pubkey),
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "Relay discovery path must stash a pending login"
         );
 
@@ -1368,7 +1391,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         let result2 = whitenoise
             .login_start(keys.secret_key().to_secret_hex())
@@ -1410,7 +1438,12 @@ mod tests {
             Ok(login_result) => {
                 assert_eq!(login_result.status, LoginStatus::NeedsRelayLists);
                 assert_eq!(login_result.account.pubkey, pubkey);
-                assert!(whitenoise.pending_logins.contains_key(&pubkey));
+                assert!(
+                    whitenoise
+                        .account_manager
+                        .pending_logins
+                        .contains_key(&pubkey)
+                );
                 let _ = whitenoise.login_cancel(&pubkey).await;
             }
             Err(e) => {
@@ -1439,7 +1472,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         // Now publish default relays to complete the login.
         let result = whitenoise
@@ -1449,7 +1487,12 @@ mod tests {
 
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(result.account.pubkey, pubkey);
-        assert!(!whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         // Verify all three relay types are stored.
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
@@ -1503,7 +1546,7 @@ mod tests {
             .find_or_create_relay_by_url(&RelayUrl::parse("wss://first-run.example.com").unwrap())
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay.clone()]),
@@ -1512,7 +1555,7 @@ mod tests {
             },
         );
 
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1521,7 +1564,11 @@ mod tests {
             },
         );
 
-        let stash = whitenoise.pending_logins.get(&pubkey).unwrap();
+        let stash = whitenoise
+            .account_manager
+            .pending_logins
+            .get(&pubkey)
+            .unwrap();
         assert!(
             stash.nip65.is_none(),
             "Second insert must overwrite the first stash"
@@ -1553,7 +1600,7 @@ mod tests {
             .create_base_account_with_private_key(&keys)
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1575,7 +1622,10 @@ mod tests {
             "Account should be deleted after cancel"
         );
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "Pending login should be removed after cancel"
         );
     }
@@ -1585,7 +1635,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1596,7 +1646,12 @@ mod tests {
 
         let result = whitenoise.login_cancel(&pubkey).await;
         assert!(result.is_ok());
-        assert!(!whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
     }
 
     #[tokio::test]
@@ -1629,7 +1684,7 @@ mod tests {
             .create_base_account_with_private_key(&keys)
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -1656,7 +1711,7 @@ mod tests {
             .find_or_create_relay_by_url(&RelayUrl::parse("wss://r.example.com").unwrap())
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: Some(vec![nip65_relay]),
@@ -1666,7 +1721,12 @@ mod tests {
         );
 
         whitenoise.login_cancel(&pubkey).await.unwrap();
-        assert!(!whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
         assert!(whitenoise.find_account_by_pubkey(&pubkey).await.is_err());
     }
 
@@ -1709,7 +1769,12 @@ mod tests {
         whitenoise.login_cancel(&pubkey).await.unwrap();
 
         assert!(whitenoise.find_account_by_pubkey(&pubkey).await.is_err());
-        assert!(!whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         let nip65_after = user
             .relays(RelayType::Nip65, &whitenoise.database)
@@ -1794,7 +1859,10 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "pending_logins must be cleared after successful publish"
         );
     }
@@ -1836,7 +1904,10 @@ mod tests {
             .unwrap();
         assert_eq!(complete.status, LoginStatus::Complete);
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "Stash must be removed after login_publish_default_relays"
         );
     }
@@ -2246,7 +2317,11 @@ mod tests {
             LoginStatus::NeedsRelayLists,
             "Still missing inbox+key_package → must stay NeedsRelayLists"
         );
-        let stash = whitenoise.pending_logins.get(&pubkey).unwrap();
+        let stash = whitenoise
+            .account_manager
+            .pending_logins
+            .get(&pubkey)
+            .unwrap();
         assert_eq!(
             stash.nip65.as_ref().map_or(0, |v| v.len()),
             1,
@@ -2300,7 +2375,10 @@ mod tests {
             "Stash already complete → must complete login"
         );
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "pending_logins must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -2330,7 +2408,10 @@ mod tests {
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
         assert!(
-            whitenoise.pending_logins.contains_key(&pubkey),
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "Stash must persist when still incomplete"
         );
 
@@ -2432,7 +2513,10 @@ mod tests {
             "login_with_custom_relay must return Complete when merged stash is complete"
         );
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "pending_logins must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -2487,7 +2571,11 @@ mod tests {
         .await;
 
         {
-            let mut stash = whitenoise.pending_logins.get_mut(&pubkey).unwrap();
+            let mut stash = whitenoise
+                .account_manager
+                .pending_logins
+                .get_mut(&pubkey)
+                .unwrap();
             stash.merge(DiscoveredRelayLists {
                 nip65: None,
                 inbox: Some(vec![inbox_relay.clone()]),
@@ -2550,7 +2638,12 @@ mod tests {
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
         assert_eq!(result.account.pubkey, pubkey);
         assert_eq!(result.account.account_type, AccountType::External);
-        assert!(whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -2593,7 +2686,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -2617,7 +2710,7 @@ mod tests {
             other => panic!("Expected LoginError::Internal, got: {:?}", other),
         }
 
-        whitenoise.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.pending_logins.remove(&pubkey);
     }
 
     #[tokio::test]
@@ -2681,7 +2774,10 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "pending_logins must be cleared after external signer publish"
         );
     }
@@ -2705,7 +2801,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -2723,7 +2819,7 @@ mod tests {
             "Must error when signer is missing from the registry"
         );
 
-        whitenoise.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.pending_logins.remove(&pubkey);
     }
 
     #[tokio::test]
@@ -3106,7 +3202,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let pubkey = Keys::generate().public_key();
 
-        whitenoise.pending_logins.insert(
+        whitenoise.account_manager.pending_logins.insert(
             pubkey,
             DiscoveredRelayLists {
                 nip65: None,
@@ -3131,7 +3227,7 @@ mod tests {
             other => panic!("Expected LoginError::Internal, got: {:?}", other),
         }
 
-        whitenoise.pending_logins.remove(&pubkey);
+        whitenoise.account_manager.pending_logins.remove(&pubkey);
     }
 
     #[tokio::test]
@@ -3164,7 +3260,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        let stash = whitenoise.pending_logins.get(&pubkey).unwrap();
+        let stash = whitenoise
+            .account_manager
+            .pending_logins
+            .get(&pubkey)
+            .unwrap();
         assert_eq!(
             stash.nip65.as_ref().map_or(0, |v| v.len()),
             1,
@@ -3218,7 +3318,10 @@ mod tests {
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(result.account.account_type, AccountType::External);
         assert!(
-            !whitenoise.pending_logins.contains_key(&pubkey),
+            !whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "Stash must be cleared after Complete"
         );
         assert_eq!(result.account.pubkey, pubkey);
@@ -3250,7 +3353,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.status, LoginStatus::NeedsRelayLists);
-        assert!(whitenoise.pending_logins.contains_key(&pubkey));
+        assert!(
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey)
+        );
 
         let _ = whitenoise.login_cancel(&pubkey).await;
     }
@@ -3285,10 +3393,16 @@ mod tests {
             .create_base_account_with_private_key(&keys)
             .await
             .unwrap();
-        whitenoise.pending_logins.insert(pubkey, partial);
+        whitenoise
+            .account_manager
+            .pending_logins
+            .insert(pubkey, partial);
 
         assert!(
-            whitenoise.pending_logins.contains_key(&pubkey),
+            whitenoise
+                .account_manager
+                .pending_logins
+                .contains_key(&pubkey),
             "User with only 10002 must be held in pending state"
         );
 

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -55,13 +55,13 @@ impl Whitenoise {
         // Three conditions must hold to short-circuit:
         // 1. Account row exists in the database.
         // 2. No pending multi-step login is in progress (pending_logins).
-        // 3. An active session exists (background_task_cancellation is set
-        //    by activate_account). Without this check, a concurrent second
-        //    call could see the DB row created by a first call that hasn't
-        //    finished activation yet and return Complete prematurely.
+        // 3. An active session exists (created by activate_account). Without
+        //    this check, a concurrent second call could see the DB row created
+        //    by a first call that hasn't finished activation yet and return
+        //    Complete prematurely.
         if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await
             && !self.account_manager.pending_logins.contains_key(&pubkey)
-            && self.background_task_cancellation.contains_key(&pubkey)
+            && self.account_manager.get_session(&pubkey).is_some()
         {
             tracing::debug!(
                 target: "whitenoise::accounts",
@@ -1352,11 +1352,7 @@ mod tests {
                 .pending_logins
                 .contains_key(&pubkey)
         );
-        assert!(
-            !whitenoise
-                .background_task_cancellation
-                .contains_key(&pubkey)
-        );
+        assert!(whitenoise.account_manager.get_session(&pubkey).is_none());
 
         let result = whitenoise
             .login_start(keys.secret_key().to_secret_hex())

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1051,6 +1051,7 @@ mod tests {
     async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
         whitenoise.background_task_cancellation.clear();
         whitenoise.external_signers.clear();
+        whitenoise.account_manager.clear_sessions();
         whitenoise.account_manager.pending_logins.clear();
         whitenoise.reset_nostr_client().await.unwrap();
         whitenoise.wipe_database().await.unwrap();

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use dashmap::mapref::entry::Entry;
 use mdk_core::prelude::group_types::GroupState;
@@ -11,6 +12,7 @@ use crate::relay_control::groups::GroupSubscriptionSpec;
 use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
 use crate::whitenoise::error::Result;
 use crate::whitenoise::relays::Relay;
+use crate::whitenoise::session::AccountSession;
 use crate::whitenoise::users::User;
 use crate::whitenoise::{Whitenoise, WhitenoiseError};
 
@@ -46,6 +48,33 @@ impl Whitenoise {
                 );
             }
         }
+    }
+
+    /// Create and insert an `AccountSession` into the `AccountManager`.
+    ///
+    /// Requires the global singleton for the `&'static Whitenoise` back-reference.
+    /// In unit tests (where the singleton is not set) this is a no-op.
+    fn insert_account_session(&self, account: &Account) -> Result<()> {
+        let wn = match Self::get_instance() {
+            Ok(wn) => wn,
+            Err(_) => {
+                tracing::debug!(
+                    target: "whitenoise::accounts",
+                    "Skipping session insertion (global singleton not available, likely in tests)"
+                );
+                return Ok(());
+            }
+        };
+
+        let mdk = self.create_mdk_for_account(account.pubkey)?;
+
+        // Resolve the signer: for local accounts, load from secrets store.
+        // For external accounts, check the external signers map.
+        let signer = self.get_signer_for_account(account).ok();
+
+        let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer, wn));
+        self.account_manager.insert_session(session);
+        Ok(())
     }
 
     #[perf_instrument("accounts")]
@@ -93,6 +122,9 @@ impl Whitenoise {
             );
         }
         sub_result?;
+
+        self.insert_account_session(account)?;
+
         tracing::debug!(target: "whitenoise::accounts", "Account activation complete");
         Ok(())
     }
@@ -115,6 +147,8 @@ impl Whitenoise {
         // Note: We skip key package setup for external signer accounts.
         // Key packages need to be published separately with the external signer.
         tracing::debug!(target: "whitenoise::accounts", "Skipping key package setup (external signer)");
+
+        self.insert_account_session(account)?;
 
         Ok(())
     }
@@ -1036,7 +1070,7 @@ mod tests {
     async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
         whitenoise.background_task_cancellation.clear();
         whitenoise.external_signers.clear();
-        whitenoise.pending_logins.clear();
+        whitenoise.account_manager.pending_logins.clear();
         whitenoise.reset_nostr_client().await.unwrap();
         whitenoise.wipe_database().await.unwrap();
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -20,15 +20,9 @@ use super::{Account, ExternalSignerRelaySetup};
 impl Whitenoise {
     fn insert_account_session(&self, account: &Account) -> Result<()> {
         if let Some(old_session) = self.account_manager.get_session(&account.pubkey) {
-            let _ = old_session.cancellation.send(true);
+            old_session.cancel();
         }
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let signer = if account.has_local_key() {
-            Some(self.get_signer_for_account(account)?)
-        } else {
-            None
-        };
-        let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
+        let session = Arc::new(AccountSession::from_account(account, self)?);
         self.account_manager.insert_session(session);
         Ok(())
     }
@@ -785,7 +779,7 @@ impl Whitenoise {
         let cancel_rx = self
             .account_manager
             .get_session(&account.pubkey)
-            .map(|s| s.cancellation.subscribe());
+            .map(|s| s.subscribe_cancellation());
         if cancel_rx.is_none() {
             tracing::debug!(
                 target: "whitenoise::accounts::background_refresh_account_group_subscriptions",
@@ -1021,7 +1015,7 @@ mod tests {
     async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
         whitenoise.external_signers.clear();
         whitenoise.account_manager.clear_sessions();
-        whitenoise.account_manager.pending_logins.clear();
+        whitenoise.account_manager.clear_pending_logins();
         whitenoise.reset_nostr_client().await.unwrap();
         whitenoise.wipe_database().await.unwrap();
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -60,6 +60,10 @@ impl Whitenoise {
     ) -> Result<()> {
         self.discovery_sync_worker.request_rebuild();
 
+        // Session must exist before subscriptions so that event handlers
+        // (e.g. contact-list guard) can look it up immediately.
+        self.insert_account_session(account)?;
+
         // Subscriptions and key package setup operate on disjoint relay
         // sessions (group/inbox plane vs ephemeral plane) with no shared
         // mutable state, so they run concurrently.  Key package setup is
@@ -77,8 +81,6 @@ impl Whitenoise {
         }
         sub_result?;
 
-        self.insert_account_session(account)?;
-
         tracing::debug!(target: "whitenoise::accounts", "Account activation complete");
         Ok(())
     }
@@ -93,14 +95,16 @@ impl Whitenoise {
     ) -> Result<()> {
         self.discovery_sync_worker.request_rebuild();
 
+        // Session must exist before subscriptions so that event handlers
+        // (e.g. contact-list guard) can look it up immediately.
+        self.insert_account_session(account)?;
+
         self.setup_subscriptions(account, inbox_relays).await?;
         tracing::debug!(target: "whitenoise::accounts", "Subscriptions setup");
 
         // Note: We skip key package setup for external signer accounts.
         // Key packages need to be published separately with the external signer.
         tracing::debug!(target: "whitenoise::accounts", "Skipping key package setup (external signer)");
-
-        self.insert_account_session(account)?;
 
         Ok(())
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -19,9 +19,6 @@ use super::{Account, ExternalSignerRelaySetup};
 
 impl Whitenoise {
     fn insert_account_session(&self, account: &Account) -> Result<()> {
-        if let Some(old_session) = self.account_manager.get_session(&account.pubkey) {
-            old_session.cancel();
-        }
         let session = Arc::new(AccountSession::from_account(account, self)?);
         self.account_manager.insert_session(session);
         Ok(())

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -50,29 +50,10 @@ impl Whitenoise {
         }
     }
 
-    /// Create and insert an `AccountSession` into the `AccountManager`.
-    ///
-    /// Requires the global singleton for the `&'static Whitenoise` back-reference.
-    /// In unit tests (where the singleton is not set) this is a no-op.
     fn insert_account_session(&self, account: &Account) -> Result<()> {
-        let wn = match Self::get_instance() {
-            Ok(wn) => wn,
-            Err(_) => {
-                tracing::debug!(
-                    target: "whitenoise::accounts",
-                    "Skipping session insertion (global singleton not available, likely in tests)"
-                );
-                return Ok(());
-            }
-        };
-
         let mdk = self.create_mdk_for_account(account.pubkey)?;
-
-        // Resolve the signer: for local accounts, load from secrets store.
-        // For external accounts, check the external signers map.
         let signer = self.get_signer_for_account(account).ok();
-
-        let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer, wn));
+        let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
         self.account_manager.insert_session(session);
         Ok(())
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use dashmap::mapref::entry::Entry;
 use mdk_core::prelude::group_types::GroupState;
 use nostr_sdk::prelude::*;
 use tokio::sync::watch;
@@ -19,38 +18,10 @@ use crate::whitenoise::{Whitenoise, WhitenoiseError};
 use super::{Account, ExternalSignerRelaySetup};
 
 impl Whitenoise {
-    fn replace_background_task_cancellation_channel(&self, account_pubkey: PublicKey) {
-        let (cancel_tx, _) = watch::channel(false);
-        let previous_cancel_tx = self
-            .background_task_cancellation
-            .insert(account_pubkey, cancel_tx);
-
-        if let Some(previous_cancel_tx) = previous_cancel_tx {
-            let _ = previous_cancel_tx.send(true);
-            tracing::debug!(
-                target: "whitenoise::accounts",
-                account_pubkey = %account_pubkey,
-                "Replaced background-task cancellation channel and cancelled prior tasks",
-            );
-        }
-    }
-
-    fn ensure_background_task_cancellation_channel(&self, account_pubkey: PublicKey) {
-        match self.background_task_cancellation.entry(account_pubkey) {
-            Entry::Occupied(_) => {}
-            Entry::Vacant(entry) => {
-                let (cancel_tx, _) = watch::channel(false);
-                entry.insert(cancel_tx);
-                tracing::debug!(
-                    target: "whitenoise::accounts",
-                    account_pubkey = %account_pubkey,
-                    "Created missing background-task cancellation channel during subscription setup",
-                );
-            }
-        }
-    }
-
     fn insert_account_session(&self, account: &Account) -> Result<()> {
+        if let Some(old_session) = self.account_manager.get_session(&account.pubkey) {
+            let _ = old_session.cancellation.send(true);
+        }
         let mdk = self.create_mdk_for_account(account.pubkey)?;
         let signer = self.get_signer_for_account(account).ok();
         let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
@@ -83,8 +54,6 @@ impl Whitenoise {
         inbox_relays: &[Relay],
         key_package_relays: &[Relay],
     ) -> Result<()> {
-        self.replace_background_task_cancellation_channel(account.pubkey);
-
         self.discovery_sync_worker.request_rebuild();
 
         // Subscriptions and key package setup operate on disjoint relay
@@ -118,8 +87,6 @@ impl Whitenoise {
         account: &Account,
         inbox_relays: &[Relay],
     ) -> Result<()> {
-        self.replace_background_task_cancellation_channel(account.pubkey);
-
         self.discovery_sync_worker.request_rebuild();
 
         self.setup_subscriptions(account, inbox_relays).await?;
@@ -808,9 +775,9 @@ impl Whitenoise {
         let account_clone = account.clone();
         let account_pubkey = account.pubkey;
         let cancel_rx = self
-            .background_task_cancellation
-            .get(&account.pubkey)
-            .map(|entry| entry.value().subscribe());
+            .account_manager
+            .get_session(&account.pubkey)
+            .map(|s| s.cancellation.subscribe());
         if cancel_rx.is_none() {
             tracing::debug!(
                 target: "whitenoise::accounts::background_refresh_account_group_subscriptions",
@@ -862,11 +829,6 @@ impl Whitenoise {
         account: &Account,
         inbox_relays: &[Relay],
     ) -> Result<()> {
-        // Restored accounts rebuild relay subscriptions at startup without
-        // going through activate_account(), but later group-plane refreshes
-        // depend on this runtime-only channel being present.
-        self.ensure_background_task_cancellation_channel(account.pubkey);
-
         tracing::debug!(
             target: "whitenoise::accounts",
             "Setting up subscriptions for account: {:?}",
@@ -1049,92 +1011,11 @@ mod tests {
 
     #[cfg(feature = "integration-tests")]
     async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
-        whitenoise.background_task_cancellation.clear();
         whitenoise.external_signers.clear();
         whitenoise.account_manager.clear_sessions();
         whitenoise.account_manager.pending_logins.clear();
         whitenoise.reset_nostr_client().await.unwrap();
         whitenoise.wipe_database().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_ensure_background_task_cancellation_channel_creates_missing_channel() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account_pubkey = Keys::generate().public_key();
-
-        assert!(
-            !whitenoise
-                .background_task_cancellation
-                .contains_key(&account_pubkey)
-        );
-
-        whitenoise.ensure_background_task_cancellation_channel(account_pubkey);
-
-        let cancel_tx = whitenoise
-            .background_task_cancellation
-            .get(&account_pubkey)
-            .expect("missing cancellation channel after ensure");
-        let cancel_rx = cancel_tx.subscribe();
-
-        assert!(
-            !*cancel_rx.borrow(),
-            "new cancellation channel should start in the non-cancelled state"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_ensure_background_task_cancellation_channel_preserves_existing_channel() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account_pubkey = Keys::generate().public_key();
-        let (existing_cancel_tx, _) = watch::channel(true);
-
-        whitenoise
-            .background_task_cancellation
-            .insert(account_pubkey, existing_cancel_tx);
-
-        whitenoise.ensure_background_task_cancellation_channel(account_pubkey);
-
-        let cancel_tx = whitenoise
-            .background_task_cancellation
-            .get(&account_pubkey)
-            .expect("missing preserved cancellation channel");
-        let cancel_rx = cancel_tx.subscribe();
-
-        assert!(
-            *cancel_rx.borrow(),
-            "existing cancellation channel should not be replaced"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_replace_background_task_cancellation_channel_cancels_existing_channel() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account_pubkey = Keys::generate().public_key();
-        let (existing_cancel_tx, _) = watch::channel(false);
-        let mut existing_cancel_rx = existing_cancel_tx.subscribe();
-
-        whitenoise
-            .background_task_cancellation
-            .insert(account_pubkey, existing_cancel_tx);
-
-        whitenoise.replace_background_task_cancellation_channel(account_pubkey);
-
-        existing_cancel_rx
-            .changed()
-            .await
-            .expect("existing receiver should observe cancellation");
-        assert!(*existing_cancel_rx.borrow_and_update());
-
-        let cancel_tx = whitenoise
-            .background_task_cancellation
-            .get(&account_pubkey)
-            .expect("missing replacement cancellation channel");
-        let cancel_rx = cancel_tx.subscribe();
-
-        assert!(
-            !*cancel_rx.borrow(),
-            "replacement cancellation channel should start in the non-cancelled state"
-        );
     }
 
     #[tokio::test]
@@ -1251,10 +1132,14 @@ mod tests {
         let member_account = whitenoise.create_identity().await.unwrap();
         wait_for_key_package_publication(whitenoise, &[&member_account]).await;
 
-        // Simulate app restart: runtime-only background-task channels are gone,
+        // Simulate app restart: runtime-only sessions are gone,
         // then startup restores relay subscriptions from persisted accounts.
-        whitenoise.background_task_cancellation.clear();
+        whitenoise.account_manager.clear_sessions();
         whitenoise.reset_nostr_client().await.unwrap();
+        whitenoise
+            .account_manager
+            .restore_sessions(whitenoise)
+            .await;
         Whitenoise::setup_accounts_subscriptions(whitenoise)
             .await
             .unwrap();
@@ -1556,17 +1441,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_background_refresh_account_group_subscriptions_no_channel_noop() {
+    async fn test_background_refresh_account_group_subscriptions_no_session_noop() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = make_stub_account(&whitenoise).await;
 
+        assert!(
+            whitenoise
+                .account_manager
+                .get_session(&account.pubkey)
+                .is_none(),
+            "stub account should not have a session"
+        );
+
         whitenoise.background_refresh_account_group_subscriptions(&account);
         tokio::task::yield_now().await;
-
-        assert!(
-            !whitenoise
-                .background_task_cancellation
-                .contains_key(&account.pubkey)
-        );
     }
 }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -23,7 +23,11 @@ impl Whitenoise {
             let _ = old_session.cancellation.send(true);
         }
         let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let signer = self.get_signer_for_account(account).ok();
+        let signer = if account.has_local_key() {
+            Some(self.get_signer_for_account(account)?)
+        } else {
+            None
+        };
         let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
         self.account_manager.insert_session(session);
         Ok(())

--- a/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
@@ -1,7 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use nostr_sdk::prelude::*;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
+use tokio::sync::{OwnedSemaphorePermit, watch};
 
 use crate::whitenoise::{
     Whitenoise,
@@ -57,9 +57,15 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn acquire_contact_list_guard(&self, account: &Account) -> Result<OwnedSemaphorePermit> {
         let semaphore = self
-            .contact_list_guards
-            .entry(account.pubkey)
-            .or_insert_with(|| Arc::new(Semaphore::new(1)))
+            .account_manager
+            .get_session(&account.pubkey)
+            .ok_or_else(|| {
+                WhitenoiseError::ContactList(format!(
+                    "No active session for account {}",
+                    account.pubkey.to_hex()
+                ))
+            })?
+            .contact_list_guard
             .clone();
 
         semaphore.acquire_owned().await.map_err(|_| {
@@ -120,12 +126,10 @@ impl Whitenoise {
         let pubkeys = pubkeys.to_vec();
         let total = pubkeys.len();
 
-        // Get a cancellation receiver for this account so the batch stops if
-        // the account logs out.
         let cancel_rx = self
-            .background_task_cancellation
-            .get(account_pubkey)
-            .map(|entry| entry.value().subscribe());
+            .account_manager
+            .get_session(account_pubkey)
+            .map(|s| s.cancellation.subscribe());
 
         let tid = crate::perf::current_trace_id();
         tokio::spawn(crate::perf::with_trace_id(tid, async move {

--- a/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
@@ -56,8 +56,7 @@ impl Whitenoise {
 
     #[perf_instrument("event_handlers")]
     async fn acquire_contact_list_guard(&self, account: &Account) -> Result<OwnedSemaphorePermit> {
-        let semaphore = self
-            .account_manager
+        self.account_manager
             .get_session(&account.pubkey)
             .ok_or_else(|| {
                 WhitenoiseError::ContactList(format!(
@@ -65,14 +64,8 @@ impl Whitenoise {
                     account.pubkey.to_hex()
                 ))
             })?
-            .contact_list_guard
-            .clone();
-
-        semaphore.acquire_owned().await.map_err(|_| {
-            WhitenoiseError::ContactList(
-                "Failed to acquire contact list processing permit".to_string(),
-            )
-        })
+            .acquire_contact_list_permit()
+            .await
     }
 
     #[perf_instrument("event_handlers")]
@@ -129,7 +122,7 @@ impl Whitenoise {
         let cancel_rx = self
             .account_manager
             .get_session(account_pubkey)
-            .map(|s| s.cancellation.subscribe());
+            .map(|s| s.subscribe_cancellation());
 
         let tid = crate::perf::current_trace_id();
         tokio::spawn(crate::perf::with_trace_id(tid, async move {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -262,7 +262,7 @@ impl Whitenoise {
             scheduler_handles: Mutex::new(Vec::new()),
             external_signers: DashMap::new(),
             background_task_cancellation: DashMap::new(),
-            account_manager: session::AccountManager::new(),
+            account_manager: session::AccountManager::default(),
             discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
             pending_push_token_responses: Arc::new(DashMap::new()),
         }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -8,7 +8,7 @@ use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::NostrSigner;
 use nostr_sdk::{EventId, PublicKey, RelayUrl};
 use tokio::sync::{
-    Mutex, OnceCell, Semaphore,
+    Mutex, OnceCell,
     mpsc::{self, Sender},
     watch,
 };
@@ -160,8 +160,6 @@ pub struct Whitenoise {
     notification_stream_manager: notification_streaming::NotificationStreamManager,
     event_sender: Sender<ProcessableEvent>,
     shutdown_sender: Sender<()>,
-    /// Per-account concurrency guards to prevent race conditions in contact list processing
-    contact_list_guards: DashMap<PublicKey, Arc<Semaphore>>,
     /// Per-user guards that dedupe targeted discovery resolution for the same pubkey.
     user_resolution_guards: DashMap<PublicKey, Arc<Mutex<()>>>,
     /// Shutdown signal for scheduled tasks
@@ -171,10 +169,6 @@ pub struct Whitenoise {
     /// External signers for accounts using NIP-55 (Amber) or similar.
     /// Maps account pubkey to their signer implementation.
     external_signers: DashMap<PublicKey, Arc<dyn NostrSigner>>,
-    /// Per-account cancellation signals for background tasks (e.g. contact list
-    /// user fetches). Sending `true` tells all background tasks for that account
-    /// to stop. A new channel is created on login and signalled on logout.
-    background_task_cancellation: DashMap<PublicKey, watch::Sender<bool>>,
     /// Per-account session manager. Holds active sessions and pending logins.
     pub(crate) account_manager: session::AccountManager,
     /// Debounced worker that coalesces discovery subscription rebuilds.
@@ -213,7 +207,6 @@ impl std::fmt::Debug for Whitenoise {
             .field("notification_stream_manager", &"<REDACTED>")
             .field("event_sender", &"<REDACTED>")
             .field("shutdown_sender", &"<REDACTED>")
-            .field("contact_list_guards", &"<REDACTED>")
             .field("user_resolution_guards", &"<REDACTED>")
             .field("scheduler_shutdown", &"<REDACTED>")
             .field("scheduler_handles", &"<REDACTED>")
@@ -256,12 +249,10 @@ impl Whitenoise {
             ),
             event_sender: components.event_sender,
             shutdown_sender: components.shutdown_sender,
-            contact_list_guards: DashMap::new(),
             user_resolution_guards: DashMap::new(),
             scheduler_shutdown: components.scheduler_shutdown,
             scheduler_handles: Mutex::new(Vec::new()),
             external_signers: DashMap::new(),
-            background_task_cancellation: DashMap::new(),
             account_manager: session::AccountManager::default(),
             discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
             pending_push_token_responses: Arc::new(DashMap::new()),

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -43,6 +43,7 @@ pub mod push_notifications;
 pub mod relays;
 pub mod scheduled_tasks;
 pub mod secrets_store;
+pub mod session;
 mod signer;
 pub mod storage;
 mod streaming;
@@ -174,11 +175,8 @@ pub struct Whitenoise {
     /// user fetches). Sending `true` tells all background tasks for that account
     /// to stop. A new channel is created on login and signalled on logout.
     background_task_cancellation: DashMap<PublicKey, watch::Sender<bool>>,
-    /// Pubkeys with a login in progress (between login_start and
-    /// login_publish_default_relays / login_with_custom_relay / login_cancel).
-    /// The value holds whichever relay lists were already discovered on the
-    /// network so that step 2a can publish defaults only for the missing ones.
-    pending_logins: DashMap<PublicKey, accounts::DiscoveredRelayLists>,
+    /// Per-account session manager. Holds active sessions and pending logins.
+    pub(crate) account_manager: session::AccountManager,
     /// Debounced worker that coalesces discovery subscription rebuilds.
     discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker,
     /// In-memory coordination for delayed MIP-05 token-list responses.
@@ -220,6 +218,7 @@ impl std::fmt::Debug for Whitenoise {
             .field("scheduler_shutdown", &"<REDACTED>")
             .field("scheduler_handles", &"<REDACTED>")
             .field("pending_push_token_responses", &"<REDACTED>")
+            .field("account_manager", &"<REDACTED>")
             .finish()
     }
 }
@@ -263,7 +262,7 @@ impl Whitenoise {
             scheduler_handles: Mutex::new(Vec::new()),
             external_signers: DashMap::new(),
             background_task_cancellation: DashMap::new(),
-            pending_logins: DashMap::new(),
+            account_manager: session::AccountManager::new(),
             discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
             pending_push_token_responses: Arc::new(DashMap::new()),
         }
@@ -589,6 +588,15 @@ impl Whitenoise {
         }
 
         init_timing::record("background_tasks");
+
+        // Restore account sessions for all persisted accounts before setting up
+        // subscriptions so that each account has an MDK instance ready.
+        whitenoise_ref
+            .account_manager
+            .restore_sessions(whitenoise_ref)
+            .await;
+
+        init_timing::record("session_restore");
 
         // Fetch events and setup subscriptions after event processing has started
         Self::setup_all_subscriptions(whitenoise_ref).await?;

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -8,7 +8,7 @@ use nostr_sdk::prelude::NostrSigner;
 use tokio::sync::RwLock;
 
 use crate::whitenoise::Whitenoise;
-use crate::whitenoise::accounts::{AccountError, DiscoveredRelayLists};
+use crate::whitenoise::accounts::DiscoveredRelayLists;
 
 /// A per-account session holding the account's MDK instance and signer.
 ///
@@ -20,8 +20,6 @@ pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
     pub signer: RwLock<Option<Arc<dyn NostrSigner>>>,
-    /// Transitional back-reference until singleton removal.
-    _wn: &'static Whitenoise,
 }
 
 impl AccountSession {
@@ -29,13 +27,11 @@ impl AccountSession {
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
         signer: Option<Arc<dyn NostrSigner>>,
-        wn: &'static Whitenoise,
     ) -> Self {
         Self {
             account_pubkey,
             mdk: Arc::new(mdk),
             signer: RwLock::new(signer),
-            _wn: wn,
         }
     }
 
@@ -43,20 +39,13 @@ impl AccountSession {
     pub async fn set_signer(&self, signer: Arc<dyn NostrSigner>) {
         *self.signer.write().await = Some(signer);
     }
-
-    /// Returns the current signer, if one is registered.
-    pub async fn get_signer(&self) -> Option<Arc<dyn NostrSigner>> {
-        self.signer.read().await.clone()
-    }
 }
 
 /// Manages active account sessions and pending logins.
 pub struct AccountManager {
     sessions: DashMap<PublicKey, Arc<AccountSession>>,
-    /// Pubkeys with a login in progress (between login_start and
-    /// login_publish_default_relays / login_with_custom_relay / login_cancel).
-    /// The value holds whichever relay lists were already discovered on the
-    /// network so that step 2a can publish defaults only for the missing ones.
+    /// Pubkeys with a login in progress. The value holds whichever relay lists
+    /// were already discovered so step 2a can publish defaults only for missing ones.
     pub(crate) pending_logins: DashMap<PublicKey, DiscoveredRelayLists>,
 }
 
@@ -70,11 +59,6 @@ impl Default for AccountManager {
 }
 
 impl AccountManager {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Insert or replace a session for the given account.
     pub fn insert_session(&self, session: Arc<AccountSession>) {
         let pubkey = session.account_pubkey;
         self.sessions.insert(pubkey, session);
@@ -85,12 +69,10 @@ impl AccountManager {
         );
     }
 
-    /// Look up an active session by public key.
     pub fn get_session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
         self.sessions.get(pubkey).map(|r| r.clone())
     }
 
-    /// Remove the session for the given public key.
     pub fn remove_session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
         let removed = self.sessions.remove(pubkey).map(|(_, s)| s);
         if removed.is_some() {
@@ -103,31 +85,11 @@ impl AccountManager {
         removed
     }
 
-    /// Returns true if a session exists for the given public key.
-    pub fn has_session(&self, pubkey: &PublicKey) -> bool {
-        self.sessions.contains_key(pubkey)
-    }
-
-    /// Returns the number of active sessions.
-    pub fn session_count(&self) -> usize {
-        self.sessions.len()
-    }
-
-    /// Returns all active session public keys.
-    pub fn session_pubkeys(&self) -> Vec<PublicKey> {
-        self.sessions.iter().map(|r| *r.key()).collect()
-    }
-
-    /// Restore sessions for all persisted accounts.
+    /// Restore sessions for all persisted accounts at startup.
     ///
-    /// Creates an `AccountSession` (with MDK but no signer) for each account
-    /// in the database. External-signer accounts will have `signer: None`
-    /// until `register_external_signer()` fills the slot. Local accounts get
-    /// their signer from the secrets store.
-    pub async fn restore_sessions(
-        &self,
-        wn: &'static Whitenoise,
-    ) -> Vec<(PublicKey, Result<(), AccountError>)> {
+    /// External-signer accounts get `signer: None` until re-registered.
+    /// Local accounts load their signer from the secrets store.
+    pub async fn restore_sessions(&self, wn: &'static Whitenoise) {
         let accounts = match crate::whitenoise::accounts::Account::all(&wn.database).await {
             Ok(accounts) => accounts,
             Err(e) => {
@@ -136,38 +98,24 @@ impl AccountManager {
                     "Failed to load accounts for session restore: {}",
                     e
                 );
-                return Vec::new();
+                return;
             }
         };
 
-        let mut results = Vec::with_capacity(accounts.len());
+        let mut ok_count = 0usize;
+        let mut err_count = 0usize;
 
         for account in &accounts {
-            let mdk_result = wn.create_mdk_for_account(account.pubkey);
-            match mdk_result {
+            match wn.create_mdk_for_account(account.pubkey) {
                 Ok(mdk) => {
-                    // For local accounts, try to load the signer from secrets store.
-                    // For external accounts, signer is None until re-registered.
                     let signer: Option<Arc<dyn NostrSigner>> = if account.has_local_key() {
-                        match wn.get_signer_for_account(account) {
-                            Ok(s) => Some(s),
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "whitenoise::session",
-                                    "Failed to load signer for local account {}: {}",
-                                    account.pubkey.to_hex(),
-                                    e
-                                );
-                                None
-                            }
-                        }
+                        wn.get_signer_for_account(account).ok()
                     } else {
                         None
                     };
-
-                    let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer, wn));
+                    let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
                     self.insert_session(session);
-                    results.push((account.pubkey, Ok(())));
+                    ok_count += 1;
                 }
                 Err(e) => {
                     tracing::error!(
@@ -176,7 +124,7 @@ impl AccountManager {
                         account.pubkey.to_hex(),
                         e
                     );
-                    results.push((account.pubkey, Err(e)));
+                    err_count += 1;
                 }
             }
         }
@@ -184,11 +132,9 @@ impl AccountManager {
         tracing::info!(
             target: "whitenoise::session",
             "Restored {} sessions ({} failed)",
-            results.iter().filter(|(_, r)| r.is_ok()).count(),
-            results.iter().filter(|(_, r)| r.is_err()).count(),
+            ok_count,
+            err_count,
         );
-
-        results
     }
 }
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -5,7 +5,7 @@ use mdk_core::prelude::MDK;
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::PublicKey;
 use nostr_sdk::prelude::NostrSigner;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Semaphore, watch};
 
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::DiscoveredRelayLists;
@@ -20,6 +20,8 @@ pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
     pub signer: RwLock<Option<Arc<dyn NostrSigner>>>,
+    pub contact_list_guard: Arc<Semaphore>,
+    pub cancellation: watch::Sender<bool>,
 }
 
 impl AccountSession {
@@ -28,10 +30,13 @@ impl AccountSession {
         mdk: MDK<MdkSqliteStorage>,
         signer: Option<Arc<dyn NostrSigner>>,
     ) -> Self {
+        let (cancellation, _) = watch::channel(false);
         Self {
             account_pubkey,
             mdk: Arc::new(mdk),
             signer: RwLock::new(signer),
+            contact_list_guard: Arc::new(Semaphore::new(1)),
+            cancellation,
         }
     }
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -85,6 +85,11 @@ impl AccountManager {
         removed
     }
 
+    /// Remove all active sessions.
+    pub fn clear_sessions(&self) {
+        self.sessions.clear();
+    }
+
     /// Restore sessions for all persisted accounts at startup.
     ///
     /// External-signer accounts get `signer: None` until re-registered.

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -26,7 +26,7 @@ pub struct AccountSession {
 }
 
 impl AccountSession {
-    pub fn new(
+    pub(crate) fn new(
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
         signer: Option<Arc<dyn NostrSigner>>,
@@ -109,8 +109,11 @@ impl Default for AccountManager {
 }
 
 impl AccountManager {
-    pub fn insert_session(&self, session: Arc<AccountSession>) {
+    pub(crate) fn insert_session(&self, session: Arc<AccountSession>) {
         let pubkey = session.account_pubkey;
+        if let Some((_, old)) = self.sessions.remove(&pubkey) {
+            old.cancel();
+        }
         self.sessions.insert(pubkey, session);
         tracing::debug!(
             target: "whitenoise::session",
@@ -135,14 +138,17 @@ impl AccountManager {
         removed
     }
 
-    /// Remove all active sessions.
+    /// Cancel and remove all active sessions.
     pub fn clear_sessions(&self) {
+        for entry in self.sessions.iter() {
+            entry.value().cancel();
+        }
         self.sessions.clear();
     }
 
     /// Record that a multi-step login is in progress for `pubkey`.
-    pub fn stash_pending_login(&self, pubkey: PublicKey, discovered: DiscoveredRelayLists) {
-        self.pending_logins.insert(pubkey, discovered);
+    pub fn stash_pending_login(&self, pubkey: &PublicKey, discovered: DiscoveredRelayLists) {
+        self.pending_logins.insert(*pubkey, discovered);
     }
 
     /// Returns `true` if a multi-step login is in progress for `pubkey`.
@@ -156,18 +162,15 @@ impl AccountManager {
     }
 
     /// Remove and return the pending-login stash for `pubkey`.
-    pub fn take_pending_login(
-        &self,
-        pubkey: &PublicKey,
-    ) -> Option<(PublicKey, DiscoveredRelayLists)> {
-        self.pending_logins.remove(pubkey)
+    pub fn take_pending_login(&self, pubkey: &PublicKey) -> Option<DiscoveredRelayLists> {
+        self.pending_logins.remove(pubkey).map(|(_, v)| v)
     }
 
     /// Merge newly-discovered relay lists into the pending-login stash and
     /// return a snapshot. The DashMap lock is released before returning so
     /// the caller is free to do async work with the result.
     ///
-    /// Returns `NoLoginInProgress` if no stash exists for `pubkey`.
+    /// Returns `None` if no stash exists for `pubkey`.
     pub fn merge_pending_login(
         &self,
         pubkey: &PublicKey,
@@ -236,5 +239,206 @@ impl Whitenoise {
     /// Look up an active session by public key.
     pub fn session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
         self.account_manager.get_session(pubkey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nostr_sdk::Keys;
+
+    use super::{AccountManager, AccountSession};
+    use crate::whitenoise::accounts::DiscoveredRelayLists;
+    use crate::whitenoise::accounts::test_utils::create_mdk;
+
+    fn test_pubkey() -> nostr_sdk::PublicKey {
+        Keys::generate().public_key()
+    }
+
+    fn empty_discovered() -> DiscoveredRelayLists {
+        DiscoveredRelayLists {
+            nip65: None,
+            inbox: None,
+            key_package: None,
+        }
+    }
+
+    fn test_session(pubkey: nostr_sdk::PublicKey) -> Arc<AccountSession> {
+        let mdk = create_mdk(pubkey);
+        Arc::new(AccountSession::new(pubkey, mdk, None))
+    }
+
+    // ── AccountManager: session CRUD ─────────────────────────────────
+
+    #[test]
+    fn insert_and_get_session() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+        let session = test_session(pk);
+
+        mgr.insert_session(session.clone());
+        let got = mgr.get_session(&pk).expect("session should exist");
+        assert_eq!(got.account_pubkey, pk);
+    }
+
+    #[test]
+    fn get_session_returns_none_for_unknown_key() {
+        let mgr = AccountManager::default();
+        assert!(mgr.get_session(&test_pubkey()).is_none());
+    }
+
+    #[test]
+    fn remove_session_returns_removed() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+        mgr.insert_session(test_session(pk));
+
+        let removed = mgr.remove_session(&pk);
+        assert!(removed.is_some());
+        assert!(mgr.get_session(&pk).is_none());
+    }
+
+    #[test]
+    fn remove_session_returns_none_when_absent() {
+        let mgr = AccountManager::default();
+        assert!(mgr.remove_session(&test_pubkey()).is_none());
+    }
+
+    #[test]
+    fn clear_sessions_empties_all() {
+        let mgr = AccountManager::default();
+        mgr.insert_session(test_session(test_pubkey()));
+        mgr.insert_session(test_session(test_pubkey()));
+
+        mgr.clear_sessions();
+        // Both are gone — we can only verify via new lookups returning None,
+        // but since keys are random we just assert the map is empty via a
+        // fresh get on any key.
+        assert!(mgr.get_session(&test_pubkey()).is_none());
+    }
+
+    // ── AccountManager: pending logins ───────────────────────────────
+
+    #[test]
+    fn stash_and_get_pending_login() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+        mgr.stash_pending_login(&pk, empty_discovered());
+
+        assert!(mgr.has_pending_login(&pk));
+        assert!(mgr.get_pending_login(&pk).is_some());
+    }
+
+    #[test]
+    fn has_pending_login_false_when_absent() {
+        let mgr = AccountManager::default();
+        assert!(!mgr.has_pending_login(&test_pubkey()));
+    }
+
+    #[test]
+    fn take_pending_login_removes_entry() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+        mgr.stash_pending_login(&pk, empty_discovered());
+
+        let taken = mgr.take_pending_login(&pk);
+        assert!(taken.is_some());
+        assert!(!mgr.has_pending_login(&pk));
+    }
+
+    #[test]
+    fn take_pending_login_returns_none_when_absent() {
+        let mgr = AccountManager::default();
+        assert!(mgr.take_pending_login(&test_pubkey()).is_none());
+    }
+
+    #[test]
+    fn merge_pending_login_combines_fields() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+
+        // Start with only nip65 discovered.
+        let initial = DiscoveredRelayLists {
+            nip65: Some(vec![]),
+            inbox: None,
+            key_package: None,
+        };
+        mgr.stash_pending_login(&pk, initial);
+
+        // Merge in inbox.
+        let update = DiscoveredRelayLists {
+            nip65: None,
+            inbox: Some(vec![]),
+            key_package: None,
+        };
+        let merged = mgr.merge_pending_login(&pk, update).expect("stash exists");
+        assert!(merged.nip65.is_some());
+        assert!(merged.inbox.is_some());
+        assert!(merged.key_package.is_none());
+    }
+
+    #[test]
+    fn merge_pending_login_returns_none_when_absent() {
+        let mgr = AccountManager::default();
+        assert!(
+            mgr.merge_pending_login(&test_pubkey(), empty_discovered())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn clear_pending_logins_empties_all() {
+        let mgr = AccountManager::default();
+        let pk = test_pubkey();
+        mgr.stash_pending_login(&pk, empty_discovered());
+
+        mgr.clear_pending_logins();
+        assert!(!mgr.has_pending_login(&pk));
+    }
+
+    // ── AccountSession ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_and_get_signer() {
+        let pk = test_pubkey();
+        let session = test_session(pk);
+
+        assert!(session.get_signer().is_none(), "starts with no signer");
+
+        let keys = Keys::generate();
+        session.set_signer(Arc::new(keys)).await;
+
+        assert!(session.get_signer().is_some(), "signer should be set");
+    }
+
+    #[tokio::test]
+    async fn cancel_signals_receivers() {
+        let pk = test_pubkey();
+        let session = test_session(pk);
+        let mut rx = session.subscribe_cancellation();
+
+        assert!(!*rx.borrow(), "not cancelled initially");
+        session.cancel();
+        rx.changed().await.expect("channel not dropped");
+        assert!(*rx.borrow(), "should be cancelled after cancel()");
+    }
+
+    #[tokio::test]
+    async fn acquire_contact_list_permit_limits_concurrency() {
+        let pk = test_pubkey();
+        let session = test_session(pk);
+
+        let _permit = session.acquire_contact_list_permit().await.unwrap();
+
+        // The semaphore has 1 permit, so a second acquire should not succeed
+        // immediately. We use try_acquire_owned on the inner semaphore
+        // indirectly by checking timeout behaviour.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            session.acquire_contact_list_permit(),
+        )
+        .await;
+        assert!(result.is_err(), "second permit should block (timeout)");
     }
 }

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -5,10 +5,11 @@ use mdk_core::prelude::MDK;
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::PublicKey;
 use nostr_sdk::prelude::NostrSigner;
-use tokio::sync::{RwLock, Semaphore, watch};
+use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore, watch};
 
 use crate::whitenoise::Whitenoise;
-use crate::whitenoise::accounts::DiscoveredRelayLists;
+use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
+use crate::whitenoise::error::{Result, WhitenoiseError};
 
 /// A per-account session holding the account's MDK instance and signer.
 ///
@@ -19,9 +20,9 @@ use crate::whitenoise::accounts::DiscoveredRelayLists;
 pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
-    pub signer: RwLock<Option<Arc<dyn NostrSigner>>>,
-    pub contact_list_guard: Arc<Semaphore>,
-    pub cancellation: watch::Sender<bool>,
+    signer: RwLock<Option<Arc<dyn NostrSigner>>>,
+    contact_list_guard: Arc<Semaphore>,
+    cancellation: watch::Sender<bool>,
 }
 
 impl AccountSession {
@@ -40,9 +41,53 @@ impl AccountSession {
         }
     }
 
+    /// Build a session from a persisted account, loading MDK and (for local
+    /// accounts) the signer from the secrets store.
+    pub(crate) fn from_account(account: &Account, wn: &Whitenoise) -> Result<Self> {
+        let mdk = wn.create_mdk_for_account(account.pubkey)?;
+        let signer = if account.has_local_key() {
+            Some(wn.get_signer_for_account(account)?)
+        } else {
+            None
+        };
+        Ok(Self::new(account.pubkey, mdk, signer))
+    }
+
     /// Replace the signer slot (e.g. when an external signer is re-registered).
     pub async fn set_signer(&self, signer: Arc<dyn NostrSigner>) {
         *self.signer.write().await = Some(signer);
+    }
+
+    /// Read the current signer, if any.
+    ///
+    /// Uses `try_read` to avoid blocking on the rare concurrent `set_signer`
+    /// write. Returns `None` when the write lock is held; callers fall through
+    /// to the legacy signer lookup which produces the same result.
+    pub fn get_signer(&self) -> Option<Arc<dyn NostrSigner>> {
+        self.signer.try_read().ok().and_then(|g| g.clone())
+    }
+
+    /// Subscribe to the cancellation channel.
+    pub fn subscribe_cancellation(&self) -> watch::Receiver<bool> {
+        self.cancellation.subscribe()
+    }
+
+    /// Signal cancellation to all background tasks associated with this session.
+    pub(crate) fn cancel(&self) {
+        let _ = self.cancellation.send(true);
+    }
+
+    /// Acquire the contact-list processing permit for this session.
+    pub async fn acquire_contact_list_permit(&self) -> Result<OwnedSemaphorePermit> {
+        self.contact_list_guard
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                WhitenoiseError::ContactList(
+                    "Failed to acquire contact list processing permit".to_string(),
+                )
+            })
     }
 }
 
@@ -51,7 +96,7 @@ pub struct AccountManager {
     sessions: DashMap<PublicKey, Arc<AccountSession>>,
     /// Pubkeys with a login in progress. The value holds whichever relay lists
     /// were already discovered so step 2a can publish defaults only for missing ones.
-    pub(crate) pending_logins: DashMap<PublicKey, DiscoveredRelayLists>,
+    pending_logins: DashMap<PublicKey, DiscoveredRelayLists>,
 }
 
 impl Default for AccountManager {
@@ -95,12 +140,57 @@ impl AccountManager {
         self.sessions.clear();
     }
 
+    /// Record that a multi-step login is in progress for `pubkey`.
+    pub fn stash_pending_login(&self, pubkey: PublicKey, discovered: DiscoveredRelayLists) {
+        self.pending_logins.insert(pubkey, discovered);
+    }
+
+    /// Returns `true` if a multi-step login is in progress for `pubkey`.
+    pub fn has_pending_login(&self, pubkey: &PublicKey) -> bool {
+        self.pending_logins.contains_key(pubkey)
+    }
+
+    /// Return a snapshot of the pending-login stash for `pubkey`.
+    pub fn get_pending_login(&self, pubkey: &PublicKey) -> Option<DiscoveredRelayLists> {
+        self.pending_logins.get(pubkey).map(|r| r.clone())
+    }
+
+    /// Remove and return the pending-login stash for `pubkey`.
+    pub fn take_pending_login(
+        &self,
+        pubkey: &PublicKey,
+    ) -> Option<(PublicKey, DiscoveredRelayLists)> {
+        self.pending_logins.remove(pubkey)
+    }
+
+    /// Merge newly-discovered relay lists into the pending-login stash and
+    /// return a snapshot. The DashMap lock is released before returning so
+    /// the caller is free to do async work with the result.
+    ///
+    /// Returns `NoLoginInProgress` if no stash exists for `pubkey`.
+    pub fn merge_pending_login(
+        &self,
+        pubkey: &PublicKey,
+        discovered: DiscoveredRelayLists,
+    ) -> Option<DiscoveredRelayLists> {
+        let mut stash = self.pending_logins.get_mut(pubkey)?;
+        stash.merge(discovered);
+        let snapshot = stash.clone();
+        drop(stash);
+        Some(snapshot)
+    }
+
+    /// Remove all pending logins.
+    pub fn clear_pending_logins(&self) {
+        self.pending_logins.clear();
+    }
+
     /// Restore sessions for all persisted accounts at startup.
     ///
     /// External-signer accounts get `signer: None` until re-registered.
     /// Local accounts load their signer from the secrets store.
     pub async fn restore_sessions(&self, wn: &'static Whitenoise) {
-        let accounts = match crate::whitenoise::accounts::Account::all(&wn.database).await {
+        let accounts = match Account::all(&wn.database).await {
             Ok(accounts) => accounts,
             Err(e) => {
                 tracing::error!(
@@ -116,33 +206,15 @@ impl AccountManager {
         let mut err_count = 0usize;
 
         for account in &accounts {
-            match wn.create_mdk_for_account(account.pubkey) {
-                Ok(mdk) => {
-                    let signer: Option<Arc<dyn NostrSigner>> = if account.has_local_key() {
-                        match wn.get_signer_for_account(account) {
-                            Ok(s) => Some(s),
-                            Err(e) => {
-                                tracing::error!(
-                                    target: "whitenoise::session",
-                                    "Failed to get signer for local account {}: {}",
-                                    account.pubkey.to_hex(),
-                                    e
-                                );
-                                err_count += 1;
-                                continue;
-                            }
-                        }
-                    } else {
-                        None
-                    };
-                    let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer));
-                    self.insert_session(session);
+            match AccountSession::from_account(account, wn) {
+                Ok(session) => {
+                    self.insert_session(Arc::new(session));
                     ok_count += 1;
                 }
                 Err(e) => {
                     tracing::error!(
                         target: "whitenoise::session",
-                        "Failed to create MDK for account {}: {}",
+                        "Failed to restore session for account {}: {}",
                         account.pubkey.to_hex(),
                         e
                     );

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -119,7 +119,19 @@ impl AccountManager {
             match wn.create_mdk_for_account(account.pubkey) {
                 Ok(mdk) => {
                     let signer: Option<Arc<dyn NostrSigner>> = if account.has_local_key() {
-                        wn.get_signer_for_account(account).ok()
+                        match wn.get_signer_for_account(account) {
+                            Ok(s) => Some(s),
+                            Err(e) => {
+                                tracing::error!(
+                                    target: "whitenoise::session",
+                                    "Failed to get signer for local account {}: {}",
+                                    account.pubkey.to_hex(),
+                                    e
+                                );
+                                err_count += 1;
+                                continue;
+                            }
+                        }
                     } else {
                         None
                     };

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use mdk_core::prelude::MDK;
+use mdk_sqlite_storage::MdkSqliteStorage;
+use nostr_sdk::PublicKey;
+use nostr_sdk::prelude::NostrSigner;
+use tokio::sync::RwLock;
+
+use crate::whitenoise::Whitenoise;
+use crate::whitenoise::accounts::{AccountError, DiscoveredRelayLists};
+
+/// A per-account session holding the account's MDK instance and signer.
+///
+/// `signer` is `None` for restored external-signer accounts whose platform
+/// signer has not yet been re-registered. Operations requiring signing should
+/// return the existing external-signer-unavailable error until
+/// `register_external_signer()` fills the slot.
+pub struct AccountSession {
+    pub account_pubkey: PublicKey,
+    pub mdk: Arc<MDK<MdkSqliteStorage>>,
+    pub signer: RwLock<Option<Arc<dyn NostrSigner>>>,
+    /// Transitional back-reference until singleton removal.
+    _wn: &'static Whitenoise,
+}
+
+impl AccountSession {
+    pub fn new(
+        account_pubkey: PublicKey,
+        mdk: MDK<MdkSqliteStorage>,
+        signer: Option<Arc<dyn NostrSigner>>,
+        wn: &'static Whitenoise,
+    ) -> Self {
+        Self {
+            account_pubkey,
+            mdk: Arc::new(mdk),
+            signer: RwLock::new(signer),
+            _wn: wn,
+        }
+    }
+
+    /// Replace the signer slot (e.g. when an external signer is re-registered).
+    pub async fn set_signer(&self, signer: Arc<dyn NostrSigner>) {
+        *self.signer.write().await = Some(signer);
+    }
+
+    /// Returns the current signer, if one is registered.
+    pub async fn get_signer(&self) -> Option<Arc<dyn NostrSigner>> {
+        self.signer.read().await.clone()
+    }
+}
+
+/// Manages active account sessions and pending logins.
+pub struct AccountManager {
+    sessions: DashMap<PublicKey, Arc<AccountSession>>,
+    /// Pubkeys with a login in progress (between login_start and
+    /// login_publish_default_relays / login_with_custom_relay / login_cancel).
+    /// The value holds whichever relay lists were already discovered on the
+    /// network so that step 2a can publish defaults only for the missing ones.
+    pub(crate) pending_logins: DashMap<PublicKey, DiscoveredRelayLists>,
+}
+
+impl Default for AccountManager {
+    fn default() -> Self {
+        Self {
+            sessions: DashMap::new(),
+            pending_logins: DashMap::new(),
+        }
+    }
+}
+
+impl AccountManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a session for the given account.
+    pub fn insert_session(&self, session: Arc<AccountSession>) {
+        let pubkey = session.account_pubkey;
+        self.sessions.insert(pubkey, session);
+        tracing::debug!(
+            target: "whitenoise::session",
+            "Inserted session for {}",
+            pubkey.to_hex()
+        );
+    }
+
+    /// Look up an active session by public key.
+    pub fn get_session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
+        self.sessions.get(pubkey).map(|r| r.clone())
+    }
+
+    /// Remove the session for the given public key.
+    pub fn remove_session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
+        let removed = self.sessions.remove(pubkey).map(|(_, s)| s);
+        if removed.is_some() {
+            tracing::debug!(
+                target: "whitenoise::session",
+                "Removed session for {}",
+                pubkey.to_hex()
+            );
+        }
+        removed
+    }
+
+    /// Returns true if a session exists for the given public key.
+    pub fn has_session(&self, pubkey: &PublicKey) -> bool {
+        self.sessions.contains_key(pubkey)
+    }
+
+    /// Returns the number of active sessions.
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Returns all active session public keys.
+    pub fn session_pubkeys(&self) -> Vec<PublicKey> {
+        self.sessions.iter().map(|r| *r.key()).collect()
+    }
+
+    /// Restore sessions for all persisted accounts.
+    ///
+    /// Creates an `AccountSession` (with MDK but no signer) for each account
+    /// in the database. External-signer accounts will have `signer: None`
+    /// until `register_external_signer()` fills the slot. Local accounts get
+    /// their signer from the secrets store.
+    pub async fn restore_sessions(
+        &self,
+        wn: &'static Whitenoise,
+    ) -> Vec<(PublicKey, Result<(), AccountError>)> {
+        let accounts = match crate::whitenoise::accounts::Account::all(&wn.database).await {
+            Ok(accounts) => accounts,
+            Err(e) => {
+                tracing::error!(
+                    target: "whitenoise::session",
+                    "Failed to load accounts for session restore: {}",
+                    e
+                );
+                return Vec::new();
+            }
+        };
+
+        let mut results = Vec::with_capacity(accounts.len());
+
+        for account in &accounts {
+            let mdk_result = wn.create_mdk_for_account(account.pubkey);
+            match mdk_result {
+                Ok(mdk) => {
+                    // For local accounts, try to load the signer from secrets store.
+                    // For external accounts, signer is None until re-registered.
+                    let signer: Option<Arc<dyn NostrSigner>> = if account.has_local_key() {
+                        match wn.get_signer_for_account(account) {
+                            Ok(s) => Some(s),
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "whitenoise::session",
+                                    "Failed to load signer for local account {}: {}",
+                                    account.pubkey.to_hex(),
+                                    e
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    let session = Arc::new(AccountSession::new(account.pubkey, mdk, signer, wn));
+                    self.insert_session(session);
+                    results.push((account.pubkey, Ok(())));
+                }
+                Err(e) => {
+                    tracing::error!(
+                        target: "whitenoise::session",
+                        "Failed to create MDK for account {}: {}",
+                        account.pubkey.to_hex(),
+                        e
+                    );
+                    results.push((account.pubkey, Err(e)));
+                }
+            }
+        }
+
+        tracing::info!(
+            target: "whitenoise::session",
+            "Restored {} sessions ({} failed)",
+            results.iter().filter(|(_, r)| r.is_ok()).count(),
+            results.iter().filter(|(_, r)| r.is_err()).count(),
+        );
+
+        results
+    }
+}
+
+impl Whitenoise {
+    /// Look up an active session by public key.
+    pub fn session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
+        self.account_manager.get_session(pubkey)
+    }
+}

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -125,7 +125,7 @@ impl Whitenoise {
     /// Returns an error if no signer is available for the account.
     pub(crate) fn get_signer_for_account(&self, account: &Account) -> Result<Arc<dyn NostrSigner>> {
         if let Some(session) = self.account_manager.get_session(&account.pubkey)
-            && let Some(signer) = session.signer.try_read().ok().and_then(|g| g.clone())
+            && let Some(signer) = session.get_signer()
         {
             tracing::debug!(
                 target: "whitenoise::signer",

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -46,6 +46,14 @@ impl Whitenoise {
         }
         self.insert_external_signer(pubkey, signer).await?;
 
+        // Update the session's signer slot so that operations going through
+        // AccountSession can use the newly registered signer.
+        if let Some(session) = self.account_manager.get_session(&pubkey)
+            && let Ok(signer_arc) = self.get_signer_for_account(&account)
+        {
+            session.set_signer(signer_arc).await;
+        }
+
         // On app restore, external accounts may exist before their signer is
         // re-registered. Startup subscription setup can fail in that gap.
         // Rebuild account subscriptions now that signing/decryption is available.

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -46,10 +46,8 @@ impl Whitenoise {
         }
         self.insert_external_signer(pubkey, signer).await?;
 
-        // Update the session's signer slot so that operations going through
-        // AccountSession can use the newly registered signer.
         if let Some(session) = self.account_manager.get_session(&pubkey)
-            && let Ok(signer_arc) = self.get_signer_for_account(&account)
+            && let Some(signer_arc) = self.get_external_signer(&pubkey)
         {
             session.set_signer(signer_arc).await;
         }

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -124,7 +124,18 @@ impl Whitenoise {
     ///
     /// Returns an error if no signer is available for the account.
     pub(crate) fn get_signer_for_account(&self, account: &Account) -> Result<Arc<dyn NostrSigner>> {
-        // First check for a registered external signer
+        if let Some(session) = self.account_manager.get_session(&account.pubkey)
+            && let Some(signer) = session.signer.try_read().ok().and_then(|g| g.clone())
+        {
+            tracing::debug!(
+                target: "whitenoise::signer",
+                "Using session signer for account {}",
+                account.pubkey.to_hex()
+            );
+            return Ok(signer);
+        }
+
+        // Pre-session login flow: signer arrives before the session exists.
         if let Some(external_signer) = self.get_external_signer(&account.pubkey) {
             tracing::debug!(
                 target: "whitenoise::signer",
@@ -134,7 +145,6 @@ impl Whitenoise {
             return Ok(external_signer);
         }
 
-        // Fall back to local keys from secrets store
         let keys = self
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)?;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/4257ded78267b670c4bcb3a7061eefc91ca0565f3c42c264753aebaf1ecf2122.jpg)

This PR adds AccountSession and AccountManager, the first step toward replacing the global singleton with per-account session objects.

## What changed

**New module: `src/whitenoise/session/mod.rs`**

Two new types that give each account its own MDK instance and signer slot:

- `AccountSession` holds a pubkey, `Arc<MDK>`, and `RwLock<Option<Arc<dyn NostrSigner>>>`. External-signer accounts start with `None` in the signer slot until the platform signer is re-registered.
- `AccountManager` tracks active sessions and pending logins via `DashMap`. The `pending_logins` state moved here from `Whitenoise`.

**Lifecycle hooks across 6 existing files:**

- `activate_account` and `activate_account_without_publishing` insert a session after setup completes
- `logout` removes the session before tearing down subscriptions
- `register_external_signer` fills the session signer slot so operations through `AccountSession` can sign
- `restore_sessions` runs at startup before subscription setup, creating sessions for all persisted accounts
- `Whitenoise::session(pubkey)` provides the public lookup

**Moved state:**

`pending_logins` moved from a standalone `DashMap` on `Whitenoise` to `AccountManager.pending_logins`. All references in `login_multistep.rs`, `login_external_signer.rs`, and test code updated.

## What didn't change

- `create_mdk_for_account()` remains as a compatibility fallback
- No external API changes
- Existing "active session" checks via `background_task_cancellation` are untouched (switching to the session map comes next)

## Marmot note

Every marmot in the colony gets their own burrow entrance now. No more sharing a single tunnel for MLS key material.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized per-account session management with automatic session restoration at startup

* **Improvements**
  * External signers now synchronize to active sessions for smoother signing
  * Multi-step login flow now tracks pending logins in centralized session store for more reliable completion
  * Background-task cancellation and concurrency controls tied to sessions for consistent behavior

* **Bug Fixes**
  * More reliable session cleanup during logout and startup/restores
<!-- end of auto-generated comment: release notes by coderabbit.ai -->