### PR TITLE
Add dual-kind SelfRemove key package lifecycle support

### DIFF
--- a/db_migrations/0046_published_key_package_kind_metadata.sql
+++ b/db_migrations/0046_published_key_package_kind_metadata.sql
@@ -1,0 +1,13 @@
+-- Track dual-published KeyPackage event metadata.
+
+ALTER TABLE published_key_packages
+ADD COLUMN kind INTEGER NOT NULL DEFAULT 443;
+
+ALTER TABLE published_key_packages
+ADD COLUMN d_tag TEXT NULL;
+
+CREATE INDEX idx_published_kp_account_hash_ref
+ON published_key_packages(account_pubkey, key_package_hash_ref);
+
+CREATE INDEX idx_published_kp_account_kind_d_tag
+ON published_key_packages(account_pubkey, kind, d_tag);

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -2259,7 +2259,7 @@ async fn keys_delete(
 async fn keys_delete_all(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
     let count = wn
-        .delete_all_key_packages_for_account(&account, true)
+        .delete_legacy_key_packages_for_account(&account)
         .await
         .map_err(|e| Response::err(e.to_string()))?;
     Ok(Response::ok(serde_json::json!({ "deleted_count": count })))

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -65,9 +65,9 @@ impl TestCase for KeyPackageMaintenanceTestCase {
         );
 
         // Delete any existing key packages to start with a clean slate. This
-        // test needs a fully empty relay state, while the app-facing "delete
-        // all" helper intentionally removes only legacy kind:443 copies.
-        let deleted = delete_all_relay_key_packages(context, &account, true).await?;
+        // test needs a fully empty relay state, while the developer-facing
+        // legacy cleanup intentionally removes only kind:443 copies.
+        let deleted = delete_all_relay_key_packages_for_test_setup(context, &account, true).await?;
         tracing::info!("✓ Deleted {} existing key package(s)", deleted);
 
         let before_delete = wait_for_key_packages(
@@ -101,7 +101,7 @@ impl TestCase for KeyPackageMaintenanceTestCase {
         );
 
         // Delete current key packages and publish an expired one.
-        delete_all_relay_key_packages(context, &account, true).await?;
+        delete_all_relay_key_packages_for_test_setup(context, &account, true).await?;
         wait_for_key_packages(
             context,
             &account,
@@ -209,7 +209,7 @@ where
     .await
 }
 
-async fn delete_all_relay_key_packages(
+async fn delete_all_relay_key_packages_for_test_setup(
     context: &ScenarioContext,
     account: &crate::Account,
     delete_mls_stored_keys: bool,

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -8,6 +8,8 @@ use crate::whitenoise::scheduled_tasks::{KeyPackageMaintenance, Task};
 use async_trait::async_trait;
 use nostr_sdk::prelude::*;
 
+const MAX_RELAY_KEY_PACKAGE_DELETE_ROUNDS: u32 = 10;
+
 /// Verifies the key package maintenance task handles both cases:
 /// 1. Publishes key packages when none exist
 /// 2. Rotates expired key packages (deletes old, publishes new)
@@ -212,15 +214,43 @@ async fn delete_all_relay_key_packages(
     account: &crate::Account,
     delete_mls_stored_keys: bool,
 ) -> Result<usize, WhitenoiseError> {
-    let key_packages = context
-        .whitenoise
-        .fetch_all_key_packages_for_account(account)
-        .await?;
+    let mut total_deleted = 0;
 
-    context
-        .whitenoise
-        .delete_key_packages_for_account(account, key_packages, delete_mls_stored_keys, 1)
-        .await
+    for round in 0..MAX_RELAY_KEY_PACKAGE_DELETE_ROUNDS {
+        let key_packages = context
+            .whitenoise
+            .fetch_all_key_packages_for_account(account)
+            .await?;
+
+        if key_packages.is_empty() {
+            return Ok(total_deleted);
+        }
+
+        let key_package_count = key_packages.len();
+        let delete_mls_stored_keys_this_round = delete_mls_stored_keys && round == 0;
+        let deleted = context
+            .whitenoise
+            .delete_key_packages_for_account(
+                account,
+                key_packages,
+                delete_mls_stored_keys_this_round,
+                1,
+            )
+            .await?;
+
+        total_deleted += deleted;
+
+        if deleted == 0 {
+            tracing::warn!(
+                "Deleted 0 key package(s) despite {} remaining after {} relay cleanup round(s)",
+                key_package_count,
+                round + 1,
+            );
+            break;
+        }
+    }
+
+    Ok(total_deleted)
 }
 
 /// Publishes a key package with a backdated timestamp using test infrastructure.

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use crate::WhitenoiseError;
 use crate::integration_tests::core::*;
+use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND_LEGACY;
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::scheduled_tasks::{KeyPackageMaintenance, Task};
 use async_trait::async_trait;
@@ -61,11 +62,10 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             initially_published.len()
         );
 
-        // Delete any existing key packages to start with a clean slate.
-        let deleted = context
-            .whitenoise
-            .delete_all_key_packages_for_account(&account, true)
-            .await?;
+        // Delete any existing key packages to start with a clean slate. This
+        // test needs a fully empty relay state, while the app-facing "delete
+        // all" helper intentionally removes only legacy kind:443 copies.
+        let deleted = delete_all_relay_key_packages(context, &account, true).await?;
         tracing::info!("✓ Deleted {} existing key package(s)", deleted);
 
         let before_delete = wait_for_key_packages(
@@ -98,11 +98,8 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             after_publish.len()
         );
 
-        // Delete current key packages and publish an expired one
-        context
-            .whitenoise
-            .delete_all_key_packages_for_account(&account, true)
-            .await?;
+        // Delete current key packages and publish an expired one.
+        delete_all_relay_key_packages(context, &account, true).await?;
         wait_for_key_packages(
             context,
             &account,
@@ -210,6 +207,22 @@ where
     .await
 }
 
+async fn delete_all_relay_key_packages(
+    context: &ScenarioContext,
+    account: &crate::Account,
+    delete_mls_stored_keys: bool,
+) -> Result<usize, WhitenoiseError> {
+    let key_packages = context
+        .whitenoise
+        .fetch_all_key_packages_for_account(account)
+        .await?;
+
+    context
+        .whitenoise
+        .delete_key_packages_for_account(account, key_packages, delete_mls_stored_keys, 1)
+        .await
+}
+
 /// Publishes a key package with a backdated timestamp using test infrastructure.
 async fn publish_backdated_key_package(
     context: &ScenarioContext,
@@ -233,7 +246,7 @@ async fn publish_backdated_key_package(
     let backdated = Timestamp::now() - Duration::from_secs(days_old * 24 * 60 * 60);
 
     // Build and sign the event with custom timestamp
-    let event = EventBuilder::new(Kind::MlsKeyPackage, &key_package_data.content)
+    let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, &key_package_data.content)
         .tags(key_package_data.tags_443.to_vec())
         .custom_created_at(backdated)
         .sign_with_keys(&keys)
@@ -253,6 +266,8 @@ async fn publish_backdated_key_package(
             &account.pubkey,
             &key_package_data.hash_ref,
             &event_id.to_hex(),
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
         )
         .await?;
 

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -19,7 +19,10 @@ use crate::{
         accounts::Account,
         aggregated_message::AggregatedMessage,
         database::{Database, published_events::PublishedEvent},
-        key_packages::{REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags},
+        key_packages::{
+            MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, REQUIRED_MLS_CIPHERSUITE_TAG,
+            is_key_package_kind, validate_marmot_key_package_tags,
+        },
         message_aggregator::DeliveryStatus,
         message_streaming::{MessageStreamManager, MessageUpdate, UpdateTrigger},
     },
@@ -81,6 +84,13 @@ pub(crate) struct EphemeralScope {
 pub(crate) enum MessagePublishResult {
     Published(Output<EventId>),
     Failed,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum KeyPackageLookup {
+    Found(Event),
+    Incompatible { event: Event, reason: String },
+    NotFound,
 }
 
 impl MessagePublishResult {
@@ -212,8 +222,20 @@ impl EphemeralPlane {
         pubkey: PublicKey,
         relays: &[RelayUrl],
     ) -> Result<Option<Event>> {
+        match self.fetch_user_key_package_lookup(pubkey, relays).await? {
+            KeyPackageLookup::Found(event) => Ok(Some(event)),
+            KeyPackageLookup::Incompatible { .. } | KeyPackageLookup::NotFound => Ok(None),
+        }
+    }
+
+    #[perf_instrument("relay")]
+    pub(crate) async fn fetch_user_key_package_lookup(
+        &self,
+        pubkey: PublicKey,
+        relays: &[RelayUrl],
+    ) -> Result<KeyPackageLookup> {
         self.anonymous_scope()
-            .fetch_user_key_package(pubkey, relays)
+            .fetch_user_key_package_lookup(pubkey, relays)
             .await
     }
 
@@ -302,13 +324,13 @@ impl EphemeralPlane {
     #[perf_instrument("relay")]
     pub(crate) async fn publish_key_package_with_signer(
         &self,
+        kind: Kind,
         encoded_key_package: &str,
         relays: &[RelayUrl],
         tags: &[Tag],
         signer: Arc<dyn NostrSigner>,
     ) -> Result<Output<EventId>> {
-        let event_builder =
-            EventBuilder::new(Kind::MlsKeyPackage, encoded_key_package).tags(tags.to_vec());
+        let event_builder = EventBuilder::new(kind, encoded_key_package).tags(tags.to_vec());
 
         self.publish_event_builder_with_signer(event_builder, relays, signer)
             .await
@@ -783,6 +805,47 @@ impl EphemeralPlane {
     fn is_key_package_event_semantically_valid(event: &Event) -> bool {
         validate_marmot_key_package_tags(event, REQUIRED_MLS_CIPHERSUITE_TAG).is_ok()
     }
+
+    pub(crate) fn key_package_lookup_from_events(events: Events) -> KeyPackageLookup {
+        let mut valid_current = Vec::new();
+        let mut valid_legacy = Vec::new();
+        let mut incompatible = Vec::new();
+
+        for event in events
+            .into_iter()
+            .filter(|event| is_key_package_kind(event.kind))
+            .filter(is_event_timestamp_valid)
+        {
+            match validate_marmot_key_package_tags(&event, REQUIRED_MLS_CIPHERSUITE_TAG) {
+                Ok(()) if event.kind == MLS_KEY_PACKAGE_KIND => valid_current.push(event),
+                Ok(()) if event.kind == MLS_KEY_PACKAGE_KIND_LEGACY => valid_legacy.push(event),
+                Ok(()) => {}
+                Err(error) => incompatible.push((event, error.to_string())),
+            }
+        }
+
+        if let Some(event) = valid_current
+            .into_iter()
+            .max_by_key(|event| (event.created_at, event.id))
+        {
+            return KeyPackageLookup::Found(event);
+        }
+
+        if let Some(event) = valid_legacy
+            .into_iter()
+            .max_by_key(|event| (event.created_at, event.id))
+        {
+            return KeyPackageLookup::Found(event);
+        }
+
+        match incompatible
+            .into_iter()
+            .max_by_key(|(event, _)| (event.created_at, event.id))
+        {
+            Some((event, reason)) => KeyPackageLookup::Incompatible { event, reason },
+            None => KeyPackageLookup::NotFound,
+        }
+    }
 }
 
 impl EphemeralScope {
@@ -830,12 +893,24 @@ impl EphemeralScope {
         pubkey: PublicKey,
         relays: &[RelayUrl],
     ) -> Result<Option<Event>> {
-        let filter = Filter::new().kind(Kind::MlsKeyPackage).author(pubkey);
+        match self.fetch_user_key_package_lookup(pubkey, relays).await? {
+            KeyPackageLookup::Found(event) => Ok(Some(event)),
+            KeyPackageLookup::Incompatible { .. } | KeyPackageLookup::NotFound => Ok(None),
+        }
+    }
+
+    #[perf_instrument("relay")]
+    pub(crate) async fn fetch_user_key_package_lookup(
+        &self,
+        pubkey: PublicKey,
+        relays: &[RelayUrl],
+    ) -> Result<KeyPackageLookup> {
+        let filter = Filter::new()
+            .kinds([MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY])
+            .author(pubkey);
         let events = self.fetch_events_from(relays, filter).await?;
 
-        EphemeralPlane::latest_from_events_with_validation(events, Kind::MlsKeyPackage, |event| {
-            EphemeralPlane::is_key_package_event_semantically_valid(event)
-        })
+        Ok(EphemeralPlane::key_package_lookup_from_events(events))
     }
 
     #[perf_instrument("relay")]
@@ -870,7 +945,10 @@ mod tests {
             observability::{RelayObservabilityConfig, RelayTelemetryKind},
             sessions::{RelaySession, RelaySessionConfig},
         },
-        whitenoise::database::{Database, relay_events::RelayEventRecord},
+        whitenoise::{
+            database::{Database, relay_events::RelayEventRecord},
+            key_packages::REQUIRED_MLS_PROPOSAL_TAGS,
+        },
     };
 
     async fn setup_test_db() -> Database {
@@ -1194,6 +1272,10 @@ mod tests {
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
             ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
             .custom_created_at(earlier)
             .sign_with_keys(&keys)
             .unwrap();
@@ -1208,6 +1290,10 @@ mod tests {
             .tag(Tag::custom(
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
             ))
             .custom_created_at(now)
             .sign_with_keys(&keys)
@@ -1252,6 +1338,10 @@ mod tests {
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
             ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
             .custom_created_at(earlier)
             .sign_with_keys(&keys)
             .unwrap();
@@ -1265,6 +1355,10 @@ mod tests {
             .tag(Tag::custom(
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
             ))
             .custom_created_at(now)
             .sign_with_keys(&keys)
@@ -1309,6 +1403,10 @@ mod tests {
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
             ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
             .custom_created_at(earlier)
             .sign_with_keys(&keys)
             .unwrap();
@@ -1322,6 +1420,10 @@ mod tests {
             .tag(Tag::custom(
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xF2EE"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
             ))
             .custom_created_at(now)
             .sign_with_keys(&keys)
@@ -1346,6 +1448,175 @@ mod tests {
             Some(newer_incompatible.id),
             "Should fall back to the newest timestamp-valid event when none are Marmot-compatible"
         );
+    }
+
+    fn key_package_tags(kind: Kind, include_encoding: bool, proposals: &[&str]) -> Vec<Tag> {
+        let mut tags = Vec::new();
+        if kind == MLS_KEY_PACKAGE_KIND {
+            tags.push(Tag::identifier(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            ));
+        }
+        tags.push(Tag::custom(
+            TagKind::Custom("mls_ciphersuite".into()),
+            [REQUIRED_MLS_CIPHERSUITE_TAG],
+        ));
+        tags.push(Tag::custom(
+            TagKind::Custom("mls_extensions".into()),
+            ["0x000a", "0xf2ee"],
+        ));
+        if !proposals.is_empty() {
+            tags.push(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                proposals.iter().copied(),
+            ));
+        }
+        if include_encoding {
+            tags.push(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]));
+        }
+        tags
+    }
+
+    fn signed_key_package_event(
+        keys: &Keys,
+        kind: Kind,
+        created_at: Timestamp,
+        include_encoding: bool,
+        proposals: &[&str],
+    ) -> Event {
+        EventBuilder::new(kind, "dGVzdF9jb250ZW50")
+            .tags(key_package_tags(kind, include_encoding, proposals))
+            .custom_created_at(created_at)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn key_package_events(keys: &Keys, events: Vec<Event>) -> Events {
+        let filter = Filter::new()
+            .kinds([MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY])
+            .author(keys.public_key());
+        let mut event_set = Events::new(&filter);
+        for event in events {
+            event_set.insert(event);
+        }
+        event_set
+    }
+
+    #[test]
+    fn test_key_package_lookup_prefers_valid_current_over_newer_valid_legacy() {
+        let keys = Keys::generate();
+        let now = Timestamp::now();
+        let older = Timestamp::from(now.as_secs() - 60);
+
+        let current = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND,
+            older,
+            true,
+            &REQUIRED_MLS_PROPOSAL_TAGS,
+        );
+        let legacy = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            now,
+            true,
+            &REQUIRED_MLS_PROPOSAL_TAGS,
+        );
+
+        let lookup = EphemeralPlane::key_package_lookup_from_events(key_package_events(
+            &keys,
+            vec![current.clone(), legacy],
+        ));
+
+        assert!(matches!(lookup, KeyPackageLookup::Found(event) if event.id == current.id));
+    }
+
+    #[test]
+    fn test_key_package_lookup_accepts_valid_legacy_without_current() {
+        let keys = Keys::generate();
+        let legacy = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            Timestamp::now(),
+            true,
+            &REQUIRED_MLS_PROPOSAL_TAGS,
+        );
+
+        let lookup = EphemeralPlane::key_package_lookup_from_events(key_package_events(
+            &keys,
+            vec![legacy.clone()],
+        ));
+
+        assert!(matches!(lookup, KeyPackageLookup::Found(event) if event.id == legacy.id));
+    }
+
+    #[test]
+    fn test_key_package_lookup_ignores_newer_invalid_current() {
+        let keys = Keys::generate();
+        let now = Timestamp::now();
+        let older = Timestamp::from(now.as_secs() - 60);
+
+        let older_valid = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND,
+            older,
+            true,
+            &REQUIRED_MLS_PROPOSAL_TAGS,
+        );
+        let newer_invalid = signed_key_package_event(&keys, MLS_KEY_PACKAGE_KIND, now, true, &[]);
+
+        let lookup = EphemeralPlane::key_package_lookup_from_events(key_package_events(
+            &keys,
+            vec![older_valid.clone(), newer_invalid],
+        ));
+
+        assert!(matches!(lookup, KeyPackageLookup::Found(event) if event.id == older_valid.id));
+    }
+
+    #[test]
+    fn test_key_package_lookup_reports_missing_self_remove_as_incompatible() {
+        let keys = Keys::generate();
+        let incompatible = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            Timestamp::now(),
+            true,
+            &[],
+        );
+
+        let lookup = EphemeralPlane::key_package_lookup_from_events(key_package_events(
+            &keys,
+            vec![incompatible.clone()],
+        ));
+
+        assert!(matches!(
+            lookup,
+            KeyPackageLookup::Incompatible { event, reason }
+                if event.id == incompatible.id && reason.contains("mls_proposals")
+        ));
+    }
+
+    #[test]
+    fn test_key_package_lookup_reports_missing_encoding_as_incompatible() {
+        let keys = Keys::generate();
+        let incompatible = signed_key_package_event(
+            &keys,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            Timestamp::now(),
+            false,
+            &REQUIRED_MLS_PROPOSAL_TAGS,
+        );
+
+        let lookup = EphemeralPlane::key_package_lookup_from_events(key_package_events(
+            &keys,
+            vec![incompatible.clone()],
+        ));
+
+        assert!(matches!(
+            lookup,
+            KeyPackageLookup::Incompatible { event, reason }
+                if event.id == incompatible.id && reason.contains("encoding")
+        ));
     }
 
     #[test]

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -29,6 +29,9 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+use crate::whitenoise::key_packages::MLS_PROPOSALS_TAG_KEY;
+
 fn build_follow_list_event_builder(
     follow_list: &[PublicKey],
     created_at: Option<Timestamp>,
@@ -1263,7 +1266,7 @@ mod tests {
         let earlier = Timestamp::from(now.as_secs() - 60);
 
         // Older event: fully Marmot-compatible
-        let older_valid = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let older_valid = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1274,7 +1277,7 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(earlier)
@@ -1282,7 +1285,7 @@ mod tests {
             .unwrap();
 
         // Newer event: has encoding tag + non-empty content but wrong ciphersuite
-        let newer_incompatible = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let newer_incompatible = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1293,7 +1296,7 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(now)
@@ -1303,14 +1306,14 @@ mod tests {
         assert!(newer_incompatible.created_at > older_valid.created_at);
 
         let filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
+            .kind(MLS_KEY_PACKAGE_KIND_LEGACY)
             .author(keys.public_key());
         let mut events = Events::new(&filter);
         events.insert(older_valid.clone());
         events.insert(newer_incompatible);
         let result = EphemeralPlane::latest_from_events_with_validation(
             events,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             EphemeralPlane::is_key_package_event_semantically_valid,
         )
         .unwrap();
@@ -1329,7 +1332,7 @@ mod tests {
         let now = Timestamp::now();
         let earlier = Timestamp::from(now.as_secs() - 60);
 
-        let older = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let older = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1340,14 +1343,14 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(earlier)
             .sign_with_keys(&keys)
             .unwrap();
 
-        let newer = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let newer = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1358,7 +1361,7 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(now)
@@ -1366,7 +1369,7 @@ mod tests {
             .unwrap();
 
         let filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
+            .kind(MLS_KEY_PACKAGE_KIND_LEGACY)
             .author(keys.public_key());
         let mut events = Events::new(&filter);
         events.insert(older);
@@ -1374,7 +1377,7 @@ mod tests {
 
         let result = EphemeralPlane::latest_from_events_with_validation(
             events,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             EphemeralPlane::is_key_package_event_semantically_valid,
         )
         .unwrap();
@@ -1394,7 +1397,7 @@ mod tests {
         let now = Timestamp::now();
         let earlier = Timestamp::from(now.as_secs() - 60);
 
-        let older_incompatible = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let older_incompatible = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1405,14 +1408,14 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(earlier)
             .sign_with_keys(&keys)
             .unwrap();
 
-        let newer_incompatible = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let newer_incompatible = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
@@ -1423,7 +1426,7 @@ mod tests {
                 ["0x000a", "0xF2EE"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .custom_created_at(now)
@@ -1431,7 +1434,7 @@ mod tests {
             .unwrap();
 
         let filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
+            .kind(MLS_KEY_PACKAGE_KIND_LEGACY)
             .author(keys.public_key());
         let mut events = Events::new(&filter);
         events.insert(older_incompatible);
@@ -1439,7 +1442,7 @@ mod tests {
 
         let result = EphemeralPlane::latest_from_events_with_validation(
             events,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             EphemeralPlane::is_key_package_event_semantically_valid,
         )
         .unwrap();
@@ -1468,7 +1471,7 @@ mod tests {
         ));
         if !proposals.is_empty() {
             tags.push(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 proposals.iter().copied(),
             ));
         }

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -19,6 +19,7 @@ use crate::{
         accounts::Account,
         aggregated_message::AggregatedMessage,
         database::{Database, published_events::PublishedEvent},
+        error::WhitenoiseError,
         key_packages::{
             MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, REQUIRED_MLS_CIPHERSUITE_TAG,
             is_key_package_kind, validate_marmot_key_package_tags,
@@ -86,10 +87,10 @@ pub(crate) enum MessagePublishResult {
     Failed,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum KeyPackageLookup {
     Found(Event),
-    Incompatible { event: Event, reason: String },
+    Incompatible { error: WhitenoiseError },
     NotFound,
 }
 
@@ -820,7 +821,7 @@ impl EphemeralPlane {
                 Ok(()) if event.kind == MLS_KEY_PACKAGE_KIND => valid_current.push(event),
                 Ok(()) if event.kind == MLS_KEY_PACKAGE_KIND_LEGACY => valid_legacy.push(event),
                 Ok(()) => {}
-                Err(error) => incompatible.push((event, error.to_string())),
+                Err(error) => incompatible.push((event, error)),
             }
         }
 
@@ -842,7 +843,7 @@ impl EphemeralPlane {
             .into_iter()
             .max_by_key(|(event, _)| (event.created_at, event.id))
         {
-            Some((event, reason)) => KeyPackageLookup::Incompatible { event, reason },
+            Some((_event, error)) => KeyPackageLookup::Incompatible { error },
             None => KeyPackageLookup::NotFound,
         }
     }
@@ -1591,8 +1592,8 @@ mod tests {
 
         assert!(matches!(
             lookup,
-            KeyPackageLookup::Incompatible { event, reason }
-                if event.id == incompatible.id && reason.contains("mls_proposals")
+            KeyPackageLookup::Incompatible { error }
+                if matches!(error, WhitenoiseError::MissingMlsProposals { .. })
         ));
     }
 
@@ -1614,8 +1615,8 @@ mod tests {
 
         assert!(matches!(
             lookup,
-            KeyPackageLookup::Incompatible { event, reason }
-                if event.id == incompatible.id && reason.contains("encoding")
+            KeyPackageLookup::Incompatible { error }
+                if matches!(error, WhitenoiseError::MissingEncodingTag)
         ));
     }
 

--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -485,6 +485,17 @@ impl RelayControlPlane {
     }
 
     #[perf_instrument("relay")]
+    pub(crate) async fn fetch_user_key_package_lookup(
+        &self,
+        pubkey: PublicKey,
+        relays: &[RelayUrl],
+    ) -> NostrResult<ephemeral::KeyPackageLookup> {
+        self.ephemeral
+            .fetch_user_key_package_lookup(pubkey, relays)
+            .await
+    }
+
+    #[perf_instrument("relay")]
     pub(crate) async fn publish_welcome(
         &self,
         receiver: &PublicKey,
@@ -551,13 +562,14 @@ impl RelayControlPlane {
     #[perf_instrument("relay")]
     pub(crate) async fn publish_key_package_with_signer(
         &self,
+        kind: nostr_sdk::Kind,
         encoded_key_package: &str,
         relays: &[RelayUrl],
         tags: &[nostr_sdk::Tag],
         signer: Arc<dyn nostr_sdk::NostrSigner>,
     ) -> NostrResult<nostr_sdk::prelude::Output<nostr_sdk::EventId>> {
         self.ephemeral
-            .publish_key_package_with_signer(encoded_key_package, relays, tags, signer)
+            .publish_key_package_with_signer(kind, encoded_key_package, relays, tags, signer)
             .await
     }
 

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -289,6 +289,7 @@ mod tests {
 
     use crate::RelayType;
     use crate::whitenoise::accounts::Account;
+    use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND;
     use crate::whitenoise::relays::Relay;
     use crate::whitenoise::test_utils::*;
 
@@ -371,9 +372,8 @@ mod tests {
                 "Key package should be authored by the account's public key"
             );
             assert_eq!(
-                event.kind,
-                Kind::MlsKeyPackage,
-                "Event should be a key package (kind 443)"
+                event.kind, MLS_KEY_PACKAGE_KIND,
+                "Event should be a canonical key package (kind 30443)"
             );
         }
     }
@@ -440,7 +440,7 @@ mod tests {
         );
         assert!(
             key_package_events.is_some(),
-            "Key package (kind 443) should be published for new accounts"
+            "Key package (kind 30443) should be published for new accounts"
         );
     }
 

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -289,7 +289,7 @@ mod tests {
 
     use crate::RelayType;
     use crate::whitenoise::accounts::Account;
-    use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND;
+    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
     use crate::whitenoise::relays::Relay;
     use crate::whitenoise::test_utils::*;
 
@@ -352,30 +352,35 @@ mod tests {
         whitenoise: &crate::whitenoise::Whitenoise,
         account: &Account,
     ) {
-        let key_package_event = whitenoise
-            .relay_control
-            .fetch_user_key_package(
-                account.pubkey,
-                &Relay::urls(&account.key_package_relays(whitenoise).await.unwrap()),
-            )
+        let key_package_events = whitenoise
+            .fetch_all_key_packages_for_account(account)
             .await
             .unwrap();
 
         assert!(
-            key_package_event.is_some(),
+            !key_package_events.is_empty(),
             "Account should have a key package published to relays"
         );
 
-        if let Some(event) = key_package_event {
+        for event in &key_package_events {
             assert_eq!(
                 event.pubkey, account.pubkey,
                 "Key package should be authored by the account's public key"
             );
-            assert_eq!(
-                event.kind, MLS_KEY_PACKAGE_KIND,
-                "Event should be a canonical key package (kind 30443)"
-            );
         }
+
+        assert!(
+            key_package_events
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND),
+            "Account should publish a canonical key package (kind 30443)"
+        );
+        assert!(
+            key_package_events
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "Account should publish a legacy key package twin (kind 443)"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1030,6 +1030,7 @@ impl Whitenoise {
 mod tests {
     use super::*;
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
+    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
     use crate::whitenoise::test_utils::*;
     use mdk_core::prelude::*;
 
@@ -1371,23 +1372,43 @@ mod tests {
         let (account, _keys) = create_test_account(&whitenoise).await;
         account.save(&whitenoise.database).await.unwrap();
 
-        // Use a valid 64-char hex string as event_id
-        let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        // Use valid 64-char hex strings as event IDs.
+        let legacy_event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let canonical_event_hex =
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let hash_ref = [1, 2, 3];
         PublishedKeyPackage::create(
             &account.pubkey,
-            &[1, 2, 3],
-            event_hex,
-            Kind::MlsKeyPackage,
+            &hash_ref,
+            legacy_event_hex,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &whitenoise.database,
         )
         .await
         .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &hash_ref,
+            canonical_event_hex,
+            MLS_KEY_PACKAGE_KIND,
+            Some("canonical-d-tag"),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
-        let event_id = EventId::parse(event_hex).unwrap();
+        let event_id = EventId::parse(legacy_event_hex).unwrap();
         assert!(
             whitenoise
                 .is_own_key_package(&account.pubkey, &event_id)
+                .await
+        );
+
+        let canonical_event_id = EventId::parse(canonical_event_hex).unwrap();
+        assert!(
+            whitenoise
+                .is_own_key_package(&account.pubkey, &canonical_event_id)
                 .await
         );
     }
@@ -1398,32 +1419,50 @@ mod tests {
         let (account, _keys) = create_test_account(&whitenoise).await;
         account.save(&whitenoise.database).await.unwrap();
 
-        let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let legacy_event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let canonical_event_hex =
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let hash_ref = [1, 2, 3];
         PublishedKeyPackage::create(
             &account.pubkey,
-            &[1, 2, 3],
-            event_hex,
-            Kind::MlsKeyPackage,
+            &hash_ref,
+            legacy_event_hex,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &whitenoise.database,
         )
         .await
         .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &hash_ref,
+            canonical_event_hex,
+            MLS_KEY_PACKAGE_KIND,
+            Some("canonical-d-tag"),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
-        // Mark key material as deleted
-        let pkg =
-            PublishedKeyPackage::find_by_event_id(&account.pubkey, event_hex, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
-        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
+            &account.pubkey,
+            &hash_ref,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
-        let event_id = EventId::parse(event_hex).unwrap();
+        let event_id = EventId::parse(legacy_event_hex).unwrap();
         assert!(
             !whitenoise
                 .is_own_key_package(&account.pubkey, &event_id)
+                .await
+        );
+
+        let canonical_event_id = EventId::parse(canonical_event_hex).unwrap();
+        assert!(
+            !whitenoise
+                .is_own_key_package(&account.pubkey, &canonical_event_id)
                 .await
         );
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1373,9 +1373,16 @@ mod tests {
 
         // Use a valid 64-char hex string as event_id
         let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        PublishedKeyPackage::create(&account.pubkey, &[1, 2, 3], event_hex, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &[1, 2, 3],
+            event_hex,
+            Kind::MlsKeyPackage,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let event_id = EventId::parse(event_hex).unwrap();
         assert!(
@@ -1392,9 +1399,16 @@ mod tests {
         account.save(&whitenoise.database).await.unwrap();
 
         let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        PublishedKeyPackage::create(&account.pubkey, &[1, 2, 3], event_hex, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &[1, 2, 3],
+            event_hex,
+            Kind::MlsKeyPackage,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Mark key material as deleted
         let pkg =

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -59,8 +59,11 @@ where
 
 impl PublishedKeyPackage {
     /// Returns the event kind as a typed [`Kind`].
+    ///
+    /// Published key package rows store custom Nostr kinds (`30443` and legacy
+    /// `443`). Standard NIP kinds would need different handling.
     pub fn kind(&self) -> Kind {
-        Kind::Custom(self.kind as u16)
+        Kind::Custom(u16::try_from(self.kind).unwrap_or_default())
     }
 
     /// Records a published key package for lifecycle tracking.
@@ -121,6 +124,28 @@ impl PublishedKeyPackage {
         .await?;
 
         Ok(row)
+    }
+
+    /// Looks up all published key packages sharing the same hash reference.
+    #[perf_instrument("db::published_key_packages")]
+    pub(crate) async fn find_by_hash_ref(
+        account_pubkey: &PublicKey,
+        hash_ref: &[u8],
+        database: &Database,
+    ) -> Result<Vec<Self>, DatabaseError> {
+        let rows = sqlx::query_as::<_, Self>(
+            "SELECT id, account_pubkey, key_package_hash_ref, event_id, kind, d_tag,
+                    consumed_at, key_material_deleted, created_at
+             FROM published_key_packages
+             WHERE account_pubkey = ? AND key_package_hash_ref = ?
+             ORDER BY created_at DESC, id DESC",
+        )
+        .bind(account_pubkey.to_hex())
+        .bind(hash_ref)
+        .fetch_all(&database.pool)
+        .await?;
+
+        Ok(rows)
     }
 
     /// Marks a published key package as consumed (used by a Welcome).
@@ -196,22 +221,6 @@ impl PublishedKeyPackage {
         Ok(rows)
     }
 
-    /// Marks a published key package's key material as deleted.
-    ///
-    /// Called after the maintenance task successfully deletes the local MLS
-    /// key material. Rows are never deleted — the table serves as an audit trail.
-    #[perf_instrument("db::published_key_packages")]
-    pub(crate) async fn mark_key_material_deleted(
-        id: i64,
-        database: &Database,
-    ) -> Result<(), DatabaseError> {
-        sqlx::query("UPDATE published_key_packages SET key_material_deleted = 1 WHERE id = ?")
-            .bind(id)
-            .execute(&database.pool)
-            .await?;
-        Ok(())
-    }
-
     /// Marks all rows sharing a key package hash as deleted.
     ///
     /// Dual-published kind:30443/kind:443 events point at the same local MLS
@@ -238,10 +247,11 @@ impl PublishedKeyPackage {
 
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::{Keys, Kind};
+    use nostr_sdk::Keys;
     use sqlx::sqlite::SqlitePoolOptions;
 
     use super::*;
+    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
 
     async fn setup_test_db() -> Database {
         let pool = SqlitePoolOptions::new()
@@ -286,7 +296,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             event_id,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -310,13 +320,27 @@ mod tests {
         let hash_ref = vec![1, 2, 3, 4, 5];
         let event_id = "abc123";
 
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            event_id,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
         // Second insert with same event_id should be ignored (INSERT OR IGNORE)
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            event_id,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         let count: (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM published_key_packages WHERE account_pubkey = ?")
@@ -346,9 +370,16 @@ mod tests {
         let hash_ref = vec![1, 2, 3];
         let event_id = "known_event";
 
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            event_id,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         let result = PublishedKeyPackage::find_by_event_id(&pubkey, event_id, &db)
             .await
@@ -375,7 +406,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "canonical_event",
-            Kind::Custom(30443),
+            MLS_KEY_PACKAGE_KIND,
             Some(d_tag),
             &db,
         )
@@ -400,7 +431,7 @@ mod tests {
             &pubkey,
             &[1, 2, 3],
             event_id,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -429,7 +460,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "canonical_event",
-            Kind::Custom(30443),
+            MLS_KEY_PACKAGE_KIND,
             Some("d-tag-value"),
             &db,
         )
@@ -439,7 +470,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "legacy_event",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -474,7 +505,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "canonical_event",
-            Kind::Custom(30443),
+            MLS_KEY_PACKAGE_KIND,
             Some("d-tag-value"),
             &db,
         )
@@ -484,7 +515,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "legacy_event",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -530,7 +561,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "canonical_burst",
-            Kind::Custom(30443),
+            MLS_KEY_PACKAGE_KIND,
             Some("d-tag"),
             &db,
         )
@@ -540,7 +571,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "legacy_burst",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -594,7 +625,7 @@ mod tests {
             &pubkey,
             &[1, 2, 3],
             event_id,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -633,7 +664,7 @@ mod tests {
             &pubkey,
             &[1, 2, 3],
             event_id,
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -643,12 +674,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Simulate key material deletion
-        let pkg = PublishedKeyPackage::find_by_event_id(&pubkey, event_id, &db)
-            .await
-            .unwrap()
-            .unwrap();
-        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &db)
+        PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(&pubkey, &[1, 2, 3], &db)
             .await
             .unwrap();
 
@@ -669,7 +695,7 @@ mod tests {
             &pubkey,
             &[1, 2, 3],
             "recent",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -735,7 +761,7 @@ mod tests {
             &pubkey,
             &[4, 5, 6],
             "recent_event",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -755,37 +781,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mark_key_material_deleted() {
+    async fn test_mark_key_material_deleted_by_hash_ref() {
         let db = setup_test_db().await;
         let pubkey = Keys::generate().public_key();
-        let event_id = "delete_test";
+        let canonical_event_id = "delete_test_canonical";
+        let legacy_event_id = "delete_test_legacy";
+        let hash_ref = [1, 2, 3];
 
         PublishedKeyPackage::create(
             &pubkey,
-            &[1, 2, 3],
-            event_id,
-            Kind::MlsKeyPackage,
+            &hash_ref,
+            canonical_event_id,
+            MLS_KEY_PACKAGE_KIND,
+            Some("test-d-tag"),
+            &db,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            legacy_event_id,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
         .await
         .unwrap();
 
-        let pkg = PublishedKeyPackage::find_by_event_id(&pubkey, event_id, &db)
+        let canonical = PublishedKeyPackage::find_by_event_id(&pubkey, canonical_event_id, &db)
             .await
             .unwrap()
             .unwrap();
-        assert!(!pkg.key_material_deleted);
-
-        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &db)
-            .await
-            .unwrap();
-
-        let pkg = PublishedKeyPackage::find_by_event_id(&pubkey, event_id, &db)
+        let legacy = PublishedKeyPackage::find_by_event_id(&pubkey, legacy_event_id, &db)
             .await
             .unwrap()
             .unwrap();
-        assert!(pkg.key_material_deleted);
+        assert!(!canonical.key_material_deleted);
+        assert!(!legacy.key_material_deleted);
+
+        let updated =
+            PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(&pubkey, &hash_ref, &db)
+                .await
+                .unwrap();
+        assert_eq!(updated, 2);
+
+        let canonical = PublishedKeyPackage::find_by_event_id(&pubkey, canonical_event_id, &db)
+            .await
+            .unwrap()
+            .unwrap();
+        let legacy = PublishedKeyPackage::find_by_event_id(&pubkey, legacy_event_id, &db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(canonical.key_material_deleted);
+        assert!(legacy.key_material_deleted);
     }
 
     #[tokio::test]
@@ -798,7 +848,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "canonical_event",
-            Kind::Custom(30443),
+            MLS_KEY_PACKAGE_KIND,
             Some("d-tag-value"),
             &db,
         )
@@ -808,7 +858,7 @@ mod tests {
             &pubkey,
             &hash_ref,
             "legacy_event",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -857,7 +907,7 @@ mod tests {
             &pubkey2,
             &[4, 5, 6],
             "event_b1",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )
@@ -899,7 +949,7 @@ mod tests {
             &pubkey,
             &[1, 2, 3],
             "unconsumed",
-            Kind::MlsKeyPackage,
+            MLS_KEY_PACKAGE_KIND_LEGACY,
             None,
             &db,
         )

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -58,6 +58,11 @@ where
 }
 
 impl PublishedKeyPackage {
+    /// Returns the event kind as a typed [`Kind`].
+    pub fn kind(&self) -> Kind {
+        Kind::Custom(self.kind as u16)
+    }
+
     /// Records a published key package for lifecycle tracking.
     ///
     /// Called at publish time with the hash_ref computed atomically during
@@ -120,9 +125,10 @@ impl PublishedKeyPackage {
 
     /// Marks a published key package as consumed (used by a Welcome).
     ///
-    /// Sets `consumed_at` to the current timestamp. A KP can be consumed
-    /// multiple times (last-resort reuse); each Welcome updates `consumed_at`,
-    /// restarting the quiet period before cleanup.
+    /// Updates `consumed_at` for all rows that share the same `key_package_hash_ref`
+    /// as the given event, so both the canonical (kind:30443) and legacy (kind:443) twins
+    /// are marked together. A KP can be consumed multiple times (last-resort reuse);
+    /// each Welcome restarts the quiet period before key material cleanup.
     ///
     /// Returns `false` if no matching row exists or key material is already deleted.
     #[perf_instrument("db::published_key_packages")]
@@ -512,6 +518,70 @@ mod tests {
             .await
             .unwrap();
         assert!(!updated);
+    }
+
+    #[tokio::test]
+    async fn test_mark_consumed_on_already_consumed_updates_timestamp_for_twins() {
+        let db = setup_test_db().await;
+        let pubkey = Keys::generate().public_key();
+        let hash_ref = vec![1, 2, 3];
+
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "canonical_burst",
+            Kind::Custom(30443),
+            Some("d-tag"),
+            &db,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "legacy_burst",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
+
+        // First consumption via canonical event_id
+        PublishedKeyPackage::mark_consumed(&pubkey, "canonical_burst", &db)
+            .await
+            .unwrap();
+        let first_canonical =
+            PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_burst", &db)
+                .await
+                .unwrap()
+                .unwrap();
+        let first_legacy = PublishedKeyPackage::find_by_event_id(&pubkey, "legacy_burst", &db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Both twins should be consumed with the same timestamp
+        assert_eq!(first_canonical.consumed_at, first_legacy.consumed_at);
+
+        // Second consumption (burst) via legacy event_id — both twins must update
+        let updated = PublishedKeyPackage::mark_consumed(&pubkey, "legacy_burst", &db)
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let second_canonical =
+            PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_burst", &db)
+                .await
+                .unwrap()
+                .unwrap();
+        let second_legacy = PublishedKeyPackage::find_by_event_id(&pubkey, "legacy_burst", &db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(second_canonical.consumed_at.unwrap() >= first_canonical.consumed_at.unwrap());
+        assert_eq!(second_canonical.consumed_at, second_legacy.consumed_at);
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -1,4 +1,4 @@
-use nostr_sdk::PublicKey;
+use nostr_sdk::{Kind, PublicKey};
 
 use super::{Database, DatabaseError};
 use crate::perf_instrument;
@@ -15,6 +15,8 @@ pub struct PublishedKeyPackage {
     pub account_pubkey: String,
     pub key_package_hash_ref: Vec<u8>,
     pub event_id: String,
+    pub kind: i64,
+    pub d_tag: Option<String>,
     pub consumed_at: Option<i64>,
     pub key_material_deleted: bool,
     pub created_at: i64,
@@ -28,12 +30,15 @@ where
     i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
     Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
     bool: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    Option<String>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
 {
     fn from_row(row: &'r R) -> std::result::Result<Self, sqlx::Error> {
         let id: i64 = row.try_get("id")?;
         let account_pubkey: String = row.try_get("account_pubkey")?;
         let key_package_hash_ref: Vec<u8> = row.try_get("key_package_hash_ref")?;
         let event_id: String = row.try_get("event_id")?;
+        let kind: i64 = row.try_get("kind")?;
+        let d_tag: Option<String> = row.try_get("d_tag")?;
         let consumed_at: Option<i64> = row.try_get("consumed_at")?;
         let key_material_deleted: bool = row.try_get("key_material_deleted")?;
         let created_at: i64 = row.try_get("created_at")?;
@@ -43,6 +48,8 @@ where
             account_pubkey,
             key_package_hash_ref,
             event_id,
+            kind,
+            d_tag,
             consumed_at,
             key_material_deleted,
             created_at,
@@ -61,15 +68,20 @@ impl PublishedKeyPackage {
         account_pubkey: &PublicKey,
         hash_ref: &[u8],
         event_id: &str,
+        kind: Kind,
+        d_tag: Option<&str>,
         database: &Database,
     ) -> Result<(), DatabaseError> {
         sqlx::query(
-            "INSERT OR IGNORE INTO published_key_packages (account_pubkey, key_package_hash_ref, event_id)
-             VALUES (?, ?, ?)",
+            "INSERT OR IGNORE INTO published_key_packages
+             (account_pubkey, key_package_hash_ref, event_id, kind, d_tag)
+             VALUES (?, ?, ?, ?, ?)",
         )
         .bind(account_pubkey.to_hex())
         .bind(hash_ref)
         .bind(event_id)
+        .bind(i64::from(kind.as_u16()))
+        .bind(d_tag)
         .execute(&database.pool)
         .await?;
 
@@ -93,7 +105,8 @@ impl PublishedKeyPackage {
         database: &Database,
     ) -> Result<Option<Self>, DatabaseError> {
         let row = sqlx::query_as::<_, Self>(
-            "SELECT id, account_pubkey, key_package_hash_ref, event_id, consumed_at, key_material_deleted, created_at
+            "SELECT id, account_pubkey, key_package_hash_ref, event_id, kind, d_tag,
+                    consumed_at, key_material_deleted, created_at
              FROM published_key_packages
              WHERE account_pubkey = ? AND event_id = ?",
         )
@@ -118,13 +131,22 @@ impl PublishedKeyPackage {
         event_id: &str,
         database: &Database,
     ) -> Result<bool, DatabaseError> {
+        let row = Self::find_by_event_id(account_pubkey, event_id, database).await?;
+        let Some(package) = row else {
+            return Ok(false);
+        };
+
+        if package.key_material_deleted {
+            return Ok(false);
+        }
+
         let result = sqlx::query(
             "UPDATE published_key_packages
              SET consumed_at = unixepoch()
-             WHERE account_pubkey = ? AND event_id = ? AND key_material_deleted = 0",
+             WHERE account_pubkey = ? AND key_package_hash_ref = ? AND key_material_deleted = 0",
         )
         .bind(account_pubkey.to_hex())
-        .bind(event_id)
+        .bind(&package.key_package_hash_ref)
         .execute(&database.pool)
         .await?;
 
@@ -145,7 +167,8 @@ impl PublishedKeyPackage {
         database: &Database,
     ) -> Result<Vec<Self>, DatabaseError> {
         let rows = sqlx::query_as::<_, Self>(
-            "SELECT id, account_pubkey, key_package_hash_ref, event_id, consumed_at, key_material_deleted, created_at
+            "SELECT id, account_pubkey, key_package_hash_ref, event_id, kind, d_tag,
+                    consumed_at, key_material_deleted, created_at
              FROM published_key_packages
              WHERE account_pubkey = ?
                AND consumed_at IS NOT NULL
@@ -182,11 +205,34 @@ impl PublishedKeyPackage {
             .await?;
         Ok(())
     }
+
+    /// Marks all rows sharing a key package hash as deleted.
+    ///
+    /// Dual-published kind:30443/kind:443 events point at the same local MLS
+    /// key material, so cleanup must update the whole hash group together.
+    #[perf_instrument("db::published_key_packages")]
+    pub(crate) async fn mark_key_material_deleted_by_hash_ref(
+        account_pubkey: &PublicKey,
+        hash_ref: &[u8],
+        database: &Database,
+    ) -> Result<u64, DatabaseError> {
+        let result = sqlx::query(
+            "UPDATE published_key_packages
+             SET key_material_deleted = 1
+             WHERE account_pubkey = ? AND key_package_hash_ref = ?",
+        )
+        .bind(account_pubkey.to_hex())
+        .bind(hash_ref)
+        .execute(&database.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::Keys;
+    use nostr_sdk::{Keys, Kind};
     use sqlx::sqlite::SqlitePoolOptions;
 
     use super::*;
@@ -204,6 +250,8 @@ mod tests {
                 account_pubkey TEXT NOT NULL,
                 key_package_hash_ref BLOB NOT NULL,
                 event_id TEXT NOT NULL,
+                kind INTEGER NOT NULL DEFAULT 443,
+                d_tag TEXT NULL,
                 consumed_at INTEGER,
                 key_material_deleted INTEGER NOT NULL DEFAULT 0,
                 created_at INTEGER NOT NULL DEFAULT (unixepoch()),
@@ -228,7 +276,15 @@ mod tests {
         let hash_ref = vec![1, 2, 3, 4, 5];
         let event_id = "abc123";
 
-        let result = PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, &db).await;
+        let result = PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await;
         assert!(result.is_ok());
 
         let count: (i64,) =
@@ -248,11 +304,11 @@ mod tests {
         let hash_ref = vec![1, 2, 3, 4, 5];
         let event_id = "abc123";
 
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, &db)
+        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
             .await
             .unwrap();
         // Second insert with same event_id should be ignored (INSERT OR IGNORE)
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, &db)
+        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
             .await
             .unwrap();
 
@@ -284,7 +340,7 @@ mod tests {
         let hash_ref = vec![1, 2, 3];
         let event_id = "known_event";
 
-        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, &db)
+        PublishedKeyPackage::create(&pubkey, &hash_ref, event_id, Kind::MlsKeyPackage, None, &db)
             .await
             .unwrap();
 
@@ -296,8 +352,36 @@ mod tests {
         let pkg = result.unwrap();
         assert_eq!(pkg.key_package_hash_ref, hash_ref);
         assert_eq!(pkg.event_id, event_id);
+        assert_eq!(pkg.kind, 443);
+        assert_eq!(pkg.d_tag, None);
         assert!(pkg.consumed_at.is_none());
         assert!(!pkg.key_material_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_create_stores_kind_and_d_tag() {
+        let db = setup_test_db().await;
+        let pubkey = Keys::generate().public_key();
+        let hash_ref = vec![1, 2, 3];
+        let d_tag = "d-tag-value";
+
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "canonical_event",
+            Kind::Custom(30443),
+            Some(d_tag),
+            &db,
+        )
+        .await
+        .unwrap();
+
+        let pkg = PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(pkg.kind, 30443);
+        assert_eq!(pkg.d_tag.as_deref(), Some(d_tag));
     }
 
     #[tokio::test]
@@ -306,9 +390,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
         let event_id = "consume_test";
 
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], event_id, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         let updated = PublishedKeyPackage::mark_consumed(&pubkey, event_id, &db)
             .await
@@ -320,6 +411,96 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(pkg.consumed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_mark_consumed_marks_key_package_twins() {
+        let db = setup_test_db().await;
+        let pubkey = Keys::generate().public_key();
+        let hash_ref = vec![1, 2, 3];
+
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "canonical_event",
+            Kind::Custom(30443),
+            Some("d-tag-value"),
+            &db,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "legacy_event",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
+
+        let updated = PublishedKeyPackage::mark_consumed(&pubkey, "canonical_event", &db)
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let canonical = PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+        let legacy = PublishedKeyPackage::find_by_event_id(&pubkey, "legacy_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(canonical.consumed_at.is_some());
+        assert_eq!(legacy.consumed_at, canonical.consumed_at);
+    }
+
+    #[tokio::test]
+    async fn test_mark_consumed_marks_canonical_when_legacy_consumed() {
+        let db = setup_test_db().await;
+        let pubkey = Keys::generate().public_key();
+        let hash_ref = vec![1, 2, 3];
+
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "canonical_event",
+            Kind::Custom(30443),
+            Some("d-tag-value"),
+            &db,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "legacy_event",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
+
+        let updated = PublishedKeyPackage::mark_consumed(&pubkey, "legacy_event", &db)
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let canonical = PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+        let legacy = PublishedKeyPackage::find_by_event_id(&pubkey, "legacy_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(legacy.consumed_at.is_some());
+        assert_eq!(canonical.consumed_at, legacy.consumed_at);
     }
 
     #[tokio::test]
@@ -339,9 +520,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
         let event_id = "burst_test";
 
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], event_id, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         // First consumption
         PublishedKeyPackage::mark_consumed(&pubkey, event_id, &db)
@@ -371,9 +559,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
         let event_id = "deleted_test";
 
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], event_id, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
         PublishedKeyPackage::mark_consumed(&pubkey, event_id, &db)
             .await
             .unwrap();
@@ -400,9 +595,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         // Insert a consumed KP with recent timestamp
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], "recent", &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            "recent",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
         PublishedKeyPackage::mark_consumed(&pubkey, "recent", &db)
             .await
             .unwrap();
@@ -459,9 +661,16 @@ mod tests {
         .unwrap();
 
         // One recently consumed KP (blocks all cleanup for this account)
-        PublishedKeyPackage::create(&pubkey, &[4, 5, 6], "recent_event", &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[4, 5, 6],
+            "recent_event",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
         PublishedKeyPackage::mark_consumed(&pubkey, "recent_event", &db)
             .await
             .unwrap();
@@ -481,9 +690,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
         let event_id = "delete_test";
 
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], event_id, &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         let pkg = PublishedKeyPackage::find_by_event_id(&pubkey, event_id, &db)
             .await
@@ -500,6 +716,52 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(pkg.key_material_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_mark_key_material_deleted_by_hash_ref_marks_twins() {
+        let db = setup_test_db().await;
+        let pubkey = Keys::generate().public_key();
+        let hash_ref = vec![1, 2, 3];
+
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "canonical_event",
+            Kind::Custom(30443),
+            Some("d-tag-value"),
+            &db,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &hash_ref,
+            "legacy_event",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
+
+        let affected =
+            PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(&pubkey, &hash_ref, &db)
+                .await
+                .unwrap();
+        assert_eq!(affected, 2);
+
+        let canonical = PublishedKeyPackage::find_by_event_id(&pubkey, "canonical_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+        let legacy = PublishedKeyPackage::find_by_event_id(&pubkey, "legacy_event", &db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(canonical.key_material_deleted);
+        assert!(legacy.key_material_deleted);
     }
 
     #[tokio::test]
@@ -521,9 +783,16 @@ mod tests {
         .unwrap();
 
         // Insert recently consumed KP for account 2
-        PublishedKeyPackage::create(&pubkey2, &[4, 5, 6], "event_b1", &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey2,
+            &[4, 5, 6],
+            "event_b1",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
         PublishedKeyPackage::mark_consumed(&pubkey2, "event_b1", &db)
             .await
             .unwrap();
@@ -556,9 +825,16 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         // Insert a published but unconsumed KP
-        PublishedKeyPackage::create(&pubkey, &[1, 2, 3], "unconsumed", &db)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &pubkey,
+            &[1, 2, 3],
+            "unconsumed",
+            Kind::MlsKeyPackage,
+            None,
+            &db,
+        )
+        .await
+        .unwrap();
 
         let eligible = PublishedKeyPackage::find_eligible_for_cleanup(&pubkey, 30, &db)
             .await

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -170,6 +170,9 @@ pub enum WhitenoiseError {
     #[error("Missing required encoding tag ['encoding','base64']")]
     MissingEncodingTag,
 
+    #[error("Missing required d tag for kind:30443 key package")]
+    MissingKeyPackageDTag,
+
     #[error("Invalid base64 key package content: {0}")]
     InvalidBase64(#[from] base64ct::Error),
 
@@ -184,6 +187,22 @@ pub enum WhitenoiseError {
 
     #[error("Missing required mls_extensions [{}]", missing.join(", "))]
     MissingMlsExtensions { missing: Vec<String> },
+
+    #[error("Missing required mls_proposals [{}]", missing.join(", "))]
+    MissingMlsProposals { missing: Vec<String> },
+
+    #[error(
+        "Cannot add this user yet. Their key package was published by an older app version and does not advertise SelfRemove support. Ask them to update White Noise and open the app so it can publish a new key package."
+    )]
+    KeyPackageMissingSelfRemove { member_pubkey: PublicKey },
+
+    #[error(
+        "Cannot add this user yet. Their key package is incompatible with this app version ({reason}). Ask them to update White Noise and open the app so it can publish a new key package."
+    )]
+    IncompatibleKeyPackage {
+        member_pubkey: PublicKey,
+        reason: String,
+    },
 
     #[error("Invalid timestamp")]
     InvalidTimestamp,

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -15,7 +15,10 @@ use crate::{
         accounts_groups::AccountGroup,
         error::{Result, WhitenoiseError},
         group_information::{GroupInformation, GroupType},
-        key_packages::{REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags},
+        key_packages::{
+            REQUIRED_MLS_CIPHERSUITE_TAG, REQUIRED_MLS_PROPOSAL_TAGS,
+            validate_marmot_key_package_tags,
+        },
         relays::Relay,
         users::User,
     },
@@ -113,10 +116,15 @@ impl Whitenoise {
         let event = match lookup {
             KeyPackageLookup::Found(event) => event,
             KeyPackageLookup::Incompatible { error } => {
-                if matches!(error, WhitenoiseError::MissingMlsProposals { .. }) {
-                    return Err(WhitenoiseError::KeyPackageMissingSelfRemove {
-                        member_pubkey: *pk,
-                    });
+                if let WhitenoiseError::MissingMlsProposals { missing } = &error {
+                    let missing_self_remove = missing
+                        .iter()
+                        .any(|proposal| proposal == REQUIRED_MLS_PROPOSAL_TAGS[0]);
+                    if missing_self_remove {
+                        return Err(WhitenoiseError::KeyPackageMissingSelfRemove {
+                            member_pubkey: *pk,
+                        });
+                    }
                 }
 
                 return Err(WhitenoiseError::IncompatibleKeyPackage {

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -8,13 +8,17 @@ use nostr_sdk::prelude::*;
 
 use crate::{
     RelayType, perf_instrument, perf_span,
+    relay_control::ephemeral::KeyPackageLookup,
     whitenoise::{
         Whitenoise,
         accounts::Account,
         accounts_groups::AccountGroup,
         error::{Result, WhitenoiseError},
         group_information::{GroupInformation, GroupType},
-        key_packages::{REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags},
+        key_packages::{
+            REQUIRED_MLS_CIPHERSUITE_TAG, missing_required_mls_proposals,
+            validate_marmot_key_package_tags,
+        },
         relays::Relay,
         users::User,
     },
@@ -106,12 +110,29 @@ impl Whitenoise {
         }
 
         let _kp_fetch = perf_span!("groups::fetch_key_package");
-        let some_event = user.key_package_event(self).await?;
+        let lookup = user.key_package_lookup(self).await?;
         drop(_kp_fetch);
 
-        let event = some_event.ok_or(WhitenoiseError::MdkCoreError(
-            mdk_core::Error::KeyPackage("Does not exist".to_owned()),
-        ))?;
+        let event = match lookup {
+            KeyPackageLookup::Found(event) => event,
+            KeyPackageLookup::Incompatible { event, reason } => {
+                if !missing_required_mls_proposals(&event).is_empty() {
+                    return Err(WhitenoiseError::KeyPackageMissingSelfRemove {
+                        member_pubkey: *pk,
+                    });
+                }
+
+                return Err(WhitenoiseError::IncompatibleKeyPackage {
+                    member_pubkey: *pk,
+                    reason,
+                });
+            }
+            KeyPackageLookup::NotFound => {
+                return Err(WhitenoiseError::MdkCoreError(mdk_core::Error::KeyPackage(
+                    "Does not exist".to_owned(),
+                )));
+            }
+        };
 
         Self::validate_fetched_member_key_package(&event, pk)?;
 
@@ -587,42 +608,7 @@ impl Whitenoise {
 
         // Fetch key packages for all members
         for pk in members.iter() {
-            let (user, newly_created) = User::find_or_create_by_pubkey(pk, &self.database).await?;
-
-            if newly_created {
-                // Sync relay lists synchronously so that the key package relay lookup below
-                // has a chance to find the user's relays before falling back to account defaults.
-                // Metadata is not needed to add a member to a group; skip it on the critical path.
-                if let Err(e) = user.update_relay_lists(self).await {
-                    tracing::warn!(
-                        target: "whitenoise::accounts::groups::add_members_to_group",
-                        "Failed to update relay lists for new user {}: {}",
-                        user.pubkey,
-                        e
-                    );
-                }
-            }
-            // Try and get user's key package relays, if they don't have any, use account's default relays
-            let mut relays_to_use = user.relays(RelayType::KeyPackage, &self.database).await?;
-            if relays_to_use.is_empty() {
-                tracing::warn!(
-                    target: "whitenoise::accounts::groups::add_members_to_group",
-                    "User {} has no relays configured, using account's default relays",
-                    user.pubkey
-                );
-                relays_to_use = account.nip65_relays(self).await?;
-            }
-            let relays_to_use_urls = Relay::urls(&relays_to_use);
-            let some_event = self
-                .relay_control
-                .fetch_user_key_package(*pk, &relays_to_use_urls)
-                .await?;
-            let event = some_event.ok_or(WhitenoiseError::MdkCoreError(
-                mdk_core::Error::KeyPackage("Does not exist".to_owned()),
-            ))?;
-
-            Self::validate_fetched_member_key_package(&event, pk)?;
-
+            let (user, event) = self.resolve_member_key_package(pk).await?;
             key_package_events.push(event);
             users.push(user);
         }

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -15,10 +15,7 @@ use crate::{
         accounts_groups::AccountGroup,
         error::{Result, WhitenoiseError},
         group_information::{GroupInformation, GroupType},
-        key_packages::{
-            REQUIRED_MLS_CIPHERSUITE_TAG, missing_required_mls_proposals,
-            validate_marmot_key_package_tags,
-        },
+        key_packages::{REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags},
         relays::Relay,
         users::User,
     },
@@ -115,8 +112,8 @@ impl Whitenoise {
 
         let event = match lookup {
             KeyPackageLookup::Found(event) => event,
-            KeyPackageLookup::Incompatible { event, reason } => {
-                if !missing_required_mls_proposals(&event).is_empty() {
+            KeyPackageLookup::Incompatible { error } => {
+                if matches!(error, WhitenoiseError::MissingMlsProposals { .. }) {
                     return Err(WhitenoiseError::KeyPackageMissingSelfRemove {
                         member_pubkey: *pk,
                     });
@@ -124,7 +121,7 @@ impl Whitenoise {
 
                 return Err(WhitenoiseError::IncompatibleKeyPackage {
                     member_pubkey: *pk,
-                    reason,
+                    reason: error.to_string(),
                 });
             }
             KeyPackageLookup::NotFound => {

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -35,6 +35,9 @@ const REQUIRED_MLS_EXTENSION_TAGS: [&str; 2] = ["0x000a", "0xf2ee"];
 /// Required proposal IDs that must appear in `mls_proposals` tags.
 pub(crate) const REQUIRED_MLS_PROPOSAL_TAGS: [&str; 1] = ["0x000a"];
 
+/// Tag name containing supported MLS proposal IDs.
+pub(crate) const MLS_PROPOSALS_TAG_KEY: &str = "mls_proposals";
+
 /// Checks if a key package event has the required encoding tag.
 ///
 /// Per MIP-00/MIP-02, key packages must have an explicit `["encoding", "base64"]` tag.
@@ -115,7 +118,7 @@ pub(crate) fn validate_marmot_key_package_tags(
 
 pub(crate) fn missing_required_mls_proposals(event: &Event) -> Vec<String> {
     let proposals: HashSet<String> =
-        normalized_tag_values(event, TagKind::Custom("mls_proposals".into()))
+        normalized_tag_values(event, TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()))
             .into_iter()
             .collect();
 
@@ -555,17 +558,30 @@ impl Whitenoise {
         delete_mls_stored_keys: bool,
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<bool> {
+        let published_package = match PublishedKeyPackage::find_by_event_id(
+            &account.pubkey,
+            &event_id.to_hex(),
+            &self.database,
+        )
+        .await
+        {
+            Ok(package) => package,
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Failed to look up published key package for event {}: {}",
+                    event_id,
+                    e
+                );
+                None
+            }
+        };
+
         // Delete local MLS key material using the hash_ref stored at publish time.
         // This avoids a relay round-trip to fetch and parse the key package event.
         if delete_mls_stored_keys {
-            match PublishedKeyPackage::find_by_event_id(
-                &account.pubkey,
-                &event_id.to_hex(),
-                &self.database,
-            )
-            .await
-            {
-                Ok(Some(pkg)) if !pkg.key_material_deleted => {
+            match &published_package {
+                Some(pkg) if !pkg.key_material_deleted => {
                     let mdk = self.create_mdk_for_account(account.pubkey)?;
                     mdk.delete_key_package_from_storage_by_hash_ref(&pkg.key_package_hash_ref)?;
                     if let Err(e) = PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
@@ -582,26 +598,18 @@ impl Whitenoise {
                         );
                     }
                 }
-                Ok(Some(_)) => {
+                Some(_) => {
                     tracing::debug!(
                         target: "whitenoise::key_packages",
                         "Key material already deleted for event {}, skipping local deletion",
                         event_id
                     );
                 }
-                Ok(None) => {
+                None => {
                     tracing::warn!(
                         target: "whitenoise::key_packages",
                         "No published key package record found for event {}, cannot delete local key material",
                         event_id
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "whitenoise::key_packages",
-                        "Failed to look up published key package for event {}: {}",
-                        event_id,
-                        e
                     );
                 }
             }
@@ -613,12 +621,69 @@ impl Whitenoise {
         }
 
         let key_package_relays_urls = Relay::urls(&key_package_relays);
+        let event_ids = self
+            .key_package_event_ids_for_deletion(account, event_id, published_package.as_ref())
+            .await;
 
         let result = self
             .relay_control
-            .publish_event_deletion_with_signer(event_id, &key_package_relays_urls, signer)
+            .publish_batch_event_deletion_with_signer(&event_ids, &key_package_relays_urls, signer)
             .await?;
         Ok(!result.success.is_empty())
+    }
+
+    async fn key_package_event_ids_for_deletion(
+        &self,
+        account: &Account,
+        event_id: &EventId,
+        published_package: Option<&PublishedKeyPackage>,
+    ) -> Vec<EventId> {
+        let mut seen = HashSet::new();
+        let mut event_ids = Vec::new();
+        if seen.insert(*event_id) {
+            event_ids.push(*event_id);
+        }
+
+        let Some(package) = published_package else {
+            return event_ids;
+        };
+
+        match PublishedKeyPackage::find_by_hash_ref(
+            &account.pubkey,
+            &package.key_package_hash_ref,
+            &self.database,
+        )
+        .await
+        {
+            Ok(packages) => {
+                for package in packages {
+                    match EventId::from_hex(&package.event_id) {
+                        Ok(package_event_id) if seen.insert(package_event_id) => {
+                            event_ids.push(package_event_id);
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "whitenoise::key_packages",
+                                "Skipping invalid tracked key package event id {}: {}",
+                                package.event_id,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Failed to find key package hash_ref twins for event {}: {}",
+                    event_id,
+                    e
+                );
+            }
+        }
+
+        event_ids
     }
 
     /// Finds and returns all key package events for the given account from its key package relays.
@@ -694,20 +759,13 @@ impl Whitenoise {
     /// Deletes all legacy key package events from relays for the given account.
     ///
     /// This developer-facing cleanup keeps canonical replaceable kind:30443 key packages
-    /// intact and only removes legacy kind:443 copies. The `delete_mls_stored_keys`
-    /// argument is preserved for API compatibility, but shared local MLS key material
-    /// is not deleted from this legacy-only path because kind:443 and kind:30443 twins
-    /// can reference the same `hash_ref`.
+    /// intact and only removes legacy kind:443 copies. Shared local MLS key material
+    /// is not deleted from this legacy-only path because kind:443 and kind:30443
+    /// twins can reference the same `hash_ref`.
     ///
     /// Automatically uses the appropriate signer for the account:
     /// - For external accounts (Amber/NIP-55): uses the registered external signer
     /// - For local accounts: uses keys from the secrets store
-    ///
-    /// # Arguments
-    ///
-    /// * `account` - The account to delete key packages for
-    /// * `delete_mls_stored_keys` - Preserved for API compatibility; ignored by this
-    ///   legacy-only cleanup path
     ///
     /// # Returns
     ///
@@ -722,14 +780,9 @@ impl Whitenoise {
     /// - Network error while fetching or publishing events
     /// - Batch deletion event publishing failed
     #[perf_instrument("key_packages")]
-    pub async fn delete_all_key_packages_for_account(
-        &self,
-        account: &Account,
-        _delete_mls_stored_keys: bool,
-    ) -> Result<usize> {
+    pub async fn delete_legacy_key_packages_for_account(&self, account: &Account) -> Result<usize> {
         let signer = self.get_signer_for_account(account)?;
-        self.delete_all_key_packages_loop(account, _delete_mls_stored_keys, signer)
-            .await
+        self.delete_legacy_key_packages_loop(account, signer).await
     }
 
     /// Deletes all legacy key package events from relays using an external signer.
@@ -738,29 +791,17 @@ impl Whitenoise {
     /// private key is not available locally. The signer is used to sign the
     /// deletion events before publishing.
     ///
-    /// # Arguments
-    ///
-    /// * `account` - The account to delete key packages for
-    /// * `delete_mls_stored_keys` - Preserved for API compatibility; ignored by this
-    ///   legacy-only cleanup path
-    /// * `signer` - The external signer to use for signing deletion events
-    ///
     /// # Returns
     ///
     /// Returns the number of legacy key packages that were successfully deleted.
     #[perf_instrument("key_packages")]
-    pub async fn delete_all_key_packages_for_account_with_signer(
+    pub async fn delete_legacy_key_packages_for_account_with_signer(
         &self,
         account: &Account,
-        _delete_mls_stored_keys: bool,
         signer: impl NostrSigner + 'static,
     ) -> Result<usize> {
-        self.delete_all_key_packages_loop(
-            account,
-            _delete_mls_stored_keys,
-            std::sync::Arc::new(signer),
-        )
-        .await
+        self.delete_legacy_key_packages_loop(account, std::sync::Arc::new(signer))
+            .await
     }
 
     /// Loops fetch-delete rounds until no legacy key packages remain on relays, up to
@@ -768,10 +809,9 @@ impl Whitenoise {
     /// only a subset of key packages per query, so a single fetch-delete pass
     /// can leave packages behind.
     #[perf_instrument("key_packages")]
-    async fn delete_all_key_packages_loop(
+    async fn delete_legacy_key_packages_loop(
         &self,
         account: &Account,
-        _delete_mls_stored_keys: bool,
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<usize> {
         let mut total_deleted = 0;
@@ -1490,7 +1530,7 @@ mod tests {
 
     /// Creates a mock key package event with the encoding tag
     fn create_key_package_event_with_encoding_tag(keys: &Keys) -> Event {
-        EventBuilder::new(Kind::MlsKeyPackage, "test_content")
+        EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "test_content")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .sign_with_keys(keys)
             .unwrap()
@@ -1498,7 +1538,7 @@ mod tests {
 
     /// Creates a mock key package event without the encoding tag.
     fn create_key_package_event_without_encoding_tag(keys: &Keys) -> Event {
-        EventBuilder::new(Kind::MlsKeyPackage, "test_content")
+        EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "test_content")
             .sign_with_keys(keys)
             .unwrap()
     }
@@ -1508,7 +1548,7 @@ mod tests {
         ciphersuite: &str,
         extensions: &[&str],
     ) -> Event {
-        EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
                 [ciphersuite],
@@ -1518,7 +1558,7 @@ mod tests {
                 extensions.iter().copied(),
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1577,7 +1617,7 @@ mod tests {
     fn test_has_encoding_tag_returns_false_for_wrong_value() {
         let keys = Keys::generate();
         // Create event with encoding tag but wrong value
-        let event = EventBuilder::new(Kind::MlsKeyPackage, "test_content")
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "test_content")
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["hex"]))
             .sign_with_keys(&keys)
             .unwrap();
@@ -1617,7 +1657,7 @@ mod tests {
                 ["0x000a", "0xf2ee"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1644,7 +1684,7 @@ mod tests {
                 ["0x000a", "0xf2ee"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1695,7 +1735,7 @@ mod tests {
     #[test]
     fn test_validate_marmot_key_package_tags_rejects_invalid_base64_content() {
         let keys = Keys::generate();
-        let event = EventBuilder::new(Kind::MlsKeyPackage, "not-base64$$$")
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "not-base64$$$")
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
                 [REQUIRED_MLS_CIPHERSUITE_TAG],
@@ -1705,7 +1745,7 @@ mod tests {
                 ["0x000a", "0xf2ee"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1730,7 +1770,7 @@ mod tests {
                 ["0x000a", "0xf2ee"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1748,7 +1788,7 @@ mod tests {
     #[test]
     fn test_validate_marmot_key_package_tags_rejects_missing_encoding_tag() {
         let keys = Keys::generate();
-        let event = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
                 [REQUIRED_MLS_CIPHERSUITE_TAG],
@@ -1768,7 +1808,7 @@ mod tests {
     #[test]
     fn test_validate_marmot_key_package_tags_rejects_missing_self_remove_proposal() {
         let keys = Keys::generate();
-        let event = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50")
             .tag(Tag::custom(
                 TagKind::Custom("mls_ciphersuite".into()),
                 [REQUIRED_MLS_CIPHERSUITE_TAG],
@@ -1778,7 +1818,7 @@ mod tests {
                 ["0x000a", "0xf2ee"],
             ))
             .tag(Tag::custom(
-                TagKind::Custom("mls_proposals".into()),
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
                 ["0x0001"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
@@ -1876,7 +1916,7 @@ mod tests {
     fn test_has_encoding_tag_with_multiple_tags() {
         let keys = Keys::generate();
         // Create event with multiple tags including encoding tag
-        let event = EventBuilder::new(Kind::MlsKeyPackage, "test_content")
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "test_content")
             .tag(Tag::custom(
                 TagKind::Custom("mls_protocol_version".into()),
                 ["1.0"],
@@ -1991,21 +2031,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_delete_all_key_packages_without_signer_fails() {
+    async fn test_delete_legacy_key_packages_without_signer_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Account without keys in secrets store — signer resolution fails
         let account = create_local_account_struct();
 
         let result = whitenoise
-            .delete_all_key_packages_for_account(&account, false)
+            .delete_legacy_key_packages_for_account(&account)
             .await;
 
         assert!(result.is_err(), "Should fail when no signer is available");
     }
 
     #[tokio::test]
-    async fn test_delete_all_key_packages_without_relays_fails() {
+    async fn test_delete_legacy_key_packages_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Create an account with keys stored but no key package relays.
@@ -2018,7 +2058,7 @@ mod tests {
             .expect("Should store keys");
 
         let result = whitenoise
-            .delete_all_key_packages_for_account(&account, false)
+            .delete_legacy_key_packages_for_account(&account)
             .await;
         assert!(result.is_err());
         assert!(matches!(
@@ -2028,13 +2068,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_delete_all_key_packages_with_signer_without_relays_fails() {
+    async fn test_delete_legacy_key_packages_with_signer_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
         let signer_keys = Keys::generate();
 
         let result = whitenoise
-            .delete_all_key_packages_for_account_with_signer(&account, false, signer_keys)
+            .delete_legacy_key_packages_for_account_with_signer(&account, signer_keys)
             .await;
         assert!(result.is_err());
         assert!(matches!(
@@ -2136,6 +2176,58 @@ mod tests {
 
         assert!(canonical_record.key_material_deleted);
         assert!(legacy_record.key_material_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_key_package_event_ids_for_deletion_includes_hash_ref_twins() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, keys) = create_account_with_relay_and_keys(&whitenoise).await;
+        let hash_ref = vec![1, 2, 3];
+
+        let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "canonical")
+            .tag(Tag::identifier("delete-twins"))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "legacy")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &hash_ref,
+            &canonical.id.to_hex(),
+            MLS_KEY_PACKAGE_KIND,
+            Some("delete-twins"),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &hash_ref,
+            &legacy.id.to_hex(),
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let canonical_record = PublishedKeyPackage::find_by_event_id(
+            &account.pubkey,
+            &canonical.id.to_hex(),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let event_ids = whitenoise
+            .key_package_event_ids_for_deletion(&account, &canonical.id, Some(&canonical_record))
+            .await;
+
+        assert_eq!(event_ids.len(), 2);
+        assert!(event_ids.contains(&canonical.id));
+        assert!(event_ids.contains(&legacy.id));
     }
 
     #[tokio::test]

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -1187,20 +1187,29 @@ impl Whitenoise {
         event_id: &str,
         age_secs: i64,
     ) -> Result<()> {
+        let package =
+            PublishedKeyPackage::find_by_event_id(account_pubkey, event_id, &self.database)
+                .await?
+                .ok_or_else(|| {
+                    WhitenoiseError::Internal(format!(
+                        "Published key package not found: {event_id}"
+                    ))
+                })?;
+
         sqlx::query(
             "UPDATE published_key_packages SET consumed_at = unixepoch() - ?
-             WHERE account_pubkey = ? AND event_id = ?",
+             WHERE account_pubkey = ? AND key_package_hash_ref = ?",
         )
         .bind(age_secs)
         .bind(account_pubkey.to_hex())
-        .bind(event_id)
+        .bind(&package.key_package_hash_ref)
         .execute(&self.database.pool)
         .await
         .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
 
         tracing::debug!(
             target: "whitenoise::key_packages",
-            "Backdated consumed_at by {}s for KP event {} (TEST ONLY)",
+            "Backdated consumed_at by {}s for KP hash_ref group containing event {} (TEST ONLY)",
             age_secs,
             event_id
         );
@@ -1244,7 +1253,13 @@ mod tests {
 
     /// Creates a persisted account with a key package relay and stored keys.
     async fn create_account_with_relay(whitenoise: &Whitenoise) -> Account {
+        let (account, _keys) = create_account_with_relay_and_keys(whitenoise).await;
+        account
+    }
+
+    async fn create_account_with_relay_and_keys(whitenoise: &Whitenoise) -> (Account, Keys) {
         let (account, keys) = create_test_account(whitenoise).await;
+        let account = account.save(&whitenoise.database).await.unwrap();
         whitenoise
             .secrets_store
             .store_private_key(&keys)
@@ -1260,7 +1275,7 @@ mod tests {
         user.add_relay(&relay, crate::RelayType::KeyPackage, &whitenoise.database)
             .await
             .unwrap();
-        account
+        (account, keys)
     }
 
     #[tokio::test]
@@ -2040,6 +2055,89 @@ mod tests {
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_key_packages_from_storage_deduplicates_hash_ref_twins() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, keys) = create_account_with_relay_and_keys(&whitenoise).await;
+        let relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let key_package_data = whitenoise
+            .encoded_key_package(&account, &relays)
+            .await
+            .unwrap();
+
+        let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, &key_package_data.content)
+            .tags(key_package_data.tags_30443.to_vec())
+            .sign_with_keys(&keys)
+            .unwrap();
+        let legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, &key_package_data.content)
+            .tags(key_package_data.tags_443.to_vec())
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &key_package_data.hash_ref,
+            &canonical.id.to_hex(),
+            MLS_KEY_PACKAGE_KIND,
+            Some(&key_package_data.d_tag),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &key_package_data.hash_ref,
+            &legacy.id.to_hex(),
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let invalid_untracked = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "not-a-key-package")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let duplicate_untracked =
+            EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "not-a-key-package")
+                .sign_with_keys(&keys)
+                .unwrap();
+
+        whitenoise
+            .delete_key_packages_from_storage(
+                &account,
+                &[
+                    canonical.clone(),
+                    legacy.clone(),
+                    invalid_untracked,
+                    duplicate_untracked,
+                ],
+                4,
+            )
+            .await
+            .unwrap();
+
+        let canonical_record = PublishedKeyPackage::find_by_event_id(
+            &account.pubkey,
+            &canonical.id.to_hex(),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let legacy_record = PublishedKeyPackage::find_by_event_id(
+            &account.pubkey,
+            &legacy.id.to_hex(),
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(canonical_record.key_material_deleted);
+        assert!(legacy_record.key_material_deleted);
     }
 
     #[tokio::test]

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -114,12 +114,10 @@ pub(crate) fn validate_marmot_key_package_tags(
 }
 
 pub(crate) fn missing_required_mls_proposals(event: &Event) -> Vec<String> {
-    let proposals: HashSet<String> = normalized_tag_values(
-        event,
-        TagKind::Custom(std::borrow::Cow::Borrowed("mls_proposals")),
-    )
-    .into_iter()
-    .collect();
+    let proposals: HashSet<String> =
+        normalized_tag_values(event, TagKind::Custom("mls_proposals".into()))
+            .into_iter()
+            .collect();
 
     REQUIRED_MLS_PROPOSAL_TAGS
         .into_iter()
@@ -727,10 +725,10 @@ impl Whitenoise {
     pub async fn delete_all_key_packages_for_account(
         &self,
         account: &Account,
-        delete_mls_stored_keys: bool,
+        _delete_mls_stored_keys: bool,
     ) -> Result<usize> {
         let signer = self.get_signer_for_account(account)?;
-        self.delete_all_key_packages_loop(account, delete_mls_stored_keys, signer)
+        self.delete_all_key_packages_loop(account, _delete_mls_stored_keys, signer)
             .await
     }
 
@@ -754,12 +752,12 @@ impl Whitenoise {
     pub async fn delete_all_key_packages_for_account_with_signer(
         &self,
         account: &Account,
-        delete_mls_stored_keys: bool,
+        _delete_mls_stored_keys: bool,
         signer: impl NostrSigner + 'static,
     ) -> Result<usize> {
         self.delete_all_key_packages_loop(
             account,
-            delete_mls_stored_keys,
+            _delete_mls_stored_keys,
             std::sync::Arc::new(signer),
         )
         .await

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -23,13 +23,22 @@ const MAX_DELETE_ROUNDS: u32 = 10;
 /// The ciphersuite currently required by Marmot key package tags.
 pub(crate) const REQUIRED_MLS_CIPHERSUITE_TAG: &str = "0x0001";
 
+/// Current Nostr event kind for MLS KeyPackage events.
+pub(crate) const MLS_KEY_PACKAGE_KIND: Kind = Kind::Custom(30443);
+
+/// Legacy Nostr event kind for MLS KeyPackage events.
+pub(crate) const MLS_KEY_PACKAGE_KIND_LEGACY: Kind = Kind::Custom(443);
+
 /// Required extension IDs that must appear in `mls_extensions` tags.
 const REQUIRED_MLS_EXTENSION_TAGS: [&str; 2] = ["0x000a", "0xf2ee"];
+
+/// Required proposal IDs that must appear in `mls_proposals` tags.
+pub(crate) const REQUIRED_MLS_PROPOSAL_TAGS: [&str; 1] = ["0x000a"];
 
 /// Checks if a key package event has the required encoding tag.
 ///
 /// Per MIP-00/MIP-02, key packages must have an explicit `["encoding", "base64"]` tag.
-/// Key packages without this tag are considered outdated and should be rotated.
+/// Key packages without this tag are incompatible with current clients.
 ///
 /// # Arguments
 ///
@@ -52,11 +61,15 @@ pub(crate) fn validate_marmot_key_package_tags(
     event: &Event,
     expected_ciphersuite: &str,
 ) -> Result<()> {
-    if event.kind != Kind::MlsKeyPackage {
+    if !is_key_package_kind(event.kind) {
         return Err(WhitenoiseError::InvalidEventKind {
-            expected: Kind::MlsKeyPackage.to_string(),
+            expected: format!("{MLS_KEY_PACKAGE_KIND} or {MLS_KEY_PACKAGE_KIND_LEGACY}"),
             got: event.kind.to_string(),
         });
+    }
+
+    if event.kind == MLS_KEY_PACKAGE_KIND && event.tags.identifier().is_none() {
+        return Err(WhitenoiseError::MissingKeyPackageDTag);
     }
 
     if !has_encoding_tag(event) {
@@ -89,7 +102,34 @@ pub(crate) fn validate_marmot_key_package_tags(
         });
     }
 
+    let missing_proposals = missing_required_mls_proposals(event);
+
+    if !missing_proposals.is_empty() {
+        return Err(WhitenoiseError::MissingMlsProposals {
+            missing: missing_proposals,
+        });
+    }
+
     Ok(())
+}
+
+pub(crate) fn missing_required_mls_proposals(event: &Event) -> Vec<String> {
+    let proposals: HashSet<String> = normalized_tag_values(
+        event,
+        TagKind::Custom(std::borrow::Cow::Borrowed("mls_proposals")),
+    )
+    .into_iter()
+    .collect();
+
+    REQUIRED_MLS_PROPOSAL_TAGS
+        .into_iter()
+        .filter(|required| !proposals.contains(*required))
+        .map(|required| required.to_string())
+        .collect()
+}
+
+pub(crate) fn is_key_package_kind(kind: Kind) -> bool {
+    kind == MLS_KEY_PACKAGE_KIND || kind == MLS_KEY_PACKAGE_KIND_LEGACY
 }
 
 fn normalized_tag_values(event: &Event, tag_kind: TagKind<'_>) -> Vec<String> {
@@ -101,27 +141,6 @@ fn normalized_tag_values(event: &Event, tag_kind: TagKind<'_>) -> Vec<String> {
         .flat_map(|value| value.split(|c: char| c == ',' || c.is_ascii_whitespace()))
         .filter(|part| !part.is_empty())
         .map(|part| part.to_ascii_lowercase())
-        .collect()
-}
-
-/// Returns key packages that are missing the required encoding tag.
-///
-/// These outdated packages were published before the MIP-00/MIP-02 encoding tag
-/// requirement was enforced. They should be deleted and replaced with new
-/// key packages that include the proper `["encoding", "base64"]` tag.
-///
-/// # Arguments
-///
-/// * `packages` - The key package events to check
-///
-/// # Returns
-///
-/// A vector of key package events that are missing the encoding tag.
-pub(crate) fn find_outdated_packages(packages: &[Event]) -> Vec<Event> {
-    packages
-        .iter()
-        .filter(|p| !has_encoding_tag(p))
-        .cloned()
         .collect()
 }
 
@@ -137,7 +156,7 @@ pub(crate) fn filter_key_package_events_for_account(
     let mut dropped_wrong_author = 0;
 
     for event in events {
-        if event.kind != Kind::MlsKeyPackage {
+        if !is_key_package_kind(event.kind) {
             dropped_wrong_kind += 1;
             continue;
         }
@@ -209,21 +228,15 @@ impl Whitenoise {
             }
 
             match self
-                .publish_key_package_to_relays(
-                    &key_package_data.content,
+                .publish_key_package_pair_to_relays(
+                    account,
+                    &key_package_data,
                     &relay_urls,
-                    &key_package_data.tags_443,
                     signer.clone(),
                 )
                 .await
             {
-                Ok(event_id) => {
-                    self.track_published_key_package(
-                        account,
-                        &key_package_data.hash_ref,
-                        &event_id,
-                    )
-                    .await;
+                Ok(()) => {
                     return Ok(());
                 }
                 Err(e) => {
@@ -263,16 +276,13 @@ impl Whitenoise {
 
         let key_package_data = self.encoded_key_package(account, &relays).await?;
         let relay_urls = Relay::urls(&relays);
-        let event_id = self
-            .publish_key_package_to_relays(
-                &key_package_data.content,
-                &relay_urls,
-                &key_package_data.tags_443,
-                std::sync::Arc::new(signer),
-            )
-            .await?;
-        self.track_published_key_package(account, &key_package_data.hash_ref, &event_id)
-            .await;
+        self.publish_key_package_pair_to_relays(
+            account,
+            &key_package_data,
+            &relay_urls,
+            std::sync::Arc::new(signer),
+        )
+        .await?;
         Ok(())
     }
 
@@ -290,16 +300,8 @@ impl Whitenoise {
         let key_package_data = self.encoded_key_package(account, relays).await?;
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
-        let event_id = self
-            .publish_key_package_to_relays(
-                &key_package_data.content,
-                &relay_urls,
-                &key_package_data.tags_443,
-                signer,
-            )
+        self.publish_key_package_pair_to_relays(account, &key_package_data, &relay_urls, signer)
             .await?;
-        self.track_published_key_package(account, &key_package_data.hash_ref, &event_id)
-            .await;
         Ok(())
     }
 
@@ -337,22 +339,15 @@ impl Whitenoise {
                     }
                 };
                 match wn
-                    .publish_key_package_to_relays(
-                        &key_package_data.content,
+                    .publish_key_package_pair_to_relays(
+                        &account,
+                        &key_package_data,
                         &relay_urls,
-                        &key_package_data.tags_443,
                         signer,
                     )
                     .await
                 {
-                    Ok(event_id) => {
-                        wn.track_published_key_package(
-                            &account,
-                            &key_package_data.hash_ref,
-                            &event_id,
-                        )
-                        .await;
-                    }
+                    Ok(()) => {}
                     Err(e) => {
                         tracing::warn!(
                             target: "whitenoise::key_packages",
@@ -365,22 +360,10 @@ impl Whitenoise {
         } else {
             // Synchronous fallback (unit tests or pre-initialization).
             match self
-                .publish_key_package_to_relays(
-                    &key_package_data.content,
-                    &relay_urls,
-                    &key_package_data.tags_443,
-                    signer,
-                )
+                .publish_key_package_pair_to_relays(account, &key_package_data, &relay_urls, signer)
                 .await
             {
-                Ok(event_id) => {
-                    self.track_published_key_package(
-                        account,
-                        &key_package_data.hash_ref,
-                        &event_id,
-                    )
-                    .await;
-                }
+                Ok(()) => {}
                 Err(e) => {
                     tracing::warn!(
                         target: "whitenoise::key_packages",
@@ -388,6 +371,67 @@ impl Whitenoise {
                         e
                     );
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[perf_instrument("key_packages")]
+    async fn publish_key_package_pair_to_relays(
+        &self,
+        account: &Account,
+        key_package_data: &KeyPackageEventData,
+        relay_urls: &[RelayUrl],
+        signer: std::sync::Arc<dyn NostrSigner>,
+    ) -> Result<()> {
+        let canonical_event_id = self
+            .publish_key_package_to_relays(
+                MLS_KEY_PACKAGE_KIND,
+                &key_package_data.content,
+                relay_urls,
+                &key_package_data.tags_30443,
+                signer.clone(),
+            )
+            .await?;
+
+        self.track_published_key_package(
+            account,
+            &key_package_data.hash_ref,
+            &canonical_event_id,
+            MLS_KEY_PACKAGE_KIND,
+            Some(&key_package_data.d_tag),
+        )
+        .await;
+
+        match self
+            .publish_key_package_to_relays(
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                &key_package_data.content,
+                relay_urls,
+                &key_package_data.tags_443,
+                signer,
+            )
+            .await
+        {
+            Ok(legacy_event_id) => {
+                self.track_published_key_package(
+                    account,
+                    &key_package_data.hash_ref,
+                    &legacy_event_id,
+                    MLS_KEY_PACKAGE_KIND_LEGACY,
+                    None,
+                )
+                .await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Published canonical kind:30443 key package for account {} but failed \
+                     to publish legacy kind:443 twin: {}",
+                    account.pubkey.to_hex(),
+                    e,
+                );
             }
         }
 
@@ -402,6 +446,7 @@ impl Whitenoise {
     #[perf_instrument("key_packages")]
     async fn publish_key_package_to_relays(
         &self,
+        kind: Kind,
         encoded_key_package: &str,
         relay_urls: &[RelayUrl],
         tags: &[Tag],
@@ -409,7 +454,7 @@ impl Whitenoise {
     ) -> Result<EventId> {
         let result = self
             .relay_control
-            .publish_key_package_with_signer(encoded_key_package, relay_urls, tags, signer)
+            .publish_key_package_with_signer(kind, encoded_key_package, relay_urls, tags, signer)
             .await?;
 
         if result.success.is_empty() {
@@ -420,7 +465,8 @@ impl Whitenoise {
 
         tracing::debug!(
             target: "whitenoise::key_packages",
-            "Published key package to {} relay(s)",
+            "Published kind:{} key package to {} relay(s)",
+            kind.as_u16(),
             result.success.len(),
         );
 
@@ -434,11 +480,15 @@ impl Whitenoise {
         account: &Account,
         hash_ref: &[u8],
         event_id: &EventId,
+        kind: Kind,
+        d_tag: Option<&str>,
     ) {
         if let Err(e) = PublishedKeyPackage::create(
             &account.pubkey,
             hash_ref,
             &event_id.to_hex(),
+            kind,
+            d_tag,
             &self.database,
         )
         .await
@@ -520,13 +570,16 @@ impl Whitenoise {
                 Ok(Some(pkg)) if !pkg.key_material_deleted => {
                     let mdk = self.create_mdk_for_account(account.pubkey)?;
                     mdk.delete_key_package_from_storage_by_hash_ref(&pkg.key_package_hash_ref)?;
-                    if let Err(e) =
-                        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &self.database).await
+                    if let Err(e) = PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
+                        &account.pubkey,
+                        &pkg.key_package_hash_ref,
+                        &self.database,
+                    )
+                    .await
                     {
                         tracing::warn!(
                             target: "whitenoise::key_packages",
-                            "Deleted key material but failed to mark record {}: {}",
-                            pkg.id,
+                            "Deleted key material but failed to mark hash_ref group: {}",
                             e
                         );
                     }
@@ -604,7 +657,7 @@ impl Whitenoise {
         }
 
         let key_package_filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
+            .kinds([MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY])
             .author(account.pubkey);
 
         let fetched = self
@@ -847,7 +900,8 @@ impl Whitenoise {
 
         // Delete from local storage on initial attempt only
         if delete_mls_stored_keys {
-            self.delete_key_packages_from_storage(account, &key_package_events, original_count)?;
+            self.delete_key_packages_from_storage(account, &key_package_events, original_count)
+                .await?;
         }
 
         let mut pending_ids: Vec<EventId> = key_package_events.iter().map(|e| e.id).collect();
@@ -921,16 +975,75 @@ impl Whitenoise {
         Ok(Relay::urls(&key_package_relays))
     }
 
-    fn delete_key_packages_from_storage(
+    async fn delete_key_packages_from_storage(
         &self,
         account: &Account,
         key_package_events: &[Event],
         initial_count: usize,
     ) -> Result<()> {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let mut deleted_hash_refs = HashSet::new();
+        let mut deleted_untracked_contents = HashSet::new();
         let mut storage_delete_count = 0;
 
         for event in key_package_events {
+            match PublishedKeyPackage::find_by_event_id(
+                &account.pubkey,
+                &event.id.to_hex(),
+                &self.database,
+            )
+            .await
+            {
+                Ok(Some(pkg)) => {
+                    if !deleted_hash_refs.insert(pkg.key_package_hash_ref.clone()) {
+                        continue;
+                    }
+
+                    match mdk.delete_key_package_from_storage_by_hash_ref(&pkg.key_package_hash_ref)
+                    {
+                        Ok(()) => {
+                            storage_delete_count += 1;
+                            if let Err(e) =
+                                PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
+                                    &account.pubkey,
+                                    &pkg.key_package_hash_ref,
+                                    &self.database,
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    target: "whitenoise::key_packages",
+                                    "Deleted key material but failed to mark hash_ref group: {}",
+                                    e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "whitenoise::key_packages",
+                                "Failed to delete key package from storage for event {}: {}",
+                                event.id,
+                                e
+                            );
+                        }
+                    }
+                    continue;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Failed to look up published key package for event {}: {}",
+                        event.id,
+                        e
+                    );
+                }
+            }
+
+            if !deleted_untracked_contents.insert(event.content.clone()) {
+                continue;
+            }
+
             match mdk.parse_key_package(event) {
                 Ok(key_package) => match mdk.delete_key_package_from_storage(&key_package) {
                     Ok(_) => storage_delete_count += 1,
@@ -1034,9 +1147,16 @@ impl Whitenoise {
         hash_ref: &[u8],
         event_id: &str,
     ) -> Result<()> {
-        PublishedKeyPackage::create(account_pubkey, hash_ref, event_id, &self.database)
-            .await
-            .map_err(WhitenoiseError::from)
+        PublishedKeyPackage::create(
+            account_pubkey,
+            hash_ref,
+            event_id,
+            Kind::MlsKeyPackage,
+            None,
+            &self.database,
+        )
+        .await
+        .map_err(WhitenoiseError::from)
     }
 
     /// Backdates the `consumed_at` timestamp for a published key package.
@@ -1347,7 +1467,7 @@ mod tests {
             .unwrap()
     }
 
-    /// Creates a mock key package event without the encoding tag (outdated)
+    /// Creates a mock key package event without the encoding tag.
     fn create_key_package_event_without_encoding_tag(keys: &Keys) -> Event {
         EventBuilder::new(Kind::MlsKeyPackage, "test_content")
             .sign_with_keys(keys)
@@ -1367,6 +1487,10 @@ mod tests {
             .tag(Tag::custom(
                 TagKind::Custom("mls_extensions".into()),
                 extensions.iter().copied(),
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .sign_with_keys(keys)
@@ -1431,6 +1555,63 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_marmot_key_package_tags_accepts_current_kind() {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "dGVzdF9jb250ZW50")
+            .tag(Tag::identifier(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_ciphersuite".into()),
+                [REQUIRED_MLS_CIPHERSUITE_TAG],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_extensions".into()),
+                ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
+            .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let result = validate_marmot_key_package_tags(&event, REQUIRED_MLS_CIPHERSUITE_TAG);
+        assert!(
+            result.is_ok(),
+            "Expected current kind key package to validate"
+        );
+    }
+
+    #[test]
+    fn test_validate_marmot_key_package_tags_rejects_current_kind_without_d_tag() {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "dGVzdF9jb250ZW50")
+            .tag(Tag::custom(
+                TagKind::Custom("mls_ciphersuite".into()),
+                [REQUIRED_MLS_CIPHERSUITE_TAG],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_extensions".into()),
+                ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
+            .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let result = validate_marmot_key_package_tags(&event, REQUIRED_MLS_CIPHERSUITE_TAG);
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::MissingKeyPackageDTag)
+        ));
+    }
+
+    #[test]
     fn test_validate_marmot_key_package_tags_rejects_wrong_ciphersuite() {
         let keys = Keys::generate();
         let event = create_key_package_event_with_compatibility_tags(
@@ -1476,6 +1657,10 @@ mod tests {
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xf2ee"],
             ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
+            ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .sign_with_keys(&keys)
             .unwrap();
@@ -1496,6 +1681,10 @@ mod tests {
             .tag(Tag::custom(
                 TagKind::Custom("mls_extensions".into()),
                 ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x000a"],
             ))
             .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
             .sign_with_keys(&keys)
@@ -1530,65 +1719,31 @@ mod tests {
     }
 
     #[test]
-    fn test_find_outdated_packages_returns_only_packages_without_tag() {
+    fn test_validate_marmot_key_package_tags_rejects_missing_self_remove_proposal() {
         let keys = Keys::generate();
-        let with_tag = create_key_package_event_with_encoding_tag(&keys);
-        let without_tag = create_key_package_event_without_encoding_tag(&keys);
+        let event = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50")
+            .tag(Tag::custom(
+                TagKind::Custom("mls_ciphersuite".into()),
+                [REQUIRED_MLS_CIPHERSUITE_TAG],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_extensions".into()),
+                ["0x000a", "0xf2ee"],
+            ))
+            .tag(Tag::custom(
+                TagKind::Custom("mls_proposals".into()),
+                ["0x0001"],
+            ))
+            .tag(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]))
+            .sign_with_keys(&keys)
+            .unwrap();
 
-        let packages = vec![with_tag.clone(), without_tag.clone()];
-        let outdated = find_outdated_packages(&packages);
-
-        assert_eq!(
-            outdated.len(),
-            1,
-            "Should find exactly one outdated package"
-        );
-        assert_eq!(
-            outdated[0].id, without_tag.id,
-            "Outdated package should be the one without encoding tag"
-        );
-    }
-
-    #[test]
-    fn test_find_outdated_packages_returns_empty_when_all_have_tag() {
-        let keys = Keys::generate();
-        let event1 = create_key_package_event_with_encoding_tag(&keys);
-        let event2 = create_key_package_event_with_encoding_tag(&keys);
-
-        let packages = vec![event1, event2];
-        let outdated = find_outdated_packages(&packages);
-
-        assert!(
-            outdated.is_empty(),
-            "Should return empty when all packages have encoding tag"
-        );
-    }
-
-    #[test]
-    fn test_find_outdated_packages_returns_all_when_none_have_tag() {
-        let keys = Keys::generate();
-        let event1 = create_key_package_event_without_encoding_tag(&keys);
-        let event2 = create_key_package_event_without_encoding_tag(&keys);
-
-        let packages = vec![event1, event2];
-        let outdated = find_outdated_packages(&packages);
-
-        assert_eq!(
-            outdated.len(),
-            2,
-            "Should return all packages when none have encoding tag"
-        );
-    }
-
-    #[test]
-    fn test_find_outdated_packages_handles_empty_list() {
-        let packages: Vec<Event> = vec![];
-        let outdated = find_outdated_packages(&packages);
-
-        assert!(
-            outdated.is_empty(),
-            "Should return empty when given empty list"
-        );
+        let result = validate_marmot_key_package_tags(&event, REQUIRED_MLS_CIPHERSUITE_TAG);
+        assert!(result.is_err(), "Expected missing SelfRemove to fail");
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::MissingMlsProposals { .. })
+        ));
     }
 
     #[test]

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -693,12 +693,13 @@ impl Whitenoise {
         Ok(key_package_events)
     }
 
-    /// Deletes all key package events from relays for the given account.
+    /// Deletes all legacy key package events from relays for the given account.
     ///
-    /// This method finds all key package events authored by the account and publishes
-    /// a batch deletion event to efficiently remove them from the relays. It then verifies
-    /// the deletions by refetching and returns the actual count of deleted key packages.
-    /// Optionally, it can also delete the MLS stored keys from local storage.
+    /// This developer-facing cleanup keeps canonical replaceable kind:30443 key packages
+    /// intact and only removes legacy kind:443 copies. The `delete_mls_stored_keys`
+    /// argument is preserved for API compatibility, but shared local MLS key material
+    /// is not deleted from this legacy-only path because kind:443 and kind:30443 twins
+    /// can reference the same `hash_ref`.
     ///
     /// Automatically uses the appropriate signer for the account:
     /// - For external accounts (Amber/NIP-55): uses the registered external signer
@@ -707,11 +708,12 @@ impl Whitenoise {
     /// # Arguments
     ///
     /// * `account` - The account to delete key packages for
-    /// * `delete_mls_stored_keys` - Whether to also delete MLS keys from local storage
+    /// * `delete_mls_stored_keys` - Preserved for API compatibility; ignored by this
+    ///   legacy-only cleanup path
     ///
     /// # Returns
     ///
-    /// Returns the number of key packages that were successfully deleted.
+    /// Returns the number of legacy key packages that were successfully deleted.
     ///
     /// # Errors
     ///
@@ -732,7 +734,7 @@ impl Whitenoise {
             .await
     }
 
-    /// Deletes all key package events from relays using an external signer.
+    /// Deletes all legacy key package events from relays using an external signer.
     ///
     /// This is used for external signer accounts (like Amber/NIP-55) where the
     /// private key is not available locally. The signer is used to sign the
@@ -741,12 +743,13 @@ impl Whitenoise {
     /// # Arguments
     ///
     /// * `account` - The account to delete key packages for
-    /// * `delete_mls_stored_keys` - Whether to also delete MLS keys from local storage
+    /// * `delete_mls_stored_keys` - Preserved for API compatibility; ignored by this
+    ///   legacy-only cleanup path
     /// * `signer` - The external signer to use for signing deletion events
     ///
     /// # Returns
     ///
-    /// Returns the number of key packages that were successfully deleted.
+    /// Returns the number of legacy key packages that were successfully deleted.
     #[perf_instrument("key_packages")]
     pub async fn delete_all_key_packages_for_account_with_signer(
         &self,
@@ -762,7 +765,7 @@ impl Whitenoise {
         .await
     }
 
-    /// Loops fetch-delete rounds until no key packages remain on relays, up to
+    /// Loops fetch-delete rounds until no legacy key packages remain on relays, up to
     /// [`MAX_DELETE_ROUNDS`]. This handles NIP-01 pagination: relays may return
     /// only a subset of key packages per query, so a single fetch-delete pass
     /// can leave packages behind.
@@ -770,18 +773,20 @@ impl Whitenoise {
     async fn delete_all_key_packages_loop(
         &self,
         account: &Account,
-        delete_mls_stored_keys: bool,
+        _delete_mls_stored_keys: bool,
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<usize> {
         let mut total_deleted = 0;
 
         for round in 0..MAX_DELETE_ROUNDS {
-            let key_package_events = self.fetch_all_key_packages_for_account(account).await?;
+            let key_package_events = Self::legacy_key_package_events(
+                self.fetch_all_key_packages_for_account(account).await?,
+            );
 
             if key_package_events.is_empty() {
                 tracing::info!(
                     target: "whitenoise::key_packages",
-                    "All key packages deleted for account {} \
+                    "All legacy key packages deleted for account {} \
                      ({} total across {} round(s))",
                     account.pubkey.to_hex(),
                     total_deleted,
@@ -792,7 +797,7 @@ impl Whitenoise {
 
             tracing::debug!(
                 target: "whitenoise::key_packages",
-                "Round {}: found {} remaining key package(s) for account {}",
+                "Round {}: found {} remaining legacy key package(s) for account {}",
                 round + 1,
                 key_package_events.len(),
                 account.pubkey.to_hex(),
@@ -804,7 +809,7 @@ impl Whitenoise {
                 .delete_key_packages_for_account_internal(
                     account,
                     key_package_events,
-                    delete_mls_stored_keys,
+                    false,
                     1,
                     signer.clone(),
                 )
@@ -817,7 +822,7 @@ impl Whitenoise {
             if deleted == 0 {
                 tracing::warn!(
                     target: "whitenoise::key_packages",
-                    "Round {} deleted 0 key packages despite {} found \
+                    "Round {} deleted 0 legacy key packages despite {} found \
                      — relays may not support deletion",
                     round + 1,
                     batch_size,
@@ -827,6 +832,13 @@ impl Whitenoise {
         }
 
         Ok(total_deleted)
+    }
+
+    fn legacy_key_package_events(events: Vec<Event>) -> Vec<Event> {
+        events
+            .into_iter()
+            .filter(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY)
+            .collect()
     }
 
     /// Deletes the specified key package events from relays for the given account.
@@ -1139,20 +1151,24 @@ impl Whitenoise {
     ///
     /// Integration-test helper for cases that manually publish custom key
     /// package events (for example with a backdated timestamp) and still need
-    /// maintenance to treat them as locally-owned packages.
+    /// maintenance to treat them as locally-owned packages. Callers pass the
+    /// event kind explicitly so canonical and legacy test fixtures match the
+    /// event that was actually published.
     #[cfg(feature = "integration-tests")]
     pub async fn track_published_key_package_for_testing(
         &self,
         account_pubkey: &nostr_sdk::PublicKey,
         hash_ref: &[u8],
         event_id: &str,
+        kind: Kind,
+        d_tag: Option<&str>,
     ) -> Result<()> {
         PublishedKeyPackage::create(
             account_pubkey,
             hash_ref,
             event_id,
-            Kind::MlsKeyPackage,
-            None,
+            kind,
+            d_tag,
             &self.database,
         )
         .await
@@ -1502,6 +1518,24 @@ mod tests {
         EventBuilder::new(Kind::TextNote, "test_content")
             .sign_with_keys(keys)
             .unwrap()
+    }
+
+    #[test]
+    fn test_legacy_key_package_events_filters_to_kind_443() {
+        let keys = Keys::generate();
+        let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "canonical")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "legacy")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let text_note = create_non_key_package_event(&keys);
+
+        let filtered =
+            Whitenoise::legacy_key_package_events(vec![canonical, legacy.clone(), text_note]);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, legacy.id);
     }
 
     #[test]

--- a/src/whitenoise/scheduled_tasks/tasks/consumed_key_package_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/consumed_key_package_cleanup.rs
@@ -1,5 +1,6 @@
 //! Scheduled task to clean up local MLS key material for consumed key packages.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -137,21 +138,26 @@ async fn cleanup_consumed_key_packages(
     );
 
     let mdk = whitenoise.create_mdk_for_account(account.pubkey)?;
+    let mut cleaned_hash_refs = HashSet::new();
     let mut cleaned = 0usize;
 
     for consumed in &eligible {
+        if !cleaned_hash_refs.insert(consumed.key_package_hash_ref.clone()) {
+            continue;
+        }
+
         match mdk.delete_key_package_from_storage_by_hash_ref(&consumed.key_package_hash_ref) {
             Ok(()) => {
-                if let Err(e) = PublishedKeyPackage::mark_key_material_deleted(
-                    consumed.id,
+                if let Err(e) = PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
+                    &account.pubkey,
+                    &consumed.key_package_hash_ref,
                     &whitenoise.database,
                 )
                 .await
                 {
                     tracing::warn!(
                         target: "whitenoise::scheduler::consumed_key_package_cleanup",
-                        "Deleted key material but failed to mark record {}: {}",
-                        consumed.id,
+                        "Deleted key material but failed to mark hash_ref group: {}",
                         e
                     );
                 }

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -376,7 +376,7 @@ async fn rotate_expired_packages(
 mod tests {
     use super::*;
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
-    use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND_LEGACY;
+    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
     use crate::whitenoise::test_utils::create_mock_whitenoise;
     use nostr_sdk::prelude::*;
 
@@ -639,6 +639,28 @@ mod tests {
             2,
             "An expired hash_ref group should be rotated as a whole"
         );
+    }
+
+    #[test]
+    fn test_count_key_package_hash_groups_deduplicates_twins() {
+        let keys = nostr_sdk::Keys::generate();
+        let canonical = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND, "canonical")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let legacy = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "legacy")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let separate = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND, "separate")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let packages = vec![
+            live_package(canonical, vec![1, 2, 3]),
+            live_package(legacy, vec![1, 2, 3]),
+            live_package(separate, vec![4, 5, 6]),
+        ];
+
+        assert_eq!(count_key_package_hash_groups(&packages), 2);
     }
 
     #[test]

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -376,7 +376,9 @@ async fn rotate_expired_packages(
 mod tests {
     use super::*;
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
-    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
+    use crate::whitenoise::key_packages::{
+        MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, MLS_PROPOSALS_TAG_KEY,
+    };
     use crate::whitenoise::test_utils::create_mock_whitenoise;
     use nostr_sdk::prelude::*;
 
@@ -392,7 +394,10 @@ mod tests {
         let tags = vec![
             Tag::custom(TagKind::MlsCiphersuite, vec![REQUIRED_MLS_CIPHERSUITE_TAG]),
             Tag::custom(TagKind::MlsExtensions, vec!["0x000a", "0xf2ee"]),
-            Tag::custom(TagKind::Custom("mls_proposals".into()), vec!["0x000a"]),
+            Tag::custom(
+                TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
+                vec!["0x000a"],
+            ),
             Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
         ];
 
@@ -547,13 +552,13 @@ mod tests {
 
         // Create an event with a timestamp 31 days in the past
         let old_timestamp = nostr_sdk::Timestamp::now() - Duration::from_secs(31 * 24 * 60 * 60);
-        let old_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old")
+        let old_event = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "old")
             .custom_created_at(old_timestamp)
             .sign_with_keys(&keys)
             .unwrap();
 
         // Create an event with a fresh timestamp
-        let fresh_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "fresh")
+        let fresh_event = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "fresh")
             .sign_with_keys(&keys)
             .unwrap();
 
@@ -571,10 +576,10 @@ mod tests {
     fn test_find_expired_packages_returns_empty_when_all_fresh() {
         let keys = nostr_sdk::Keys::generate();
 
-        let fresh1 = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "fresh1")
+        let fresh1 = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "fresh1")
             .sign_with_keys(&keys)
             .unwrap();
-        let fresh2 = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "fresh2")
+        let fresh2 = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "fresh2")
             .sign_with_keys(&keys)
             .unwrap();
 
@@ -594,11 +599,11 @@ mod tests {
         let keys = nostr_sdk::Keys::generate();
         let old_timestamp = nostr_sdk::Timestamp::now() - Duration::from_secs(31 * 24 * 60 * 60);
 
-        let old_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old")
+        let old_event = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "old")
             .custom_created_at(old_timestamp)
             .sign_with_keys(&keys)
             .unwrap();
-        let fresh_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "fresh")
+        let fresh_event = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "fresh")
             .sign_with_keys(&keys)
             .unwrap();
 
@@ -619,11 +624,11 @@ mod tests {
         let keys = nostr_sdk::Keys::generate();
         let old_timestamp = nostr_sdk::Timestamp::now() - Duration::from_secs(31 * 24 * 60 * 60);
 
-        let old_event_a = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old-a")
+        let old_event_a = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "old-a")
             .custom_created_at(old_timestamp)
             .sign_with_keys(&keys)
             .unwrap();
-        let old_event_b = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old-b")
+        let old_event_b = nostr_sdk::EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "old-b")
             .custom_created_at(old_timestamp)
             .sign_with_keys(&keys)
             .unwrap();

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt};
@@ -9,6 +12,9 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
 use crate::whitenoise::error::WhitenoiseError;
+use crate::whitenoise::key_packages::{
+    REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags,
+};
 use crate::whitenoise::scheduled_tasks::Task;
 
 /// Maximum age for a key package before it should be rotated (30 days).
@@ -16,6 +22,12 @@ const KEY_PACKAGE_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 /// Maximum number of accounts to process concurrently.
 const MAX_CONCURRENT_ACCOUNTS: usize = 5;
+
+#[derive(Debug, Clone)]
+struct LivePublishedKeyPackage {
+    event: Event,
+    key_package_hash_ref: Vec<u8>,
+}
 
 pub(crate) struct KeyPackageMaintenance;
 
@@ -150,11 +162,12 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
         Ok(packages) => packages,
         Err(e) => return MaintenanceResult::Error(e),
     };
+    let our_packages = filter_compatible_key_packages(our_packages);
 
     if our_packages.is_empty() {
         tracing::info!(
             target: "whitenoise::scheduler::key_package_maintenance",
-            "Account {} has key package events on relays but none with live local state, publishing new one",
+            "Account {} has key package events on relays but none with live compatible local state, publishing new one",
             account.pubkey.to_hex()
         );
         return publish_new_key_package(whitenoise, account).await;
@@ -166,7 +179,7 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
     if our_expired_packages.is_empty() {
         tracing::debug!(
             target: "whitenoise::scheduler::key_package_maintenance",
-            "Account {} has {} live tracked key package(s), none expired",
+            "Account {} has {} live compatible tracked key package(s), none expired",
             account.pubkey.to_hex(),
             our_packages.len()
         );
@@ -175,25 +188,72 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
 
     // Delete expired packages, only republishing if all our packages are
     // expired (so we'd have zero left after deletion).
+    let total_package_group_count = count_key_package_hash_groups(&our_packages);
     rotate_expired_packages(
         whitenoise,
         account,
         our_expired_packages,
-        our_packages.len(),
+        total_package_group_count,
     )
     .await
 }
 
-/// Returns key packages that are older than the maximum age threshold.
-fn find_expired_packages(packages: &[Event]) -> Vec<Event> {
+fn filter_compatible_key_packages(
+    packages: Vec<LivePublishedKeyPackage>,
+) -> Vec<LivePublishedKeyPackage> {
+    packages
+        .into_iter()
+        .filter(|package| {
+            match validate_marmot_key_package_tags(&package.event, REQUIRED_MLS_CIPHERSUITE_TAG) {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::debug!(
+                        target: "whitenoise::scheduler::key_package_maintenance",
+                        "Ignoring locally tracked key package {} because it is incompatible: {}",
+                        package.event.id,
+                        e
+                    );
+                    false
+                }
+            }
+        })
+        .collect()
+}
+
+/// Returns whole key package hash groups whose newest event is older than the maximum age.
+fn find_expired_packages(packages: &[LivePublishedKeyPackage]) -> Vec<LivePublishedKeyPackage> {
     let now = Timestamp::now();
     let max_age_secs = KEY_PACKAGE_MAX_AGE.as_secs();
+    let mut packages_by_hash_ref: HashMap<Vec<u8>, Vec<LivePublishedKeyPackage>> = HashMap::new();
 
+    for package in packages {
+        packages_by_hash_ref
+            .entry(package.key_package_hash_ref.clone())
+            .or_default()
+            .push(package.clone());
+    }
+
+    packages_by_hash_ref
+        .into_values()
+        .filter(|package_group| {
+            package_group
+                .iter()
+                .map(|package| package.event.created_at)
+                .max()
+                .is_some_and(|most_recent| {
+                    now.as_secs().saturating_sub(most_recent.as_secs()) >= max_age_secs
+                })
+        })
+        .flatten()
+        .collect()
+}
+
+fn count_key_package_hash_groups(packages: &[LivePublishedKeyPackage]) -> usize {
     packages
         .iter()
-        .filter(|p| now.as_secs().saturating_sub(p.created_at.as_secs()) >= max_age_secs)
-        .cloned()
-        .collect()
+        .map(|package| &package.key_package_hash_ref)
+        .collect::<HashSet<_>>()
+        .len()
 }
 
 /// Returns relay key packages that this device published and still has usable local state for.
@@ -202,7 +262,7 @@ async fn find_live_published_key_packages(
     whitenoise: &Whitenoise,
     account: &Account,
     packages: Vec<Event>,
-) -> Result<Vec<Event>, WhitenoiseError> {
+) -> Result<Vec<LivePublishedKeyPackage>, WhitenoiseError> {
     let mut our_packages = Vec::new();
 
     for event in packages {
@@ -213,9 +273,11 @@ async fn find_live_published_key_packages(
         )
         .await?
         {
-            Some(pkg) if !pkg.key_material_deleted && pkg.consumed_at.is_none() => {
-                our_packages.push(event)
-            }
+            Some(pkg) if !pkg.key_material_deleted && pkg.consumed_at.is_none() => our_packages
+                .push(LivePublishedKeyPackage {
+                    event,
+                    key_package_hash_ref: pkg.key_package_hash_ref,
+                }),
             Some(_) | None => {}
         }
     }
@@ -255,21 +317,27 @@ async fn publish_new_key_package(whitenoise: &Whitenoise, account: &Account) -> 
 async fn rotate_expired_packages(
     whitenoise: &Whitenoise,
     account: &Account,
-    expired_packages: Vec<Event>,
-    total_package_count: usize,
+    expired_packages: Vec<LivePublishedKeyPackage>,
+    total_package_group_count: usize,
 ) -> MaintenanceResult {
-    let non_expired_count = total_package_count - expired_packages.len();
+    let expired_group_count = count_key_package_hash_groups(&expired_packages);
+    let non_expired_group_count = total_package_group_count.saturating_sub(expired_group_count);
+    let expired_events: Vec<Event> = expired_packages
+        .into_iter()
+        .map(|package| package.event)
+        .collect();
 
     tracing::info!(
         target: "whitenoise::scheduler::key_package_maintenance",
-        "Account {} has {} expired key package(s) and {} non-expired, cleaning up",
+        "Account {} has {} expired key package group(s) ({} event(s)) and {} non-expired group(s), cleaning up",
         account.pubkey.to_hex(),
-        expired_packages.len(),
-        non_expired_count
+        expired_group_count,
+        expired_events.len(),
+        non_expired_group_count
     );
 
     // Only publish a new key package if deleting the expired ones would leave zero packages
-    if non_expired_count == 0 {
+    if non_expired_group_count == 0 {
         if let Err(e) = whitenoise.publish_key_package_for_account(account).await {
             match e {
                 WhitenoiseError::AccountMissingKeyPackageRelays => {
@@ -288,7 +356,7 @@ async fn rotate_expired_packages(
 
     // Delete expired key packages (don't delete MLS stored keys for now)
     match whitenoise
-        .delete_key_packages_for_account(account, expired_packages, false, 1)
+        .delete_key_packages_for_account(account, expired_events, false, 1)
         .await
     {
         Ok(deleted) => MaintenanceResult::RotatedExpired { deleted },
@@ -308,7 +376,31 @@ async fn rotate_expired_packages(
 mod tests {
     use super::*;
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
+    use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND_LEGACY;
     use crate::whitenoise::test_utils::create_mock_whitenoise;
+    use nostr_sdk::prelude::*;
+
+    fn live_package(event: Event, key_package_hash_ref: Vec<u8>) -> LivePublishedKeyPackage {
+        LivePublishedKeyPackage {
+            event,
+            key_package_hash_ref,
+        }
+    }
+
+    fn compatible_key_package_event(content: &str) -> Event {
+        let keys = Keys::generate();
+        let tags = vec![
+            Tag::custom(TagKind::MlsCiphersuite, vec![REQUIRED_MLS_CIPHERSUITE_TAG]),
+            Tag::custom(TagKind::MlsExtensions, vec!["0x000a", "0xf2ee"]),
+            Tag::custom(TagKind::Custom("mls_proposals".into()), vec!["0x000a"]),
+            Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
+        ];
+
+        EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, content)
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_execute_republishes_when_local_key_material_is_missing() {
@@ -465,11 +557,14 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
 
-        let packages = vec![old_event.clone(), fresh_event.clone()];
+        let packages = vec![
+            live_package(old_event.clone(), vec![1]),
+            live_package(fresh_event.clone(), vec![2]),
+        ];
         let expired = find_expired_packages(&packages);
 
         assert_eq!(expired.len(), 1);
-        assert_eq!(expired[0].id, old_event.id);
+        assert_eq!(expired[0].event.id, old_event.id);
     }
 
     #[test]
@@ -483,7 +578,8 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
 
-        let expired = find_expired_packages(&[fresh1, fresh2]);
+        let packages = vec![live_package(fresh1, vec![1]), live_package(fresh2, vec![2])];
+        let expired = find_expired_packages(&packages);
         assert!(expired.is_empty());
     }
 
@@ -491,6 +587,79 @@ mod tests {
     fn test_find_expired_packages_handles_empty_input() {
         let expired = find_expired_packages(&[]);
         assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn test_find_expired_packages_keeps_group_when_twin_is_fresh() {
+        let keys = nostr_sdk::Keys::generate();
+        let old_timestamp = nostr_sdk::Timestamp::now() - Duration::from_secs(31 * 24 * 60 * 60);
+
+        let old_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old")
+            .custom_created_at(old_timestamp)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let fresh_event = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "fresh")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let packages = vec![
+            live_package(old_event, vec![1, 2, 3]),
+            live_package(fresh_event, vec![1, 2, 3]),
+        ];
+        let expired = find_expired_packages(&packages);
+
+        assert!(
+            expired.is_empty(),
+            "A hash_ref group should not expire while any twin is fresh"
+        );
+    }
+
+    #[test]
+    fn test_find_expired_packages_returns_entire_expired_group() {
+        let keys = nostr_sdk::Keys::generate();
+        let old_timestamp = nostr_sdk::Timestamp::now() - Duration::from_secs(31 * 24 * 60 * 60);
+
+        let old_event_a = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old-a")
+            .custom_created_at(old_timestamp)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let old_event_b = nostr_sdk::EventBuilder::new(nostr_sdk::Kind::MlsKeyPackage, "old-b")
+            .custom_created_at(old_timestamp)
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let packages = vec![
+            live_package(old_event_a, vec![1, 2, 3]),
+            live_package(old_event_b, vec![1, 2, 3]),
+        ];
+        let expired = find_expired_packages(&packages);
+
+        assert_eq!(
+            expired.len(),
+            2,
+            "An expired hash_ref group should be rotated as a whole"
+        );
+    }
+
+    #[test]
+    fn test_filter_compatible_key_packages_requires_self_remove() {
+        let compatible = compatible_key_package_event("Y29tcGF0aWJsZQ==");
+        let incompatible = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "aW5jb21wYXRpYmxl")
+            .tags(vec![
+                Tag::custom(TagKind::MlsCiphersuite, vec![REQUIRED_MLS_CIPHERSUITE_TAG]),
+                Tag::custom(TagKind::MlsExtensions, vec!["0x000a", "0xf2ee"]),
+                Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
+            ])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        let filtered = filter_compatible_key_packages(vec![
+            live_package(compatible.clone(), vec![1]),
+            live_package(incompatible, vec![2]),
+        ]);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].event.id, compatible.id);
     }
 
     #[test]

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -9,7 +9,6 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
 use crate::whitenoise::error::WhitenoiseError;
-use crate::whitenoise::key_packages::find_outdated_packages;
 use crate::whitenoise::scheduled_tasks::Task;
 
 /// Maximum age for a key package before it should be rotated (30 days).
@@ -58,12 +57,10 @@ impl Task for KeyPackageMaintenance {
         tracing::info!(
             target: "whitenoise::scheduler::key_package_maintenance",
             "Key package maintenance completed: {} checked, {} published, \
-             {} rotated (expired), {} deleted (outdated), {} skipped, \
-             {} errors",
+             {} rotated (expired), {} skipped, {} errors",
             summary.checked,
             summary.published,
             summary.rotated_expired,
-            summary.deleted_outdated,
             summary.skipped,
             summary.errors
         );
@@ -79,8 +76,6 @@ enum MaintenanceResult {
     Published,
     /// Rotated expired key packages (>30 days old)
     RotatedExpired { deleted: usize },
-    /// Deleted outdated key packages (missing encoding tag) without republishing
-    DeletedOutdated { deleted: usize },
     /// Account has no key package relays configured
     Skipped,
     /// An error occurred
@@ -93,7 +88,6 @@ struct MaintenanceSummary {
     checked: usize,
     published: usize,
     rotated_expired: usize,
-    deleted_outdated: usize,
     skipped: usize,
     errors: usize,
 }
@@ -111,14 +105,6 @@ fn summarize_maintenance_results(results: Vec<MaintenanceResult>) -> Maintenance
                 tracing::debug!(
                     target: "whitenoise::scheduler::key_package_maintenance",
                     "Rotated expired key package, deleted {} old one(s)",
-                    deleted
-                );
-            }
-            MaintenanceResult::DeletedOutdated { deleted } => {
-                summary.deleted_outdated += 1;
-                tracing::info!(
-                    target: "whitenoise::scheduler::key_package_maintenance",
-                    "Deleted {} outdated key package(s) missing encoding tag",
                     deleted
                 );
             }
@@ -156,74 +142,7 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
         return publish_new_key_package(whitenoise, account).await;
     }
 
-    // Case 2: Check for outdated packages (missing encoding tag)
-    // These are broken for newer MDK versions and should be cleaned up.
-    // We only delete outdated packages if there are also valid (non-outdated)
-    // packages remaining, to avoid leaving the account with zero packages.
-    // We do NOT republish here -- each device should maintain a single key
-    // package that only gets rotated when used.
-    //
-    // Ownership caveat: outdated packages lack the encoding tag required by
-    // parse_key_package, so we cannot verify local key material ownership.
-    // They also predate the "client" tag, ruling out app-level filtering.
-    // We still delete them because they are unusable by any current MDK
-    // consumer and the deletion event is self-signed (same account pubkey).
-    let outdated_packages = find_outdated_packages(&packages);
-
-    if !outdated_packages.is_empty() {
-        let valid_packages: Vec<Event> = packages
-            .iter()
-            .filter(|event| {
-                !outdated_packages
-                    .iter()
-                    .any(|outdated| outdated.id == event.id)
-            })
-            .cloned()
-            .collect();
-
-        if valid_packages.is_empty() {
-            // All packages are outdated -- publish a new valid one instead of deleting.
-            // The outdated packages will naturally age out and be caught by the expired
-            // package rotation (30 days), or will be cleaned up once a valid package exists.
-            tracing::info!(
-                target: "whitenoise::scheduler::key_package_maintenance",
-                "Account {} has {} outdated key package(s) but no valid \
-                 packages, publishing new one",
-                account.pubkey.to_hex(),
-                outdated_packages.len()
-            );
-            return publish_new_key_package(whitenoise, account).await;
-        }
-
-        let live_valid_packages =
-            match find_live_published_key_packages(whitenoise, account, valid_packages).await {
-                Ok(packages) => packages,
-                Err(e) => return MaintenanceResult::Error(e),
-            };
-
-        if live_valid_packages.is_empty() {
-            tracing::info!(
-                target: "whitenoise::scheduler::key_package_maintenance",
-                "Account {} has {} outdated and {} valid key package(s), but none with live local state; publishing new one",
-                account.pubkey.to_hex(),
-                outdated_packages.len(),
-                packages.len() - outdated_packages.len()
-            );
-            return publish_new_key_package(whitenoise, account).await;
-        }
-
-        tracing::info!(
-            target: "whitenoise::scheduler::key_package_maintenance",
-            "Account {} has {} outdated and {} valid key package(s), \
-             deleting outdated",
-            account.pubkey.to_hex(),
-            outdated_packages.len(),
-            packages.len() - outdated_packages.len()
-        );
-        return delete_outdated_packages(whitenoise, account, outdated_packages).await;
-    }
-
-    // Case 3: Check whether any relay key packages still belong to this app
+    // Case 2: Check whether any relay key packages still belong to this app
     // and still have live local key material. This mirrors the login-time
     // recovery path: if every relay package is foreign or already consumed on
     // this device, publish a fresh one.
@@ -241,7 +160,7 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
         return publish_new_key_package(whitenoise, account).await;
     }
 
-    // Case 4: Check for expired packages (>30 days old)
+    // Case 3: Check for expired packages (>30 days old)
     let our_expired_packages = find_expired_packages(&our_packages);
 
     if our_expired_packages.is_empty() {
@@ -385,195 +304,11 @@ async fn rotate_expired_packages(
     }
 }
 
-/// Deletes outdated key packages (missing encoding tag) without publishing a replacement.
-///
-/// Outdated key packages were published before the MIP-00/MIP-02 encoding tag requirement
-/// was enforced. They cause interop failures with newer MDK versions. We only delete
-/// them (without republishing) because the account already has at least one valid key
-/// package. This avoids unnecessary key package churn.
-#[perf_instrument("scheduled::key_package_maintenance")]
-async fn delete_outdated_packages(
-    whitenoise: &Whitenoise,
-    account: &Account,
-    outdated_packages: Vec<Event>,
-) -> MaintenanceResult {
-    match whitenoise
-        .delete_key_packages_for_account(account, outdated_packages, false, 1)
-        .await
-    {
-        Ok(deleted) => MaintenanceResult::DeletedOutdated { deleted },
-        Err(e) => {
-            tracing::warn!(
-                target: "whitenoise::scheduler::key_package_maintenance",
-                "Failed to delete outdated key packages for account {}: {}",
-                account.pubkey.to_hex(),
-                e
-            );
-            MaintenanceResult::DeletedOutdated { deleted: 0 }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::{
-        Client, EventBuilder, EventId, FromBech32, Keys, Kind, SecretKey, Tag, TagKind,
-    };
-
     use super::*;
     use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
-    use crate::whitenoise::key_packages::has_encoding_tag;
-    use crate::whitenoise::relays::Relay;
     use crate::whitenoise::test_utils::create_mock_whitenoise;
-
-    /// Publishes a key package without the encoding tag for testing outdated package rotation.
-    async fn publish_outdated_key_package(
-        whitenoise: &Whitenoise,
-        account: &crate::whitenoise::accounts::Account,
-        relays: &[Relay],
-    ) -> Result<EventId, crate::whitenoise::error::WhitenoiseError> {
-        let key_package_data = whitenoise.encoded_key_package(account, relays).await?;
-
-        let nsec = whitenoise.export_account_nsec(account).await?;
-        let secret_key =
-            SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
-        let keys = Keys::new(secret_key);
-
-        // Filter out the encoding tag to simulate an outdated key package
-        let tags_without_encoding: Vec<Tag> = key_package_data
-            .tags_443
-            .into_iter()
-            .filter(|tag| tag.kind() != TagKind::Custom("encoding".into()))
-            .collect();
-
-        let event = EventBuilder::new(Kind::MlsKeyPackage, &key_package_data.content)
-            .tags(tags_without_encoding)
-            .sign_with_keys(&keys)
-            .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
-
-        let event_id = event.id;
-
-        let client = Client::default();
-        for relay in relays {
-            client.add_relay(relay.url.as_str()).await?;
-        }
-        client.connect().await;
-        client.set_signer(keys).await;
-        client.send_event(&event).await?;
-        client.disconnect().await;
-
-        Ok(event_id)
-    }
-
-    #[tokio::test]
-    async fn test_execute_deletes_outdated_packages_when_valid_exists() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let whitenoise: &'static Whitenoise = Box::leak(Box::new(whitenoise));
-
-        // Create account (this publishes a valid key package automatically)
-        let account = whitenoise.create_identity().await.unwrap();
-        let kp_relays = account.key_package_relays(whitenoise).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Also publish an outdated key package (missing encoding tag)
-        let outdated_event_id = publish_outdated_key_package(whitenoise, &account, &kp_relays)
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Verify we have both packages
-        let before = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-        assert_eq!(before.len(), 2, "Should have two key packages");
-
-        let has_outdated = before.iter().any(|e| e.id == outdated_event_id);
-        assert!(has_outdated, "Should have the outdated package");
-
-        let valid_count = before.iter().filter(|e| has_encoding_tag(e)).count();
-        assert_eq!(valid_count, 1, "Should have one valid package");
-
-        // Run maintenance - should delete only the outdated package (no republish)
-        let task = KeyPackageMaintenance;
-        task.execute(whitenoise).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Verify only the outdated package was deleted
-        let after = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-
-        // Should still have the valid package
-        assert_eq!(after.len(), 1, "Should have exactly one key package");
-        assert!(
-            has_encoding_tag(&after[0]),
-            "Remaining package should have encoding tag"
-        );
-
-        // The outdated package should be gone
-        let outdated_still_exists = after.iter().any(|e| e.id == outdated_event_id);
-        assert!(
-            !outdated_still_exists,
-            "Outdated key package should have been deleted"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_execute_publishes_new_when_all_packages_outdated() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let whitenoise: &'static Whitenoise = Box::leak(Box::new(whitenoise));
-
-        // Create account and get its key package relays
-        let account = whitenoise.create_identity().await.unwrap();
-        let kp_relays = account.key_package_relays(whitenoise).await.unwrap();
-
-        // Delete any existing key packages
-        whitenoise
-            .delete_all_key_packages_for_account(&account, true)
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Publish only an outdated key package (missing encoding tag)
-        publish_outdated_key_package(whitenoise, &account, &kp_relays)
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Verify we have only the outdated package
-        let before = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-        assert_eq!(before.len(), 1, "Should have exactly one key package");
-        assert!(
-            !has_encoding_tag(&before[0]),
-            "Package should be outdated (no encoding tag)"
-        );
-
-        // Run maintenance - should publish a new valid package (not delete the outdated one)
-        let task = KeyPackageMaintenance;
-        task.execute(whitenoise).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // Verify a new valid package was published
-        let after = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-
-        // Should have at least the new valid package
-        let valid_packages: Vec<_> = after.iter().filter(|e| has_encoding_tag(e)).collect();
-        assert!(
-            !valid_packages.is_empty(),
-            "Should have a new valid key package"
-        );
-
-        // The outdated package may still exist (we didn't delete it)
-        // It will age out via the expired package rotation
-    }
 
     #[tokio::test]
     async fn test_execute_republishes_when_local_key_material_is_missing() {
@@ -587,7 +322,11 @@ mod tests {
             .fetch_all_key_packages_for_account(&account)
             .await
             .unwrap();
-        assert_eq!(before.len(), 1, "Should start with exactly one key package");
+        assert_eq!(
+            before.len(),
+            2,
+            "Should start with the canonical and legacy key package twins"
+        );
 
         let tracked = PublishedKeyPackage::find_by_event_id(
             &account.pubkey,
@@ -601,9 +340,13 @@ mod tests {
         let mdk = whitenoise.create_mdk_for_account(account.pubkey).unwrap();
         mdk.delete_key_package_from_storage_by_hash_ref(&tracked.key_package_hash_ref)
             .unwrap();
-        PublishedKeyPackage::mark_key_material_deleted(tracked.id, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(
+            &account.pubkey,
+            &tracked.key_package_hash_ref,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Validate the precondition for this regression: the relay event still
         // exists, but this device no longer has any live local state for it.
@@ -644,7 +387,11 @@ mod tests {
             .fetch_all_key_packages_for_account(&account)
             .await
             .unwrap();
-        assert_eq!(before.len(), 1, "Should start with exactly one key package");
+        assert_eq!(
+            before.len(),
+            2,
+            "Should start with the canonical and legacy key package twins"
+        );
 
         PublishedKeyPackage::mark_consumed(
             &account.pubkey,
@@ -678,73 +425,6 @@ mod tests {
         assert!(
             !live_after.is_empty(),
             "Maintenance should publish a fresh key package when only consumed packages remain"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_execute_republishes_when_outdated_and_only_consumed_valid_packages_remain() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let whitenoise: &'static Whitenoise = Box::leak(Box::new(whitenoise));
-
-        let account = whitenoise.create_identity().await.unwrap();
-        let kp_relays = account.key_package_relays(whitenoise).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let before = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-        assert_eq!(
-            before.len(),
-            1,
-            "Should start with exactly one valid key package"
-        );
-
-        PublishedKeyPackage::mark_consumed(
-            &account.pubkey,
-            &before[0].id.to_hex(),
-            &whitenoise.database,
-        )
-        .await
-        .unwrap();
-
-        publish_outdated_key_package(whitenoise, &account, &kp_relays)
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let packages = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-        assert_eq!(
-            packages.len(),
-            2,
-            "Should have one valid and one outdated package"
-        );
-
-        let live_before = find_live_published_key_packages(whitenoise, &account, packages.clone())
-            .await
-            .unwrap();
-        assert!(
-            live_before.is_empty(),
-            "Consumed valid packages plus outdated packages should still count as no live local state"
-        );
-
-        let task = KeyPackageMaintenance;
-        task.execute(whitenoise).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let after = whitenoise
-            .fetch_all_key_packages_for_account(&account)
-            .await
-            .unwrap();
-        let live_after = find_live_published_key_packages(whitenoise, &account, after)
-            .await
-            .unwrap();
-        assert!(
-            !live_after.is_empty(),
-            "Maintenance should publish a fresh key package when outdated packages coexist with only consumed valid ones"
         );
     }
 
@@ -825,17 +505,15 @@ mod tests {
             MaintenanceResult::Fresh,
             MaintenanceResult::Published,
             MaintenanceResult::RotatedExpired { deleted: 3 },
-            MaintenanceResult::DeletedOutdated { deleted: 2 },
             MaintenanceResult::Skipped,
             MaintenanceResult::Error(WhitenoiseError::AccountNotFound),
             MaintenanceResult::Fresh,
         ];
 
         let summary = summarize_maintenance_results(results);
-        assert_eq!(summary.checked, 7);
+        assert_eq!(summary.checked, 6);
         assert_eq!(summary.published, 1);
         assert_eq!(summary.rotated_expired, 1);
-        assert_eq!(summary.deleted_outdated, 1);
         assert_eq!(summary.skipped, 1);
         assert_eq!(summary.errors, 1);
     }

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -30,7 +30,7 @@ mod relay_sync;
 pub use key_package::KeyPackageStatus;
 
 #[cfg(test)]
-use key_package::{classify_key_package, has_valid_encoding_tag};
+use key_package::classify_key_package;
 
 /// Timeout for a targeted discovery catch-up query.
 ///
@@ -2422,73 +2422,12 @@ mod tests {
         }
     }
 
-    mod has_valid_encoding_tag_tests {
-        use super::*;
-
-        async fn create_key_package_event_with_tags(tags: Vec<Tag>) -> Event {
-            let keys = Keys::generate();
-            let builder = EventBuilder::new(Kind::MlsKeyPackage, "test-content").tags(tags);
-            builder.sign(&keys).await.unwrap()
-        }
-
-        #[tokio::test]
-        async fn test_valid_encoding_tag() {
-            let event = create_key_package_event_with_tags(vec![Tag::custom(
-                TagKind::Custom("encoding".into()),
-                vec!["base64"],
-            )])
-            .await;
-            assert!(has_valid_encoding_tag(&event));
-        }
-
-        #[tokio::test]
-        async fn test_no_encoding_tag() {
-            let event = create_key_package_event_with_tags(vec![Tag::custom(
-                TagKind::Custom("mls_protocol_version".into()),
-                vec!["1.0"],
-            )])
-            .await;
-            assert!(!has_valid_encoding_tag(&event));
-        }
-
-        #[tokio::test]
-        async fn test_wrong_encoding_value() {
-            let event = create_key_package_event_with_tags(vec![Tag::custom(
-                TagKind::Custom("encoding".into()),
-                vec!["hex"],
-            )])
-            .await;
-            assert!(!has_valid_encoding_tag(&event));
-        }
-
-        #[tokio::test]
-        async fn test_encoding_tag_among_other_tags() {
-            let event = create_key_package_event_with_tags(vec![
-                Tag::custom(TagKind::Custom("mls_protocol_version".into()), vec!["1.0"]),
-                Tag::custom(TagKind::Custom("mls_ciphersuite".into()), vec!["0x0001"]),
-                Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
-                Tag::custom(
-                    TagKind::Custom("relays".into()),
-                    vec!["wss://relay.example.com"],
-                ),
-            ])
-            .await;
-            assert!(has_valid_encoding_tag(&event));
-        }
-
-        #[tokio::test]
-        async fn test_empty_tags() {
-            let event = create_key_package_event_with_tags(vec![]).await;
-            assert!(!has_valid_encoding_tag(&event));
-        }
-    }
-
     mod classify_key_package_tests {
         use super::*;
 
         async fn create_event_with_tags(tags: Vec<Tag>) -> Event {
             let keys = Keys::generate();
-            let builder = EventBuilder::new(Kind::MlsKeyPackage, "test-content").tags(tags);
+            let builder = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50").tags(tags);
             builder.sign(&keys).await.unwrap()
         }
 
@@ -2499,10 +2438,15 @@ mod tests {
 
         #[tokio::test]
         async fn test_valid_event_returns_valid() {
-            let event = create_event_with_tags(vec![Tag::custom(
-                TagKind::Custom("encoding".into()),
-                vec!["base64"],
-            )])
+            let event = create_event_with_tags(vec![
+                Tag::custom(TagKind::Custom("mls_ciphersuite".into()), vec!["0x0001"]),
+                Tag::custom(
+                    TagKind::Custom("mls_extensions".into()),
+                    vec!["0x000a", "0xf2ee"],
+                ),
+                Tag::custom(TagKind::Custom("mls_proposals".into()), vec!["0x000a"]),
+                Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
+            ])
             .await;
             let result = classify_key_package(Some(event));
             assert!(matches!(result, KeyPackageStatus::Valid(_)));

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -30,6 +30,8 @@ mod relay_sync;
 pub use key_package::KeyPackageStatus;
 
 #[cfg(test)]
+use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND_LEGACY, MLS_PROPOSALS_TAG_KEY};
+#[cfg(test)]
 use key_package::classify_key_package;
 
 /// Timeout for a targeted discovery catch-up query.
@@ -2427,7 +2429,8 @@ mod tests {
 
         async fn create_event_with_tags(tags: Vec<Tag>) -> Event {
             let keys = Keys::generate();
-            let builder = EventBuilder::new(Kind::MlsKeyPackage, "dGVzdF9jb250ZW50").tags(tags);
+            let builder =
+                EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "dGVzdF9jb250ZW50").tags(tags);
             builder.sign(&keys).await.unwrap()
         }
 
@@ -2444,7 +2447,10 @@ mod tests {
                     TagKind::Custom("mls_extensions".into()),
                     vec!["0x000a", "0xf2ee"],
                 ),
-                Tag::custom(TagKind::Custom("mls_proposals".into()), vec!["0x000a"]),
+                Tag::custom(
+                    TagKind::Custom(MLS_PROPOSALS_TAG_KEY.into()),
+                    vec!["0x000a"],
+                ),
                 Tag::custom(TagKind::Custom("encoding".into()), vec!["base64"]),
             ])
             .await;

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -9,6 +9,11 @@ use crate::whitenoise::{
     users::User,
 };
 
+#[cfg(test)]
+use crate::whitenoise::key_packages::{
+    REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags,
+};
+
 /// Status of a user's key package on relays.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyPackageStatus {
@@ -152,10 +157,6 @@ impl User {
 /// Determines [`KeyPackageStatus`] from an optional key package event.
 #[cfg(test)]
 pub(super) fn classify_key_package(event: Option<Event>) -> KeyPackageStatus {
-    use crate::whitenoise::key_packages::{
-        REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags,
-    };
-
     match event {
         None => KeyPackageStatus::NotFound,
         Some(event) => {

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -1,6 +1,7 @@
 use nostr_sdk::prelude::*;
 
 use crate::perf_instrument;
+use crate::relay_control::ephemeral::KeyPackageLookup;
 use crate::whitenoise::{
     Whitenoise,
     error::Result,
@@ -78,6 +79,17 @@ impl User {
     /// * `whitenoise` - The Whitenoise instance used to access the Nostr client and database
     #[perf_instrument("users")]
     pub async fn key_package_event(&self, whitenoise: &Whitenoise) -> Result<Option<Event>> {
+        match self.key_package_lookup(whitenoise).await? {
+            KeyPackageLookup::Found(event) => Ok(Some(event)),
+            KeyPackageLookup::Incompatible { .. } | KeyPackageLookup::NotFound => Ok(None),
+        }
+    }
+
+    #[perf_instrument("users")]
+    pub(crate) async fn key_package_lookup(
+        &self,
+        whitenoise: &Whitenoise,
+    ) -> Result<KeyPackageLookup> {
         let relay_urls = self.key_package_relay_urls(whitenoise).await?;
         if relay_urls.is_empty() {
             tracing::warn!(
@@ -85,14 +97,14 @@ impl User {
                 "No relays available for user {}; returning None",
                 self.pubkey
             );
-            return Ok(None);
+            return Ok(KeyPackageLookup::NotFound);
         }
 
-        let event = whitenoise
+        let lookup = whitenoise
             .relay_control
-            .fetch_user_key_package(self.pubkey, &relay_urls)
+            .fetch_user_key_package_lookup(self.pubkey, &relay_urls)
             .await?;
-        Ok(event)
+        Ok(lookup)
     }
 
     /// Checks the status of a user's key package on relays.
@@ -105,8 +117,8 @@ impl User {
     /// method will perform a blocking relay sync and retry once.
     #[perf_instrument("users")]
     pub async fn key_package_status(&self, whitenoise: &Whitenoise) -> Result<KeyPackageStatus> {
-        let event = self.key_package_event(whitenoise).await?;
-        let status = classify_key_package(event);
+        let lookup = self.key_package_lookup(whitenoise).await?;
+        let status = classify_key_package_lookup(lookup);
 
         match status {
             KeyPackageStatus::NotFound
@@ -129,36 +141,37 @@ impl User {
                     );
                     return Ok(KeyPackageStatus::NotFound);
                 }
-                let event = self.key_package_event(whitenoise).await?;
-                Ok(classify_key_package(event))
+                let lookup = self.key_package_lookup(whitenoise).await?;
+                Ok(classify_key_package_lookup(lookup))
             }
             other => Ok(other),
         }
     }
 }
 
-/// Checks whether a key package event has the required `["encoding", "base64"]` tag.
-///
-/// Per MIP-00/MIP-02, key package events must include an explicit encoding tag.
-/// Old key packages published before this requirement lack this tag and are
-/// incompatible with current clients.
-pub(super) fn has_valid_encoding_tag(event: &Event) -> bool {
-    event.tags.iter().any(|tag| {
-        let s = tag.as_slice();
-        s.len() >= 2 && s[0] == "encoding" && s[1] == "base64"
-    })
-}
-
 /// Determines [`KeyPackageStatus`] from an optional key package event.
+#[cfg(test)]
 pub(super) fn classify_key_package(event: Option<Event>) -> KeyPackageStatus {
+    use crate::whitenoise::key_packages::{
+        REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags,
+    };
+
     match event {
         None => KeyPackageStatus::NotFound,
         Some(event) => {
-            if has_valid_encoding_tag(&event) {
+            if validate_marmot_key_package_tags(&event, REQUIRED_MLS_CIPHERSUITE_TAG).is_ok() {
                 KeyPackageStatus::Valid(Box::new(event))
             } else {
                 KeyPackageStatus::Incompatible
             }
         }
+    }
+}
+
+fn classify_key_package_lookup(lookup: KeyPackageLookup) -> KeyPackageStatus {
+    match lookup {
+        KeyPackageLookup::Found(event) => KeyPackageStatus::Valid(Box::new(event)),
+        KeyPackageLookup::Incompatible { .. } => KeyPackageStatus::Incompatible,
+        KeyPackageLookup::NotFound => KeyPackageStatus::NotFound,
     }
 }


### PR DESCRIPTION
## Summary
- Publish MLS key packages as both canonical `30443` and legacy `443` events from the same generated package.
- Fetch both key package kinds, prefer valid `30443`, and fall back to compatible `443` only when needed.
- Require SelfRemove proposal support before group creation or member add, with a distinct update-needed error for incompatible packages.
- Track published key package `kind` and `d_tag`, and treat dual-published rows with the same `hash_ref` as one lifecycle unit.
- Remove the legacy missing-encoding cleanup path and deduplicate consumed key material deletion by `hash_ref`.

## Testing
- `just check-clippy`
- `just precommit-quick`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish and track paired key-package variants (canonical + legacy) with a lookup that prefers the newest valid canonical package and reports incompatibility or absence.

* **Bug Fixes**
  * Deduplicate cleanup and deletion by key-package group so twin records are handled together and redundant work is avoided.
  * Legacy-only deletion now preserves canonical packages.

* **Improvements**
  * Stricter key-package validation and clearer incompatibility/missing-metadata statuses.
  * Database migration adds columns and indexes to speed key-package lookups and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->