### PR TITLE
Rate-limit inbound MIP-05 token requests and removals

### DIFF
--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -201,14 +201,15 @@ impl Whitenoise {
             let _ = cancel_tx.send(true);
         }
 
-        // Evict rate-limiter entries for this account to prevent unbounded growth.
-        self.token_request_timestamps
-            .retain(|(account_pk, _, _, _), _| account_pk != pubkey);
-
         // Unsubscribe from account-specific subscriptions before logout
         self.relay_control
             .deactivate_account_subscriptions(pubkey)
             .await;
+
+        // Evict rate-limiter entries for this account to prevent unbounded growth.
+        // Runs after subscription teardown to minimise the repopulation window.
+        self.token_request_timestamps
+            .retain(|(account_pk, _, _, _), _| account_pk != pubkey);
 
         if !ephemeral_warm_relays.is_empty()
             && let Err(error) = self

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -890,6 +890,71 @@ mod tests {
         );
     }
 
+    /// Verifies that logging out evicts all rate-limiter entries for that account,
+    /// while preserving entries for other accounts.
+    #[tokio::test]
+    async fn test_logout_evicts_rate_limiter_entries() {
+        use crate::whitenoise::push_notifications::TokenRateKind;
+        use mdk_core::prelude::GroupId;
+
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let account_a = whitenoise.create_identity().await.unwrap();
+        let account_b = whitenoise.create_identity().await.unwrap();
+
+        let group_id = GroupId::from_slice(&[1u8; 32]);
+
+        // Seed entries for both accounts
+        whitenoise.token_request_timestamps.insert(
+            (
+                account_a.pubkey,
+                group_id.clone(),
+                0,
+                TokenRateKind::Request,
+            ),
+            std::time::Instant::now(),
+        );
+        whitenoise.token_request_timestamps.insert(
+            (
+                account_b.pubkey,
+                group_id.clone(),
+                0,
+                TokenRateKind::Request,
+            ),
+            std::time::Instant::now(),
+        );
+
+        assert_eq!(
+            whitenoise.token_request_timestamps.len(),
+            2,
+            "both entries should be present before logout"
+        );
+
+        whitenoise.logout(&account_a.pubkey).await.unwrap();
+
+        // account_a's entry must be gone
+        assert!(
+            !whitenoise.token_request_timestamps.contains_key(&(
+                account_a.pubkey,
+                group_id.clone(),
+                0,
+                TokenRateKind::Request
+            )),
+            "logout should remove rate-limiter entries for the logged-out account"
+        );
+
+        // account_b's entry must survive
+        assert!(
+            whitenoise.token_request_timestamps.contains_key(&(
+                account_b.pubkey,
+                group_id,
+                0,
+                TokenRateKind::Request
+            )),
+            "logout should not remove rate-limiter entries for other accounts"
+        );
+    }
+
     /// Test upload_profile_picture uploads to blossom server and returns URL.
     /// Requires blossom server running on localhost:3000.
     #[ignore]

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -201,6 +201,10 @@ impl Whitenoise {
             let _ = cancel_tx.send(true);
         }
 
+        // Evict rate-limiter entries for this account to prevent unbounded growth.
+        self.token_request_timestamps
+            .retain(|(account_pk, _, _, _), _| account_pk != pubkey);
+
         // Unsubscribe from account-specific subscriptions before logout
         self.relay_control
             .deactivate_account_subscriptions(pubkey)

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -187,8 +187,10 @@ pub struct Whitenoise {
     /// See [`push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS`] for the cap value.
     token_response_semaphore: Arc<Semaphore>,
     /// Per-sender rate limiter for inbound MIP-05 token requests and removals.
-    /// Maps `(account_pubkey, GroupId, sender_leaf_index)` → last accepted `Instant`.
-    token_request_timestamps: DashMap<(PublicKey, GroupId, u32), std::time::Instant>,
+    /// Maps `(account_pubkey, GroupId, sender_leaf_index, kind)` → last accepted
+    /// `Instant`.  Requests and removals have independent cooldown buckets.
+    token_request_timestamps:
+        DashMap<(PublicKey, GroupId, u32, push_notifications::TokenRateKind), std::time::Instant>,
 }
 
 static GLOBAL_WHITENOISE: OnceCell<Whitenoise> = OnceCell::const_new();

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -186,6 +186,9 @@ pub struct Whitenoise {
     /// Bounds the number of concurrently-active delayed MIP-05 token-list response tasks.
     /// See [`push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS`] for the cap value.
     token_response_semaphore: Arc<Semaphore>,
+    /// Per-sender rate limiter for inbound MIP-05 token requests and removals.
+    /// Maps `(account_pubkey, GroupId, sender_leaf_index)` → last accepted `Instant`.
+    token_request_timestamps: DashMap<(PublicKey, GroupId, u32), std::time::Instant>,
 }
 
 static GLOBAL_WHITENOISE: OnceCell<Whitenoise> = OnceCell::const_new();
@@ -224,6 +227,7 @@ impl std::fmt::Debug for Whitenoise {
             .field("scheduler_handles", &"<REDACTED>")
             .field("pending_push_token_responses", &"<REDACTED>")
             .field("token_response_semaphore", &"<REDACTED>")
+            .field("token_request_timestamps", &"<REDACTED>")
             .finish()
     }
 }
@@ -273,6 +277,7 @@ impl Whitenoise {
             token_response_semaphore: Arc::new(Semaphore::new(
                 push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,
             )),
+            token_request_timestamps: DashMap::new(),
         }
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -37,11 +37,18 @@ use crate::{
     relay_control::{RelayControlPlane, ephemeral::EphemeralPlane},
 };
 
-/// Minimum interval between accepted MIP-05 token requests from the same
-/// `(group_id, sender_leaf_index)` pair.  Requests that arrive before the
-/// cooldown expires are silently dropped.  Normal usage is ≤5 requests per
-/// hour, so 30 seconds is generous while blocking sustained spam.
+/// Minimum interval between accepted MIP-05 token messages of the same kind
+/// from the same `(account, group_id, sender_leaf_index)` tuple.  Messages
+/// that arrive before the cooldown expires are silently dropped.  Normal usage
+/// is ≤5 requests per hour, so 30 seconds is generous while blocking spam.
 const TOKEN_REQUEST_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Discriminator so token requests and removals have independent cooldowns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum TokenRateKind {
+    Request,
+    Removal,
+}
 
 /// Maximum number of groups to publish push token events to concurrently.
 /// Caps relay connection pressure while still parallelising the bulk of the
@@ -767,6 +774,7 @@ impl Whitenoise {
                     &account.pubkey,
                     &message.mls_group_id,
                     leaf_index,
+                    TokenRateKind::Request,
                 ) {
                     tracing::debug!(
                         target: "whitenoise::push_notifications",
@@ -815,6 +823,7 @@ impl Whitenoise {
                     &account.pubkey,
                     &message.mls_group_id,
                     leaf_index,
+                    TokenRateKind::Removal,
                 ) {
                     tracing::debug!(
                         target: "whitenoise::push_notifications",
@@ -888,17 +897,19 @@ impl Whitenoise {
         ))
     }
 
-    /// Returns `true` if the MIP-05 message from `(account, group_id, leaf_index)`
-    /// is allowed, i.e. no request from that sender has been accepted within the
-    /// [`TOKEN_REQUEST_COOLDOWN`] window. On acceptance the timestamp is updated
-    /// via the `entry()` API to hold the shard lock for the full check-and-update.
+    /// Returns `true` if the MIP-05 message from `(account, group_id, leaf_index, kind)`
+    /// is allowed, i.e. no message of the same kind from that sender has been accepted
+    /// within the [`TOKEN_REQUEST_COOLDOWN`] window. On acceptance the timestamp is
+    /// updated via the `entry()` API to hold the shard lock for the full
+    /// check-and-update.
     fn check_token_request_rate(
         &self,
         account_pubkey: &PublicKey,
         group_id: &GroupId,
         leaf_index: u32,
+        kind: TokenRateKind,
     ) -> bool {
-        let key = (*account_pubkey, group_id.clone(), leaf_index);
+        let key = (*account_pubkey, group_id.clone(), leaf_index, kind);
         let now = Instant::now();
 
         match self.token_request_timestamps.entry(key) {
@@ -3343,7 +3354,7 @@ mod tests {
         let group_id = GroupId::from_slice(&[42; 32]);
 
         assert!(
-            whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request),
             "first request from a sender must be allowed"
         );
     }
@@ -3354,9 +3365,9 @@ mod tests {
         let acct = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[42; 32]);
 
-        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,));
         assert!(
-            !whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            !whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,),
             "immediate second request from the same sender must be rejected"
         );
     }
@@ -3367,9 +3378,9 @@ mod tests {
         let acct = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[42; 32]);
 
-        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,));
         assert!(
-            whitenoise.check_token_request_rate(&acct, &group_id, 1),
+            whitenoise.check_token_request_rate(&acct, &group_id, 1, TokenRateKind::Request,),
             "request from a different leaf index must be allowed"
         );
     }
@@ -3381,9 +3392,9 @@ mod tests {
         let group_a = GroupId::from_slice(&[42; 32]);
         let group_b = GroupId::from_slice(&[43; 32]);
 
-        assert!(whitenoise.check_token_request_rate(&acct, &group_a, 0));
+        assert!(whitenoise.check_token_request_rate(&acct, &group_a, 0, TokenRateKind::Request,));
         assert!(
-            whitenoise.check_token_request_rate(&acct, &group_b, 0),
+            whitenoise.check_token_request_rate(&acct, &group_b, 0, TokenRateKind::Request,),
             "same leaf index in a different group must be allowed"
         );
     }
@@ -3395,10 +3406,25 @@ mod tests {
         let acct_b = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[42; 32]);
 
-        assert!(whitenoise.check_token_request_rate(&acct_a, &group_id, 0));
         assert!(
-            whitenoise.check_token_request_rate(&acct_b, &group_id, 0),
+            whitenoise.check_token_request_rate(&acct_a, &group_id, 0, TokenRateKind::Request,)
+        );
+        assert!(
+            whitenoise.check_token_request_rate(&acct_b, &group_id, 0, TokenRateKind::Request,),
             "same group+leaf from a different account must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_request_does_not_suppress_removal() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,));
+        assert!(
+            whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Removal,),
+            "a request must not suppress a removal from the same sender"
         );
     }
 
@@ -3500,17 +3526,17 @@ mod tests {
         let acct = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[42; 32]);
 
-        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,));
 
         // Backdate the stored timestamp beyond the cooldown window.
-        let key = (acct, group_id.clone(), 0u32);
+        let key = (acct, group_id.clone(), 0u32, TokenRateKind::Request);
         let backdated = Instant::now()
             .checked_sub(TOKEN_REQUEST_COOLDOWN + Duration::from_millis(1))
             .expect("system uptime must exceed cooldown window");
         whitenoise.token_request_timestamps.insert(key, backdated);
 
         assert!(
-            whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            whitenoise.check_token_request_rate(&acct, &group_id, 0, TokenRateKind::Request,),
             "request after cooldown has elapsed must be allowed"
         );
     }

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeMap, HashSet},
     str::FromStr,
@@ -36,6 +36,12 @@ use crate::{
     perf_instrument,
     relay_control::{RelayControlPlane, ephemeral::EphemeralPlane},
 };
+
+/// Minimum interval between accepted MIP-05 token requests from the same
+/// `(group_id, sender_leaf_index)` pair.  Requests that arrive before the
+/// cooldown expires are silently dropped.  Normal usage is ≤5 requests per
+/// hour, so 30 seconds is generous while blocking sustained spam.
+const TOKEN_REQUEST_COOLDOWN: Duration = Duration::from_secs(30);
 
 /// Maximum number of groups to publish push token events to concurrently.
 /// Caps relay connection pressure while still parallelising the bulk of the
@@ -757,6 +763,20 @@ impl Whitenoise {
                     )
                 })?;
 
+                if !self.check_token_request_rate(
+                    &account.pubkey,
+                    &message.mls_group_id,
+                    leaf_index,
+                ) {
+                    tracing::debug!(
+                        target: "whitenoise::push_notifications",
+                        group_id = %hex::encode(message.mls_group_id.as_slice()),
+                        leaf_index,
+                        "Dropping rate-limited MIP-05 token request"
+                    );
+                    return Ok(true);
+                }
+
                 self.merge_token_request(
                     account,
                     &message.mls_group_id,
@@ -790,6 +810,20 @@ impl Whitenoise {
                         "MIP-05 token removal missing sender leaf index".to_string(),
                     )
                 })?;
+
+                if !self.check_token_request_rate(
+                    &account.pubkey,
+                    &message.mls_group_id,
+                    leaf_index,
+                ) {
+                    tracing::debug!(
+                        target: "whitenoise::push_notifications",
+                        group_id = %hex::encode(message.mls_group_id.as_slice()),
+                        leaf_index,
+                        "Dropping rate-limited MIP-05 token removal"
+                    );
+                    return Ok(true);
+                }
 
                 GroupPushToken::delete(
                     &account.pubkey,
@@ -852,6 +886,35 @@ impl Whitenoise {
             group_id.clone(),
             *request_event_id,
         ))
+    }
+
+    /// Returns `true` if the MIP-05 message from `(account, group_id, leaf_index)`
+    /// is allowed, i.e. no request from that sender has been accepted within the
+    /// [`TOKEN_REQUEST_COOLDOWN`] window. On acceptance the timestamp is updated
+    /// via the `entry()` API to hold the shard lock for the full check-and-update.
+    fn check_token_request_rate(
+        &self,
+        account_pubkey: &PublicKey,
+        group_id: &GroupId,
+        leaf_index: u32,
+    ) -> bool {
+        let key = (*account_pubkey, group_id.clone(), leaf_index);
+        let now = Instant::now();
+
+        match self.token_request_timestamps.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if now.duration_since(*entry.get()) < TOKEN_REQUEST_COOLDOWN {
+                    false
+                } else {
+                    entry.insert(now);
+                    true
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(now);
+                true
+            }
+        }
     }
 
     pub(crate) fn clear_pending_token_response(
@@ -1469,8 +1532,9 @@ impl PushRegistration {
 mod tests {
     use std::{collections::BTreeMap, time::Duration};
 
-    use mdk_core::mip05::parse_notification_request_rumor;
+    use mdk_core::mip05::{EncryptedToken, TokenTag, parse_notification_request_rumor};
     use mdk_core::prelude::NostrGroupDataUpdate;
+    use mdk_core::prelude::message_types::MessageState;
     use nostr_sdk::{Filter, Keys, Kind, RelayUrl, Tag, nips::nip59};
 
     use super::*;
@@ -3269,6 +3333,185 @@ mod tests {
                 .iter()
                 .any(|token| token.member_pubkey == member_account.pubkey),
             "declining a group should remove any cached push token"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_first_request() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(
+            whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            "first request from a sender must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_blocks_rapid_duplicate() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+        assert!(
+            !whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            "immediate second request from the same sender must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_different_senders() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+        assert!(
+            whitenoise.check_token_request_rate(&acct, &group_id, 1),
+            "request from a different leaf index must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_different_groups() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_a = GroupId::from_slice(&[42; 32]);
+        let group_b = GroupId::from_slice(&[43; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct, &group_a, 0));
+        assert!(
+            whitenoise.check_token_request_rate(&acct, &group_b, 0),
+            "same leaf index in a different group must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_different_accounts() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct_a = Keys::generate().public_key();
+        let acct_b = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct_a, &group_id, 0));
+        assert!(
+            whitenoise.check_token_request_rate(&acct_b, &group_id, 0),
+            "same group+leaf from a different account must be allowed"
+        );
+    }
+
+    /// Builds a minimal valid `TokenRequest` [`Message`] for use in push
+    /// notification handler tests. The `UnsignedEvent` inside carries a
+    /// properly-formatted `token` tag so that `parse_group_message` succeeds.
+    fn make_token_request_message(
+        sender: &Keys,
+        group_id: GroupId,
+    ) -> mdk_core::prelude::message_types::Message {
+        let token_tag = TokenTag {
+            encrypted_token: EncryptedToken::from_slice(&[0u8; 1084]).unwrap(),
+            server_pubkey: Keys::generate().public_key(),
+            relay_hint: RelayUrl::parse("wss://push.example.com").unwrap(),
+        };
+        let rumor = build_token_request_rumor(
+            sender.public_key(),
+            nostr_sdk::Timestamp::now(),
+            vec![token_tag],
+        )
+        .unwrap();
+
+        mdk_core::prelude::message_types::Message {
+            id: rumor.id.unwrap_or(nostr_sdk::EventId::all_zeros()),
+            pubkey: sender.public_key(),
+            kind: rumor.kind,
+            mls_group_id: group_id,
+            created_at: rumor.created_at,
+            processed_at: nostr_sdk::Timestamp::now(),
+            content: rumor.content.clone(),
+            tags: rumor.tags.clone(),
+            event: rumor,
+            wrapper_event_id: nostr_sdk::EventId::all_zeros(),
+            epoch: None,
+            state: MessageState::Processed,
+        }
+    }
+
+    /// Verifies the rate check is wired into the message handler, not just
+    /// that `check_token_request_rate` works in isolation.
+    ///
+    /// Two distinct `TokenRequest` messages from the same `(group, leaf_index)`
+    /// arrive back-to-back. Only the first should schedule a pending response;
+    /// the second must be silently dropped by the rate limiter.
+    #[tokio::test]
+    async fn test_rate_limiter_wires_into_message_handler() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let mdk = whitenoise.create_mdk_for_account(account.pubkey).unwrap();
+
+        let sender = Keys::generate();
+        let group_id = GroupId::from_slice(&[77; 32]);
+        let leaf_index: u32 = 3;
+
+        // Two different messages from the same sender+group+leaf.
+        let msg1 = make_token_request_message(&sender, group_id.clone());
+        let msg2 = make_token_request_message(&sender, group_id.clone());
+        let event_id_1 = msg1.event.id;
+        let event_id_2 = msg2.event.id;
+
+        // First call — must be accepted.
+        let handled1 = whitenoise
+            .handle_received_push_group_message(&mdk, &account, &msg1, Some(leaf_index))
+            .await
+            .unwrap();
+        assert!(handled1, "first token request must be handled");
+
+        // Second call — must be rate-limited (same group+leaf within cooldown).
+        let handled2 = whitenoise
+            .handle_received_push_group_message(&mdk, &account, &msg2, Some(leaf_index))
+            .await
+            .unwrap();
+        assert!(
+            handled2,
+            "rate-limited request still returns true (it is a push message)"
+        );
+
+        // The first request must have scheduled a pending response.
+        if let Some(eid) = event_id_1 {
+            assert!(
+                whitenoise.has_pending_token_response(&account.pubkey, &group_id, &eid),
+                "first request must have a pending response scheduled"
+            );
+        }
+
+        // The second request must NOT have scheduled a pending response — it
+        // was dropped before `schedule_pending_token_response` was reached.
+        if let Some(eid) = event_id_2 {
+            assert!(
+                !whitenoise.has_pending_token_response(&account.pubkey, &group_id, &eid),
+                "rate-limited request must not schedule a pending response"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_after_cooldown() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let acct = Keys::generate().public_key();
+        let group_id = GroupId::from_slice(&[42; 32]);
+
+        assert!(whitenoise.check_token_request_rate(&acct, &group_id, 0));
+
+        // Backdate the stored timestamp beyond the cooldown window.
+        let key = (acct, group_id.clone(), 0u32);
+        let backdated = Instant::now()
+            .checked_sub(TOKEN_REQUEST_COOLDOWN + Duration::from_millis(1))
+            .expect("system uptime must exceed cooldown window");
+        whitenoise.token_request_timestamps.insert(key, backdated);
+
+        assert!(
+            whitenoise.check_token_request_rate(&acct, &group_id, 0),
+            "request after cooldown has elapsed must be allowed"
         );
     }
 }

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -911,21 +911,22 @@ impl Whitenoise {
     ) -> bool {
         let key = (*account_pubkey, group_id.clone(), leaf_index, kind);
         let now = Instant::now();
+        let mut allowed = false;
 
-        match self.token_request_timestamps.entry(key) {
-            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
-                if now.duration_since(*entry.get()) < TOKEN_REQUEST_COOLDOWN {
-                    false
-                } else {
-                    entry.insert(now);
-                    true
+        self.token_request_timestamps
+            .entry(key)
+            .and_modify(|last| {
+                if now.duration_since(*last) >= TOKEN_REQUEST_COOLDOWN {
+                    *last = now;
+                    allowed = true;
                 }
-            }
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                entry.insert(now);
-                true
-            }
-        }
+            })
+            .or_insert_with(|| {
+                allowed = true;
+                now
+            });
+
+        allowed
     }
 
     pub(crate) fn clear_pending_token_response(


### PR DESCRIPTION
## Summary

Closes #704

- Adds a per-sender rate limiter (`DashMap<(PublicKey, GroupId, u32), Instant>`) that drops duplicate MIP-05 token requests and removals arriving within a 30-second cooldown window
- Uses DashMap's `entry()` API for atomic check-and-update under a single shard lock
- Gates both `TokenRequest` and `TokenRemoval` message types — prevents DB spam from either vector
- Key includes `account_pubkey` so multi-account devices don't bleed rate limits across accounts

## Test plan

- [x] `test_rate_limiter_allows_first_request` — first request passes
- [x] `test_rate_limiter_blocks_rapid_duplicate` — immediate repeat blocked
- [x] `test_rate_limiter_allows_different_senders` — different leaf index unaffected
- [x] `test_rate_limiter_allows_different_groups` — different group unaffected
- [x] `test_rate_limiter_allows_different_accounts` — different account unaffected
- [x] `test_rate_limiter_allows_after_cooldown` — request after 30s allowed
- [x] `test_rate_limiter_wires_into_message_handler` — end-to-end handler integration
- [x] `just check-fmt` passes
- [x] `just check-clippy` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-account/group rate limiting for token requests and removals with a 30‑second cooldown; requests and removals use separate cooldown buckets to avoid cross-suppression and duplicate handling.

* **Bug Fixes / Cleanup**
  * Cleared token-rate entries for an account on logout to prevent stale cooldown state.

* **Tests**
  * Added tests for allowance, rapid-duplicate rejection, parameter isolation, prevention of duplicate responses, and cooldown expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->