### PR TITLE
Add background notification collection API for iOS silent push

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -176,13 +176,16 @@ fn result_to_json(result: BackgroundNotificationResult) -> String {
 /// or CString construction fails for any reason, the static fallback JSON is
 /// used instead.
 fn string_to_raw(json: String) -> *mut c_char {
-    // CString::new rejects interior NULs. First try the happy path.
-    if let Ok(cstr) = CString::new(json.clone()) {
-        return cstr.into_raw();
-    }
+    // CString::new rejects interior NULs. First try the happy path. On failure
+    // it hands back the original bytes via NulError::into_vec(), so we can
+    // recover ownership without needing to clone up front.
+    let bytes = match CString::new(json) {
+        Ok(cstr) => return cstr.into_raw(),
+        Err(nul_err) => nul_err.into_vec(),
+    };
 
     // Interior NUL present. Strip NUL bytes and retry.
-    let sanitized: String = json.chars().filter(|c| *c != '\0').collect();
+    let sanitized: Vec<u8> = bytes.into_iter().filter(|b| *b != 0).collect();
     if let Ok(cstr) = CString::new(sanitized) {
         return cstr.into_raw();
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -87,7 +87,16 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
         );
         let max_wait = Duration::from_millis(u64::from(max_wait_ms));
 
-        let rt = match tokio::runtime::Runtime::new() {
+        // Use a current-thread runtime: this FFI call is a bounded, single
+        // async operation driven to completion via block_on. A multi-threaded
+        // runtime would spawn worker threads we don't need for a background
+        // iOS push handler. `enable_all()` keeps net + time + the blocking
+        // worker pool available for SQLite and any spawn_blocking callers
+        // down the call stack.
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
             Ok(rt) => rt,
             Err(e) => {
                 return result_to_json(BackgroundNotificationResult::failed(format!(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,19 +1,51 @@
 //! C ABI entrypoints for native iOS background push handling.
 //!
-//! These functions are callable from Swift via the static library without
-//! requiring Flutter or FRB. The interface is intentionally minimal: pass in
-//! directory paths and a timeout, get back a JSON string.
+//! Callable from Swift via the static library without requiring Flutter or FRB.
+//!
+//! # Design — why callback + length-prefixed bytes
+//!
+//! The FFI surface is designed for safety across the Rust/Swift boundary:
+//!
+//! * **Length-prefixed byte slices on input.** All string inputs are passed as
+//!   `(ptr, len)` pairs rather than NUL-terminated C strings. This avoids
+//!   unbounded scanning into foreign memory and keeps inputs binary-safe.
+//!
+//! * **Callback for output.** JSON results are delivered via a callback
+//!   invoked while Rust still owns the bytes. The caller can read (and copy)
+//!   during the callback; after the callback returns, the buffer is freed
+//!   deterministically by Rust. There is no `into_raw` / `from_raw` ownership
+//!   handoff across the boundary, so use-after-free and double-free are
+//!   structurally impossible.
 //!
 //! # Contract guarantees
 //!
-//! * [`wn_collect_notifications_after_push`] **never returns NULL** under any
-//!   circumstances — callers can unconditionally treat the result as a valid,
-//!   NUL-terminated UTF-8 C string.
-//! * It **never panics across the FFI boundary** — all internal panics are
-//!   caught and converted to a failure JSON response.
-//! * It **always returns valid JSON** conforming to the documented shape.
+//! * [`wn_collect_notifications_after_push`] **never panics across the FFI
+//!   boundary on outbound Rust→Swift unwinds** — all internal panics are
+//!   caught and surfaced as a failure JSON callback invocation.
+//! * It **always invokes the callback exactly once** before returning,
+//!   regardless of init/runtime/serialization failures.
+//! * The JSON payload delivered to the callback **always** conforms to:
+//!   ```json
+//!   {
+//!     "status": "new_data" | "no_data" | "failed",
+//!     "notifications": [ ... ],
+//!     "error": "..."   // only present when status is "failed"
+//!   }
+//!   ```
+//!
+//! # Caller responsibilities
+//!
+//! The caller must ensure the supplied [`WnJsonCallback`] does not panic or
+//! unwind. Panicking across an `extern "C"` boundary is undefined behavior in
+//! Rust and in practice will abort the process. On Darwin, Swift runtime
+//! traps (`fatalError`, force-unwrap nil, index-out-of-range) terminate via
+//! `abort()` rather than a structured unwind, so they cannot damage Rust's
+//! state, but they will kill the process immediately. Write callbacks that
+//! only copy bytes and return — do no work that could trap.
 
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::c_void;
+use std::panic::AssertUnwindSafe;
+use std::slice;
 use std::time::Duration;
 
 use crate::whitenoise::WhitenoiseConfig;
@@ -21,64 +53,93 @@ use crate::whitenoise::background_notifications::{
     BackgroundNotificationResult, collect_notifications_after_push,
 };
 
-/// Static fallback JSON used when dynamic string construction fails.
-/// This string is guaranteed to:
-/// * be valid JSON conforming to the documented shape,
-/// * contain no interior NUL bytes,
-/// * be convertible to a `CString` without allocation failure.
+/// Static fallback JSON used when dynamic serialization fails.
+/// Guaranteed to be valid JSON conforming to the documented shape.
 const FALLBACK_FAILURE_JSON: &str =
     r#"{"status":"failed","notifications":[],"error":"internal error: failed to build response"}"#;
+
+/// Callback invoked with a JSON payload.
+///
+/// # Parameters
+///
+/// * `json_ptr` — Pointer to a UTF-8 byte buffer. Not NUL-terminated.
+///   **Valid only for the duration of the callback invocation.** Must not
+///   be retained past the callback's return.
+/// * `json_len` — Length of the buffer in bytes.
+/// * `user_data` — Opaque context pointer passed through from the caller.
+///
+/// Callers must copy any data they wish to retain before returning.
+pub type WnJsonCallback =
+    extern "C" fn(json_ptr: *const u8, json_len: usize, user_data: *mut c_void);
 
 /// Collect notification updates after an iOS silent push wake.
 ///
 /// Initializes Whitenoise if needed, refreshes relay subscriptions, and
 /// collects any notification updates that arrive within the time window.
+/// The resulting JSON is delivered to `callback` exactly once before this
+/// function returns.
 ///
-/// Returns a JSON string that the caller must free with [`wn_string_free`].
-/// **This function never returns NULL** — every code path produces a valid
-/// JSON response. The JSON shape is:
+/// # Parameters
 ///
-/// ```json
-/// {
-///   "status": "new_data" | "no_data" | "failed",
-///   "notifications": [ ... ],
-///   "error": "..." // only present when status is "failed"
-/// }
-/// ```
+/// * `data_dir_ptr`, `data_dir_len` — UTF-8 bytes for the app data directory.
+/// * `logs_dir_ptr`, `logs_dir_len` — UTF-8 bytes for the logs directory.
+/// * `keyring_service_id_ptr`, `keyring_service_id_len` — UTF-8 bytes for the
+///   keyring service identifier.
+/// * `max_wait_ms` — Hard deadline for collection in milliseconds.
+/// * `callback` — Function invoked with the JSON result. See
+///   [`WnJsonCallback`] for lifetime rules.
+/// * `user_data` — Opaque context passed through to `callback`. Not
+///   interpreted by Rust.
 ///
 /// # Safety
 ///
-/// * `data_dir`, `logs_dir`, and `keyring_service_id` should be valid
-///   NUL-terminated UTF-8 C strings. Null pointers and invalid UTF-8 are
-///   handled gracefully by returning a failure JSON response.
-/// * The returned pointer must be freed with [`wn_string_free`].
+/// * `data_dir_ptr`, `logs_dir_ptr`, and `keyring_service_id_ptr` must each
+///   either be null or point to a valid readable buffer of at least the
+///   corresponding `*_len` bytes. Null pointers with non-zero length are
+///   treated as an error (reported via the callback).
+/// * `callback` must be a valid function pointer safe to call with
+///   `extern "C"` calling convention.
+/// * `user_data` is treated as opaque; Rust neither reads nor writes through
+///   it. It is the caller's responsibility to ensure any pointer-derived
+///   `user_data` remains valid for the duration of this call.
+/// * The buffer passed to `callback` is only valid until the callback
+///   returns. Callers must copy any bytes they wish to retain.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wn_collect_notifications_after_push(
-    data_dir: *const c_char,
-    logs_dir: *const c_char,
-    keyring_service_id: *const c_char,
+    data_dir_ptr: *const u8,
+    data_dir_len: usize,
+    logs_dir_ptr: *const u8,
+    logs_dir_len: usize,
+    keyring_service_id_ptr: *const u8,
+    keyring_service_id_len: usize,
     max_wait_ms: u32,
-) -> *mut c_char {
-    // Run the entire body under catch_unwind so no panic can ever cross the
-    // FFI boundary. The closure produces a `String` which we then turn into
-    // a CString with fallbacks.
-    let json = std::panic::catch_unwind(|| {
-        // SAFETY: these reads are inside catch_unwind. Null pointers are
-        // checked explicitly before CStr::from_ptr; invalid UTF-8 is handled
-        // via to_str() without panicking.
-        let data_dir = match unsafe { c_str_to_string(data_dir, "data_dir") } {
+    callback: WnJsonCallback,
+    user_data: *mut c_void,
+) {
+    // Run the body under catch_unwind so that no internal Rust panic can
+    // cross the FFI boundary as an unwind. The closure produces a JSON
+    // String which is then delivered to the callback below.
+    let json = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        // Validate and decode each input. Any failure produces a failure
+        // JSON payload without proceeding.
+        let data_dir = match unsafe { slice_to_string(data_dir_ptr, data_dir_len, "data_dir") } {
             Ok(s) => s,
             Err(json) => return json,
         };
-        let logs_dir = match unsafe { c_str_to_string(logs_dir, "logs_dir") } {
+        let logs_dir = match unsafe { slice_to_string(logs_dir_ptr, logs_dir_len, "logs_dir") } {
             Ok(s) => s,
             Err(json) => return json,
         };
-        let keyring_service_id =
-            match unsafe { c_str_to_string(keyring_service_id, "keyring_service_id") } {
-                Ok(s) => s,
-                Err(json) => return json,
-            };
+        let keyring_service_id = match unsafe {
+            slice_to_string(
+                keyring_service_id_ptr,
+                keyring_service_id_len,
+                "keyring_service_id",
+            )
+        } {
+            Ok(s) => s,
+            Err(json) => return json,
+        };
 
         let config = WhitenoiseConfig::new(
             std::path::Path::new(&data_dir),
@@ -107,49 +168,47 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
 
         let result = rt.block_on(collect_notifications_after_push(config, max_wait));
         result_to_json(result)
-    })
+    }))
     .unwrap_or_else(|_| {
-        // Panic escaped. Log is not useful here (tracing may be down). Fall
-        // back to a static failure JSON that cannot fail further operations.
+        // Internal panic escaped. Fall back to a static failure JSON; the
+        // callback is still invoked exactly once below.
         r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#
             .to_string()
     });
 
-    // Convert to CString. If there's an interior NUL (shouldn't happen with
-    // our shapes, but defensively), sanitize by stripping NUL bytes. If even
-    // that fails, fall back to the static JSON.
-    string_to_raw(json)
+    // Invoke the callback with the JSON bytes. The buffer lives on Rust's
+    // stack frame for the duration of this call and is dropped when this
+    // function returns, so the pointer is valid exactly for the callback's
+    // execution. Per the module-level docs, the callback must not panic or
+    // trap — doing so is UB across `extern "C"` and will abort the process.
+    let bytes = json.as_bytes();
+    callback(bytes.as_ptr(), bytes.len(), user_data);
 }
 
-/// Free a string previously returned by [`wn_collect_notifications_after_push`].
+/// Convert a `(ptr, len)` byte slice into an owned `String`, returning a
+/// failure JSON payload on null-with-length, invalid UTF-8, or other
+/// unrecoverable condition.
+///
+/// A null pointer with `len == 0` is treated as an empty string — this is
+/// what Swift's `UnsafePointer` APIs produce for empty strings and is less
+/// brittle than rejecting it outright.
 ///
 /// # Safety
 ///
-/// * `ptr` must have been returned by a `wn_*` function that allocates via `CString`.
-/// * Must not be called more than once for the same pointer.
-/// * Passing a null pointer is a safe no-op.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn wn_string_free(ptr: *mut c_char) {
-    if !ptr.is_null() {
-        drop(unsafe { CString::from_raw(ptr) });
-    }
-}
-
-/// Convert a C string pointer into an owned `String`, returning a failure
-/// JSON payload on null or invalid UTF-8.
-///
-/// # Safety
-///
-/// Caller must ensure `ptr` is either null or a valid NUL-terminated C string.
-unsafe fn c_str_to_string(ptr: *const c_char, field: &str) -> Result<String, String> {
+/// Caller must ensure that if `ptr` is non-null, it points to a valid readable
+/// buffer of at least `len` bytes.
+unsafe fn slice_to_string(ptr: *const u8, len: usize, field: &str) -> Result<String, String> {
     if ptr.is_null() {
+        if len == 0 {
+            return Ok(String::new());
+        }
         return Err(result_to_json(BackgroundNotificationResult::failed(
-            format!("null pointer for `{field}`"),
+            format!("null pointer for `{field}` with non-zero length"),
         )));
     }
-    // SAFETY: ptr is non-null; caller guarantees NUL termination.
-    let cstr = unsafe { CStr::from_ptr(ptr) };
-    match cstr.to_str() {
+    // SAFETY: ptr is non-null; caller guarantees `len` bytes are valid.
+    let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+    match std::str::from_utf8(bytes) {
         Ok(s) => Ok(s.to_string()),
         Err(e) => Err(result_to_json(BackgroundNotificationResult::failed(
             format!("`{field}` is not valid UTF-8: {e}"),
@@ -170,132 +229,217 @@ fn result_to_json(result: BackgroundNotificationResult) -> String {
     })
 }
 
-/// Convert an owned `String` of JSON into a leaked C string pointer.
-///
-/// Guaranteed to never return NULL: if the input contains interior NUL bytes
-/// or CString construction fails for any reason, the static fallback JSON is
-/// used instead.
-fn string_to_raw(json: String) -> *mut c_char {
-    // CString::new rejects interior NULs. First try the happy path. On failure
-    // it hands back the original bytes via NulError::into_vec(), so we can
-    // recover ownership without needing to clone up front.
-    let bytes = match CString::new(json) {
-        Ok(cstr) => return cstr.into_raw(),
-        Err(nul_err) => nul_err.into_vec(),
-    };
-
-    // Interior NUL present. Strip NUL bytes and retry.
-    let sanitized: Vec<u8> = bytes.into_iter().filter(|b| *b != 0).collect();
-    if let Ok(cstr) = CString::new(sanitized) {
-        return cstr.into_raw();
-    }
-
-    // Last-resort static fallback. This is statically known to not contain
-    // NUL bytes, so CString::new cannot fail — but we still guard with
-    // unwrap_or_else to absolutely guarantee no NULL return.
-    CString::new(FALLBACK_FAILURE_JSON)
-        .unwrap_or_else(|_| {
-            // This branch is unreachable given FALLBACK_FAILURE_JSON is a
-            // static ASCII string with no NULs, but we cannot use
-            // `unreachable!()` (which panics) because this whole file's
-            // contract is "never panic across FFI". Fall back to the empty
-            // (but valid) JSON object as an absolute last resort.
-            CString::new("{}").expect("{} has no NUL")
-        })
-        .into_raw()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::CString;
+    use std::sync::Mutex;
 
-    /// Helper: convert the raw pointer returned by FFI back into an owned
-    /// String and free the pointer.
-    unsafe fn consume(ptr: *mut c_char) -> String {
-        assert!(
-            !ptr.is_null(),
-            "FFI returned NULL — never-NULL contract violated"
-        );
-        let s = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        unsafe { wn_string_free(ptr) };
-        s
+    /// Thread-safe collector for callback payloads.
+    ///
+    /// Swift passes its own context pointer; tests use this to capture the
+    /// bytes delivered to the callback.
+    #[derive(Default)]
+    struct Capture {
+        payloads: Mutex<Vec<Vec<u8>>>,
+    }
+
+    impl Capture {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn take_only(&self) -> Vec<u8> {
+            let mut payloads = self.payloads.lock().unwrap();
+            assert_eq!(
+                payloads.len(),
+                1,
+                "callback must be invoked exactly once; got {} invocations",
+                payloads.len()
+            );
+            payloads.pop().unwrap()
+        }
+
+        fn invocation_count(&self) -> usize {
+            self.payloads.lock().unwrap().len()
+        }
+    }
+
+    extern "C" fn capture_callback(ptr: *const u8, len: usize, user_data: *mut c_void) {
+        // SAFETY: tests pass a `&Capture` as user_data.
+        let capture = unsafe { &*(user_data as *const Capture) };
+        let bytes = if ptr.is_null() || len == 0 {
+            Vec::new()
+        } else {
+            // SAFETY: the FFI function guarantees `ptr`/`len` validity for the
+            // duration of this callback.
+            let slice = unsafe { slice::from_raw_parts(ptr, len) };
+            slice.to_vec()
+        };
+        capture.payloads.lock().unwrap().push(bytes);
+    }
+
+    /// Helper: call the FFI with valid inputs for the null-checks, returning
+    /// the captured JSON payload as a parsed Value. The argument list mirrors
+    /// the FFI's own (ptr, len) pairs plus null-override booleans per input,
+    /// so the count is inherent rather than incidental.
+    #[allow(clippy::too_many_arguments)]
+    fn call_ffi(
+        data_dir: &str,
+        data_dir_len: usize,
+        data_dir_ptr_null: bool,
+        logs_dir: &str,
+        logs_dir_len: usize,
+        logs_dir_ptr_null: bool,
+        svc: &str,
+        svc_len: usize,
+        svc_ptr_null: bool,
+    ) -> serde_json::Value {
+        let capture = Capture::new();
+        let user_data = &capture as *const Capture as *mut c_void;
+
+        let data_ptr = if data_dir_ptr_null {
+            std::ptr::null()
+        } else {
+            data_dir.as_ptr()
+        };
+        let logs_ptr = if logs_dir_ptr_null {
+            std::ptr::null()
+        } else {
+            logs_dir.as_ptr()
+        };
+        let svc_ptr = if svc_ptr_null {
+            std::ptr::null()
+        } else {
+            svc.as_ptr()
+        };
+
+        unsafe {
+            wn_collect_notifications_after_push(
+                data_ptr,
+                data_dir_len,
+                logs_ptr,
+                logs_dir_len,
+                svc_ptr,
+                svc_len,
+                1000,
+                capture_callback,
+                user_data,
+            );
+        }
+
+        let bytes = capture.take_only();
+        let s = std::str::from_utf8(&bytes).expect("callback payload must be valid UTF-8");
+        serde_json::from_str(s).expect("callback payload must be valid JSON")
     }
 
     #[test]
-    fn null_data_dir_returns_failure_not_null() {
-        let logs = CString::new("/tmp/logs").unwrap();
-        let svc = CString::new("test.svc").unwrap();
-
-        let ptr = unsafe {
-            wn_collect_notifications_after_push(std::ptr::null(), logs.as_ptr(), svc.as_ptr(), 1000)
-        };
-
-        let json = unsafe { consume(ptr) };
-        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    fn null_data_dir_ptr_with_len_reports_failure_via_callback() {
+        let logs = "/tmp/logs";
+        let svc = "test.svc";
+        let v = call_ffi(
+            "",
+            10, // non-zero len with null ptr
+            true,
+            logs,
+            logs.len(),
+            false,
+            svc,
+            svc.len(),
+            false,
+        );
         assert_eq!(v["status"], "failed");
         assert!(
             v["error"].as_str().unwrap().contains("data_dir"),
-            "error mentions data_dir, got: {json}"
+            "error mentions data_dir, got: {v}"
         );
     }
 
     #[test]
-    fn null_logs_dir_returns_failure_not_null() {
-        let data = CString::new("/tmp/data").unwrap();
-        let svc = CString::new("test.svc").unwrap();
-
-        let ptr = unsafe {
-            wn_collect_notifications_after_push(data.as_ptr(), std::ptr::null(), svc.as_ptr(), 1000)
-        };
-
-        let json = unsafe { consume(ptr) };
-        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    fn null_logs_dir_ptr_with_len_reports_failure_via_callback() {
+        let data = "/tmp/data";
+        let svc = "test.svc";
+        let v = call_ffi(data, data.len(), false, "", 10, true, svc, svc.len(), false);
         assert_eq!(v["status"], "failed");
         assert!(v["error"].as_str().unwrap().contains("logs_dir"));
     }
 
     #[test]
-    fn null_keyring_service_id_returns_failure_not_null() {
-        let data = CString::new("/tmp/data").unwrap();
-        let logs = CString::new("/tmp/logs").unwrap();
-
-        let ptr = unsafe {
-            wn_collect_notifications_after_push(
-                data.as_ptr(),
-                logs.as_ptr(),
-                std::ptr::null(),
-                1000,
-            )
-        };
-
-        let json = unsafe { consume(ptr) };
-        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    fn null_keyring_service_id_ptr_with_len_reports_failure_via_callback() {
+        let data = "/tmp/data";
+        let logs = "/tmp/logs";
+        let v = call_ffi(
+            data,
+            data.len(),
+            false,
+            logs,
+            logs.len(),
+            false,
+            "",
+            10,
+            true,
+        );
         assert_eq!(v["status"], "failed");
         assert!(v["error"].as_str().unwrap().contains("keyring_service_id"));
     }
 
     #[test]
-    fn wn_string_free_null_is_safe() {
-        unsafe { wn_string_free(std::ptr::null_mut()) };
+    fn invalid_utf8_input_reports_failure_via_callback() {
+        // 0xFF is not valid UTF-8.
+        let bad: [u8; 3] = [b'/', 0xFF, b'x'];
+        let logs = "/tmp/logs";
+        let svc = "test.svc";
+
+        let capture = Capture::new();
+        let user_data = &capture as *const Capture as *mut c_void;
+
+        unsafe {
+            wn_collect_notifications_after_push(
+                bad.as_ptr(),
+                bad.len(),
+                logs.as_ptr(),
+                logs.len(),
+                svc.as_ptr(),
+                svc.len(),
+                1000,
+                capture_callback,
+                user_data,
+            );
+        }
+
+        let bytes = capture.take_only();
+        let s = std::str::from_utf8(&bytes).expect("payload must be valid UTF-8");
+        let v: serde_json::Value = serde_json::from_str(s).expect("valid JSON");
+        assert_eq!(v["status"], "failed");
+        assert!(v["error"].as_str().unwrap().contains("UTF-8"));
+        assert!(v["error"].as_str().unwrap().contains("data_dir"));
     }
 
     #[test]
-    fn string_to_raw_handles_interior_nul() {
-        let json_with_nul = String::from("{\"status\":\"failed\",\"error\":\"bad\0value\"}");
-        let ptr = string_to_raw(json_with_nul);
-        assert!(!ptr.is_null());
+    fn callback_invoked_exactly_once_even_on_failure() {
+        // Several failure paths — null pointer, invalid UTF-8, etc. — must
+        // each invoke the callback exactly once. We already assert this in
+        // `Capture::take_only`; this test makes the contract explicit.
+        let logs = "/tmp/logs";
+        let svc = "test.svc";
 
-        let s = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        unsafe { drop(CString::from_raw(ptr)) };
+        let capture = Capture::new();
+        let user_data = &capture as *const Capture as *mut c_void;
 
-        // The sanitized version should still be valid JSON.
-        assert!(!s.contains('\0'));
-        let _: serde_json::Value = serde_json::from_str(&s).expect("sanitized is valid JSON");
+        unsafe {
+            wn_collect_notifications_after_push(
+                std::ptr::null(),
+                10,
+                logs.as_ptr(),
+                logs.len(),
+                svc.as_ptr(),
+                svc.len(),
+                1000,
+                capture_callback,
+                user_data,
+            );
+        }
+
+        assert_eq!(capture.invocation_count(), 1);
     }
 
     #[test]
@@ -306,5 +450,51 @@ mod tests {
         assert!(v["error"].is_string());
         assert!(v["notifications"].is_array());
         assert!(!FALLBACK_FAILURE_JSON.contains('\0'));
+    }
+
+    #[test]
+    fn null_ptr_with_zero_len_is_empty_string_not_failure() {
+        // Swift may produce null pointer + len=0 for empty strings. Our code
+        // treats that as an empty string rather than an error; the actual
+        // config will then fail later (empty keyring id rejected) or succeed
+        // (empty path, though practically unlikely). Here we just verify the
+        // slice-to-string helper's handling, exercised via an empty
+        // keyring_service_id where Whitenoise init will reject it explicitly
+        // with a different error. Use this to confirm the ptr=null+len=0
+        // branch does NOT itself surface as a null-pointer error.
+
+        // Using a valid-but-nonexistent data dir so init will fail quickly;
+        // the important assertion is that the failure is NOT about null
+        // pointers.
+        let logs = "/tmp";
+        let svc = "";
+        let capture = Capture::new();
+        let user_data = &capture as *const Capture as *mut c_void;
+        unsafe {
+            wn_collect_notifications_after_push(
+                std::ptr::null(), // data_dir ptr is null...
+                0,                // ...but len is 0, so treated as empty
+                logs.as_ptr(),
+                logs.len(),
+                svc.as_ptr(),
+                svc.len(),
+                1000,
+                capture_callback,
+                user_data,
+            );
+        }
+
+        let bytes = capture.take_only();
+        let s = std::str::from_utf8(&bytes).expect("payload must be valid UTF-8");
+        let v: serde_json::Value = serde_json::from_str(s).expect("valid JSON");
+        // Whatever the outcome, it should NOT be a null-pointer error — the
+        // empty string case is accepted and init continues.
+        if v["status"] == "failed" {
+            let err = v["error"].as_str().unwrap_or("");
+            assert!(
+                !err.contains("null pointer"),
+                "empty string via (null, 0) must not be treated as null pointer, got: {err}"
+            );
+        }
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -46,6 +46,7 @@
 use std::ffi::c_void;
 use std::panic::AssertUnwindSafe;
 use std::slice;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::whitenoise::WhitenoiseConfig;
@@ -57,6 +58,53 @@ use crate::whitenoise::background_notifications::{
 /// Guaranteed to be valid JSON conforming to the documented shape.
 const FALLBACK_FAILURE_JSON: &str =
     r#"{"status":"failed","notifications":[],"error":"internal error: failed to build response"}"#;
+
+/// Process-lifetime Tokio runtime used by [`wn_collect_notifications_after_push`].
+///
+/// The runtime **must** outlive every FFI call because `initialize_whitenoise`
+/// spawns long-lived tasks (event processor, scheduled tasks, discovery sync
+/// worker) onto whichever runtime is active when `block_on` is running. If we
+/// created a fresh runtime per FFI call and dropped it on return, those tasks
+/// would be aborted, leaving the `GLOBAL_WHITENOISE` singleton populated but
+/// functionally dead: the next FFI call would fast-path through
+/// `ensure_initialized` yet silently produce `no_data` because no event
+/// processor is running.
+///
+/// A current-thread runtime is sufficient: between FFI calls the runtime is
+/// idle (no one is driving it), and when a later `block_on` is invoked the
+/// runtime resumes driving any tasks parked across the previous call.
+static FFI_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Get or lazily initialize the process-lifetime Tokio runtime.
+///
+/// Returns `None` if the runtime could not be constructed (extremely rare —
+/// typically only happens if OS thread/fd allocation fails). Callers should
+/// surface this as a failure JSON via the callback.
+fn ffi_runtime() -> Option<&'static tokio::runtime::Runtime> {
+    if let Some(rt) = FFI_RUNTIME.get() {
+        return Some(rt);
+    }
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => {
+            // If another caller raced us to init, `set` returns Err with the
+            // losing value (which is then dropped). Either way, `get` returns
+            // the winner.
+            let _ = FFI_RUNTIME.set(rt);
+            FFI_RUNTIME.get()
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "whitenoise::ffi",
+                "Failed to build FFI Tokio runtime: {}",
+                e
+            );
+            None
+        }
+    }
+}
 
 /// Callback invoked with a JSON payload.
 ///
@@ -148,21 +196,16 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
         );
         let max_wait = Duration::from_millis(u64::from(max_wait_ms));
 
-        // Use a current-thread runtime: this FFI call is a bounded, single
-        // async operation driven to completion via block_on. A multi-threaded
-        // runtime would spawn worker threads we don't need for a background
-        // iOS push handler. `enable_all()` keeps net + time + the blocking
-        // worker pool available for SQLite and any spawn_blocking callers
-        // down the call stack.
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                return result_to_json(BackgroundNotificationResult::failed(format!(
-                    "failed to create tokio runtime: {e}"
-                )));
+        // Drive the async work on a process-lifetime runtime. See
+        // [`FFI_RUNTIME`] for why this cannot be a per-call runtime: the
+        // spawned tasks inside `initialize_whitenoise` must outlive the
+        // `block_on` that spawned them.
+        let rt = match ffi_runtime() {
+            Some(rt) => rt,
+            None => {
+                return result_to_json(BackgroundNotificationResult::failed(
+                    "failed to create tokio runtime".to_string(),
+                ));
             }
         };
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,12 +3,31 @@
 //! These functions are callable from Swift via the static library without
 //! requiring Flutter or FRB. The interface is intentionally minimal: pass in
 //! directory paths and a timeout, get back a JSON string.
+//!
+//! # Contract guarantees
+//!
+//! * [`wn_collect_notifications_after_push`] **never returns NULL** under any
+//!   circumstances — callers can unconditionally treat the result as a valid,
+//!   NUL-terminated UTF-8 C string.
+//! * It **never panics across the FFI boundary** — all internal panics are
+//!   caught and converted to a failure JSON response.
+//! * It **always returns valid JSON** conforming to the documented shape.
 
 use std::ffi::{CStr, CString, c_char};
 use std::time::Duration;
 
 use crate::whitenoise::WhitenoiseConfig;
-use crate::whitenoise::background_notifications::collect_notifications_after_push;
+use crate::whitenoise::background_notifications::{
+    BackgroundNotificationResult, collect_notifications_after_push,
+};
+
+/// Static fallback JSON used when dynamic string construction fails.
+/// This string is guaranteed to:
+/// * be valid JSON conforming to the documented shape,
+/// * contain no interior NUL bytes,
+/// * be convertible to a `CString` without allocation failure.
+const FALLBACK_FAILURE_JSON: &str =
+    r#"{"status":"failed","notifications":[],"error":"internal error: failed to build response"}"#;
 
 /// Collect notification updates after an iOS silent push wake.
 ///
@@ -16,7 +35,8 @@ use crate::whitenoise::background_notifications::collect_notifications_after_pus
 /// collects any notification updates that arrive within the time window.
 ///
 /// Returns a JSON string that the caller must free with [`wn_string_free`].
-/// The JSON shape is:
+/// **This function never returns NULL** — every code path produces a valid
+/// JSON response. The JSON shape is:
 ///
 /// ```json
 /// {
@@ -28,8 +48,9 @@ use crate::whitenoise::background_notifications::collect_notifications_after_pus
 ///
 /// # Safety
 ///
-/// * `data_dir`, `logs_dir`, and `keyring_service_id` must be valid,
-///   non-null, NUL-terminated UTF-8 C strings.
+/// * `data_dir`, `logs_dir`, and `keyring_service_id` should be valid
+///   NUL-terminated UTF-8 C strings. Null pointers and invalid UTF-8 are
+///   handled gracefully by returning a failure JSON response.
 /// * The returned pointer must be freed with [`wn_string_free`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wn_collect_notifications_after_push(
@@ -38,52 +59,57 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
     keyring_service_id: *const c_char,
     max_wait_ms: u32,
 ) -> *mut c_char {
-    // Null-pointer guards: CStr::from_ptr on a null pointer is UB and may not
-    // be caught by catch_unwind. Check before entering the unsafe block.
-    if data_dir.is_null() || logs_dir.is_null() || keyring_service_id.is_null() {
-        let json = r#"{"status":"failed","notifications":[],"error":"null pointer passed to wn_collect_notifications_after_push"}"#;
-        return CString::new(json)
-            .expect("static JSON has no interior NUL")
-            .into_raw();
-    }
-
-    let result = std::panic::catch_unwind(|| {
-        // SAFETY: all three pointers confirmed non-null above; caller
-        // guarantees they are valid NUL-terminated UTF-8 strings.
-        let data_dir = unsafe { CStr::from_ptr(data_dir) }
-            .to_str()
-            .expect("data_dir is not valid UTF-8");
-        let logs_dir = unsafe { CStr::from_ptr(logs_dir) }
-            .to_str()
-            .expect("logs_dir is not valid UTF-8");
-        let keyring_service_id = unsafe { CStr::from_ptr(keyring_service_id) }
-            .to_str()
-            .expect("keyring_service_id is not valid UTF-8");
+    // Run the entire body under catch_unwind so no panic can ever cross the
+    // FFI boundary. The closure produces a `String` which we then turn into
+    // a CString with fallbacks.
+    let json = std::panic::catch_unwind(|| {
+        // SAFETY: these reads are inside catch_unwind. Null pointers are
+        // checked explicitly before CStr::from_ptr; invalid UTF-8 is handled
+        // via to_str() without panicking.
+        let data_dir = match unsafe { c_str_to_string(data_dir, "data_dir") } {
+            Ok(s) => s,
+            Err(json) => return json,
+        };
+        let logs_dir = match unsafe { c_str_to_string(logs_dir, "logs_dir") } {
+            Ok(s) => s,
+            Err(json) => return json,
+        };
+        let keyring_service_id =
+            match unsafe { c_str_to_string(keyring_service_id, "keyring_service_id") } {
+                Ok(s) => s,
+                Err(json) => return json,
+            };
 
         let config = WhitenoiseConfig::new(
-            std::path::Path::new(data_dir),
-            std::path::Path::new(logs_dir),
-            keyring_service_id,
+            std::path::Path::new(&data_dir),
+            std::path::Path::new(&logs_dir),
+            &keyring_service_id,
         );
         let max_wait = Duration::from_millis(u64::from(max_wait_ms));
 
-        let rt = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
-        let result = rt.block_on(collect_notifications_after_push(config, max_wait));
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return result_to_json(BackgroundNotificationResult::failed(format!(
+                    "failed to create tokio runtime: {e}"
+                )));
+            }
+        };
 
-        serde_json::to_string(&result).expect("failed to serialize notification result")
+        let result = rt.block_on(collect_notifications_after_push(config, max_wait));
+        result_to_json(result)
+    })
+    .unwrap_or_else(|_| {
+        // Panic escaped. Log is not useful here (tracing may be down). Fall
+        // back to a static failure JSON that cannot fail further operations.
+        r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#
+            .to_string()
     });
 
-    let json = match result {
-        Ok(json) => json,
-        Err(_) => {
-            r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#
-                .to_string()
-        }
-    };
-
-    CString::new(json)
-        .expect("JSON contained interior NUL")
-        .into_raw()
+    // Convert to CString. If there's an interior NUL (shouldn't happen with
+    // our shapes, but defensively), sanitize by stripping NUL bytes. If even
+    // that fails, fall back to the static JSON.
+    string_to_raw(json)
 }
 
 /// Free a string previously returned by [`wn_collect_notifications_after_push`].
@@ -97,5 +123,176 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
 pub unsafe extern "C" fn wn_string_free(ptr: *mut c_char) {
     if !ptr.is_null() {
         drop(unsafe { CString::from_raw(ptr) });
+    }
+}
+
+/// Convert a C string pointer into an owned `String`, returning a failure
+/// JSON payload on null or invalid UTF-8.
+///
+/// # Safety
+///
+/// Caller must ensure `ptr` is either null or a valid NUL-terminated C string.
+unsafe fn c_str_to_string(ptr: *const c_char, field: &str) -> Result<String, String> {
+    if ptr.is_null() {
+        return Err(result_to_json(BackgroundNotificationResult::failed(
+            format!("null pointer for `{field}`"),
+        )));
+    }
+    // SAFETY: ptr is non-null; caller guarantees NUL termination.
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    match cstr.to_str() {
+        Ok(s) => Ok(s.to_string()),
+        Err(e) => Err(result_to_json(BackgroundNotificationResult::failed(
+            format!("`{field}` is not valid UTF-8: {e}"),
+        ))),
+    }
+}
+
+/// Serialize a `BackgroundNotificationResult` to JSON, falling back to a
+/// hardcoded failure payload if serialization itself fails.
+fn result_to_json(result: BackgroundNotificationResult) -> String {
+    serde_json::to_string(&result).unwrap_or_else(|e| {
+        tracing::error!(
+            target: "whitenoise::ffi",
+            "Failed to serialize BackgroundNotificationResult: {}",
+            e
+        );
+        FALLBACK_FAILURE_JSON.to_string()
+    })
+}
+
+/// Convert an owned `String` of JSON into a leaked C string pointer.
+///
+/// Guaranteed to never return NULL: if the input contains interior NUL bytes
+/// or CString construction fails for any reason, the static fallback JSON is
+/// used instead.
+fn string_to_raw(json: String) -> *mut c_char {
+    // CString::new rejects interior NULs. First try the happy path.
+    if let Ok(cstr) = CString::new(json.clone()) {
+        return cstr.into_raw();
+    }
+
+    // Interior NUL present. Strip NUL bytes and retry.
+    let sanitized: String = json.chars().filter(|c| *c != '\0').collect();
+    if let Ok(cstr) = CString::new(sanitized) {
+        return cstr.into_raw();
+    }
+
+    // Last-resort static fallback. This is statically known to not contain
+    // NUL bytes, so CString::new cannot fail — but we still guard with
+    // unwrap_or_else to absolutely guarantee no NULL return.
+    CString::new(FALLBACK_FAILURE_JSON)
+        .unwrap_or_else(|_| {
+            // This branch is unreachable given FALLBACK_FAILURE_JSON is a
+            // static ASCII string with no NULs, but we cannot use
+            // `unreachable!()` (which panics) because this whole file's
+            // contract is "never panic across FFI". Fall back to the empty
+            // (but valid) JSON object as an absolute last resort.
+            CString::new("{}").expect("{} has no NUL")
+        })
+        .into_raw()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Helper: convert the raw pointer returned by FFI back into an owned
+    /// String and free the pointer.
+    unsafe fn consume(ptr: *mut c_char) -> String {
+        assert!(
+            !ptr.is_null(),
+            "FFI returned NULL — never-NULL contract violated"
+        );
+        let s = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { wn_string_free(ptr) };
+        s
+    }
+
+    #[test]
+    fn null_data_dir_returns_failure_not_null() {
+        let logs = CString::new("/tmp/logs").unwrap();
+        let svc = CString::new("test.svc").unwrap();
+
+        let ptr = unsafe {
+            wn_collect_notifications_after_push(std::ptr::null(), logs.as_ptr(), svc.as_ptr(), 1000)
+        };
+
+        let json = unsafe { consume(ptr) };
+        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+        assert_eq!(v["status"], "failed");
+        assert!(
+            v["error"].as_str().unwrap().contains("data_dir"),
+            "error mentions data_dir, got: {json}"
+        );
+    }
+
+    #[test]
+    fn null_logs_dir_returns_failure_not_null() {
+        let data = CString::new("/tmp/data").unwrap();
+        let svc = CString::new("test.svc").unwrap();
+
+        let ptr = unsafe {
+            wn_collect_notifications_after_push(data.as_ptr(), std::ptr::null(), svc.as_ptr(), 1000)
+        };
+
+        let json = unsafe { consume(ptr) };
+        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+        assert_eq!(v["status"], "failed");
+        assert!(v["error"].as_str().unwrap().contains("logs_dir"));
+    }
+
+    #[test]
+    fn null_keyring_service_id_returns_failure_not_null() {
+        let data = CString::new("/tmp/data").unwrap();
+        let logs = CString::new("/tmp/logs").unwrap();
+
+        let ptr = unsafe {
+            wn_collect_notifications_after_push(
+                data.as_ptr(),
+                logs.as_ptr(),
+                std::ptr::null(),
+                1000,
+            )
+        };
+
+        let json = unsafe { consume(ptr) };
+        let v: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+        assert_eq!(v["status"], "failed");
+        assert!(v["error"].as_str().unwrap().contains("keyring_service_id"));
+    }
+
+    #[test]
+    fn wn_string_free_null_is_safe() {
+        unsafe { wn_string_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn string_to_raw_handles_interior_nul() {
+        let json_with_nul = String::from("{\"status\":\"failed\",\"error\":\"bad\0value\"}");
+        let ptr = string_to_raw(json_with_nul);
+        assert!(!ptr.is_null());
+
+        let s = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { drop(CString::from_raw(ptr)) };
+
+        // The sanitized version should still be valid JSON.
+        assert!(!s.contains('\0'));
+        let _: serde_json::Value = serde_json::from_str(&s).expect("sanitized is valid JSON");
+    }
+
+    #[test]
+    fn fallback_failure_json_is_valid() {
+        let v: serde_json::Value = serde_json::from_str(FALLBACK_FAILURE_JSON)
+            .expect("FALLBACK_FAILURE_JSON must be valid JSON");
+        assert_eq!(v["status"], "failed");
+        assert!(v["error"].is_string());
+        assert!(v["notifications"].is_array());
+        assert!(!FALLBACK_FAILURE_JSON.contains('\0'));
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,8 +38,18 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
     keyring_service_id: *const c_char,
     max_wait_ms: u32,
 ) -> *mut c_char {
+    // Null-pointer guards: CStr::from_ptr on a null pointer is UB and may not
+    // be caught by catch_unwind. Check before entering the unsafe block.
+    if data_dir.is_null() || logs_dir.is_null() || keyring_service_id.is_null() {
+        let json = r#"{"status":"failed","notifications":[],"error":"null pointer passed to wn_collect_notifications_after_push"}"#;
+        return CString::new(json)
+            .expect("static JSON has no interior NUL")
+            .into_raw();
+    }
+
     let result = std::panic::catch_unwind(|| {
-        // SAFETY: caller guarantees valid NUL-terminated UTF-8 strings.
+        // SAFETY: all three pointers confirmed non-null above; caller
+        // guarantees they are valid NUL-terminated UTF-8 strings.
         let data_dir = unsafe { CStr::from_ptr(data_dir) }
             .to_str()
             .expect("data_dir is not valid UTF-8");

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,91 @@
+//! C ABI entrypoints for native iOS background push handling.
+//!
+//! These functions are callable from Swift via the static library without
+//! requiring Flutter or FRB. The interface is intentionally minimal: pass in
+//! directory paths and a timeout, get back a JSON string.
+
+use std::ffi::{CStr, CString, c_char};
+use std::time::Duration;
+
+use crate::whitenoise::WhitenoiseConfig;
+use crate::whitenoise::background_notifications::collect_notifications_after_push;
+
+/// Collect notification updates after an iOS silent push wake.
+///
+/// Initializes Whitenoise if needed, refreshes relay subscriptions, and
+/// collects any notification updates that arrive within the time window.
+///
+/// Returns a JSON string that the caller must free with [`wn_string_free`].
+/// The JSON shape is:
+///
+/// ```json
+/// {
+///   "status": "new_data" | "no_data" | "failed",
+///   "notifications": [ ... ],
+///   "error": "..." // only present when status is "failed"
+/// }
+/// ```
+///
+/// # Safety
+///
+/// * `data_dir`, `logs_dir`, and `keyring_service_id` must be valid,
+///   non-null, NUL-terminated UTF-8 C strings.
+/// * The returned pointer must be freed with [`wn_string_free`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wn_collect_notifications_after_push(
+    data_dir: *const c_char,
+    logs_dir: *const c_char,
+    keyring_service_id: *const c_char,
+    max_wait_ms: u32,
+) -> *mut c_char {
+    let result = std::panic::catch_unwind(|| {
+        // SAFETY: caller guarantees valid NUL-terminated UTF-8 strings.
+        let data_dir = unsafe { CStr::from_ptr(data_dir) }
+            .to_str()
+            .expect("data_dir is not valid UTF-8");
+        let logs_dir = unsafe { CStr::from_ptr(logs_dir) }
+            .to_str()
+            .expect("logs_dir is not valid UTF-8");
+        let keyring_service_id = unsafe { CStr::from_ptr(keyring_service_id) }
+            .to_str()
+            .expect("keyring_service_id is not valid UTF-8");
+
+        let config = WhitenoiseConfig::new(
+            std::path::Path::new(data_dir),
+            std::path::Path::new(logs_dir),
+            keyring_service_id,
+        );
+        let max_wait = Duration::from_millis(u64::from(max_wait_ms));
+
+        let rt = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let result = rt.block_on(collect_notifications_after_push(config, max_wait));
+
+        serde_json::to_string(&result).expect("failed to serialize notification result")
+    });
+
+    let json = match result {
+        Ok(json) => json,
+        Err(_) => {
+            r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#
+                .to_string()
+        }
+    };
+
+    CString::new(json)
+        .expect("JSON contained interior NUL")
+        .into_raw()
+}
+
+/// Free a string previously returned by [`wn_collect_notifications_after_push`].
+///
+/// # Safety
+///
+/// * `ptr` must have been returned by a `wn_*` function that allocates via `CString`.
+/// * Must not be called more than once for the same pointer.
+/// * Passing a null pointer is a safe no-op.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wn_string_free(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(unsafe { CString::from_raw(ptr) });
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -59,20 +59,39 @@ use crate::whitenoise::background_notifications::{
 const FALLBACK_FAILURE_JSON: &str =
     r#"{"status":"failed","notifications":[],"error":"internal error: failed to build response"}"#;
 
+/// Static failure JSON used specifically when the main body's `catch_unwind`
+/// catches an internal panic. Distinct from [`FALLBACK_FAILURE_JSON`] so that
+/// debugging can distinguish a panic origin from a serialization-failure
+/// origin. Both are intentionally hardcoded so they cannot themselves fail.
+const PANIC_FAILURE_JSON: &str = r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#;
+
+/// Number of worker threads for [`FFI_RUNTIME`]. Two is the minimum that
+/// guarantees the event processor and the drain loop can make concurrent
+/// progress: one worker drives `drain_notifications` (blocked on the
+/// broadcast receiver), the other drives the spawned event processor that
+/// feeds it. More than two would be wasteful for this workload.
+const FFI_RUNTIME_WORKERS: usize = 2;
+
 /// Process-lifetime Tokio runtime used by [`wn_collect_notifications_after_push`].
 ///
-/// The runtime **must** outlive every FFI call because `initialize_whitenoise`
-/// spawns long-lived tasks (event processor, scheduled tasks, discovery sync
-/// worker) onto whichever runtime is active when `block_on` is running. If we
-/// created a fresh runtime per FFI call and dropped it on return, those tasks
-/// would be aborted, leaving the `GLOBAL_WHITENOISE` singleton populated but
-/// functionally dead: the next FFI call would fast-path through
-/// `ensure_initialized` yet silently produce `no_data` because no event
-/// processor is running.
+/// Two reasons this must be process-lifetime *and* multi-threaded:
 ///
-/// A current-thread runtime is sufficient: between FFI calls the runtime is
-/// idle (no one is driving it), and when a later `block_on` is invoked the
-/// runtime resumes driving any tasks parked across the previous call.
+/// 1. **Outlive the FFI call.** `initialize_whitenoise` spawns long-lived
+///    tasks (event processor, scheduled tasks, discovery sync worker) onto
+///    whichever runtime is active when `block_on` is running. If we built
+///    a fresh runtime per FFI call and dropped it on return, those tasks
+///    would be aborted, leaving the `GLOBAL_WHITENOISE` singleton populated
+///    but functionally dead: the next FFI call would fast-path through
+///    `ensure_initialized` yet silently produce `no_data` because no event
+///    processor is running.
+/// 2. **Multi-threaded for concurrency.** A `current_thread` runtime can in
+///    principle interleave tasks during `await` points, but it is fragile:
+///    any synchronous CPU work in the event-processor / decryption path
+///    would stall the drain loop, and any future code that does a small
+///    blocking call inline would deadlock. A multi-thread runtime sized for
+///    this workload (event processor on one worker, drain on another)
+///    eliminates that class of concern entirely. iOS background processes
+///    can comfortably afford two worker threads.
 static FFI_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 /// Get or lazily initialize the process-lifetime Tokio runtime.
@@ -84,8 +103,10 @@ fn ffi_runtime() -> Option<&'static tokio::runtime::Runtime> {
     if let Some(rt) = FFI_RUNTIME.get() {
         return Some(rt);
     }
-    match tokio::runtime::Builder::new_current_thread()
+    match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(FFI_RUNTIME_WORKERS)
         .enable_all()
+        .thread_name("wn-ffi")
         .build()
     {
         Ok(rt) => {
@@ -133,7 +154,11 @@ pub type WnJsonCallback =
 /// * `logs_dir_ptr`, `logs_dir_len` — UTF-8 bytes for the logs directory.
 /// * `keyring_service_id_ptr`, `keyring_service_id_len` — UTF-8 bytes for the
 ///   keyring service identifier.
-/// * `max_wait_ms` — Hard deadline for collection in milliseconds.
+/// * `max_wait_ms` — Hard deadline for collection in milliseconds. `u32` is
+///   intentional: it matches the C `uint32_t` convention for short timeouts
+///   and gives a maximum representable wait of ~49 days, far above the
+///   internal `IOS_MAX_WAIT` clamp (25 s). A wider integer would suggest the
+///   value is unbounded in practice, which it is not.
 /// * `callback` — Function invoked with the JSON result. See
 ///   [`WnJsonCallback`] for lifetime rules.
 /// * `user_data` — Opaque context passed through to `callback`. Not
@@ -215,8 +240,7 @@ pub unsafe extern "C" fn wn_collect_notifications_after_push(
     .unwrap_or_else(|_| {
         // Internal panic escaped. Fall back to a static failure JSON; the
         // callback is still invoked exactly once below.
-        r#"{"status":"failed","notifications":[],"error":"internal panic in wn_collect_notifications_after_push"}"#
-            .to_string()
+        PANIC_FAILURE_JSON.to_string()
     });
 
     // Invoke the callback with the JSON bytes. The buffer lives on Rust's
@@ -321,55 +345,39 @@ mod tests {
         capture.payloads.lock().unwrap().push(bytes);
     }
 
-    /// Helper: call the FFI with valid inputs for the null-checks, returning
-    /// the captured JSON payload as a parsed Value. The argument list mirrors
-    /// the FFI's own (ptr, len) pairs plus null-override booleans per input,
-    /// so the count is inherent rather than incidental.
-    #[allow(clippy::too_many_arguments)]
-    fn call_ffi(
-        data_dir: &str,
-        data_dir_len: usize,
-        data_dir_ptr_null: bool,
-        logs_dir: &str,
-        logs_dir_len: usize,
-        logs_dir_ptr_null: bool,
-        svc: &str,
-        svc_len: usize,
-        svc_ptr_null: bool,
+    /// Returns the (ptr, len) pair representing a null pointer with a
+    /// caller-supplied non-zero length — the input shape we want to reject.
+    fn null_with_len(len: usize) -> (*const u8, usize) {
+        (std::ptr::null(), len)
+    }
+
+    /// Returns the (ptr, len) pair for a valid string view.
+    fn from_str(s: &str) -> (*const u8, usize) {
+        (s.as_ptr(), s.len())
+    }
+
+    /// Run the FFI once with explicit (ptr, len) pairs for each input and
+    /// return the parsed JSON payload delivered to the callback.
+    fn run_ffi(
+        data_dir: (*const u8, usize),
+        logs_dir: (*const u8, usize),
+        svc: (*const u8, usize),
     ) -> serde_json::Value {
         let capture = Capture::new();
         let user_data = &capture as *const Capture as *mut c_void;
-
-        let data_ptr = if data_dir_ptr_null {
-            std::ptr::null()
-        } else {
-            data_dir.as_ptr()
-        };
-        let logs_ptr = if logs_dir_ptr_null {
-            std::ptr::null()
-        } else {
-            logs_dir.as_ptr()
-        };
-        let svc_ptr = if svc_ptr_null {
-            std::ptr::null()
-        } else {
-            svc.as_ptr()
-        };
-
         unsafe {
             wn_collect_notifications_after_push(
-                data_ptr,
-                data_dir_len,
-                logs_ptr,
-                logs_dir_len,
-                svc_ptr,
-                svc_len,
+                data_dir.0,
+                data_dir.1,
+                logs_dir.0,
+                logs_dir.1,
+                svc.0,
+                svc.1,
                 1000,
                 capture_callback,
                 user_data,
             );
         }
-
         let bytes = capture.take_only();
         let s = std::str::from_utf8(&bytes).expect("callback payload must be valid UTF-8");
         serde_json::from_str(s).expect("callback payload must be valid JSON")
@@ -377,18 +385,10 @@ mod tests {
 
     #[test]
     fn null_data_dir_ptr_with_len_reports_failure_via_callback() {
-        let logs = "/tmp/logs";
-        let svc = "test.svc";
-        let v = call_ffi(
-            "",
-            10, // non-zero len with null ptr
-            true,
-            logs,
-            logs.len(),
-            false,
-            svc,
-            svc.len(),
-            false,
+        let v = run_ffi(
+            null_with_len(10),
+            from_str("/tmp/logs"),
+            from_str("test.svc"),
         );
         assert_eq!(v["status"], "failed");
         assert!(
@@ -399,27 +399,21 @@ mod tests {
 
     #[test]
     fn null_logs_dir_ptr_with_len_reports_failure_via_callback() {
-        let data = "/tmp/data";
-        let svc = "test.svc";
-        let v = call_ffi(data, data.len(), false, "", 10, true, svc, svc.len(), false);
+        let v = run_ffi(
+            from_str("/tmp/data"),
+            null_with_len(10),
+            from_str("test.svc"),
+        );
         assert_eq!(v["status"], "failed");
         assert!(v["error"].as_str().unwrap().contains("logs_dir"));
     }
 
     #[test]
     fn null_keyring_service_id_ptr_with_len_reports_failure_via_callback() {
-        let data = "/tmp/data";
-        let logs = "/tmp/logs";
-        let v = call_ffi(
-            data,
-            data.len(),
-            false,
-            logs,
-            logs.len(),
-            false,
-            "",
-            10,
-            true,
+        let v = run_ffi(
+            from_str("/tmp/data"),
+            from_str("/tmp/logs"),
+            null_with_len(10),
         );
         assert_eq!(v["status"], "failed");
         assert!(v["error"].as_str().unwrap().contains("keyring_service_id"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod relay_control;
 // Crate-private because the macro expands to `crate::perf_span!(...)` which
 // only resolves inside this crate.
 pub(crate) use whitenoise_macros::perf_instrument;
+pub mod ffi;
 pub mod mdk;
 mod types;
 pub mod whitenoise;
@@ -91,6 +92,11 @@ pub use whitenoise::user_streaming::{UserSubscription, UserUpdate, UserUpdateTri
 // Notification streaming
 pub use whitenoise::notification_streaming::{
     NotificationSubscription, NotificationTrigger, NotificationUpdate, NotificationUser,
+};
+
+// Background notification collection (iOS silent push)
+pub use whitenoise::background_notifications::{
+    BackgroundNotificationResult, BackgroundNotificationStatus,
 };
 pub use whitenoise::push_notifications::{
     GroupPushDebugInfo, GroupPushToken, PushPlatform, PushRegistration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,18 +9,18 @@ use tracing_subscriber::filter::LevelFilter;
 #[cfg(feature = "benchmark-tests")]
 use crate::integration_tests::benchmarks::PerfTracingLayer;
 
+pub mod ffi;
+pub mod mdk;
 mod nostr_manager;
 pub mod perf;
 pub(crate) mod relay_control;
+mod types;
+pub mod whitenoise;
 
 // Re-export proc macro for ergonomic `#[perf_instrument("prefix")]` usage.
 // Crate-private because the macro expands to `crate::perf_span!(...)` which
 // only resolves inside this crate.
 pub(crate) use whitenoise_macros::perf_instrument;
-pub mod ffi;
-pub mod mdk;
-mod types;
-pub mod whitenoise;
 
 #[cfg(feature = "cli")]
 pub mod cli;
@@ -94,10 +94,12 @@ pub use whitenoise::notification_streaming::{
     NotificationSubscription, NotificationTrigger, NotificationUpdate, NotificationUser,
 };
 
-// Background notification collection (iOS silent push)
+// Background notification collection (iOS silent push). The async function
+// is re-exported alongside the result types so Rust callers can drive
+// collection directly without going through the FFI layer.
 pub use whitenoise::background_notifications::{
     BackgroundNotificationResult, BackgroundNotificationStatus, NotificationDto,
-    NotificationUserDto,
+    NotificationUserDto, collect_notifications_after_push,
 };
 pub use whitenoise::push_notifications::{
     GroupPushDebugInfo, GroupPushToken, PushPlatform, PushRegistration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,8 @@ pub use whitenoise::notification_streaming::{
 
 // Background notification collection (iOS silent push)
 pub use whitenoise::background_notifications::{
-    BackgroundNotificationResult, BackgroundNotificationStatus,
+    BackgroundNotificationResult, BackgroundNotificationStatus, NotificationDto,
+    NotificationUserDto,
 };
 pub use whitenoise::push_notifications::{
     GroupPushDebugInfo, GroupPushToken, PushPlatform, PushRegistration,

--- a/src/whitenoise/background_notifications.rs
+++ b/src/whitenoise/background_notifications.rs
@@ -123,6 +123,18 @@ impl BackgroundNotificationResult {
 /// Default quiet window: if no notification arrives within this duration, stop collecting.
 const DEFAULT_QUIET_WINDOW: Duration = Duration::from_millis(1000);
 
+/// Hard ceiling on any caller-provided `max_wait`. iOS gives silent-push
+/// handlers roughly 30 seconds of background execution; we clamp to 25s to
+/// leave a safety margin for init, response serialization, and the native
+/// local-notification scheduling that happens after this returns.
+const IOS_MAX_WAIT: Duration = Duration::from_secs(25);
+
+/// Upper bound on the number of notifications returned in a single collection
+/// pass. Guards against memory growth during relay bursts and matches the UX
+/// reality that a user cannot meaningfully triage dozens of notifications from
+/// a single background wake.
+const MAX_COLLECTED: usize = 50;
+
 /// Collect notification updates after a background push wake.
 ///
 /// This is the core async function that:
@@ -145,6 +157,10 @@ pub async fn collect_notifications_after_push(
     config: WhitenoiseConfig,
     max_wait: Duration,
 ) -> BackgroundNotificationResult {
+    // Clamp caller-provided wait to an iOS-safe ceiling. Protects against
+    // accidental long waits from buggy callers that might otherwise outlive
+    // the iOS background execution budget and get the process killed.
+    let max_wait = max_wait.min(IOS_MAX_WAIT);
     match collect_notifications_inner(config, max_wait).await {
         Ok(result) => result,
         Err(e) => {
@@ -191,9 +207,37 @@ async fn collect_notifications_inner(
         "Subscriptions refreshed, starting collection window"
     );
 
-    // Step 4: Collect notifications with quiet-window + hard deadline.
+    // Step 4: Collect notifications with quiet-window + hard deadline +
+    // size cap (MAX_COLLECTED).
+    let collected = drain_notifications(&mut rx, max_wait).await;
+
+    tracing::info!(
+        target: "whitenoise::background_notifications",
+        count = collected.len(),
+        "Background notification collection complete"
+    );
+
+    if collected.is_empty() {
+        Ok(BackgroundNotificationResult::no_data())
+    } else {
+        Ok(BackgroundNotificationResult::new_data(collected))
+    }
+}
+
+/// Drain notification updates from a receiver until one of the following stops:
+/// * the quiet window expires with no new notification,
+/// * the hard deadline (`max_wait`) is reached,
+/// * `MAX_COLLECTED` notifications have been collected,
+/// * the channel closes.
+///
+/// Extracted so it can be unit-tested against a synthetic
+/// `broadcast::Receiver` without needing a full `Whitenoise` instance.
+async fn drain_notifications(
+    rx: &mut broadcast::Receiver<NotificationUpdate>,
+    max_wait: Duration,
+) -> Vec<NotificationUpdate> {
     let deadline = Instant::now() + max_wait;
-    let mut collected = Vec::new();
+    let mut collected = Vec::with_capacity(MAX_COLLECTED);
 
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -217,6 +261,14 @@ async fn collect_notifications_inner(
                     "Collected notification"
                 );
                 collected.push(update);
+                if collected.len() >= MAX_COLLECTED {
+                    tracing::warn!(
+                        target: "whitenoise::background_notifications",
+                        cap = MAX_COLLECTED,
+                        "Notification collection cap reached; stopping early"
+                    );
+                    break;
+                }
             }
             Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
                 tracing::warn!(
@@ -245,17 +297,7 @@ async fn collect_notifications_inner(
         }
     }
 
-    tracing::info!(
-        target: "whitenoise::background_notifications",
-        count = collected.len(),
-        "Background notification collection complete"
-    );
-
-    if collected.is_empty() {
-        Ok(BackgroundNotificationResult::no_data())
-    } else {
-        Ok(BackgroundNotificationResult::new_data(collected))
-    }
+    collected
 }
 
 #[cfg(test)]
@@ -361,5 +403,57 @@ mod tests {
         assert_eq!(notifications[0]["trigger"], "message");
         assert_eq!(notifications[1]["trigger"], "invite");
         assert_eq!(notifications[2]["trigger"], "message");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_notifications_caps_at_max_collected() {
+        // Create a standalone broadcast channel and pre-fill it with more
+        // than MAX_COLLECTED notifications before starting the drain. The
+        // drain must stop at exactly MAX_COLLECTED even though more items
+        // are waiting in the channel and the deadline has not been reached.
+        let flood = MAX_COLLECTED + 25;
+        let (tx, mut rx) = broadcast::channel(flood);
+        for i in 0..flood {
+            let content = format!("msg {i}");
+            tx.send(make_test_notification(
+                NotificationTrigger::NewMessage,
+                &content,
+            ))
+            .expect("send should succeed while rx is alive");
+        }
+
+        // Generous deadline — we want the cap, not the deadline, to stop us.
+        let collected = drain_notifications(&mut rx, Duration::from_secs(60)).await;
+
+        assert_eq!(
+            collected.len(),
+            MAX_COLLECTED,
+            "drain should stop exactly at MAX_COLLECTED"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_notifications_quiet_window_stops_below_cap() {
+        // If fewer than MAX_COLLECTED notifications arrive and the channel
+        // goes quiet, the quiet window should trip instead of the cap.
+        let (tx, mut rx) = broadcast::channel(16);
+        for i in 0..5 {
+            let content = format!("msg {i}");
+            tx.send(make_test_notification(
+                NotificationTrigger::NewMessage,
+                &content,
+            ))
+            .expect("send should succeed while rx is alive");
+        }
+
+        let collected = drain_notifications(&mut rx, Duration::from_secs(60)).await;
+        assert_eq!(collected.len(), 5);
+    }
+
+    #[test]
+    fn ios_max_wait_is_under_ios_budget() {
+        // Sanity check: the clamp must be strictly below the iOS 30s ceiling
+        // so we never outlive the system-provided background budget.
+        assert!(IOS_MAX_WAIT < Duration::from_secs(30));
     }
 }

--- a/src/whitenoise/background_notifications.rs
+++ b/src/whitenoise/background_notifications.rs
@@ -178,6 +178,12 @@ async fn collect_notifications_inner(
     config: WhitenoiseConfig,
     max_wait: Duration,
 ) -> Result<BackgroundNotificationResult> {
+    // Start the budget clock before init so the whole call — not just the
+    // drain phase — stays within `max_wait`. If cold init consumes most or
+    // all of the budget, drain gets whatever is left (down to zero, in which
+    // case drain returns immediately with an empty collection).
+    let start = std::time::Instant::now();
+
     tracing::info!(
         target: "whitenoise::background_notifications",
         max_wait_ms = max_wait.as_millis() as u64,
@@ -202,14 +208,19 @@ async fn collect_notifications_inner(
     // than a misleading "no_data" result.
     whitenoise.ensure_all_subscriptions().await?;
 
+    let init_elapsed = start.elapsed();
+    let drain_budget = max_wait.saturating_sub(init_elapsed);
     tracing::debug!(
         target: "whitenoise::background_notifications",
+        init_ms = init_elapsed.as_millis() as u64,
+        drain_budget_ms = drain_budget.as_millis() as u64,
         "Subscriptions refreshed, starting collection window"
     );
 
     // Step 4: Collect notifications with quiet-window + hard deadline +
-    // size cap (MAX_COLLECTED).
-    let collected = drain_notifications(&mut rx, max_wait).await;
+    // size cap (MAX_COLLECTED). Uses the *remaining* budget after init so
+    // the total call stays within `max_wait`.
+    let collected = drain_notifications(&mut rx, drain_budget).await;
 
     tracing::info!(
         target: "whitenoise::background_notifications",
@@ -448,6 +459,27 @@ mod tests {
 
         let collected = drain_notifications(&mut rx, Duration::from_secs(60)).await;
         assert_eq!(collected.len(), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_notifications_zero_budget_returns_empty_immediately() {
+        // When init has consumed the entire caller-provided budget, the drain
+        // phase receives `Duration::ZERO`. It must not panic and must not
+        // pull any events off the channel — it should return an empty Vec
+        // on the very first loop iteration.
+        let (tx, mut rx) = broadcast::channel(16);
+        // Put events on the channel so we can prove we don't consume any.
+        for i in 0..3 {
+            let content = format!("msg {i}");
+            tx.send(make_test_notification(
+                NotificationTrigger::NewMessage,
+                &content,
+            ))
+            .expect("send should succeed while rx is alive");
+        }
+
+        let collected = drain_notifications(&mut rx, Duration::ZERO).await;
+        assert_eq!(collected.len(), 0, "zero budget must not drain any events");
     }
 
     #[test]

--- a/src/whitenoise/background_notifications.rs
+++ b/src/whitenoise/background_notifications.rs
@@ -117,13 +117,10 @@ async fn collect_notifications_inner(
     // Step 3: Refresh relay subscriptions. This reconnects dead relays and
     // fetches missed events using `since` timestamps. The event processor
     // decrypts and processes them, emitting NotificationUpdates.
-    if let Err(e) = whitenoise.ensure_all_subscriptions().await {
-        tracing::warn!(
-            target: "whitenoise::background_notifications",
-            "ensure_all_subscriptions failed (continuing with collection): {}",
-            e
-        );
-    }
+    // Propagate errors here — if subscriptions fail to refresh, no events
+    // will arrive and the caller should receive an explicit failure rather
+    // than a misleading "no_data" result.
+    whitenoise.ensure_all_subscriptions().await?;
 
     tracing::debug!(
         target: "whitenoise::background_notifications",

--- a/src/whitenoise/background_notifications.rs
+++ b/src/whitenoise/background_notifications.rs
@@ -1,11 +1,12 @@
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::broadcast;
 use tokio::time::timeout;
 
 use crate::whitenoise::error::Result;
-use crate::whitenoise::notification_streaming::NotificationUpdate;
+use crate::whitenoise::notification_streaming::{NotificationTrigger, NotificationUpdate};
 use crate::whitenoise::{Whitenoise, WhitenoiseConfig};
 
 /// Status of the background notification collection.
@@ -20,11 +21,69 @@ pub enum BackgroundNotificationStatus {
     Failed,
 }
 
+/// A notification user in the DTO payload (pubkey as hex string).
+#[derive(Debug, Clone, Serialize)]
+pub struct NotificationUserDto {
+    /// Hex-encoded public key.
+    pub pubkey: String,
+    pub display_name: Option<String>,
+    pub picture_url: Option<String>,
+}
+
+/// A single notification entry in the JSON payload returned to iOS.
+///
+/// This DTO is the stable external contract for the iOS background push
+/// integration. It is intentionally decoupled from `NotificationUpdate` so
+/// the internal broadcast type can evolve without breaking the Swift side.
+#[derive(Debug, Clone, Serialize)]
+pub struct NotificationDto {
+    /// Trigger as a lowercase string: `"message"` or `"invite"`.
+    pub trigger: &'static str,
+    /// Hex-encoded MLS group id.
+    pub mls_group_id: String,
+    pub group_name: Option<String>,
+    pub is_dm: bool,
+    pub receiver: NotificationUserDto,
+    pub sender: NotificationUserDto,
+    pub content: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl NotificationDto {
+    fn from_update(update: NotificationUpdate) -> Self {
+        Self {
+            trigger: trigger_value(update.trigger),
+            mls_group_id: hex::encode(update.mls_group_id.as_slice()),
+            group_name: update.group_name,
+            is_dm: update.is_dm,
+            receiver: NotificationUserDto {
+                pubkey: update.receiver.pubkey.to_hex(),
+                display_name: update.receiver.display_name,
+                picture_url: update.receiver.picture_url,
+            },
+            sender: NotificationUserDto {
+                pubkey: update.sender.pubkey.to_hex(),
+                display_name: update.sender.display_name,
+                picture_url: update.sender.picture_url,
+            },
+            content: update.content,
+            timestamp: update.timestamp,
+        }
+    }
+}
+
+fn trigger_value(trigger: NotificationTrigger) -> &'static str {
+    match trigger {
+        NotificationTrigger::NewMessage => "message",
+        NotificationTrigger::GroupInvite => "invite",
+    }
+}
+
 /// Result of a background notification collection pass.
 #[derive(Debug, Clone, Serialize)]
 pub struct BackgroundNotificationResult {
     pub status: BackgroundNotificationStatus,
-    pub notifications: Vec<NotificationUpdate>,
+    pub notifications: Vec<NotificationDto>,
     /// If status is `Failed`, contains the error description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -34,7 +93,10 @@ impl BackgroundNotificationResult {
     fn new_data(notifications: Vec<NotificationUpdate>) -> Self {
         Self {
             status: BackgroundNotificationStatus::NewData,
-            notifications,
+            notifications: notifications
+                .into_iter()
+                .map(NotificationDto::from_update)
+                .collect(),
             error: None,
         }
     }
@@ -47,7 +109,9 @@ impl BackgroundNotificationResult {
         }
     }
 
-    fn failed(error: String) -> Self {
+    /// Public so the FFI layer can construct failure results without
+    /// duplicating the JSON shape.
+    pub fn failed(error: String) -> Self {
         Self {
             status: BackgroundNotificationStatus::Failed,
             notifications: Vec::new(),
@@ -211,7 +275,7 @@ mod tests {
 
         NotificationUpdate {
             trigger,
-            mls_group_id: GroupId::from_slice(&[1, 2, 3, 4]),
+            mls_group_id: GroupId::from_slice(&[0xab, 0xcd, 0xef, 0x01]),
             group_name: Some("Test Group".to_string()),
             is_dm: false,
             receiver: NotificationUser {
@@ -229,53 +293,73 @@ mod tests {
         }
     }
 
+    fn parse(result: &BackgroundNotificationResult) -> serde_json::Value {
+        let json = serde_json::to_string(result).expect("serialization failed");
+        serde_json::from_str(&json).expect("deserialization failed")
+    }
+
     #[test]
-    fn result_new_data_serializes_correctly() {
+    fn result_new_data_shape() {
         let notification = make_test_notification(NotificationTrigger::NewMessage, "Hello world");
         let result = BackgroundNotificationResult::new_data(vec![notification]);
+        let v = parse(&result);
 
-        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
-
-        assert!(json.contains("\"status\": \"new_data\""));
-        assert!(json.contains("\"trigger\": \"NewMessage\""));
-        assert!(json.contains("Hello world"));
-        assert!(!json.contains("\"error\""));
+        assert_eq!(v["status"], "new_data");
+        assert!(v.get("error").is_none());
+        let notifications = v["notifications"].as_array().expect("notifications array");
+        assert_eq!(notifications.len(), 1);
+        let n = &notifications[0];
+        assert_eq!(n["trigger"], "message");
+        assert_eq!(n["mls_group_id"], "abcdef01");
+        assert_eq!(n["group_name"], "Test Group");
+        assert_eq!(n["is_dm"], false);
+        assert_eq!(n["content"], "Hello world");
+        // pubkey is serialized as a hex string (64 chars for 32-byte key).
+        let sender_pubkey = n["sender"]["pubkey"].as_str().expect("sender pubkey");
+        assert_eq!(sender_pubkey.len(), 64);
+        assert!(sender_pubkey.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(n["sender"]["display_name"], "Bob");
+        assert!(n["sender"]["picture_url"].is_null());
     }
 
     #[test]
-    fn result_no_data_serializes_correctly() {
+    fn result_invite_trigger_is_invite() {
+        let notification = make_test_notification(NotificationTrigger::GroupInvite, "");
+        let result = BackgroundNotificationResult::new_data(vec![notification]);
+        let v = parse(&result);
+        assert_eq!(v["notifications"][0]["trigger"], "invite");
+    }
+
+    #[test]
+    fn result_no_data_shape() {
         let result = BackgroundNotificationResult::no_data();
-
-        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
-
-        assert!(json.contains("\"status\": \"no_data\""));
-        assert!(json.contains("\"notifications\": []"));
-        assert!(!json.contains("\"error\""));
+        let v = parse(&result);
+        assert_eq!(v["status"], "no_data");
+        assert_eq!(v["notifications"].as_array().unwrap().len(), 0);
+        assert!(v.get("error").is_none());
     }
 
     #[test]
-    fn result_failed_serializes_correctly() {
+    fn result_failed_shape() {
         let result = BackgroundNotificationResult::failed("something broke".to_string());
-
-        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
-
-        assert!(json.contains("\"status\": \"failed\""));
-        assert!(json.contains("\"error\": \"something broke\""));
-        assert!(json.contains("\"notifications\": []"));
+        let v = parse(&result);
+        assert_eq!(v["status"], "failed");
+        assert_eq!(v["error"], "something broke");
+        assert_eq!(v["notifications"].as_array().unwrap().len(), 0);
     }
 
     #[test]
-    fn result_multiple_notifications_serializes_correctly() {
+    fn result_multiple_notifications() {
         let n1 = make_test_notification(NotificationTrigger::NewMessage, "msg 1");
         let n2 = make_test_notification(NotificationTrigger::GroupInvite, "");
         let n3 = make_test_notification(NotificationTrigger::NewMessage, "msg 2");
         let result = BackgroundNotificationResult::new_data(vec![n1, n2, n3]);
+        let v = parse(&result);
 
-        let json = serde_json::to_string(&result).expect("serialization failed");
-        let parsed: serde_json::Value =
-            serde_json::from_str(&json).expect("deserialization failed");
-
-        assert_eq!(parsed["notifications"].as_array().unwrap().len(), 3);
-        assert_eq!(parsed["notifications"][1]["trigger"], "GroupInvite");
+        let notifications = v["notifications"].as_array().unwrap();
+        assert_eq!(notifications.len(), 3);
+        assert_eq!(notifications[0]["trigger"], "message");
+        assert_eq!(notifications[1]["trigger"], "invite");
+        assert_eq!(notifications[2]["trigger"], "message");
     }
 }

--- a/src/whitenoise/background_notifications.rs
+++ b/src/whitenoise/background_notifications.rs
@@ -1,0 +1,284 @@
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
+
+use crate::whitenoise::error::Result;
+use crate::whitenoise::notification_streaming::NotificationUpdate;
+use crate::whitenoise::{Whitenoise, WhitenoiseConfig};
+
+/// Status of the background notification collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundNotificationStatus {
+    /// New notification data was collected.
+    NewData,
+    /// No new notifications were found.
+    NoData,
+    /// An error occurred during collection.
+    Failed,
+}
+
+/// Result of a background notification collection pass.
+#[derive(Debug, Clone, Serialize)]
+pub struct BackgroundNotificationResult {
+    pub status: BackgroundNotificationStatus,
+    pub notifications: Vec<NotificationUpdate>,
+    /// If status is `Failed`, contains the error description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl BackgroundNotificationResult {
+    fn new_data(notifications: Vec<NotificationUpdate>) -> Self {
+        Self {
+            status: BackgroundNotificationStatus::NewData,
+            notifications,
+            error: None,
+        }
+    }
+
+    fn no_data() -> Self {
+        Self {
+            status: BackgroundNotificationStatus::NoData,
+            notifications: Vec::new(),
+            error: None,
+        }
+    }
+
+    fn failed(error: String) -> Self {
+        Self {
+            status: BackgroundNotificationStatus::Failed,
+            notifications: Vec::new(),
+            error: Some(error),
+        }
+    }
+}
+
+/// Default quiet window: if no notification arrives within this duration, stop collecting.
+const DEFAULT_QUIET_WINDOW: Duration = Duration::from_millis(1000);
+
+/// Collect notification updates after a background push wake.
+///
+/// This is the core async function that:
+/// 1. Ensures Whitenoise is initialized (cold or warm start).
+/// 2. Subscribes to the notification broadcast channel.
+/// 3. Refreshes relay subscriptions to fetch missed events.
+/// 4. Collects emitted `NotificationUpdate`s within a bounded time window.
+///
+/// The function uses a quiet-window strategy: it stops collecting once no new
+/// notification arrives for 1 second (the quiet window), or when `max_wait` is
+/// reached, whichever comes first.
+///
+/// # Arguments
+///
+/// * `config` - Whitenoise configuration (data dir, logs dir, keyring service).
+///   Ignored if Whitenoise is already initialized.
+/// * `max_wait` - Hard deadline for the entire collection pass. iOS background
+///   execution is limited to ~30 seconds; this should be well under that.
+pub async fn collect_notifications_after_push(
+    config: WhitenoiseConfig,
+    max_wait: Duration,
+) -> BackgroundNotificationResult {
+    match collect_notifications_inner(config, max_wait).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!(
+                target: "whitenoise::background_notifications",
+                "Background notification collection failed: {}",
+                e
+            );
+            BackgroundNotificationResult::failed(e.to_string())
+        }
+    }
+}
+
+async fn collect_notifications_inner(
+    config: WhitenoiseConfig,
+    max_wait: Duration,
+) -> Result<BackgroundNotificationResult> {
+    tracing::info!(
+        target: "whitenoise::background_notifications",
+        max_wait_ms = max_wait.as_millis() as u64,
+        "Starting background notification collection"
+    );
+
+    // Step 1: Ensure Whitenoise is initialized (no-op if warm, full boot if cold).
+    let whitenoise = Whitenoise::ensure_initialized(config).await?;
+
+    // Step 2: Subscribe to notification broadcast BEFORE refreshing subscriptions.
+    // This ordering is critical — events processed after ensure_all_subscriptions()
+    // will be emitted to the broadcast, and our subscriber must be in place to
+    // receive them. The `has_subscribers()` gate in the emit methods would otherwise
+    // drop them silently.
+    let mut rx = whitenoise.subscribe_to_notifications().updates;
+
+    // Step 3: Refresh relay subscriptions. This reconnects dead relays and
+    // fetches missed events using `since` timestamps. The event processor
+    // decrypts and processes them, emitting NotificationUpdates.
+    if let Err(e) = whitenoise.ensure_all_subscriptions().await {
+        tracing::warn!(
+            target: "whitenoise::background_notifications",
+            "ensure_all_subscriptions failed (continuing with collection): {}",
+            e
+        );
+    }
+
+    tracing::debug!(
+        target: "whitenoise::background_notifications",
+        "Subscriptions refreshed, starting collection window"
+    );
+
+    // Step 4: Collect notifications with quiet-window + hard deadline.
+    let deadline = Instant::now() + max_wait;
+    let mut collected = Vec::new();
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tracing::debug!(
+                target: "whitenoise::background_notifications",
+                "Hard deadline reached after collecting {} notifications",
+                collected.len()
+            );
+            break;
+        }
+
+        let wait = remaining.min(DEFAULT_QUIET_WINDOW);
+        match timeout(wait, rx.recv()).await {
+            Ok(Ok(update)) => {
+                tracing::debug!(
+                    target: "whitenoise::background_notifications",
+                    trigger = ?update.trigger,
+                    is_dm = update.is_dm,
+                    group_name = ?update.group_name,
+                    "Collected notification"
+                );
+                collected.push(update);
+            }
+            Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+                tracing::warn!(
+                    target: "whitenoise::background_notifications",
+                    "Notification receiver lagged by {} messages",
+                    n
+                );
+                continue;
+            }
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                tracing::debug!(
+                    target: "whitenoise::background_notifications",
+                    "Notification channel closed"
+                );
+                break;
+            }
+            Err(_) => {
+                // Timeout — quiet window expired with no new notification.
+                tracing::debug!(
+                    target: "whitenoise::background_notifications",
+                    "Quiet window expired after collecting {} notifications",
+                    collected.len()
+                );
+                break;
+            }
+        }
+    }
+
+    tracing::info!(
+        target: "whitenoise::background_notifications",
+        count = collected.len(),
+        "Background notification collection complete"
+    );
+
+    if collected.is_empty() {
+        Ok(BackgroundNotificationResult::no_data())
+    } else {
+        Ok(BackgroundNotificationResult::new_data(collected))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use mdk_core::prelude::GroupId;
+    use nostr_sdk::Keys;
+
+    use super::*;
+    use crate::whitenoise::notification_streaming::{
+        NotificationTrigger, NotificationUpdate, NotificationUser,
+    };
+
+    fn make_test_notification(trigger: NotificationTrigger, content: &str) -> NotificationUpdate {
+        let keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        NotificationUpdate {
+            trigger,
+            mls_group_id: GroupId::from_slice(&[1, 2, 3, 4]),
+            group_name: Some("Test Group".to_string()),
+            is_dm: false,
+            receiver: NotificationUser {
+                pubkey: keys.public_key(),
+                display_name: Some("Alice".to_string()),
+                picture_url: None,
+            },
+            sender: NotificationUser {
+                pubkey: sender_keys.public_key(),
+                display_name: Some("Bob".to_string()),
+                picture_url: None,
+            },
+            content: content.to_string(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn result_new_data_serializes_correctly() {
+        let notification = make_test_notification(NotificationTrigger::NewMessage, "Hello world");
+        let result = BackgroundNotificationResult::new_data(vec![notification]);
+
+        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
+
+        assert!(json.contains("\"status\": \"new_data\""));
+        assert!(json.contains("\"trigger\": \"NewMessage\""));
+        assert!(json.contains("Hello world"));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn result_no_data_serializes_correctly() {
+        let result = BackgroundNotificationResult::no_data();
+
+        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
+
+        assert!(json.contains("\"status\": \"no_data\""));
+        assert!(json.contains("\"notifications\": []"));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn result_failed_serializes_correctly() {
+        let result = BackgroundNotificationResult::failed("something broke".to_string());
+
+        let json = serde_json::to_string_pretty(&result).expect("serialization failed");
+
+        assert!(json.contains("\"status\": \"failed\""));
+        assert!(json.contains("\"error\": \"something broke\""));
+        assert!(json.contains("\"notifications\": []"));
+    }
+
+    #[test]
+    fn result_multiple_notifications_serializes_correctly() {
+        let n1 = make_test_notification(NotificationTrigger::NewMessage, "msg 1");
+        let n2 = make_test_notification(NotificationTrigger::GroupInvite, "");
+        let n3 = make_test_notification(NotificationTrigger::NewMessage, "msg 2");
+        let result = BackgroundNotificationResult::new_data(vec![n1, n2, n3]);
+
+        let json = serde_json::to_string(&result).expect("serialization failed");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("deserialization failed");
+
+        assert_eq!(parsed["notifications"].as_array().unwrap().len(), 3);
+        assert_eq!(parsed["notifications"][1]["trigger"], "GroupInvite");
+    }
+}

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -19,6 +19,7 @@ pub mod accounts;
 pub mod accounts_groups;
 pub mod aggregated_message;
 pub mod app_settings;
+pub mod background_notifications;
 pub(crate) mod cached_graph_user;
 pub mod chat_list;
 pub mod chat_list_streaming;
@@ -639,6 +640,26 @@ impl Whitenoise {
         GLOBAL_WHITENOISE
             .get()
             .ok_or(WhitenoiseError::Initialization)
+    }
+
+    /// Ensures the global Whitenoise singleton is initialized, returning a reference to it.
+    ///
+    /// If Whitenoise is already running (warm start), returns the existing instance immediately.
+    /// If not yet initialized (cold start), performs full initialization first.
+    ///
+    /// This is the primary entry point for contexts where the caller does not know whether
+    /// Whitenoise has already been started — for example, iOS background push handlers that
+    /// may fire when the app process is still alive or after a full cold launch.
+    ///
+    /// Unlike calling [`initialize_whitenoise`] directly, this method is safe to call
+    /// repeatedly — it will never start duplicate event processors or background tasks.
+    ///
+    /// [`initialize_whitenoise`]: Self::initialize_whitenoise
+    pub async fn ensure_initialized(config: WhitenoiseConfig) -> Result<&'static Self> {
+        if GLOBAL_WHITENOISE.get().is_none() {
+            Self::initialize_whitenoise(config).await?;
+        }
+        Self::get_instance()
     }
 
     /// Gracefully shuts down all background tasks without deleting data.

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -197,6 +197,14 @@ pub struct Whitenoise {
 
 static GLOBAL_WHITENOISE: OnceCell<Whitenoise> = OnceCell::const_new();
 
+/// Serializes callers of [`Whitenoise::ensure_initialized`] so two concurrent
+/// invokers cannot both observe an uninitialized singleton and both drive
+/// [`Whitenoise::initialize_whitenoise`]. The mutex is only held across the
+/// check-and-possibly-init; once `GLOBAL_WHITENOISE` is populated, subsequent
+/// callers acquire it, observe the populated singleton, and release it
+/// immediately without doing work.
+static ENSURE_INITIALIZED_LOCK: Mutex<()> = Mutex::const_new(());
+
 struct WhitenoiseComponents {
     event_tracker: std::sync::Arc<dyn event_tracker::EventTracker>,
     secrets_store: SecretsStore,
@@ -651,11 +659,32 @@ impl Whitenoise {
     /// Whitenoise has already been started — for example, iOS background push handlers that
     /// may fire when the app process is still alive or after a full cold launch.
     ///
-    /// Unlike calling [`initialize_whitenoise`] directly, this method is safe to call
-    /// repeatedly — it will never start duplicate event processors or background tasks.
+    /// # Concurrency
+    ///
+    /// Concurrent callers are serialized through a module-private mutex so that
+    /// exactly one caller drives [`initialize_whitenoise`] on cold start; all others
+    /// observe the populated singleton and return immediately. This guarantees the
+    /// documented "never start duplicate event processors or background tasks"
+    /// contract even when multiple iOS silent-push handlers run concurrently on
+    /// different threads.
+    ///
+    /// Note: this does not protect against a caller invoking [`initialize_whitenoise`]
+    /// directly in parallel with `ensure_initialized`. Outside of this background
+    /// push path, init is expected to be serialized by the caller (e.g. a single
+    /// Flutter cold-start path).
     ///
     /// [`initialize_whitenoise`]: Self::initialize_whitenoise
     pub async fn ensure_initialized(config: WhitenoiseConfig) -> Result<&'static Self> {
+        // Fast path: already initialized. Avoids taking the lock in the warm case,
+        // which is the common case once the app has been running.
+        if let Some(instance) = GLOBAL_WHITENOISE.get() {
+            return Ok(instance);
+        }
+
+        // Cold / contested path: take the lock and re-check under it. Only the
+        // first holder observes `is_none()` and drives initialization; later
+        // holders see the now-populated cell and fall through.
+        let _guard = ENSURE_INITIALIZED_LOCK.lock().await;
         if GLOBAL_WHITENOISE.get().is_none() {
             Self::initialize_whitenoise(config).await?;
         }


### PR DESCRIPTION
## Summary

- Adds `Whitenoise::ensure_initialized()` — an idempotent entry point that handles warm, suspended, and cold start scenarios without risking duplicate event processors or background tasks
- Adds `collect_notifications_after_push()` — subscribes to the notification broadcast, refreshes relay subscriptions to fetch missed events, and collects `NotificationUpdate`s within a bounded quiet-window + hard deadline
- Adds C ABI wrapper (`wn_collect_notifications_after_push` / `wn_string_free`) returning JSON for direct Swift interop without Flutter/FRB

This is the Rust-side implementation for iOS silent push notification support. The native iOS `BackgroundPushCoordinator` will call the C ABI function to collect notifications and schedule local `UNNotification`s.

## Design

The API handles three iOS app states with a single code path:
1. **Warm** (app active) — `ensure_initialized()` returns instantly, collection window likely yields no data (Flutter already handling)
2. **Suspended** (process frozen by iOS) — `ensure_initialized()` returns instantly, `ensure_all_subscriptions()` reconnects dead relays and fetches missed events
3. **Cold** (process terminated) — full Whitenoise initialization (~500-900ms), then normal collection

Cold-start benchmarks show initialization completes well within the iOS 30-second background execution budget.

## Test plan

- [x] Unit tests for JSON serialization of all result status variants (`new_data`, `no_data`, `failed`)
- [x] `just precommit-quick` passes
- [ ] Integration testing with iOS silent push on device (future: app repo work)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background notification collection after push events with a configurable wait timeout.
  * Native JSON-based interface for other apps to trigger background collection and receive results.
  * Stable, public notification result and status types exposed for downstream use.
  * Idempotent initialization helper to ensure safe startup of the notification system.

* **Tests**
  * Unit tests validating JSON shapes, trigger mapping, draining behavior, and native-interface handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->