### PR TITLE
[codex] Fix FRB push notification bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,9 @@ pub mod test_fixtures;
 // Core types
 pub use types::{
     AccountInboxPlaneStateSnapshot, AccountInboxPlanesStateSnapshot, DiscoveryPlaneStateSnapshot,
-    GroupPlaneGroupStateSnapshot, GroupPlaneStateSnapshot, ImageType, MessageWithTokens,
-    RelayControlStateSnapshot, RelaySessionRelayStateSnapshot, RelaySessionStateSnapshot,
+    GroupPlaneGroupStateSnapshot, GroupPlaneStateSnapshot, ImageType, ImageTypeError,
+    MessageWithTokens, RelayControlStateSnapshot, RelaySessionRelayStateSnapshot,
+    RelaySessionStateSnapshot,
 };
 pub use whitenoise::{Whitenoise, WhitenoiseConfig};
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -993,15 +993,22 @@ impl Whitenoise {
         // Drive groups concurrently with a bounded cap so relay connections
         // are not overwhelmed. RTTs for independent groups overlap while
         // total in-flight publishes stay within a reasonable limit.
-        let failures: Vec<String> = stream::iter(groups.iter())
+        let failures: Vec<String> = stream::iter(groups)
             .map(|group| {
-                self.share_token_to_single_group(
-                    &mdk,
-                    account,
-                    &group.mls_group_id,
-                    group.state,
-                    token_tag,
-                )
+                let group_state = group.state;
+                let group_id = group.mls_group_id;
+                let mdk = &mdk;
+
+                async move {
+                    self.share_token_to_single_group(
+                        mdk,
+                        account,
+                        &group_id,
+                        group_state,
+                        token_tag,
+                    )
+                    .await
+                }
             })
             .buffer_unordered(MAX_CONCURRENT_GROUP_PUBLISHES)
             .filter_map(|r| async move { r.err() })
@@ -1190,9 +1197,16 @@ impl Whitenoise {
         // Drive groups concurrently with a bounded cap so relay connections
         // are not overwhelmed. RTTs for independent groups overlap while
         // total in-flight publishes stay within a reasonable limit.
-        let failures: Vec<String> = stream::iter(groups.iter())
+        let failures: Vec<String> = stream::iter(groups)
             .map(|group| {
-                self.remove_token_from_single_group(&mdk, account, &group.mls_group_id, group.state)
+                let group_state = group.state;
+                let group_id = group.mls_group_id;
+                let mdk = &mdk;
+
+                async move {
+                    self.remove_token_from_single_group(mdk, account, &group_id, group_state)
+                        .await
+                }
             })
             .buffer_unordered(MAX_CONCURRENT_GROUP_PUBLISHES)
             .filter_map(|r| async move { r.err() })


### PR DESCRIPTION
## Summary

- Move joined-group push token share/remove fanout onto owned group IDs and states before constructing async futures.
- Re-export `ImageTypeError` beside `ImageType` so downstream crates can name the `TryFrom`/detection error type through the public crate API.

## Root Cause

The push-token group iteration built futures from `groups.iter()` and borrowed `&Group` fields across the future, which Flutter Rust Bridge rejects as not general enough when exposing the registration APIs. Separately, `ImageType` was public but its `TryFrom` error type was only available through the private `types` module.

## Validation

- `just precommit-quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * `ImageTypeError` type is now publicly exported for error handling.

* **Refactor**
  * Internal improvements to concurrent push token management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->