### PR TITLE
Add SQLCipher encryption for Whitenoise database

### DIFF
--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -3,6 +3,11 @@ use std::process::Command;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
 use clap::Parser;
 use keyring_core::Entry;
 use nostr_sdk::Keys;
@@ -16,10 +21,6 @@ use ::whitenoise::integration_tests::benchmarks::registry::BenchmarkRegistry;
 use ::whitenoise::integration_tests::benchmarks::{DETAILED_MODE, init_perf_layer};
 use ::whitenoise::whitenoise::secrets_store::SecretsStore;
 use ::whitenoise::*;
-
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
-
 /// Filename written into the data directory by `--login` and read by `--seed-nsec`.
 ///
 /// The file contains one line per keyring entry that must survive the process
@@ -27,13 +28,15 @@ use std::os::unix::fs::OpenOptionsExt;
 ///
 ///   `<keyring_key_id>` `<hex-encoded secret>`
 ///
-/// Only MDK DB encryption keys (`mdk.db.key.*`) are written. The Nostr private
-/// key is not needed across the boundary because the warm-init run does not
-/// call `login()`.
+/// Only database encryption keys are written. The Nostr private key is not
+/// needed across the boundary because the warm-init run does not call `login()`.
 const KEYRING_SIDECAR: &str = "benchmark_keyring.txt";
 
 /// Service name used for all keyring entries in benchmark builds.
 const KEYRING_SERVICE: &str = "com.whitenoise.benchmark";
+
+/// Benchmark-scoped keyring key id used by the Whitenoise SQLCipher database.
+const BENCHMARK_WHITENOISE_DB_KEY_ID: &str = "benchmark.whitenoise.db.key.v1";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -52,9 +55,9 @@ struct Args {
     /// to sync from relays, then shut down. Use this to seed a data directory
     /// with a real account before running `--init-only` measurements.
     ///
-    /// After shutdown, the MDK DB encryption key is written to a sidecar file
+    /// After shutdown, database encryption keys are written to a sidecar file
     /// inside `--data-dir` so that subsequent `--init-only --seed-nsec` runs
-    /// can restore it to the in-memory keyring before opening the encrypted DB.
+    /// can restore them to the in-memory keyring before opening encrypted DBs.
     #[clap(long, value_name = "NSEC")]
     login: Option<String>,
 
@@ -63,13 +66,13 @@ struct Args {
     ///
     /// The mock keyring used in benchmark builds is in-memory and does not
     /// survive across process boundaries.  The seeding `--login` run generates
-    /// a random 32-byte MDK DB encryption key, stores it in the mock keyring,
-    /// writes the DB, and exits — the key is gone.  The next `--init-only`
-    /// process starts with an empty mock keyring, finds the encrypted SQLite
-    /// file on disk, and fails with `KeyringEntryMissingForExistingDatabase`.
+    /// random 32-byte DB encryption keys, stores them in the mock keyring,
+    /// writes the DBs, and exits — the keys are gone.  The next `--init-only`
+    /// process starts with an empty mock keyring, finds encrypted SQLite files
+    /// on disk, and fails while opening them.
     ///
-    /// `--login` writes the MDK key to `<data-dir>/benchmark_keyring.txt`.
-    /// Passing `--seed-nsec <NSEC>` reads that sidecar and injects the key
+    /// `--login` writes DB keys to `<data-dir>/benchmark_keyring.txt`.
+    /// Passing `--seed-nsec <NSEC>` reads that sidecar and injects the keys
     /// back into the mock keyring before `initialize_whitenoise` is called.
     /// The nsec is required so the Nostr private key is also re-seeded (some
     /// startup paths read the account keys from the keyring).
@@ -141,23 +144,32 @@ fn write_json_output(
 /// Saves keyring entries that must survive across process boundaries to a
 /// plain-text sidecar file inside the benchmark data directory.
 ///
-/// Only the MDK DB encryption key for the given account pubkey is saved — it
-/// is a random 32-byte blob that cannot be re-derived from any other material.
-/// The Nostr private key is re-seeded separately in `restore_keyring_sidecar`.
+/// The DB encryption keys are random 32-byte blobs that cannot be re-derived
+/// from any other material. The Nostr private key is re-seeded separately in
+/// `restore_keyring_sidecar`.
 fn save_keyring_sidecar(
     data_dir: &std::path::Path,
     pubkey_hex: &str,
 ) -> Result<(), WhitenoiseError> {
-    let db_key_id = format!("mdk.db.key.{pubkey_hex}");
-    let entry = Entry::new(KEYRING_SERVICE, &db_key_id)
-        .map_err(|e| WhitenoiseError::Internal(format!("keyring entry error: {e}")))?;
+    let db_key_ids = [
+        BENCHMARK_WHITENOISE_DB_KEY_ID.to_string(),
+        format!("mdk.db.key.{pubkey_hex}"),
+    ];
 
-    let secret = entry.get_secret().map_err(|e| {
-        WhitenoiseError::Internal(format!("failed to read MDK DB key from keyring: {e}"))
-    })?;
+    let mut sidecar = String::new();
+    for db_key_id in &db_key_ids {
+        let entry = Entry::new(KEYRING_SERVICE, db_key_id)
+            .map_err(|e| WhitenoiseError::Internal(format!("keyring entry error: {e}")))?;
 
-    let hex_secret = hex::encode(&secret);
-    let line = format!("{db_key_id} {hex_secret}\n");
+        let secret = entry.get_secret().map_err(|e| {
+            WhitenoiseError::Internal(format!(
+                "failed to read DB key {db_key_id} from keyring: {e}"
+            ))
+        })?;
+
+        let hex_secret = hex::encode(&secret);
+        sidecar.push_str(&format!("{db_key_id} {hex_secret}\n"));
+    }
 
     let path = data_dir.join(KEYRING_SIDECAR);
     // Use OpenOptions with mode 0o600 at create time so the file is never
@@ -165,7 +177,6 @@ fn save_keyring_sidecar(
     // where the raw encryption key is exposed with the process umask.
     #[cfg(unix)]
     {
-        use std::io::Write;
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -175,21 +186,21 @@ fn save_keyring_sidecar(
             .map_err(|e| {
                 WhitenoiseError::Internal(format!("failed to create keyring sidecar: {e}"))
             })?;
-        file.write_all(line.as_bytes()).map_err(|e| {
+        file.write_all(sidecar.as_bytes()).map_err(|e| {
             WhitenoiseError::Internal(format!("failed to write keyring sidecar: {e}"))
         })?;
     }
     #[cfg(not(unix))]
     {
-        std::fs::write(&path, &line).map_err(|e| {
+        std::fs::write(&path, &sidecar).map_err(|e| {
             WhitenoiseError::Internal(format!("failed to write keyring sidecar: {e}"))
         })?;
     }
 
     tracing::info!(
-        "Saved MDK DB key to sidecar {} (key_id={})",
+        "Saved DB keys to sidecar {} (key_ids={})",
         path.display(),
-        db_key_id
+        db_key_ids.join(",")
     );
     Ok(())
 }
@@ -197,9 +208,8 @@ fn save_keyring_sidecar(
 /// Restores keyring entries from the sidecar file written by `save_keyring_sidecar`,
 /// and also re-seeds the Nostr private key.
 ///
-/// Must be called BEFORE `Whitenoise::initialize_whitenoise` so that the MDK
-/// DB encryption key is present when `MdkSqliteStorage::new` tries to open the
-/// existing database.
+/// Must be called BEFORE `Whitenoise::initialize_whitenoise` so database
+/// encryption keys are present before existing encrypted databases are opened.
 fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(), WhitenoiseError> {
     // Must initialise the mock store before any keyring_core::Entry calls.
     Whitenoise::initialize_mock_keyring_store();
@@ -215,7 +225,7 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
         keys.public_key().to_hex()
     );
 
-    // Restore MDK DB encryption keys from the sidecar.
+    // Restore database encryption keys from the sidecar.
     let path = data_dir.join(KEYRING_SIDECAR);
     let content = std::fs::read_to_string(&path).map_err(|e| {
         WhitenoiseError::Internal(format!(
@@ -263,14 +273,15 @@ async fn main() -> Result<(), WhitenoiseError> {
 
     tracing::info!("=== Starting Whitenoise Performance Benchmark Suite ===");
 
-    // Warm-init runs: restore MDK DB encryption key from the sidecar written by
+    // Warm-init runs: restore DB encryption keys from the sidecar written by
     // the preceding --login run, and re-seed the Nostr private key. Both must be
-    // in the mock keyring BEFORE initialize_whitenoise opens the encrypted MLS DB.
+    // in the mock keyring BEFORE initialize_whitenoise opens encrypted DBs.
     if let Some(ref nsec) = args.seed_nsec {
         restore_keyring_sidecar(&args.data_dir, nsec)?;
     }
 
-    let config = WhitenoiseConfig::new(&args.data_dir, &args.logs_dir, KEYRING_SERVICE);
+    let config = WhitenoiseConfig::new(&args.data_dir, &args.logs_dir, KEYRING_SERVICE)
+        .with_database_key_id(BENCHMARK_WHITENOISE_DB_KEY_ID);
     if let Err(err) = Whitenoise::initialize_whitenoise(config).await {
         tracing::error!("Failed to initialize Whitenoise: {}", err);
         std::process::exit(1);
@@ -296,8 +307,8 @@ async fn main() -> Result<(), WhitenoiseError> {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
-        // Save the MDK DB encryption key to a sidecar file so that subsequent
-        // --init-only --seed-nsec runs can restore it to their empty mock keyrings.
+        // Save DB encryption keys to a sidecar file so that subsequent
+        // --init-only --seed-nsec runs can restore them to their empty mock keyrings.
         save_keyring_sidecar(&args.data_dir, &account.pubkey.to_hex())?;
 
         whitenoise.shutdown().await?;

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -6,6 +6,8 @@ use nostr_sdk::RelayUrl;
 use ::whitenoise::integration_tests::registry::ScenarioRegistry;
 use ::whitenoise::*;
 
+const INTEGRATION_WHITENOISE_DB_KEY_ID: &str = "integration.whitenoise.db.key.v1";
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 struct Args {
@@ -36,6 +38,7 @@ async fn main() -> Result<(), WhitenoiseError> {
         &args.logs_dir,
         "com.whitenoise.integration-test",
     )
+    .with_database_key_id(INTEGRATION_WHITENOISE_DB_KEY_ID)
     .with_discovery_relays(vec![
         RelayUrl::parse("ws://localhost:8080").unwrap(),
         RelayUrl::parse("ws://localhost:7777").unwrap(),

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -77,22 +77,21 @@ impl Whitenoise {
 
         self.discovery_sync_worker.request_rebuild();
 
-        // Subscriptions and key package setup operate on disjoint relay
-        // sessions (group/inbox plane vs ephemeral plane) with no shared
-        // mutable state, so they run concurrently.  Key package setup is
-        // best-effort — the KeyPackageMaintenance scheduler retries failures.
-        let (sub_result, kp_result) = tokio::join!(
-            self.setup_subscriptions(account, inbox_relays),
-            self.setup_key_package(account, is_new_account, key_package_relays),
-        );
-        if let Err(e) = kp_result {
+        self.setup_subscriptions(account, inbox_relays).await?;
+
+        // Key package publish uses the account-scoped ephemeral session that
+        // subscription setup warms. Run it after subscription setup so the
+        // background publish does not race a still-starting relay session.
+        if let Err(e) = self
+            .setup_key_package(account, is_new_account, key_package_relays)
+            .await
+        {
             tracing::warn!(
                 target: "whitenoise::accounts",
                 "Key package setup failed, scheduler will retry: {}",
                 e
             );
         }
-        sub_result?;
 
         tracing::debug!(target: "whitenoise::accounts", "Account activation complete");
         Ok(())

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -127,7 +127,17 @@ async fn migrate_plaintext_database(
         return Err(err.into());
     }
 
-    validate_encrypted_database(db_path, config).await?;
+    if let Err(err) = validate_encrypted_database(db_path, config).await {
+        fs::rename(&backup_path, db_path).map_err(|rollback_err| {
+            DatabaseError::EncryptionMigration(format!(
+                "Encrypted database validation failed ({err}); rollback from {} to {} failed: {rollback_err}",
+                backup_path.display(),
+                db_path.display(),
+            ))
+        })?;
+        return Err(err);
+    }
+
     remove_file_if_exists(&backup_path)?;
 
     Ok(())

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -90,7 +90,7 @@ async fn assert_sqlcipher_available() -> Result<(), DatabaseError> {
 
     if version.is_empty() {
         return Err(DatabaseError::EncryptionMigration(
-            "SQLite was built without SQLCipher support".to_string(),
+            "SQLCipher is not available (cipher_version is empty)".to_string(),
         ));
     }
 
@@ -128,6 +128,14 @@ async fn migrate_plaintext_database(
     }
 
     if let Err(err) = validate_encrypted_database(db_path, config).await {
+        if let Err(rollback_err) = remove_file_if_exists(db_path) {
+            return Err(DatabaseError::EncryptionMigration(format!(
+                "Encrypted database validation failed ({err}); rollback from {} to {} failed while removing bad encrypted database: {rollback_err}",
+                backup_path.display(),
+                db_path.display(),
+            )));
+        }
+
         fs::rename(&backup_path, db_path).map_err(|rollback_err| {
             DatabaseError::EncryptionMigration(format!(
                 "Encrypted database validation failed ({err}); rollback from {} to {} failed: {rollback_err}",
@@ -147,16 +155,13 @@ async fn recover_interrupted_migration(
     db_path: &Path,
     config: &EncryptionConfig,
 ) -> Result<(), DatabaseError> {
-    if db_path.exists() {
-        let temp_path = sidecar_path(db_path, ".encrypted.tmp");
-        if database_file_state(db_path)? == DatabaseFileState::Plaintext {
-            remove_file_if_exists(&temp_path)?;
-        }
-        return Ok(());
-    }
-
     let temp_path = sidecar_path(db_path, ".encrypted.tmp");
     let backup_path = sidecar_path(db_path, ".plaintext.backup");
+
+    if db_path.exists() {
+        remove_file_if_exists(&temp_path)?;
+        return Ok(());
+    }
 
     if temp_path.exists() {
         match validate_encrypted_database(&temp_path, config).await {

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -1,0 +1,395 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{ErrorKind, Read},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use mdk_sqlite_storage::{EncryptionConfig, keyring};
+use sqlx::{ConnectOptions, Connection, Row, sqlite::SqliteConnectOptions};
+
+use super::DatabaseError;
+
+pub(super) const WHITENOISE_DB_KEY_ID: &str = "whitenoise.db.key.v1";
+
+const SQLITE_HEADER: &[u8; 16] = b"SQLite format 3\0";
+const MIGRATION_LOCK_STALE_SECS: u64 = 15 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DatabaseFileState {
+    MissingOrEmpty,
+    Plaintext,
+    Encrypted,
+}
+
+pub(super) async fn prepare_sqlcipher_database(
+    db_path: &Path,
+    keyring_service_id: &str,
+    key_id: &str,
+) -> Result<EncryptionConfig, DatabaseError> {
+    assert_sqlcipher_available().await?;
+
+    let mut state = database_file_state(db_path)?;
+    let config = match state {
+        DatabaseFileState::Encrypted => existing_key(db_path, keyring_service_id, key_id)?,
+        DatabaseFileState::MissingOrEmpty | DatabaseFileState::Plaintext => {
+            get_or_create_key(keyring_service_id, key_id)?
+        }
+    };
+
+    recover_interrupted_migration(db_path, &config).await?;
+    state = database_file_state(db_path)?;
+
+    match state {
+        DatabaseFileState::Plaintext => migrate_plaintext_database(db_path, &config).await?,
+        DatabaseFileState::Encrypted | DatabaseFileState::MissingOrEmpty => {}
+    }
+
+    Ok(config)
+}
+
+pub(super) fn cleanup_completed_migration(db_path: &Path) -> Result<(), DatabaseError> {
+    if database_file_state(db_path)? == DatabaseFileState::Encrypted {
+        remove_file_if_exists(&sidecar_path(db_path, ".encrypted.tmp"))?;
+        remove_file_if_exists(&sidecar_path(db_path, ".plaintext.backup"))?;
+    }
+
+    Ok(())
+}
+
+pub(super) fn key_pragma_value(config: &EncryptionConfig) -> String {
+    format!("\"x'{}'\"", hex::encode(config.key()))
+}
+
+pub(super) async fn validate_encrypted_database(
+    db_path: &Path,
+    config: &EncryptionConfig,
+) -> Result<(), DatabaseError> {
+    let mut conn = encrypted_connect_options(db_path, config, false)
+        .connect()
+        .await?;
+    validate_encrypted_connection(&mut conn).await
+}
+
+#[cfg(test)]
+pub(super) fn is_plaintext_sqlite_database(db_path: &Path) -> Result<bool, DatabaseError> {
+    Ok(database_file_state(db_path)? == DatabaseFileState::Plaintext)
+}
+
+#[cfg(test)]
+pub(super) fn is_sqlcipher_database(db_path: &Path) -> Result<bool, DatabaseError> {
+    Ok(database_file_state(db_path)? == DatabaseFileState::Encrypted)
+}
+
+async fn assert_sqlcipher_available() -> Result<(), DatabaseError> {
+    let mut conn = SqliteConnectOptions::new()
+        .in_memory(true)
+        .connect()
+        .await?;
+    let version = sqlcipher_version(&mut conn).await?;
+
+    if version.is_empty() {
+        return Err(DatabaseError::EncryptionMigration(
+            "SQLite was built without SQLCipher support".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn migrate_plaintext_database(
+    db_path: &Path,
+    config: &EncryptionConfig,
+) -> Result<(), DatabaseError> {
+    let lock_path = sidecar_path(db_path, ".encryption.lock");
+    let _lock = MigrationLock::acquire(&lock_path)?;
+
+    if database_file_state(db_path)? != DatabaseFileState::Plaintext {
+        return Ok(());
+    }
+
+    let temp_path = sidecar_path(db_path, ".encrypted.tmp");
+    let backup_path = sidecar_path(db_path, ".plaintext.backup");
+
+    remove_file_if_exists(&temp_path)?;
+    File::create(&temp_path)?;
+    checkpoint_plaintext_database(db_path).await?;
+    remove_sqlite_sidecars(db_path)?;
+
+    export_plaintext_to_encrypted(db_path, &temp_path, config).await?;
+    validate_encrypted_database(&temp_path, config).await?;
+
+    remove_file_if_exists(&backup_path)?;
+    fs::rename(db_path, &backup_path)?;
+
+    if let Err(err) = fs::rename(&temp_path, db_path) {
+        let _ = fs::rename(&backup_path, db_path);
+        return Err(err.into());
+    }
+
+    validate_encrypted_database(db_path, config).await?;
+    remove_file_if_exists(&backup_path)?;
+
+    Ok(())
+}
+
+async fn recover_interrupted_migration(
+    db_path: &Path,
+    config: &EncryptionConfig,
+) -> Result<(), DatabaseError> {
+    if db_path.exists() {
+        let temp_path = sidecar_path(db_path, ".encrypted.tmp");
+        if database_file_state(db_path)? == DatabaseFileState::Plaintext {
+            remove_file_if_exists(&temp_path)?;
+        }
+        return Ok(());
+    }
+
+    let temp_path = sidecar_path(db_path, ".encrypted.tmp");
+    let backup_path = sidecar_path(db_path, ".plaintext.backup");
+
+    if temp_path.exists() {
+        match validate_encrypted_database(&temp_path, config).await {
+            Ok(()) => {
+                fs::rename(&temp_path, db_path)?;
+                return Ok(());
+            }
+            Err(err) => {
+                if backup_path.exists() {
+                    remove_file_if_exists(&temp_path)?;
+                    fs::rename(&backup_path, db_path)?;
+                    return Ok(());
+                }
+
+                return Err(err);
+            }
+        }
+    }
+
+    if backup_path.exists() {
+        fs::rename(&backup_path, db_path)?;
+    }
+
+    Ok(())
+}
+
+async fn checkpoint_plaintext_database(db_path: &Path) -> Result<(), DatabaseError> {
+    let mut conn = plaintext_connect_options(db_path, false).connect().await?;
+    let row = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .fetch_one(&mut conn)
+        .await?;
+    let busy: i64 = row.try_get(0)?;
+
+    if busy != 0 {
+        return Err(DatabaseError::EncryptionMigration(
+            "Could not checkpoint plaintext database before encryption migration".to_string(),
+        ));
+    }
+
+    conn.close().await?;
+    Ok(())
+}
+
+async fn export_plaintext_to_encrypted(
+    db_path: &Path,
+    temp_path: &Path,
+    config: &EncryptionConfig,
+) -> Result<(), DatabaseError> {
+    let mut conn = plaintext_connect_options(db_path, false).connect().await?;
+    let temp_path_literal = sql_string_literal(&temp_path.display().to_string());
+    let attach = format!(
+        "ATTACH DATABASE {temp_path_literal} AS encrypted KEY {};",
+        key_pragma_value(config)
+    );
+
+    sqlx::query(sqlx::AssertSqlSafe(attach))
+        .execute(&mut conn)
+        .await?;
+    sqlx::query("PRAGMA encrypted.cipher_compatibility = 4")
+        .execute(&mut conn)
+        .await?;
+    sqlx::query("SELECT sqlcipher_export('encrypted')")
+        .execute(&mut conn)
+        .await?;
+    sqlx::query("DETACH DATABASE encrypted")
+        .execute(&mut conn)
+        .await?;
+
+    conn.close().await?;
+    Ok(())
+}
+
+async fn validate_encrypted_connection(
+    conn: &mut sqlx::SqliteConnection,
+) -> Result<(), DatabaseError> {
+    let version = sqlcipher_version(conn).await?;
+
+    if version.is_empty() {
+        return Err(DatabaseError::EncryptionMigration(
+            "SQLite connection did not report a SQLCipher version".to_string(),
+        ));
+    }
+
+    sqlx::query("SELECT count(*) FROM sqlite_master")
+        .fetch_one(&mut *conn)
+        .await?;
+
+    let row = sqlx::query("PRAGMA integrity_check")
+        .fetch_one(&mut *conn)
+        .await?;
+    let integrity: String = row.try_get(0)?;
+
+    if integrity != "ok" {
+        return Err(DatabaseError::EncryptionMigration(format!(
+            "Encrypted database integrity check failed: {integrity}"
+        )));
+    }
+
+    Ok(())
+}
+
+async fn sqlcipher_version(conn: &mut sqlx::SqliteConnection) -> Result<String, DatabaseError> {
+    let row = sqlx::query("PRAGMA cipher_version")
+        .fetch_optional(conn)
+        .await?;
+
+    match row {
+        Some(row) => Ok(row.try_get::<String, _>(0).unwrap_or_default()),
+        None => Ok(String::new()),
+    }
+}
+
+fn existing_key(
+    db_path: &Path,
+    keyring_service_id: &str,
+    key_id: &str,
+) -> Result<EncryptionConfig, DatabaseError> {
+    let config = keyring::get_db_key(keyring_service_id, key_id)
+        .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))?;
+
+    match config {
+        Some(config) => Ok(config),
+        None => Err(DatabaseError::MissingEncryptionKey {
+            path: db_path.display().to_string(),
+            key_id: key_id.to_string(),
+        }),
+    }
+}
+
+fn get_or_create_key(
+    keyring_service_id: &str,
+    key_id: &str,
+) -> Result<EncryptionConfig, DatabaseError> {
+    keyring::get_or_create_db_key(keyring_service_id, key_id)
+        .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))
+}
+
+fn database_file_state(db_path: &Path) -> Result<DatabaseFileState, DatabaseError> {
+    if !db_path.exists() {
+        return Ok(DatabaseFileState::MissingOrEmpty);
+    }
+
+    if db_path.metadata()?.len() == 0 {
+        return Ok(DatabaseFileState::MissingOrEmpty);
+    }
+
+    let mut file = File::open(db_path)?;
+    let mut header = [0_u8; 16];
+
+    match file.read_exact(&mut header) {
+        Ok(()) if header == *SQLITE_HEADER => Ok(DatabaseFileState::Plaintext),
+        Ok(()) => Ok(DatabaseFileState::Encrypted),
+        Err(err) if err.kind() == ErrorKind::UnexpectedEof => Ok(DatabaseFileState::Encrypted),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn plaintext_connect_options(db_path: &Path, create: bool) -> SqliteConnectOptions {
+    SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(create)
+        .busy_timeout(Duration::from_millis(u64::from(super::DB_BUSY_TIMEOUT_MS)))
+}
+
+pub(super) fn encrypted_connect_options(
+    db_path: &Path,
+    config: &EncryptionConfig,
+    create: bool,
+) -> SqliteConnectOptions {
+    SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(create)
+        .pragma("key", key_pragma_value(config))
+        .pragma("cipher_compatibility", "4")
+        .pragma("temp_store", "MEMORY")
+        .busy_timeout(Duration::from_millis(u64::from(super::DB_BUSY_TIMEOUT_MS)))
+}
+
+fn remove_sqlite_sidecars(db_path: &Path) -> Result<(), DatabaseError> {
+    remove_file_if_exists(&sidecar_path(db_path, "-wal"))?;
+    remove_file_if_exists(&sidecar_path(db_path, "-shm"))?;
+    remove_file_if_exists(&sidecar_path(db_path, "-journal"))?;
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), DatabaseError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = db_path.as_os_str().to_owned();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+struct MigrationLock {
+    path: PathBuf,
+}
+
+impl MigrationLock {
+    fn acquire(path: &Path) -> Result<Self, DatabaseError> {
+        match OpenOptions::new().write(true).create_new(true).open(path) {
+            Ok(_) => Ok(Self {
+                path: path.to_path_buf(),
+            }),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                if Self::is_stale(path)? {
+                    remove_file_if_exists(path)?;
+                    OpenOptions::new().write(true).create_new(true).open(path)?;
+                    return Ok(Self {
+                        path: path.to_path_buf(),
+                    });
+                }
+
+                Err(DatabaseError::EncryptionMigration(format!(
+                    "Database encryption migration is already running: {}",
+                    path.display()
+                )))
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn is_stale(path: &Path) -> Result<bool, DatabaseError> {
+        let modified = path
+            .metadata()?
+            .modified()
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        let age = modified.elapsed().unwrap_or_default();
+        Ok(age.as_secs() > MIGRATION_LOCK_STALE_SECS)
+    }
+}
+
+impl Drop for MigrationLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -166,6 +166,10 @@ async fn recover_interrupted_migration(
             }
             Err(err) => {
                 if backup_path.exists() {
+                    tracing::warn!(
+                        target: "whitenoise::database",
+                        "Encrypted temp database is invalid ({err}); restoring plaintext backup"
+                    );
                     remove_file_if_exists(&temp_path)?;
                     fs::rename(&backup_path, db_path)?;
                     return Ok(());
@@ -185,15 +189,15 @@ async fn recover_interrupted_migration(
 
 async fn checkpoint_plaintext_database(db_path: &Path) -> Result<(), DatabaseError> {
     let mut conn = plaintext_connect_options(db_path, false).connect().await?;
-    let row = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-        .fetch_one(&mut conn)
-        .await?;
-    let busy: i64 = row.try_get(0)?;
+    let (busy, log, checkpointed): (i64, i64, i64) =
+        sqlx::query_as("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_one(&mut conn)
+            .await?;
 
-    if busy != 0 {
-        return Err(DatabaseError::EncryptionMigration(
-            "Could not checkpoint plaintext database before encryption migration".to_string(),
-        ));
+    if busy != 0 || log != checkpointed {
+        return Err(DatabaseError::EncryptionMigration(format!(
+            "WAL checkpoint incomplete before encryption migration: busy={busy}, log={log}, checkpointed={checkpointed}"
+        )));
     }
 
     conn.close().await?;
@@ -356,6 +360,8 @@ fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+// SQLite's ATTACH DATABASE does not accept bind parameters — only literal strings — so we
+// must embed the path directly with proper SQL single-quote escaping.
 fn sql_string_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
@@ -373,10 +379,20 @@ impl MigrationLock {
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {
                 if Self::is_stale(path)? {
                     remove_file_if_exists(path)?;
-                    OpenOptions::new().write(true).create_new(true).open(path)?;
-                    return Ok(Self {
-                        path: path.to_path_buf(),
-                    });
+                    match OpenOptions::new().write(true).create_new(true).open(path) {
+                        Ok(_) => {
+                            return Ok(Self {
+                                path: path.to_path_buf(),
+                            });
+                        }
+                        Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                            return Err(DatabaseError::EncryptionMigration(format!(
+                                "Database encryption migration is already running: {}",
+                                path.display()
+                            )));
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
                 }
 
                 Err(DatabaseError::EncryptionMigration(format!(

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -128,21 +128,22 @@ async fn migrate_plaintext_database(
     }
 
     if let Err(err) = validate_encrypted_database(db_path, config).await {
-        if let Err(rollback_err) = remove_file_if_exists(db_path) {
-            return Err(DatabaseError::EncryptionMigration(format!(
-                "Encrypted database validation failed ({err}); rollback from {} to {} failed while removing bad encrypted database: {rollback_err}",
-                backup_path.display(),
-                db_path.display(),
-            )));
+        if let Err(rename_err) = fs::rename(&backup_path, db_path) {
+            remove_file_if_exists(db_path).map_err(|rollback_err| {
+                DatabaseError::EncryptionMigration(format!(
+                    "Encrypted database validation failed ({err}); rollback from {} to {} failed after direct restore failed ({rename_err}) and removing bad encrypted database failed: {rollback_err}",
+                    backup_path.display(),
+                    db_path.display(),
+                ))
+            })?;
+            fs::rename(&backup_path, db_path).map_err(|rollback_err| {
+                DatabaseError::EncryptionMigration(format!(
+                    "Encrypted database validation failed ({err}); rollback from {} to {} failed after direct restore failed ({rename_err}): {rollback_err}",
+                    backup_path.display(),
+                    db_path.display(),
+                ))
+            })?;
         }
-
-        fs::rename(&backup_path, db_path).map_err(|rollback_err| {
-            DatabaseError::EncryptionMigration(format!(
-                "Encrypted database validation failed ({err}); rollback from {} to {} failed: {rollback_err}",
-                backup_path.display(),
-                db_path.display(),
-            ))
-        })?;
         return Err(err);
     }
 

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -122,10 +122,6 @@ impl Database {
         keyring_service_id: &str,
         key_id: &str,
     ) -> Result<Self, DatabaseError> {
-        if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let encryption_config =
             encryption::prepare_sqlcipher_database(&db_path, keyring_service_id, key_id).await?;
         let database = Self::open(db_path.clone(), Some(&encryption_config)).await?;
@@ -200,13 +196,6 @@ impl Database {
             })
             .connect_with(connect_options)
             .await?;
-
-        if encryption_config.is_some() {
-            // Confirm the pool can acquire a working connection end-to-end. Key correctness and
-            // schema integrity are already verified in prepare_sqlcipher_database before we reach here.
-            let mut conn = pool.acquire().await?;
-            sqlx::query("SELECT 1").fetch_one(&mut *conn).await?;
-        }
 
         Ok(pool)
     }
@@ -461,9 +450,9 @@ where
 mod tests {
     use super::*;
     use std::{
-        fs::File,
+        fs::{self, File},
         io::Read,
-        path::PathBuf,
+        path::{Path, PathBuf},
         sync::atomic::{AtomicU64, Ordering},
     };
 
@@ -480,7 +469,7 @@ mod tests {
         format!("com.whitenoise.database-test.{id}")
     }
 
-    fn read_db_header(db_path: &PathBuf) -> [u8; 16] {
+    fn read_db_header(db_path: &Path) -> [u8; 16] {
         let mut file = File::open(db_path).expect("Failed to open database file");
         let mut header = [0_u8; 16];
         file.read_exact(&mut header)
@@ -607,6 +596,46 @@ mod tests {
         assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
         assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
         assert!(!PathBuf::from(format!("{}.plaintext.backup", db_path.display())).exists());
+    }
+
+    #[tokio::test]
+    async fn test_interrupted_migration_restores_plaintext_backup_when_database_missing() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("recover-backup.db");
+        let backup_path = PathBuf::from(format!("{}.plaintext.backup", db_path.display()));
+        let service_id = unique_service_id();
+        let pubkey = "cc".repeat(32);
+
+        let plaintext = Database::new(db_path.clone())
+            .await
+            .expect("Failed to create plaintext database");
+        setup_account(&plaintext, &pubkey).await;
+        sqlx::query_as::<_, (i64, i64, i64)>("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_one(&plaintext.pool)
+            .await
+            .expect("Failed to checkpoint plaintext database");
+        drop(plaintext);
+
+        fs::rename(&db_path, &backup_path).expect("Failed to move plaintext database to backup");
+
+        assert!(!db_path.exists());
+        assert_eq!(read_db_header(&backup_path), *SQLITE_HEADER);
+
+        let encrypted = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to recover and migrate plaintext backup");
+
+        let account_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&encrypted.pool)
+            .await
+            .expect("Failed to count recovered accounts");
+
+        assert_eq!(account_count.0, 1);
+        assert!(db_path.exists());
+        assert!(!backup_path.exists());
+        assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
+        assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -1,15 +1,18 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::LazyLock,
     time::{Duration, SystemTime},
 };
 
+use mdk_sqlite_storage::EncryptionConfig;
 use sqlx::{
-    ConnectOptions, Sqlite, SqlitePool,
-    migrate::{MigrateDatabase, Migrator},
+    ConnectOptions, SqlitePool,
+    migrate::Migrator,
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
 };
 use thiserror::Error;
+
+mod encryption;
 
 pub mod account_settings;
 pub mod accounts;
@@ -56,6 +59,12 @@ pub enum DatabaseError {
     Serialization(#[from] serde_json::Error),
     #[error("Search query did not return a position column for message {message_id}")]
     MissingSearchPosition { message_id: String },
+    #[error("Database encryption key error: {0}")]
+    EncryptionKey(String),
+    #[error("Encrypted database {path} is missing keyring key {key_id}")]
+    MissingEncryptionKey { path: String, key_id: String },
+    #[error("Database encryption migration error: {0}")]
+    EncryptionMigration(String),
 }
 
 impl DatabaseError {
@@ -84,40 +93,55 @@ pub struct Database {
 
 impl Database {
     pub async fn new(db_path: PathBuf) -> Result<Self, DatabaseError> {
-        // Create parent directories if they don't exist
+        Self::open(db_path, None).await
+    }
+
+    pub async fn new_encrypted(
+        db_path: PathBuf,
+        keyring_service_id: &str,
+    ) -> Result<Self, DatabaseError> {
+        Self::open_encrypted(
+            db_path,
+            keyring_service_id,
+            encryption::WHITENOISE_DB_KEY_ID,
+        )
+        .await
+    }
+
+    #[cfg(feature = "benchmark-tests")]
+    pub(crate) async fn new_encrypted_with_key_id(
+        db_path: PathBuf,
+        keyring_service_id: &str,
+        key_id: &str,
+    ) -> Result<Self, DatabaseError> {
+        Self::open_encrypted(db_path, keyring_service_id, key_id).await
+    }
+
+    async fn open_encrypted(
+        db_path: PathBuf,
+        keyring_service_id: &str,
+        key_id: &str,
+    ) -> Result<Self, DatabaseError> {
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        let db_url = format!("sqlite://{}", db_path.display());
+        let encryption_config =
+            encryption::prepare_sqlcipher_database(&db_path, keyring_service_id, key_id).await?;
+        let database = Self::open(db_path.clone(), Some(&encryption_config)).await?;
+        encryption::cleanup_completed_migration(&db_path)?;
+        Ok(database)
+    }
 
-        // Create database if it doesn't exist
-        tracing::debug!("Checking if DB exists...{:?}", db_url);
-        match Sqlite::database_exists(&db_url).await {
-            Ok(true) => {
-                tracing::debug!("DB exists");
-            }
-            Ok(false) => {
-                tracing::debug!("DB does not exist, creating...");
-                Sqlite::create_database(&db_url).await.map_err(|e| {
-                    tracing::error!("Error creating DB: {:?}", e);
-                    DatabaseError::Sqlx(e)
-                })?;
-                tracing::debug!("DB created");
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Could not check if database exists: {:?}, attempting to create",
-                    e
-                );
-                Sqlite::create_database(&db_url).await.map_err(|e| {
-                    tracing::error!("Error creating DB: {:?}", e);
-                    DatabaseError::Sqlx(e)
-                })?;
-            }
+    async fn open(
+        db_path: PathBuf,
+        encryption_config: Option<&EncryptionConfig>,
+    ) -> Result<Self, DatabaseError> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
         }
 
-        let pool = Self::create_connection_pool(&db_url).await?;
+        let pool = Self::create_connection_pool(&db_path, encryption_config).await?;
 
         // Automatically run migrations
         MIGRATOR.run(&pool).await?;
@@ -130,7 +154,10 @@ impl Database {
     }
 
     /// Creates and configures a SQLite connection pool
-    async fn create_connection_pool(db_url: &str) -> Result<SqlitePool, DatabaseError> {
+    async fn create_connection_pool(
+        db_path: &Path,
+        encryption_config: Option<&EncryptionConfig>,
+    ) -> Result<SqlitePool, DatabaseError> {
         tracing::debug!("Creating connection pool...");
 
         // Log every SQL statement only when explicitly opted in (e.g. benchmarks).
@@ -141,8 +168,7 @@ impl Database {
             tracing::log::LevelFilter::Off
         };
 
-        let connect_options = format!("{db_url}?mode=rwc")
-            .parse::<SqliteConnectOptions>()?
+        let connect_options = Self::connect_options(db_path, encryption_config)
             .log_statements(log_statements_level)
             .log_slow_statements(tracing::log::LevelFilter::Warn, Duration::from_millis(500));
 
@@ -174,7 +200,29 @@ impl Database {
             })
             .connect_with(connect_options)
             .await?;
+
+        if let Some(config) = encryption_config {
+            let mut conn = pool.acquire().await?;
+            encryption::validate_encrypted_database(db_path, config).await?;
+            sqlx::query("SELECT count(*) FROM sqlite_master")
+                .fetch_one(&mut *conn)
+                .await?;
+        }
+
         Ok(pool)
+    }
+
+    fn connect_options(
+        db_path: &Path,
+        encryption_config: Option<&EncryptionConfig>,
+    ) -> SqliteConnectOptions {
+        match encryption_config {
+            Some(config) => encryption::encrypted_connect_options(db_path, config, true),
+            None => SqliteConnectOptions::new()
+                .filename(db_path)
+                .create_if_missing(true)
+                .busy_timeout(Duration::from_millis(u64::from(DB_BUSY_TIMEOUT_MS))),
+        }
     }
 
     /// Runs all pending database migrations
@@ -413,8 +461,33 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::{
+        fs::File,
+        io::Read,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use mdk_sqlite_storage::keyring;
     use tempfile::TempDir;
+
+    use crate::whitenoise::Whitenoise;
+
+    const SQLITE_HEADER: &[u8; 16] = b"SQLite format 3\0";
+
+    fn unique_service_id() -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        format!("com.whitenoise.database-test.{id}")
+    }
+
+    fn read_db_header(db_path: &PathBuf) -> [u8; 16] {
+        let mut file = File::open(db_path).expect("Failed to open database file");
+        let mut header = [0_u8; 16];
+        file.read_exact(&mut header)
+            .expect("Failed to read database header");
+        header
+    }
 
     async fn create_test_db() -> (Database, TempDir) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
@@ -451,6 +524,112 @@ mod tests {
         let db = db.unwrap();
         assert_eq!(db.path, db_path);
         assert!(db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_database_creation() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("encrypted.db");
+        let service_id = unique_service_id();
+
+        let db = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to create encrypted database");
+
+        assert_eq!(db.path, db_path);
+        assert!(db_path.exists());
+        assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
+        assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
+
+        let result =
+            sqlx::query("SELECT name FROM sqlite_master WHERE type='table' AND name='accounts'")
+                .fetch_optional(&db.pool)
+                .await
+                .expect("Failed to check accounts table");
+
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_database_reopen_existing() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("encrypted-reopen.db");
+        let service_id = unique_service_id();
+        let pubkey = "aa".repeat(32);
+
+        let db = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to create encrypted database");
+        setup_account(&db, &pubkey).await;
+        drop(db);
+
+        let reopened = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to reopen encrypted database");
+
+        let account_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&reopened.pool)
+            .await
+            .expect("Failed to count accounts");
+
+        assert_eq!(account_count.0, 1);
+        assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_database_migrates_to_encrypted_without_data_loss() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("migrate.db");
+        let service_id = unique_service_id();
+        let pubkey = "bb".repeat(32);
+
+        let plaintext = Database::new(db_path.clone())
+            .await
+            .expect("Failed to create plaintext database");
+        setup_account(&plaintext, &pubkey).await;
+        drop(plaintext);
+
+        assert_eq!(read_db_header(&db_path), *SQLITE_HEADER);
+        assert!(encryption::is_plaintext_sqlite_database(&db_path).unwrap());
+
+        let encrypted = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to migrate plaintext database");
+
+        let account_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&encrypted.pool)
+            .await
+            .expect("Failed to count migrated accounts");
+
+        assert_eq!(account_count.0, 1);
+        assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
+        assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
+        assert!(!PathBuf::from(format!("{}.plaintext.backup", db_path.display())).exists());
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_database_requires_existing_key() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("missing-key.db");
+        let service_id = unique_service_id();
+
+        let db = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to create encrypted database");
+        drop(db);
+
+        keyring::delete_db_key(&service_id, encryption::WHITENOISE_DB_KEY_ID)
+            .expect("Failed to delete database key");
+
+        let err = Database::new_encrypted(db_path, &service_id)
+            .await
+            .expect_err("Encrypted database should require its existing key");
+
+        assert!(matches!(err, DatabaseError::MissingEncryptionKey { .. }));
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -108,7 +108,7 @@ impl Database {
         .await
     }
 
-    #[cfg(feature = "benchmark-tests")]
+    #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
     pub(crate) async fn new_encrypted_with_key_id(
         db_path: PathBuf,
         keyring_service_id: &str,
@@ -201,12 +201,9 @@ impl Database {
             .connect_with(connect_options)
             .await?;
 
-        if let Some(config) = encryption_config {
+        if encryption_config.is_some() {
             let mut conn = pool.acquire().await?;
-            encryption::validate_encrypted_database(db_path, config).await?;
-            sqlx::query("SELECT count(*) FROM sqlite_master")
-                .fetch_one(&mut *conn)
-                .await?;
+            sqlx::query("SELECT 1").fetch_one(&mut *conn).await?;
         }
 
         Ok(pool)

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -202,6 +202,8 @@ impl Database {
             .await?;
 
         if encryption_config.is_some() {
+            // Confirm the pool can acquire a working connection end-to-end. Key correctness and
+            // schema integrity are already verified in prepare_sqlcipher_database before we reach here.
             let mut conn = pool.acquire().await?;
             sqlx::query("SELECT 1").fetch_one(&mut *conn).await?;
         }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -91,7 +91,7 @@ pub struct WhitenoiseConfig {
     /// to avoid key collisions in the system keyring.
     pub keyring_service_id: String,
 
-    /// Test-only override for the Whitenoise SQLCipher keyring key id.
+    /// Override for the Whitenoise SQLCipher keyring key id; available in test and benchmark builds.
     #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
     pub database_key_id: Option<String>,
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -91,8 +91,8 @@ pub struct WhitenoiseConfig {
     /// to avoid key collisions in the system keyring.
     pub keyring_service_id: String,
 
-    /// Benchmark-only override for the Whitenoise SQLCipher keyring key id.
-    #[cfg(feature = "benchmark-tests")]
+    /// Test-only override for the Whitenoise SQLCipher keyring key id.
+    #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
     pub database_key_id: Option<String>,
 
     /// Configured discovery relays for the relay-control discovery plane.
@@ -114,7 +114,7 @@ impl WhitenoiseConfig {
             logs_dir: formatted_logs_dir,
             message_aggregator_config: None, // Use default MessageAggregator configuration
             keyring_service_id: keyring_service_id.to_string(),
-            #[cfg(feature = "benchmark-tests")]
+            #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
             database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
         }
@@ -140,7 +140,7 @@ impl WhitenoiseConfig {
             logs_dir: formatted_logs_dir,
             message_aggregator_config: Some(aggregator_config),
             keyring_service_id: keyring_service_id.to_string(),
-            #[cfg(feature = "benchmark-tests")]
+            #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
             database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
         }
@@ -151,7 +151,7 @@ impl WhitenoiseConfig {
         self
     }
 
-    #[cfg(feature = "benchmark-tests")]
+    #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
     pub fn with_database_key_id(mut self, database_key_id: &str) -> Self {
         self.database_key_id = Some(database_key_id.to_string());
         self
@@ -502,7 +502,7 @@ impl Whitenoise {
         init_timing::record("directories_and_logging");
 
         let database_path = data_dir.join("whitenoise.sqlite");
-        #[cfg(feature = "benchmark-tests")]
+        #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
         let database = Arc::new(match config.database_key_id.as_deref() {
             Some(database_key_id) => {
                 Database::new_encrypted_with_key_id(
@@ -514,7 +514,7 @@ impl Whitenoise {
             }
             None => Database::new_encrypted(database_path, &keyring_service_id).await?,
         });
-        #[cfg(not(feature = "benchmark-tests"))]
+        #[cfg(not(any(test, feature = "integration-tests", feature = "benchmark-tests")))]
         let database = Arc::new(Database::new_encrypted(database_path, &keyring_service_id).await?);
 
         init_timing::record("database");
@@ -812,6 +812,8 @@ impl Whitenoise {
 
 #[cfg(test)]
 pub mod test_utils {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
     use crate::whitenoise::accounts_groups::AccountGroup;
     use crate::whitenoise::group_information::GroupInformation;
@@ -822,13 +824,16 @@ pub mod test_utils {
 
     // Test configuration and setup helpers
     pub(crate) fn create_test_config() -> (WhitenoiseConfig, TempDir, TempDir) {
+        static TEST_CONFIG_ID: AtomicU64 = AtomicU64::new(0);
+        let id = TEST_CONFIG_ID.fetch_add(1, Ordering::SeqCst);
         let data_temp_dir = TempDir::new().expect("Failed to create temp data dir");
         let logs_temp_dir = TempDir::new().expect("Failed to create temp logs dir");
         let config = WhitenoiseConfig::new(
             data_temp_dir.path(),
             logs_temp_dir.path(),
-            "com.whitenoise.test",
+            &format!("com.whitenoise.test.{id}"),
         )
+        .with_database_key_id(&format!("test.whitenoise.db.key.{id}"))
         .with_discovery_relays(Relay::urls(&Relay::defaults()));
         (config, data_temp_dir, logs_temp_dir)
     }
@@ -876,12 +881,9 @@ pub mod test_utils {
         init_tracing(&config.logs_dir);
 
         let database = Arc::new(
-            Database::new_encrypted(
-                config.data_dir.join("test.sqlite"),
-                &config.keyring_service_id,
-            )
-            .await
-            .unwrap(),
+            Database::new(config.data_dir.join("test.sqlite"))
+                .await
+                .unwrap(),
         );
         let secrets_store = SecretsStore::new(&config.keyring_service_id);
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -91,6 +91,10 @@ pub struct WhitenoiseConfig {
     /// to avoid key collisions in the system keyring.
     pub keyring_service_id: String,
 
+    /// Benchmark-only override for the Whitenoise SQLCipher keyring key id.
+    #[cfg(feature = "benchmark-tests")]
+    pub database_key_id: Option<String>,
+
     /// Configured discovery relays for the relay-control discovery plane.
     pub discovery_relays: Vec<RelayUrl>,
 }
@@ -110,6 +114,8 @@ impl WhitenoiseConfig {
             logs_dir: formatted_logs_dir,
             message_aggregator_config: None, // Use default MessageAggregator configuration
             keyring_service_id: keyring_service_id.to_string(),
+            #[cfg(feature = "benchmark-tests")]
+            database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
         }
     }
@@ -134,12 +140,20 @@ impl WhitenoiseConfig {
             logs_dir: formatted_logs_dir,
             message_aggregator_config: Some(aggregator_config),
             keyring_service_id: keyring_service_id.to_string(),
+            #[cfg(feature = "benchmark-tests")]
+            database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
         }
     }
 
     pub fn with_discovery_relays(mut self, discovery_relays: Vec<RelayUrl>) -> Self {
         self.discovery_relays = discovery_relays;
+        self
+    }
+
+    #[cfg(feature = "benchmark-tests")]
+    pub fn with_database_key_id(mut self, database_key_id: &str) -> Self {
+        self.database_key_id = Some(database_key_id.to_string());
         self
     }
 }
@@ -487,7 +501,21 @@ impl Whitenoise {
 
         init_timing::record("directories_and_logging");
 
-        let database = Arc::new(Database::new(data_dir.join("whitenoise.sqlite")).await?);
+        let database_path = data_dir.join("whitenoise.sqlite");
+        #[cfg(feature = "benchmark-tests")]
+        let database = Arc::new(match config.database_key_id.as_deref() {
+            Some(database_key_id) => {
+                Database::new_encrypted_with_key_id(
+                    database_path,
+                    &keyring_service_id,
+                    database_key_id,
+                )
+                .await?
+            }
+            None => Database::new_encrypted(database_path, &keyring_service_id).await?,
+        });
+        #[cfg(not(feature = "benchmark-tests"))]
+        let database = Arc::new(Database::new_encrypted(database_path, &keyring_service_id).await?);
 
         init_timing::record("database");
 
@@ -848,9 +876,12 @@ pub mod test_utils {
         init_tracing(&config.logs_dir);
 
         let database = Arc::new(
-            Database::new(config.data_dir.join("test.sqlite"))
-                .await
-                .unwrap(),
+            Database::new_encrypted(
+                config.data_dir.join("test.sqlite"),
+                &config.keyring_service_id,
+            )
+            .await
+            .unwrap(),
         );
         let secrets_store = SecretsStore::new(&config.keyring_service_id);
 


### PR DESCRIPTION
## Summary
- Open the Whitenoise SQLite database through SQLCipher during app initialization.
- Add plaintext database detection and one-time migration to an encrypted database using `sqlcipher_export`.
- Preserve user data during migration with WAL checkpointing, temp encrypted DB validation, backup/restore handling, and cleanup.
- Add tests for encrypted DB creation, reopen, plaintext migration, and missing key handling.
- Scope benchmark DB key restoration to a benchmark-only Whitenoise key id.

## Testing
- `just precommit-quick`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end on-disk DB encryption support: encrypted DB init, guarded plaintext→encrypted migration, and per-run database key selection (including test/benchmark variants).
  * Config builder option to select a specific database key id for a run.

* **Bug Fixes / Behaviour**
  * More robust migration/recovery with sidecar validation, stale-lock detection, atomic swap/rollback, and multi-key sidecar restoration.
  * Subscription setup now awaits before key-package setup to avoid races.

* **Tests**
  * Added tests for encrypted DB creation, migration, reopen persistence, and missing-key failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->