### PR TITLE
Move inbox plane ownership into AccountSession (Phase 3b)

### DIFF
--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -17,7 +17,7 @@ use std::{
 
 use nostr_sdk::{PublicKey, RelayUrl};
 use sha2::{Digest, Sha256};
-use tokio::sync::{Mutex, RwLock, broadcast, mpsc::Sender};
+use tokio::sync::{Mutex, broadcast, mpsc::Sender};
 use tokio::task::JoinHandle;
 
 pub(crate) mod account_inbox;
@@ -34,40 +34,24 @@ use crate::whitenoise::database::{Database, DatabaseError};
 use crate::{
     RelayType,
     nostr_manager::Result as NostrResult,
-    types::{AccountInboxPlanesStateSnapshot, ProcessableEvent, RelayControlStateSnapshot},
+    types::{
+        AccountInboxPlaneStateSnapshot, AccountInboxPlanesStateSnapshot, ProcessableEvent,
+        RelayControlStateSnapshot,
+    },
 };
 
 /// Top-level relay-control owner hosted by `Whitenoise`.
 ///
 /// This type defines the long-term system boundary described in
-/// `relay-control-plane-rearchitecture.md`. Discovery, group, and account
-/// inbox subscriptions already route through this boundary; remaining query
-/// and publish work still migrates incrementally.
-#[derive(Debug)]
-struct AccountInboxEntry {
-    plane: account_inbox::AccountInboxPlane,
-    telemetry_handle: JoinHandle<()>,
-}
-
-impl AccountInboxEntry {
-    async fn deactivate(self) {
-        self.telemetry_handle.abort();
-        self.plane.deactivate().await;
-    }
-
-    fn plane(&self) -> account_inbox::AccountInboxPlane {
-        self.plane.clone()
-    }
-}
-
+/// `relay-control-plane-rearchitecture.md`. Discovery, group, and ephemeral
+/// subscriptions route through this boundary, and it provides factory methods
+/// for account inbox planes whose ownership lives in `AccountSession`.
 #[derive(Debug)]
 pub(crate) struct RelayControlPlane {
     database: Arc<Database>,
     event_sender: Sender<ProcessableEvent>,
     session_salt: [u8; 16],
     discovery: discovery::DiscoveryPlane,
-    account_inbox_planes: RwLock<HashMap<PublicKey, AccountInboxEntry>>,
-    account_inbox_activation_locks: Mutex<HashMap<PublicKey, Arc<Mutex<()>>>>,
     group_plane: groups::GroupPlane,
     ephemeral: ephemeral::EphemeralPlane,
     observability: observability::RelayObservability,
@@ -104,8 +88,6 @@ impl RelayControlPlane {
             event_sender,
             session_salt,
             discovery,
-            account_inbox_planes: RwLock::new(HashMap::new()),
-            account_inbox_activation_locks: Mutex::new(HashMap::new()),
             group_plane,
             ephemeral,
             observability,
@@ -128,15 +110,6 @@ impl RelayControlPlane {
             .await;
         self.spawn_telemetry_persistor("group", self.group_plane.telemetry())
             .await;
-    }
-
-    async fn account_inbox_activation_lock(&self, account_pubkey: PublicKey) -> Arc<Mutex<()>> {
-        self.account_inbox_activation_locks
-            .lock()
-            .await
-            .entry(account_pubkey)
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
     }
 
     /// Structured relay observability configuration and helpers.
@@ -260,81 +233,6 @@ impl RelayControlPlane {
         Ok(())
     }
 
-    /// Activate group and inbox subscriptions for an account.
-    ///
-    /// **Atomicity:** First-time activation is NOT atomic across planes. Group
-    /// subscriptions are established first; if inbox activation subsequently
-    /// fails, group subscriptions may already be active. Refreshing an already
-    /// active account attempts to restore the previous group state on inbox
-    /// activation failure.
-    #[perf_instrument("relay")]
-    pub(crate) async fn activate_account_subscriptions(
-        &self,
-        account_pubkey: PublicKey,
-        inbox_relays: &[RelayUrl],
-        group_specs: &[groups::GroupSubscriptionSpec],
-        since: Option<nostr_sdk::Timestamp>,
-        signer: Arc<dyn nostr_sdk::NostrSigner>,
-    ) -> NostrResult<()> {
-        let account_lock = self.account_inbox_activation_lock(account_pubkey).await;
-        let _account_guard = account_lock.lock().await;
-        let previous_group_state = self.group_plane.account_state(&account_pubkey).await;
-
-        self.group_plane
-            .update_account(account_pubkey, group_specs, since)
-            .await?;
-
-        let plane = account_inbox::AccountInboxPlane::new(
-            account_inbox::AccountInboxPlaneConfig::new(account_pubkey, inbox_relays.to_vec()),
-            self.event_sender.clone(),
-            self.session_salt,
-        );
-
-        if let Err(error) = plane.activate(inbox_relays, since, signer).await {
-            plane.deactivate().await;
-
-            if let Some(previous_group_specs) = previous_group_state {
-                if let Err(restore_error) = self
-                    .group_plane
-                    .update_account(account_pubkey, &previous_group_specs, since)
-                    .await
-                {
-                    tracing::error!(
-                        target: "whitenoise::relay_control",
-                        account_pubkey = %account_pubkey,
-                        "Failed to restore previous group-plane state after inbox activation error: {restore_error}"
-                    );
-                }
-            } else {
-                self.group_plane.remove_account(&account_pubkey).await;
-            }
-
-            return Err(error);
-        }
-
-        let telemetry_receiver = plane.telemetry();
-        let telemetry_handle = self.spawn_telemetry_persistor_task(
-            &format!("account_inbox:{}", account_pubkey.to_hex()),
-            telemetry_receiver,
-        );
-
-        let previous_entry = {
-            let mut map = self.account_inbox_planes.write().await;
-            map.insert(
-                account_pubkey,
-                AccountInboxEntry {
-                    plane,
-                    telemetry_handle,
-                },
-            )
-        };
-        if let Some(previous_entry) = previous_entry {
-            previous_entry.deactivate().await;
-        }
-
-        Ok(())
-    }
-
     /// Returns the number of groups in the group plane for an account.
     pub(crate) async fn group_plane_account_group_count(&self, pubkey: &PublicKey) -> usize {
         self.group_plane.account_group_count(pubkey).await
@@ -352,71 +250,67 @@ impl RelayControlPlane {
             .await
     }
 
-    #[perf_instrument("relay")]
-    pub(crate) async fn deactivate_account_subscriptions(&self, account_pubkey: &PublicKey) {
-        let account_lock = self.account_inbox_activation_lock(*account_pubkey).await;
-        let _account_guard = account_lock.lock().await;
-
-        let entry = {
-            let mut map = self.account_inbox_planes.write().await;
-            map.remove(account_pubkey)
-        };
-        if let Some(entry) = entry {
-            entry.deactivate().await;
-        }
-
-        self.group_plane.remove_account(account_pubkey).await;
-        self.ephemeral.remove_account_scope(account_pubkey).await;
+    /// Snapshot the current group-plane state for an account (for rollback).
+    pub(crate) async fn group_plane_account_state(
+        &self,
+        pubkey: &PublicKey,
+    ) -> Option<Vec<groups::GroupSubscriptionSpec>> {
+        self.group_plane.account_state(pubkey).await
     }
 
-    /// Deactivates all account subscriptions. Called during full data teardown.
+    /// Remove an account from the group plane entirely.
+    pub(crate) async fn remove_account_from_group_plane(&self, pubkey: &PublicKey) {
+        self.group_plane.remove_account(pubkey).await;
+    }
+
+    /// Create an inbox plane for an account. The caller owns the returned plane.
+    pub(crate) fn create_account_inbox_plane(
+        &self,
+        account_pubkey: PublicKey,
+        inbox_relays: Vec<RelayUrl>,
+    ) -> account_inbox::AccountInboxPlane {
+        account_inbox::AccountInboxPlane::new(
+            account_inbox::AccountInboxPlaneConfig::new(account_pubkey, inbox_relays),
+            self.event_sender.clone(),
+            self.session_salt,
+        )
+    }
+
+    /// Spawn a telemetry persistor task for an account inbox plane.
+    /// The caller owns the returned handle and is responsible for aborting it.
+    pub(crate) fn spawn_account_inbox_telemetry(
+        &self,
+        account_pubkey: &PublicKey,
+        receiver: broadcast::Receiver<observability::RelayTelemetry>,
+    ) -> JoinHandle<()> {
+        self.spawn_telemetry_persistor_task(
+            &format!("account_inbox:{}", account_pubkey.to_hex()),
+            receiver,
+        )
+    }
+
+    /// Shut down shared relay infrastructure (group, ephemeral, telemetry).
+    ///
+    /// Account inbox planes are owned by `AccountSession` and must be
+    /// deactivated through the session before calling this method.
     #[perf_instrument("relay")]
     pub(crate) async fn shutdown_all(&self) {
-        let planes: Vec<_> = self
-            .account_inbox_planes
-            .write()
-            .await
-            .drain()
-            .map(|(_, entry)| entry)
-            .collect();
-
-        for entry in planes {
-            entry.deactivate().await;
-        }
-
         self.abort_control_plane_telemetry_persistors().await;
-
-        // Reset group and ephemeral planes independently to ensure any
-        // orphaned entries (e.g. from partial activation failures) are
-        // cleaned up, not just accounts that had inbox planes.
         self.group_plane.reset().await;
         self.ephemeral.remove_all_scopes().await;
-        self.account_inbox_activation_locks.lock().await.clear();
     }
 
+    /// Check if the group plane has an active subscription for this account.
     #[perf_instrument("relay")]
-    pub(crate) async fn has_account_subscriptions(&self, account_pubkey: &PublicKey) -> bool {
-        // Both planes must confirm the account is active. The group plane
-        // keeps an entry even for accounts with zero groups (empty state), so
-        // a missing entry unambiguously means setup never completed or failed.
-        let inbox_healthy = {
-            let plane = self
-                .account_inbox_planes
-                .read()
-                .await
-                .get(account_pubkey)
-                .map(AccountInboxEntry::plane);
-            match plane {
-                Some(plane) => plane.has_connected_relay().await,
-                None => false,
-            }
-        };
+    pub(crate) async fn has_group_subscription(&self, account_pubkey: &PublicKey) -> bool {
+        self.group_plane
+            .has_active_subscription(account_pubkey)
+            .await
+    }
 
-        inbox_healthy
-            && self
-                .group_plane
-                .has_active_subscription(account_pubkey)
-                .await
+    /// Remove an account's ephemeral relay scopes.
+    pub(crate) async fn remove_account_ephemeral_scope(&self, account_pubkey: &PublicKey) {
+        self.ephemeral.remove_account_scope(account_pubkey).await;
     }
 
     #[perf_instrument("relay")]
@@ -585,24 +479,17 @@ impl RelayControlPlane {
             .await
     }
 
+    /// Build a diagnostic snapshot. Inbox snapshots are collected from sessions
+    /// by the caller and passed in, since inbox planes are now session-owned.
     #[perf_instrument("relay")]
-    pub(crate) async fn snapshot(&self) -> RelayControlStateSnapshot {
+    pub(crate) async fn snapshot(
+        &self,
+        mut account_inbox_snapshots: Vec<AccountInboxPlaneStateSnapshot>,
+    ) -> RelayControlStateSnapshot {
         let discovery = self.discovery.snapshot().await;
         let ephemeral = self.ephemeral.snapshot().await;
 
-        let inbox_planes = self
-            .account_inbox_planes
-            .read()
-            .await
-            .iter()
-            .map(|(pubkey, entry)| (*pubkey, entry.plane()))
-            .collect::<Vec<_>>();
-
-        let mut account_snapshots = Vec::with_capacity(inbox_planes.len());
-        for (_, plane) in inbox_planes {
-            account_snapshots.push(plane.snapshot().await);
-        }
-        account_snapshots
+        account_inbox_snapshots
             .sort_unstable_by(|left, right| left.account_pubkey.cmp(&right.account_pubkey));
 
         RelayControlStateSnapshot {
@@ -610,8 +497,8 @@ impl RelayControlPlane {
             discovery,
             ephemeral,
             account_inbox: AccountInboxPlanesStateSnapshot {
-                active_account_count: account_snapshots.len(),
-                accounts: account_snapshots,
+                active_account_count: account_inbox_snapshots.len(),
+                accounts: account_inbox_snapshots,
             },
             group: self.group_plane.snapshot().await,
         }
@@ -620,23 +507,9 @@ impl RelayControlPlane {
     #[cfg(feature = "integration-tests")]
     pub(crate) async fn reset_for_tests(&self) -> NostrResult<()> {
         self.discovery.retire_all().await;
-
-        let inbox_planes = self
-            .account_inbox_planes
-            .write()
-            .await
-            .drain()
-            .map(|(_, entry)| entry)
-            .collect::<Vec<_>>();
-
-        for entry in inbox_planes {
-            entry.deactivate().await;
-        }
-
         self.abort_control_plane_telemetry_persistors().await;
         self.group_plane.reset().await;
         self.ephemeral.remove_all_scopes().await;
-        self.account_inbox_activation_locks.lock().await.clear();
         Ok(())
     }
 }
@@ -872,7 +745,7 @@ mod tests {
         let (event_sender, _) = tokio::sync::mpsc::channel(8);
         let relay_control = RelayControlPlane::new(database, Vec::new(), event_sender, [1; 16]);
 
-        let snapshot = relay_control.snapshot().await;
+        let snapshot = relay_control.snapshot(vec![]).await;
 
         assert_eq!(snapshot.ephemeral.account_scope_count, 0);
         assert!(snapshot.ephemeral.anonymous.is_none());
@@ -959,13 +832,13 @@ mod tests {
             .warm_ephemeral_relays_for_account(account_pubkey, std::slice::from_ref(&account_relay))
             .await;
 
-        let before = relay_control.snapshot().await;
+        let before = relay_control.snapshot(vec![]).await;
         assert!(before.ephemeral.anonymous.is_some());
         assert_eq!(before.ephemeral.account_scope_count, 1);
 
         relay_control.shutdown_all().await;
 
-        let after = relay_control.snapshot().await;
+        let after = relay_control.snapshot(vec![]).await;
         assert!(after.ephemeral.anonymous.is_none());
         assert_eq!(after.ephemeral.account_scope_count, 0);
     }

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -201,11 +201,8 @@ impl Whitenoise {
         // need the entry to exist.
         if let Some(session) = self.account_manager.get_session(pubkey) {
             session.cancel();
+            session.deactivate_subscriptions().await;
         }
-
-        self.relay_control
-            .deactivate_account_subscriptions(pubkey)
-            .await;
 
         self.account_manager.remove_session(pubkey);
 

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -862,13 +862,17 @@ impl Whitenoise {
 
         let signer = self.get_signer_for_account(account)?;
 
+        let Some(session) = self.session(&account.pubkey) else {
+            return Err(WhitenoiseError::AccountNotFound);
+        };
+
         // Activation (group + inbox planes) and ephemeral warming operate on
         // completely disjoint relay sessions with no shared mutable state, so
         // they can run concurrently. Using join! ensures both run to completion
         // — avoids cancelling a partially-warmed session if activation fails.
         let (activation_result, _) = tokio::join!(
-            self.relay_control.activate_account_subscriptions(
-                account.pubkey,
+            session.activate_subscriptions(
+                &self.relay_control,
                 &inbox_relays,
                 &group_specs,
                 since,
@@ -924,14 +928,16 @@ impl Whitenoise {
 
         let signer = self.get_signer_for_account(account)?;
 
+        let Some(session) = self.session(&account.pubkey) else {
+            return Err(WhitenoiseError::AccountNotFound);
+        };
+
         // All inputs ready — now safe to tear down and replace.
-        self.relay_control
-            .deactivate_account_subscriptions(&account.pubkey)
-            .await;
+        session.deactivate_subscriptions().await;
 
         let (activation_result, _) = tokio::join!(
-            self.relay_control.activate_account_subscriptions(
-                account.pubkey,
+            session.activate_subscriptions(
+                &self.relay_control,
                 &inbox_relays,
                 &group_specs,
                 since,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -664,7 +664,10 @@ impl Whitenoise {
         // Shutdown gracefully before deleting data
         self.shutdown().await?;
 
-        // Tear down all relay-control subscriptions
+        // Deactivate session-owned inbox planes before tearing down shared infra
+        self.account_manager.deactivate_all_inboxes().await;
+
+        // Tear down shared relay-control subscriptions (group, ephemeral, telemetry)
         self.relay_control.shutdown_all().await;
 
         // Remove database (accounts and media) data
@@ -2810,10 +2813,10 @@ mod tests {
 
             // Tear down subscriptions to simulate the welcome-processing
             // cascade failure (group exists in MDK but not in group plane)
-            whitenoise
-                .relay_control
-                .deactivate_account_subscriptions(&creator_account.pubkey)
-                .await;
+            let session = whitenoise
+                .session(&creator_account.pubkey)
+                .expect("session should exist");
+            session.deactivate_subscriptions().await;
 
             // Re-activate inbox only (without groups) to isolate the test
             // to the group count parity check — inbox is healthy, groups are not
@@ -2824,10 +2827,9 @@ mod tests {
                     .await
                     .unwrap(),
             );
-            whitenoise
-                .relay_control
-                .activate_account_subscriptions(
-                    creator_account.pubkey,
+            session
+                .activate_subscriptions(
+                    &whitenoise.relay_control,
                     &inbox_relays,
                     &[], // empty group specs — simulates the missing group
                     creator_account.since_timestamp(10),
@@ -2947,10 +2949,10 @@ mod tests {
             );
 
             // Test recovery - ensure_account_subscriptions should fix broken state
-            whitenoise
-                .relay_control
-                .deactivate_account_subscriptions(&account.pubkey)
-                .await;
+            let session = whitenoise
+                .session(&account.pubkey)
+                .expect("session should exist");
+            session.deactivate_subscriptions().await;
 
             let is_operational = whitenoise
                 .is_account_subscriptions_operational(&account)
@@ -3050,10 +3052,10 @@ mod tests {
             let account2 = whitenoise.create_identity().await.unwrap();
 
             // Break account1's subscriptions
-            whitenoise
-                .relay_control
-                .deactivate_account_subscriptions(&account1.pubkey)
-                .await;
+            let session1 = whitenoise
+                .session(&account1.pubkey)
+                .expect("session should exist");
+            session1.deactivate_subscriptions().await;
 
             // Verify account1 is not operational
             let account1_operational = whitenoise
@@ -3471,10 +3473,10 @@ mod tests {
 
             // Simulate app startup gap: no signer registered yet + account subscriptions missing.
             whitenoise.remove_external_signer(&account.pubkey);
-            whitenoise
-                .relay_control
-                .deactivate_account_subscriptions(&account.pubkey)
-                .await;
+            let session = whitenoise
+                .session(&account.pubkey)
+                .expect("session should exist");
+            session.deactivate_subscriptions().await;
 
             let before = whitenoise
                 .is_account_subscriptions_operational(&account)

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -5,10 +5,16 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use mdk_core::prelude::MDK;
 use mdk_sqlite_storage::MdkSqliteStorage;
-use nostr_sdk::PublicKey;
 use nostr_sdk::prelude::NostrSigner;
-use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore, watch};
+use nostr_sdk::{PublicKey, RelayUrl};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore, watch};
+use tokio::task::JoinHandle;
 
+use crate::nostr_manager::Result as NostrResult;
+use crate::relay_control::RelayControlPlane;
+use crate::relay_control::account_inbox::AccountInboxPlane;
+use crate::relay_control::groups::GroupSubscriptionSpec;
+use crate::types::AccountInboxPlaneStateSnapshot;
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
 use crate::whitenoise::error::{Result, WhitenoiseError};
@@ -19,6 +25,23 @@ use crate::whitenoise::error::{Result, WhitenoiseError};
 /// yet been re-registered. Handles that need signing return
 /// [`WhitenoiseError::SignerUnavailable`] until the slot is filled.
 pub(crate) type SharedSigner = Arc<RwLock<Option<Arc<dyn NostrSigner>>>>;
+
+/// Owned inbox plane state held by `AccountSession`.
+///
+/// Wraps the plane together with its telemetry persistor task handle so they
+/// share a single lifecycle: when the inbox is deactivated the telemetry task
+/// is aborted and the plane's relay session is shut down.
+struct AccountInboxState {
+    plane: AccountInboxPlane,
+    telemetry_handle: JoinHandle<()>,
+}
+
+impl AccountInboxState {
+    async fn deactivate(self) {
+        self.telemetry_handle.abort();
+        self.plane.deactivate().await;
+    }
+}
 
 /// A per-account session holding the account's MDK instance and signer.
 ///
@@ -34,6 +57,10 @@ pub struct AccountSession {
     cancellation: watch::Sender<bool>,
     pub(crate) ephemeral: relay_handles::AccountEphemeralHandle,
     pub(crate) group_handle: relay_handles::AccountGroupHandle,
+    /// Owned inbox plane, `None` until first activation.
+    inbox: RwLock<Option<AccountInboxState>>,
+    /// Serializes concurrent activate/deactivate operations.
+    activation_lock: Mutex<()>,
 }
 
 impl AccountSession {
@@ -60,6 +87,8 @@ impl AccountSession {
             cancellation,
             ephemeral,
             group_handle,
+            inbox: RwLock::new(None),
+            activation_lock: Mutex::new(()),
         }
     }
 
@@ -117,6 +146,106 @@ impl AccountSession {
                 )
             })
     }
+
+    // ── Inbox plane lifecycle ──────────────────────────────────────
+
+    /// Activate group and inbox subscriptions for this session.
+    ///
+    /// **Atomicity:** Group subscriptions are established first; if inbox
+    /// activation subsequently fails, group subscriptions are rolled back to
+    /// their previous state.
+    pub(crate) async fn activate_subscriptions(
+        &self,
+        relay_control: &RelayControlPlane,
+        inbox_relays: &[RelayUrl],
+        group_specs: &[GroupSubscriptionSpec],
+        since: Option<nostr_sdk::Timestamp>,
+        signer: Arc<dyn NostrSigner>,
+    ) -> NostrResult<()> {
+        let _guard = self.activation_lock.lock().await;
+
+        let previous_group_state = self.group_handle.save_state().await;
+
+        self.group_handle
+            .sync_subscriptions(group_specs, since)
+            .await?;
+
+        let plane =
+            relay_control.create_account_inbox_plane(self.account_pubkey, inbox_relays.to_vec());
+
+        if let Err(error) = plane.activate(inbox_relays, since, signer).await {
+            plane.deactivate().await;
+
+            if let Some(previous_group_specs) = previous_group_state {
+                if let Err(restore_error) = self
+                    .group_handle
+                    .sync_subscriptions(&previous_group_specs, since)
+                    .await
+                {
+                    tracing::error!(
+                        target: "whitenoise::session",
+                        account_pubkey = %self.account_pubkey,
+                        "Failed to restore previous group-plane state after inbox activation error: {restore_error}"
+                    );
+                }
+            } else {
+                self.group_handle.remove().await;
+            }
+
+            return Err(error);
+        }
+
+        let telemetry_receiver = plane.telemetry();
+        let telemetry_handle =
+            relay_control.spawn_account_inbox_telemetry(&self.account_pubkey, telemetry_receiver);
+
+        let previous = self.inbox.write().await.replace(AccountInboxState {
+            plane,
+            telemetry_handle,
+        });
+        if let Some(previous) = previous {
+            previous.deactivate().await;
+        }
+
+        Ok(())
+    }
+
+    /// Deactivate all subscriptions (inbox, group, ephemeral) for this session.
+    pub(crate) async fn deactivate_subscriptions(&self) {
+        let _guard = self.activation_lock.lock().await;
+
+        let state = self.inbox.write().await.take();
+        if let Some(state) = state {
+            state.deactivate().await;
+        }
+
+        self.group_handle.remove().await;
+        self.group_handle.remove_ephemeral_scope().await;
+    }
+
+    /// Deactivate only the inbox plane (used during shutdown).
+    pub(crate) async fn deactivate_inbox(&self) {
+        let state = self.inbox.write().await.take();
+        if let Some(state) = state {
+            state.deactivate().await;
+        }
+    }
+
+    /// Check if the inbox plane has a connected relay.
+    pub(crate) async fn has_inbox_subscription(&self) -> bool {
+        match &*self.inbox.read().await {
+            Some(state) => state.plane.has_connected_relay().await,
+            None => false,
+        }
+    }
+
+    /// Capture a diagnostic snapshot of the inbox plane, if active.
+    pub(crate) async fn inbox_snapshot(&self) -> Option<AccountInboxPlaneStateSnapshot> {
+        match &*self.inbox.read().await {
+            Some(state) => Some(state.plane.snapshot().await),
+            None => None,
+        }
+    }
 }
 
 /// Manages active account sessions and pending logins.
@@ -172,6 +301,26 @@ impl AccountManager {
             entry.value().cancel();
         }
         self.sessions.clear();
+    }
+
+    /// Deactivate all session inbox planes. Called before relay-control shutdown.
+    pub(crate) async fn deactivate_all_inboxes(&self) {
+        let sessions: Vec<_> = self.sessions.iter().map(|e| e.value().clone()).collect();
+        for session in sessions {
+            session.deactivate_inbox().await;
+        }
+    }
+
+    /// Collect inbox snapshots from all active sessions for diagnostics.
+    pub(crate) async fn collect_inbox_snapshots(&self) -> Vec<AccountInboxPlaneStateSnapshot> {
+        let sessions: Vec<_> = self.sessions.iter().map(|e| e.value().clone()).collect();
+        let mut snapshots = Vec::with_capacity(sessions.len());
+        for session in sessions {
+            if let Some(snapshot) = session.inbox_snapshot().await {
+                snapshots.push(snapshot);
+            }
+        }
+        snapshots
     }
 
     /// Record that a multi-step login is in progress for `pubkey`.

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -249,7 +249,6 @@ impl AccountGroupHandle {
         }
     }
 
-    #[expect(dead_code, reason = "used by group migration in later phases")]
     pub(crate) async fn sync_subscriptions(
         &self,
         group_specs: &[GroupSubscriptionSpec],
@@ -260,9 +259,23 @@ impl AccountGroupHandle {
             .await
     }
 
+    /// Snapshot the current group-plane state for rollback during activation.
+    pub(crate) async fn save_state(&self) -> Option<Vec<GroupSubscriptionSpec>> {
+        self.relay_control
+            .group_plane_account_state(&self.account_pubkey)
+            .await
+    }
+
+    /// Remove this account from the group plane entirely.
+    pub(crate) async fn remove(&self) {
+        self.relay_control
+            .remove_account_from_group_plane(&self.account_pubkey)
+            .await;
+    }
+
     pub(crate) async fn has_active_subscription(&self) -> bool {
         self.relay_control
-            .has_account_subscriptions(&self.account_pubkey)
+            .has_group_subscription(&self.account_pubkey)
             .await
     }
 
@@ -270,6 +283,13 @@ impl AccountGroupHandle {
         self.relay_control
             .group_plane_account_group_count(&self.account_pubkey)
             .await
+    }
+
+    /// Remove this account's ephemeral relay scopes.
+    pub(crate) async fn remove_ephemeral_scope(&self) {
+        self.relay_control
+            .remove_account_ephemeral_scope(&self.account_pubkey)
+            .await;
     }
 }
 

--- a/src/whitenoise/subscriptions.rs
+++ b/src/whitenoise/subscriptions.rs
@@ -225,9 +225,10 @@ impl Whitenoise {
             return Ok(false);
         };
 
-        let relay_healthy = session.group_handle.has_active_subscription().await;
+        let inbox_healthy = session.has_inbox_subscription().await;
+        let group_healthy = session.group_handle.has_active_subscription().await;
 
-        if !relay_healthy {
+        if !inbox_healthy || !group_healthy {
             return Ok(false);
         }
 
@@ -287,7 +288,8 @@ impl Whitenoise {
     /// Returns a live in-memory snapshot of relay-plane state for debugging.
     #[perf_instrument("whitenoise")]
     pub async fn get_relay_control_state(&self) -> RelayControlStateSnapshot {
-        self.relay_control.snapshot().await
+        let inbox_snapshots = self.account_manager.collect_inbox_snapshots().await;
+        self.relay_control.snapshot(inbox_snapshots).await
     }
 
     #[perf_instrument("whitenoise")]


### PR DESCRIPTION
![marmot](https://blossom.primal.net/e0796073ad8d9876ea5be0754de883e30c6f21019f84bcd167afafdc49bbc478.jpg)

## What

This marmot carried its mailbox home. AccountInboxPlane ownership moves from RelayControlPlane (a shared HashMap) into AccountSession, where it belongs.

Ephemeral and group planes are shared infrastructure accessed through scoped handles. The inbox plane is different: each account gets its own dedicated relay session, its own telemetry persistor, its own lifecycle. Storing it in a global HashMap keyed by pubkey was a holdover from before sessions existed.

## Why

The session/projection rearchitecture (Phase 3b) calls for each piece of state to have a declared owner. The inbox plane's owner is the account session, period. Parking it in RelayControlPlane forced every activate/deactivate call to route through the control plane and look up the right entry. Now the session creates, activates, and tears down its own inbox directly.

## How

**AccountSession gains inbox ownership:**
- New `AccountInboxState` struct wraps the plane + telemetry task handle
- `inbox: RwLock<Option<AccountInboxState>>` field, `None` until first activation
- `activation_lock: Mutex<()>` serializes concurrent activate/deactivate calls
- `activate_subscriptions()` orchestrates group update, inbox creation, telemetry spawn, and rollback on failure
- `deactivate_subscriptions()` tears down inbox + group + ephemeral scopes
- `has_inbox_subscription()` and `inbox_snapshot()` for health checks and diagnostics

**RelayControlPlane becomes a factory and shared-infra host:**
- `AccountInboxEntry`, `account_inbox_planes` HashMap, and `account_inbox_activation_locks` removed
- `activate_account_subscriptions()` and `deactivate_account_subscriptions()` removed
- New factory methods: `create_account_inbox_plane()`, `spawn_account_inbox_telemetry()`
- New delegation helpers: `group_plane_account_state()`, `remove_account_from_group_plane()`, `has_group_subscription()`, `remove_account_ephemeral_scope()`
- `snapshot()` accepts pre-collected inbox snapshots from the caller

**AccountGroupHandle extended for rollback support:**
- `save_state()`, `remove()`, `remove_ephemeral_scope()`
- `has_active_subscription()` checks only group health (inbox health checked via session)

**Callers updated:**
- `setup_account_subscriptions` and `refresh_account_subscriptions` route through the session
- `logout` deactivates subscriptions via the session before removing it
- `is_account_subscriptions_operational` checks both `session.has_inbox_subscription()` and `session.group_handle.has_active_subscription()`
- `get_relay_control_state` collects inbox snapshots from `AccountManager`
- `delete_all_data` deactivates session inboxes before shared-infra shutdown
- All tests updated to use session-based activation

## Validation

- `just check` (fmt, clippy, docs, dead_code): all pass
- 68 refactor-specific tests: all pass
- Full unit test suite: passes (known flaky key-package-timeout tests excluded)