### PR TITLE
Add scoped relay handles to AccountSession (Phase 3)

### DIFF
--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -963,10 +963,19 @@ impl Whitenoise {
 
         // Warm both scopes concurrently — they use separate relay sessions
         // so there's no contention, and this halves the worst-case timeout.
+        let session = self.session(&account.pubkey);
         let (anon_result, account_result) = tokio::join!(
             self.relay_control.warm_ephemeral_relays(&warm_relays),
-            self.relay_control
-                .warm_ephemeral_relays_for_account(account.pubkey, &warm_relays),
+            async {
+                match &session {
+                    Some(s) => s.ephemeral.warm_relays(&warm_relays).await,
+                    None => {
+                        self.relay_control
+                            .warm_ephemeral_relays_for_account(account.pubkey, &warm_relays)
+                            .await
+                    }
+                }
+            },
         );
 
         if let Err(error) = anon_result {

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -83,6 +83,9 @@ pub enum WhitenoiseError {
     #[error("Cannot register external signer for a non-external account")]
     NotExternalSignerAccount,
 
+    #[error("Signer unavailable for account {0} — external signer not yet registered")]
+    SignerUnavailable(PublicKey),
+
     #[error("MDK error: {0}")]
     MdkCoreError(#[from] mdk_core::Error),
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod relay_handles;
+
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -11,6 +13,13 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
 use crate::whitenoise::error::{Result, WhitenoiseError};
 
+/// Signer slot shared between `AccountSession` and its relay handles.
+///
+/// `None` for restored external-signer accounts whose platform signer has not
+/// yet been re-registered. Handles that need signing return
+/// [`WhitenoiseError::SignerUnavailable`] until the slot is filled.
+pub(crate) type SharedSigner = Arc<RwLock<Option<Arc<dyn NostrSigner>>>>;
+
 /// A per-account session holding the account's MDK instance and signer.
 ///
 /// `signer` is `None` for restored external-signer accounts whose platform
@@ -20,9 +29,11 @@ use crate::whitenoise::error::{Result, WhitenoiseError};
 pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
-    signer: RwLock<Option<Arc<dyn NostrSigner>>>,
+    pub(crate) signer: SharedSigner,
     contact_list_guard: Arc<Semaphore>,
     cancellation: watch::Sender<bool>,
+    pub(crate) ephemeral: relay_handles::AccountEphemeralHandle,
+    pub(crate) group_handle: relay_handles::AccountGroupHandle,
 }
 
 impl AccountSession {
@@ -30,14 +41,25 @@ impl AccountSession {
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
         signer: Option<Arc<dyn NostrSigner>>,
+        ephemeral_plane: crate::relay_control::ephemeral::EphemeralPlane,
+        relay_control: Arc<crate::relay_control::RelayControlPlane>,
     ) -> Self {
         let (cancellation, _) = watch::channel(false);
+        let signer: SharedSigner = Arc::new(RwLock::new(signer));
+        let ephemeral = relay_handles::AccountEphemeralHandle::new(
+            account_pubkey,
+            ephemeral_plane,
+            signer.clone(),
+        );
+        let group_handle = relay_handles::AccountGroupHandle::new(account_pubkey, relay_control);
         Self {
             account_pubkey,
             mdk: Arc::new(mdk),
-            signer: RwLock::new(signer),
+            signer,
             contact_list_guard: Arc::new(Semaphore::new(1)),
             cancellation,
+            ephemeral,
+            group_handle,
         }
     }
 
@@ -50,7 +72,13 @@ impl AccountSession {
         } else {
             None
         };
-        Ok(Self::new(account.pubkey, mdk, signer))
+        Ok(Self::new(
+            account.pubkey,
+            mdk,
+            signer,
+            wn.relay_control.ephemeral(),
+            wn.relay_control.clone(),
+        ))
     }
 
     /// Replace the signer slot (e.g. when an external signer is re-registered).
@@ -243,14 +271,66 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+pub(crate) mod test_helpers {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    use super::*;
+    use crate::relay_control::RelayControlPlane;
+    use crate::relay_control::ephemeral::{EphemeralPlane, EphemeralPlaneConfig};
+    use crate::relay_control::observability::{RelayObservability, RelayObservabilityConfig};
+    use crate::whitenoise::accounts::test_utils::create_mdk;
+    use crate::whitenoise::database::Database;
+
+    async fn test_db() -> Arc<Database> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let database = Database {
+            pool,
+            path: PathBuf::from(":memory:"),
+            last_connected: SystemTime::now(),
+        };
+        database.migrate_up().await.unwrap();
+        Arc::new(database)
+    }
+
+    /// Build a minimal `AccountSession` for tests that don't exercise relay handles.
+    pub async fn test_session(pubkey: PublicKey) -> Arc<AccountSession> {
+        let mdk = create_mdk(pubkey);
+        let db = test_db().await;
+        let (event_sender, _) = tokio::sync::mpsc::channel(1);
+        let ephemeral = EphemeralPlane::new(
+            EphemeralPlaneConfig::default(),
+            db.clone(),
+            event_sender.clone(),
+            RelayObservability::new(RelayObservabilityConfig::default()),
+        );
+        let relay_control = Arc::new(RelayControlPlane::new(db, vec![], event_sender, [0u8; 16]));
+        Arc::new(AccountSession::new(
+            pubkey,
+            mdk,
+            None,
+            ephemeral,
+            relay_control,
+        ))
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use nostr_sdk::Keys;
 
-    use super::{AccountManager, AccountSession};
+    use super::AccountManager;
+    use super::test_helpers::test_session;
     use crate::whitenoise::accounts::DiscoveredRelayLists;
-    use crate::whitenoise::accounts::test_utils::create_mdk;
 
     fn test_pubkey() -> nostr_sdk::PublicKey {
         Keys::generate().public_key()
@@ -264,18 +344,13 @@ mod tests {
         }
     }
 
-    fn test_session(pubkey: nostr_sdk::PublicKey) -> Arc<AccountSession> {
-        let mdk = create_mdk(pubkey);
-        Arc::new(AccountSession::new(pubkey, mdk, None))
-    }
-
     // ── AccountManager: session CRUD ─────────────────────────────────
 
-    #[test]
-    fn insert_and_get_session() {
+    #[tokio::test]
+    async fn insert_and_get_session() {
         let mgr = AccountManager::default();
         let pk = test_pubkey();
-        let session = test_session(pk);
+        let session = test_session(pk).await;
 
         mgr.insert_session(session.clone());
         let got = mgr.get_session(&pk).expect("session should exist");
@@ -288,11 +363,11 @@ mod tests {
         assert!(mgr.get_session(&test_pubkey()).is_none());
     }
 
-    #[test]
-    fn remove_session_returns_removed() {
+    #[tokio::test]
+    async fn remove_session_returns_removed() {
         let mgr = AccountManager::default();
         let pk = test_pubkey();
-        mgr.insert_session(test_session(pk));
+        mgr.insert_session(test_session(pk).await);
 
         let removed = mgr.remove_session(&pk);
         assert!(removed.is_some());
@@ -305,11 +380,11 @@ mod tests {
         assert!(mgr.remove_session(&test_pubkey()).is_none());
     }
 
-    #[test]
-    fn clear_sessions_empties_all() {
+    #[tokio::test]
+    async fn clear_sessions_empties_all() {
         let mgr = AccountManager::default();
-        mgr.insert_session(test_session(test_pubkey()));
-        mgr.insert_session(test_session(test_pubkey()));
+        mgr.insert_session(test_session(test_pubkey()).await);
+        mgr.insert_session(test_session(test_pubkey()).await);
 
         mgr.clear_sessions();
         // Both are gone — we can only verify via new lookups returning None,
@@ -402,7 +477,7 @@ mod tests {
     #[tokio::test]
     async fn set_and_get_signer() {
         let pk = test_pubkey();
-        let session = test_session(pk);
+        let session = test_session(pk).await;
 
         assert!(session.get_signer().is_none(), "starts with no signer");
 
@@ -415,7 +490,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_signals_receivers() {
         let pk = test_pubkey();
-        let session = test_session(pk);
+        let session = test_session(pk).await;
         let mut rx = session.subscribe_cancellation();
 
         assert!(!*rx.borrow(), "not cancelled initially");
@@ -427,7 +502,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_contact_list_permit_limits_concurrency() {
         let pk = test_pubkey();
-        let session = test_session(pk);
+        let session = test_session(pk).await;
 
         let _permit = session.acquire_contact_list_permit().await.unwrap();
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -285,7 +285,7 @@ pub(crate) mod test_helpers {
     use crate::whitenoise::accounts::test_utils::create_mdk;
     use crate::whitenoise::database::Database;
 
-    async fn test_db() -> Arc<Database> {
+    pub async fn test_db() -> Arc<Database> {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -1,0 +1,359 @@
+use std::sync::Arc;
+
+use mdk_core::prelude::GroupId;
+use nostr_sdk::prelude::*;
+use nostr_sdk::{PublicKey, RelayUrl};
+
+use super::SharedSigner;
+use crate::RelayType;
+use crate::nostr_manager::{NostrManagerError, Result as NostrResult};
+use crate::relay_control::RelayControlPlane;
+use crate::relay_control::ephemeral::{EphemeralPlane, MessagePublishResult};
+use crate::relay_control::groups::GroupSubscriptionSpec;
+use crate::whitenoise::database::Database;
+use crate::whitenoise::error::WhitenoiseError;
+use crate::whitenoise::message_streaming::MessageStreamManager;
+
+/// Scoped handle into the shared ephemeral relay plane.
+///
+/// Carries this account's identity and signer reference. Delegates to shared
+/// warm relay connections internally. The API never exposes the pubkey or signer
+/// — they are baked in at construction time.
+pub(crate) struct AccountEphemeralHandle {
+    account_pubkey: PublicKey,
+    ephemeral: EphemeralPlane,
+    signer: SharedSigner,
+}
+
+#[expect(dead_code, reason = "signing/fetch helpers used by later phases")]
+impl AccountEphemeralHandle {
+    pub(crate) fn new(
+        account_pubkey: PublicKey,
+        ephemeral: EphemeralPlane,
+        signer: SharedSigner,
+    ) -> Self {
+        Self {
+            account_pubkey,
+            ephemeral,
+            signer,
+        }
+    }
+
+    /// Read the current signer, returning an error if none is set.
+    async fn require_signer(&self) -> NostrResult<Arc<dyn NostrSigner>> {
+        self.signer.read().await.clone().ok_or_else(|| {
+            NostrManagerError::WhitenoiseInstance(
+                WhitenoiseError::SignerUnavailable(self.account_pubkey).to_string(),
+            )
+        })
+    }
+
+    // ── Publish helpers (signer baked in) ───────────────────────────
+
+    pub(crate) async fn publish_gift_wrap(
+        &self,
+        receiver: &PublicKey,
+        rumor: UnsignedEvent,
+        extra_tags: &[Tag],
+        relays: &[RelayUrl],
+    ) -> NostrResult<Output<EventId>> {
+        let signer = self.require_signer().await?;
+        self.ephemeral
+            .publish_gift_wrap_to(
+                receiver,
+                rumor,
+                extra_tags,
+                self.account_pubkey,
+                relays,
+                signer,
+            )
+            .await
+    }
+
+    pub(crate) async fn publish_metadata(
+        &self,
+        metadata: &Metadata,
+        relays: &[RelayUrl],
+    ) -> NostrResult<Output<EventId>> {
+        let signer = self.require_signer().await?;
+        self.ephemeral
+            .publish_metadata_with_signer(metadata, relays, signer)
+            .await
+    }
+
+    pub(crate) async fn publish_relay_list(
+        &self,
+        relay_list: &[RelayUrl],
+        relay_type: RelayType,
+        target_relays: &[RelayUrl],
+    ) -> NostrResult<()> {
+        let signer = self.require_signer().await?;
+        self.ephemeral
+            .publish_relay_list_with_signer(relay_list, relay_type, target_relays, signer)
+            .await
+    }
+
+    pub(crate) async fn publish_follow_list(
+        &self,
+        follow_list: &[PublicKey],
+        target_relays: &[RelayUrl],
+        created_at: Option<Timestamp>,
+    ) -> NostrResult<()> {
+        let signer = self.require_signer().await?;
+        self.ephemeral
+            .publish_follow_list_with_signer_at(follow_list, target_relays, created_at, signer)
+            .await
+    }
+
+    pub(crate) async fn publish_key_package(
+        &self,
+        encoded_key_package: &str,
+        relays: &[RelayUrl],
+        tags: &[Tag],
+    ) -> NostrResult<Output<EventId>> {
+        let signer = self.require_signer().await?;
+        self.ephemeral
+            .publish_key_package_with_signer(encoded_key_package, relays, tags, signer)
+            .await
+    }
+
+    pub(crate) async fn publish_event_deletion(
+        &self,
+        event_ids: &[EventId],
+        relays: &[RelayUrl],
+    ) -> NostrResult<Output<EventId>> {
+        let signer = self.require_signer().await?;
+        if event_ids.len() == 1 {
+            self.ephemeral
+                .publish_event_deletion_with_signer(&event_ids[0], relays, signer)
+                .await
+        } else {
+            self.ephemeral
+                .publish_batch_event_deletion_with_signer(event_ids, relays, signer)
+                .await
+        }
+    }
+
+    // ── Publish helpers (event already signed) ──────────────────────
+
+    pub(crate) async fn publish_event(
+        &self,
+        event: Event,
+        relays: &[RelayUrl],
+        quorum_threshold: Option<usize>,
+    ) -> NostrResult<Output<EventId>> {
+        match quorum_threshold {
+            Some(threshold) => {
+                self.ephemeral
+                    .publish_event_with_quorum(event, &self.account_pubkey, relays, threshold)
+                    .await
+            }
+            None => {
+                self.ephemeral
+                    .publish_event_to(event, &self.account_pubkey, relays)
+                    .await
+            }
+        }
+    }
+
+    pub(crate) async fn publish_message_event(
+        &self,
+        event: Event,
+        relays: &[RelayUrl],
+        event_id: &str,
+        group_id: &GroupId,
+        database: &Database,
+        stream_manager: &Arc<MessageStreamManager>,
+    ) -> MessagePublishResult {
+        self.ephemeral
+            .publish_message_event(
+                event,
+                &self.account_pubkey,
+                relays,
+                event_id,
+                group_id,
+                database,
+                stream_manager,
+            )
+            .await
+    }
+
+    // ── Fetch helpers (anonymous scope, no signer needed) ───────────
+
+    pub(crate) async fn fetch_metadata(
+        &self,
+        relays: &[RelayUrl],
+        pubkey: PublicKey,
+    ) -> NostrResult<Option<Event>> {
+        self.ephemeral.fetch_metadata_from(relays, pubkey).await
+    }
+
+    pub(crate) async fn fetch_user_relays(
+        &self,
+        pubkey: PublicKey,
+        relay_type: RelayType,
+        relays: &[RelayUrl],
+    ) -> NostrResult<Option<Event>> {
+        self.ephemeral
+            .fetch_user_relays(pubkey, relay_type, relays)
+            .await
+    }
+
+    pub(crate) async fn fetch_user_key_package(
+        &self,
+        pubkey: PublicKey,
+        relays: &[RelayUrl],
+    ) -> NostrResult<Option<Event>> {
+        self.ephemeral.fetch_user_key_package(pubkey, relays).await
+    }
+
+    // ── Relay warming ───────────────────────────────────────────────
+
+    pub(crate) async fn warm_relays(&self, relays: &[RelayUrl]) -> NostrResult<()> {
+        self.ephemeral
+            .warm_relays_for_account(self.account_pubkey, relays)
+            .await
+    }
+}
+
+/// Scoped handle into the shared group relay plane.
+///
+/// One shared group relay session serves all accounts. This handle manages
+/// subscriptions for one account only, baking in the account identity so
+/// callers never pass a pubkey.
+pub(crate) struct AccountGroupHandle {
+    account_pubkey: PublicKey,
+    relay_control: Arc<RelayControlPlane>,
+}
+
+impl AccountGroupHandle {
+    pub(crate) fn new(account_pubkey: PublicKey, relay_control: Arc<RelayControlPlane>) -> Self {
+        Self {
+            account_pubkey,
+            relay_control,
+        }
+    }
+
+    #[expect(dead_code, reason = "used by group migration in later phases")]
+    pub(crate) async fn sync_subscriptions(
+        &self,
+        group_specs: &[GroupSubscriptionSpec],
+        since: Option<Timestamp>,
+    ) -> NostrResult<()> {
+        self.relay_control
+            .sync_account_group_subscriptions(self.account_pubkey, group_specs, since)
+            .await
+    }
+
+    pub(crate) async fn has_active_subscription(&self) -> bool {
+        self.relay_control
+            .has_account_subscriptions(&self.account_pubkey)
+            .await
+    }
+
+    pub(crate) async fn group_count(&self) -> usize {
+        self.relay_control
+            .group_plane_account_group_count(&self.account_pubkey)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use nostr_sdk::Keys;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::relay_control::observability::{RelayObservability, RelayObservabilityConfig};
+
+    async fn setup_test_db() -> Arc<Database> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let database = Database {
+            pool,
+            path: PathBuf::from(":memory:"),
+            last_connected: SystemTime::now(),
+        };
+        database.migrate_up().await.unwrap();
+        Arc::new(database)
+    }
+
+    fn test_ephemeral_plane(database: Arc<Database>) -> EphemeralPlane {
+        let (event_sender, _) = tokio::sync::mpsc::channel(16);
+        EphemeralPlane::new(
+            crate::relay_control::ephemeral::EphemeralPlaneConfig::default(),
+            database,
+            event_sender,
+            RelayObservability::new(RelayObservabilityConfig::default()),
+        )
+    }
+
+    // ── AccountEphemeralHandle ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn ephemeral_handle_require_signer_returns_error_when_none() {
+        let db = setup_test_db().await;
+        let plane = test_ephemeral_plane(db);
+        let pk = Keys::generate().public_key();
+        let signer: SharedSigner = Arc::new(RwLock::new(None));
+
+        let handle = AccountEphemeralHandle::new(pk, plane, signer);
+        let result = handle.require_signer().await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn ephemeral_handle_require_signer_returns_signer_when_set() {
+        let db = setup_test_db().await;
+        let plane = test_ephemeral_plane(db);
+        let keys = Keys::generate();
+        let pk = keys.public_key();
+        let signer: SharedSigner = Arc::new(RwLock::new(Some(Arc::new(keys))));
+
+        let handle = AccountEphemeralHandle::new(pk, plane, signer);
+        let result = handle.require_signer().await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ephemeral_handle_sees_signer_updates() {
+        let db = setup_test_db().await;
+        let plane = test_ephemeral_plane(db);
+        let pk = Keys::generate().public_key();
+        let signer: SharedSigner = Arc::new(RwLock::new(None));
+
+        let handle = AccountEphemeralHandle::new(pk, plane, signer.clone());
+
+        // Initially no signer.
+        assert!(handle.require_signer().await.is_err());
+
+        // Simulate external signer registration (writes to the shared slot).
+        *signer.write().await = Some(Arc::new(Keys::generate()));
+
+        // Handle sees the update.
+        assert!(handle.require_signer().await.is_ok());
+    }
+
+    // ── AccountGroupHandle ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn group_handle_delegates_group_count() {
+        let db = setup_test_db().await;
+        let (event_sender, _) = tokio::sync::mpsc::channel(16);
+        let relay_control = Arc::new(RelayControlPlane::new(db, vec![], event_sender, [0u8; 16]));
+        let pk = Keys::generate().public_key();
+        let handle = AccountGroupHandle::new(pk, relay_control);
+
+        assert_eq!(handle.group_count().await, 0);
+    }
+}

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -25,7 +25,6 @@ pub(crate) struct AccountEphemeralHandle {
     signer: SharedSigner,
 }
 
-#[expect(dead_code, reason = "signing/fetch helpers used by later phases")]
 impl AccountEphemeralHandle {
     pub(crate) fn new(
         account_pubkey: PublicKey,
@@ -50,6 +49,7 @@ impl AccountEphemeralHandle {
 
     // ── Publish helpers (signer baked in) ───────────────────────────
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_gift_wrap(
         &self,
         receiver: &PublicKey,
@@ -70,6 +70,7 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_metadata(
         &self,
         metadata: &Metadata,
@@ -81,6 +82,7 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 5+")]
     pub(crate) async fn publish_relay_list(
         &self,
         relay_list: &[RelayUrl],
@@ -93,6 +95,7 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 5+")]
     pub(crate) async fn publish_follow_list(
         &self,
         follow_list: &[PublicKey],
@@ -105,6 +108,7 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 14")]
     pub(crate) async fn publish_key_package(
         &self,
         encoded_key_package: &str,
@@ -117,11 +121,17 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_event_deletion(
         &self,
         event_ids: &[EventId],
         relays: &[RelayUrl],
     ) -> NostrResult<Output<EventId>> {
+        if event_ids.is_empty() {
+            return Err(NostrManagerError::WhitenoiseInstance(
+                "Cannot publish event deletion with empty event_ids list".to_string(),
+            ));
+        }
         let signer = self.require_signer().await?;
         if event_ids.len() == 1 {
             self.ephemeral
@@ -136,6 +146,7 @@ impl AccountEphemeralHandle {
 
     // ── Publish helpers (event already signed) ──────────────────────
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_event(
         &self,
         event: Event,
@@ -156,6 +167,7 @@ impl AccountEphemeralHandle {
         }
     }
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_message_event(
         &self,
         event: Event,
@@ -180,6 +192,7 @@ impl AccountEphemeralHandle {
 
     // ── Fetch helpers (anonymous scope, no signer needed) ───────────
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn fetch_metadata(
         &self,
         relays: &[RelayUrl],
@@ -188,6 +201,7 @@ impl AccountEphemeralHandle {
         self.ephemeral.fetch_metadata_from(relays, pubkey).await
     }
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn fetch_user_relays(
         &self,
         pubkey: PublicKey,
@@ -199,6 +213,7 @@ impl AccountEphemeralHandle {
             .await
     }
 
+    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn fetch_user_key_package(
         &self,
         pubkey: PublicKey,
@@ -260,31 +275,14 @@ impl AccountGroupHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::sync::Arc;
-    use std::time::SystemTime;
 
     use nostr_sdk::Keys;
-    use sqlx::sqlite::SqlitePoolOptions;
     use tokio::sync::RwLock;
 
     use super::*;
     use crate::relay_control::observability::{RelayObservability, RelayObservabilityConfig};
-
-    async fn setup_test_db() -> Arc<Database> {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .unwrap();
-        let database = Database {
-            pool,
-            path: PathBuf::from(":memory:"),
-            last_connected: SystemTime::now(),
-        };
-        database.migrate_up().await.unwrap();
-        Arc::new(database)
-    }
+    use crate::whitenoise::session::test_helpers::test_db;
 
     fn test_ephemeral_plane(database: Arc<Database>) -> EphemeralPlane {
         let (event_sender, _) = tokio::sync::mpsc::channel(16);
@@ -300,7 +298,7 @@ mod tests {
 
     #[tokio::test]
     async fn ephemeral_handle_require_signer_returns_error_when_none() {
-        let db = setup_test_db().await;
+        let db = test_db().await;
         let plane = test_ephemeral_plane(db);
         let pk = Keys::generate().public_key();
         let signer: SharedSigner = Arc::new(RwLock::new(None));
@@ -313,7 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn ephemeral_handle_require_signer_returns_signer_when_set() {
-        let db = setup_test_db().await;
+        let db = test_db().await;
         let plane = test_ephemeral_plane(db);
         let keys = Keys::generate();
         let pk = keys.public_key();
@@ -327,7 +325,7 @@ mod tests {
 
     #[tokio::test]
     async fn ephemeral_handle_sees_signer_updates() {
-        let db = setup_test_db().await;
+        let db = test_db().await;
         let plane = test_ephemeral_plane(db);
         let pk = Keys::generate().public_key();
         let signer: SharedSigner = Arc::new(RwLock::new(None));
@@ -348,7 +346,7 @@ mod tests {
 
     #[tokio::test]
     async fn group_handle_delegates_group_count() {
-        let db = setup_test_db().await;
+        let db = test_db().await;
         let (event_sender, _) = tokio::sync::mpsc::channel(16);
         let relay_control = Arc::new(RelayControlPlane::new(db, vec![], event_sender, [0u8; 16]));
         let pk = Keys::generate().public_key();

--- a/src/whitenoise/subscriptions.rs
+++ b/src/whitenoise/subscriptions.rs
@@ -221,20 +221,18 @@ impl Whitenoise {
     /// (e.g. because the background subscription setup failed on mobile).
     #[perf_instrument("whitenoise")]
     pub async fn is_account_subscriptions_operational(&self, account: &Account) -> Result<bool> {
-        let relay_healthy = self
-            .relay_control
-            .has_account_subscriptions(&account.pubkey)
-            .await;
+        let Some(session) = self.session(&account.pubkey) else {
+            return Ok(false);
+        };
+
+        let relay_healthy = session.group_handle.has_active_subscription().await;
 
         if !relay_healthy {
             return Ok(false);
         }
 
         let mdk_count = self.active_group_count(account)?;
-        let plane_count = self
-            .relay_control
-            .group_plane_account_group_count(&account.pubkey)
-            .await;
+        let plane_count = session.group_handle.group_count().await;
 
         if mdk_count != plane_count {
             tracing::info!(


### PR DESCRIPTION
![marmot](https://blossom.primal.net/8e7e2bdd445609317a78758badbd26bbf85e983ef6bc31c72591b9b0843b0f88.jpg)

## What

Phase 3 of the session-projection rearchitecture (see `docs/session-projection-implementation-plan.md`). Adds scoped relay handles to `AccountSession` so each session carries identity-bound access to the shared ephemeral and group relay planes.

## Why

Today, every account-scoped relay operation passes `account_pubkey` and `signer` as loose arguments through `RelayControlPlane`. The compiler cannot enforce that the right identity is used for the right account. Scoped handles bake the identity in at construction time: callers use `session.ephemeral.publish_gift_wrap(...)` with no pubkey or signer argument, and the handle routes through shared connections internally.

This is the prerequisite for later phases that migrate callers off the global `relay_control` facade and onto session-owned operations.

## How

**New file: `src/whitenoise/session/relay_handles.rs`**

Two handle types, both constructed inside `AccountSession::new()`:

- `AccountEphemeralHandle` wraps `EphemeralPlane` + a shared signer slot (`Arc<RwLock<Option<Arc<dyn NostrSigner>>>>`). Provides signing helpers for gift wraps, metadata, relay lists, key packages, deletions, and follow lists. Provides fetch helpers and relay warming. The signer slot is shared with the session, so `register_external_signer()` updates propagate to the handle without reconstruction.

- `AccountGroupHandle` wraps `Arc<RelayControlPlane>` + account pubkey. Provides subscription sync, health checks, and group count queries.

**Migrated callers (proof of concept):**

- `subscriptions.rs`: `is_account_subscriptions_operational` now routes through the session's group handle instead of calling `relay_control` directly.
- `setup.rs`: account-scoped ephemeral relay warming routes through the session's ephemeral handle when a session exists.

**Other changes:**

- `SharedSigner` type alias in `session/mod.rs` for the `Arc<RwLock<Option<Arc<dyn NostrSigner>>>>` pattern.
- `WhitenoiseError::SignerUnavailable` variant for when a handle needs a signer but none is registered.
- `AccountSession::from_account` pulls `EphemeralPlane` and `Arc<RelayControlPlane>` from `Whitenoise` to build handles during construction.
- Test helpers extracted to `session::test_helpers` with async `test_session()` that builds minimal relay infrastructure.

## API consolidation on the handle

The handle API is tighter than the underlying `EphemeralPlane` surface it wraps:

| EphemeralPlane (two methods) | Handle (one method) |
|---|---|
| `publish_follow_list_with_signer` + `publish_follow_list_with_signer_at` | `publish_follow_list(..., created_at: Option<Timestamp>)` |
| `publish_event_deletion_with_signer` + `publish_batch_event_deletion_with_signer` | `publish_event_deletion(event_ids: &[EventId], ...)` |
| `publish_event_to` + `publish_event_with_quorum` | `publish_event(..., quorum_threshold: Option<usize>)` |

## Validation

- `just check-fmt` / `just check-clippy` / `just check-docs` / `just check-dead-code-allows`: all pass
- New tests (4 in `relay_handles`, 15 existing session tests updated): all pass
- Handle methods not yet called from production use `#[expect(dead_code)]` (passes the `allow(dead_code)` lint check and will warn when later phases activate them)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clearer error messages when attempting to use external signers that have not been registered
  * Refactored session and relay management architecture for improved system stability and reliability
  * Optimized relay connection warming and subscription health monitoring through enhanced internal implementation
  * Better organization of relay operations within account sessions for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->