### PR TITLE
Migrate message ops to session views + delivery-status scope fix (Phases 6+7)

### DIFF
--- a/db_migrations/0045_delivery_status_account_scope.sql
+++ b/db_migrations/0045_delivery_status_account_scope.sql
@@ -1,0 +1,43 @@
+-- Fix delivery-status account scope bug (GitHub issue #739).
+--
+-- The message_delivery_status table was keyed by (message_id, mls_group_id)
+-- with no account_pubkey, so sender-local delivery state bled across accounts
+-- in the same group.  This migration adds account_pubkey to the primary key.
+--
+-- Backfill strategy: join on aggregated_messages.author to attribute existing
+-- rows to the message sender.  Rows that cannot be attributed (author NULL or
+-- missing) are dropped — they represent stale state that will self-correct on
+-- next message send.
+
+-- SQLite cannot ALTER a PRIMARY KEY, so we recreate the table.
+
+CREATE TABLE message_delivery_status_new (
+    message_id      TEXT NOT NULL,
+    mls_group_id    BLOB NOT NULL,
+    account_pubkey  TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    PRIMARY KEY (message_id, mls_group_id, account_pubkey),
+    FOREIGN KEY (message_id, mls_group_id)
+        REFERENCES aggregated_messages(message_id, mls_group_id)
+        ON DELETE CASCADE
+);
+
+-- Backfill: attribute existing rows to the message author.
+INSERT INTO message_delivery_status_new (message_id, mls_group_id, account_pubkey, status)
+SELECT
+    mds.message_id,
+    mds.mls_group_id,
+    am.author,
+    mds.status
+FROM message_delivery_status mds
+INNER JOIN aggregated_messages am
+    ON am.message_id = mds.message_id
+   AND am.mls_group_id = mds.mls_group_id
+WHERE am.author IS NOT NULL;
+
+DROP TABLE message_delivery_status;
+ALTER TABLE message_delivery_status_new RENAME TO message_delivery_status;
+
+-- Recreate index with account_pubkey for per-account queries.
+CREATE INDEX idx_mds_group_account_status
+    ON message_delivery_status (mls_group_id, account_pubkey, status);

--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -202,7 +202,7 @@ call sites are migrated.
 
 ### Phase 6: Migrate message read/search operations (~500 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #760
 
 <details>
 <summary>Details</summary>
@@ -224,7 +224,7 @@ current shared `Database`.
 
 ### Phase 7: Migrate message send/retry/projection write path + delivery-status scope fix (~1000 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #760
 
 <details>
 <summary>Details</summary>

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -569,6 +569,7 @@ impl EphemeralPlane {
                     Self::update_and_emit_delivery_status(
                         event_id,
                         group_id,
+                        account_pubkey,
                         &status,
                         database,
                         stream_manager,
@@ -581,6 +582,7 @@ impl EphemeralPlane {
                 Self::update_and_emit_delivery_status(
                     event_id,
                     group_id,
+                    account_pubkey,
                     &status,
                     database,
                     stream_manager,
@@ -609,6 +611,7 @@ impl EphemeralPlane {
                 Self::update_and_emit_delivery_status(
                     event_id,
                     group_id,
+                    account_pubkey,
                     &status,
                     database,
                     stream_manager,
@@ -681,12 +684,17 @@ impl EphemeralPlane {
     async fn update_and_emit_delivery_status(
         event_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         status: &DeliveryStatus,
         database: &Database,
         stream_manager: &MessageStreamManager,
     ) {
         match AggregatedMessage::update_delivery_status_with_retry(
-            event_id, group_id, status, database,
+            event_id,
+            group_id,
+            account_pubkey,
+            status,
+            database,
         )
         .await
         {

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -1046,9 +1046,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg1, &group1.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg1,
+            &group1.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let msg2 = ChatMessage {
             id: format!("{:0>64}", "2"),
@@ -1065,9 +1070,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg2, &group2.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg2,
+            &group2.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1229,9 +1239,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1291,9 +1306,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group1.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg,
+            &group1.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
 
@@ -1380,9 +1400,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let result = whitenoise
             .build_chat_list_item(&creator, &group.mls_group_id)
@@ -1672,9 +1697,14 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group.mls_group_id,
+                &creator.pubkey,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
         }
 
         // Order should be stable when timestamps are identical

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -259,6 +259,7 @@ impl AggregatedMessage {
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_by_group(
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         chat_cleared_at_ms: Option<i64>,
         database: &Database,
     ) -> Result<Vec<ChatMessage>> {
@@ -267,11 +268,13 @@ impl AggregatedMessage {
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                  AND mds.account_pubkey = ?
              WHERE am.kind = 9 AND am.mls_group_id = ?
                AND am.created_at > COALESCE(?, 0)
                AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              ORDER BY am.created_at",
         )
+        .bind(account_pubkey.to_hex())
         .bind(group_id.as_slice())
         .bind(chat_cleared_at_ms)
         .fetch_all(&database.pool)
@@ -307,6 +310,7 @@ impl AggregatedMessage {
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_by_group_paginated(
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         database: &Database,
         options: &PaginationOptions,
         limit: Option<u32>,
@@ -398,6 +402,7 @@ impl AggregatedMessage {
                      FROM aggregated_messages am
                      LEFT JOIN message_delivery_status mds
                        ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                          AND mds.account_pubkey = ?
                      WHERE am.kind = 9 AND am.mls_group_id = ?
                        AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at < ? OR (am.created_at = ? AND am.message_id < ?))
@@ -405,6 +410,7 @@ impl AggregatedMessage {
                      ORDER BY am.created_at DESC, am.message_id DESC
                      LIMIT ?",
                 )
+                .bind(account_pubkey.to_hex())
                 .bind(group_id.as_slice())
                 .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
@@ -420,6 +426,7 @@ impl AggregatedMessage {
                      FROM aggregated_messages am
                      LEFT JOIN message_delivery_status mds
                        ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                          AND mds.account_pubkey = ?
                      WHERE am.kind = 9 AND am.mls_group_id = ?
                        AND am.created_at > COALESCE(?, 0)
                        AND (am.created_at > ? OR (am.created_at = ? AND am.message_id > ?))
@@ -427,6 +434,7 @@ impl AggregatedMessage {
                      ORDER BY am.created_at ASC, am.message_id ASC
                      LIMIT ?",
                 )
+                .bind(account_pubkey.to_hex())
                 .bind(group_id.as_slice())
                 .bind(chat_cleared_at_ms)
                 .bind(cursor_ms)
@@ -471,6 +479,7 @@ impl AggregatedMessage {
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_messages_with_unread_minimum(
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         read_marker: Option<&EventId>,
         minimum: u32,
         database: &Database,
@@ -501,6 +510,7 @@ impl AggregatedMessage {
                LEFT JOIN message_delivery_status mds
                  ON am.message_id = mds.message_id
                 AND am.mls_group_id = mds.mls_group_id
+                AND mds.account_pubkey = ?
                WHERE am.mls_group_id = ?
                  AND am.kind = 9
                  AND am.deletion_event_id IS NULL
@@ -517,6 +527,7 @@ impl AggregatedMessage {
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id
               AND am.mls_group_id = mds.mls_group_id
+              AND mds.account_pubkey = ?
              WHERE am.kind = 9
                AND am.mls_group_id = ?
                AND am.created_at > COALESCE(?, 0)
@@ -524,10 +535,12 @@ impl AggregatedMessage {
              ORDER BY am.created_at DESC, am.message_id DESC
              LIMIT MAX((SELECT cnt FROM unread_count), ?)",
         )
+        .bind(account_pubkey.to_hex()) // unread CTE: account_pubkey for delivery status
         .bind(group_id.as_slice()) // unread CTE: mls_group_id
         .bind(marker_hex.as_deref()) // unread CTE: read marker message_id (NULL = no marker)
         .bind(group_id.as_slice()) // unread CTE: mls_group_id for marker lookup
         .bind(chat_cleared_at_ms) // unread CTE: chat_cleared_at floor
+        .bind(account_pubkey.to_hex()) // outer SELECT: account_pubkey for delivery status
         .bind(group_id.as_slice()) // outer SELECT: mls_group_id
         .bind(chat_cleared_at_ms) // outer SELECT: chat_cleared_at floor
         .bind(minimum_val) // MAX(cnt, minimum)
@@ -565,6 +578,7 @@ impl AggregatedMessage {
     /// so the window scan uses an index walk instead of a temp B-tree sort.
     pub async fn search_messages_in_group(
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         query: &str,
         limit: u32,
         database: &Database,
@@ -581,17 +595,19 @@ impl AggregatedMessage {
                FROM aggregated_messages am
                LEFT JOIN message_delivery_status mds
                  ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                    AND mds.account_pubkey = ?1
                WHERE am.kind = 9
-                 AND am.mls_group_id = ?1
-                 AND am.created_at > COALESCE(?2, 0)
+                 AND am.mls_group_id = ?2
+                 AND am.created_at > COALESCE(?3, 0)
                  AND (mds.status IS NULL OR mds.status != '\"Retried\"')
              )
              SELECT * FROM ranked
              WHERE deletion_event_id IS NULL
-               AND content_normalized LIKE ?3
+               AND content_normalized LIKE ?4
              ORDER BY created_at DESC, message_id DESC
-             LIMIT ?4",
+             LIMIT ?5",
         )
+        .bind(account_pubkey.to_hex())
         .bind(group_id.as_slice())
         .bind(chat_cleared_at_ms)
         .bind(&like_pattern)
@@ -649,6 +665,7 @@ impl AggregatedMessage {
                  ON ag.mls_group_id = am.mls_group_id
                LEFT JOIN message_delivery_status mds
                  ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                    AND mds.account_pubkey = ?1
                WHERE am.kind = 9
                  AND ag.account_pubkey = ?1
                  AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)
@@ -805,6 +822,7 @@ impl AggregatedMessage {
     pub async fn insert_message(
         message: &ChatMessage,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         database: &Database,
     ) -> Result<()> {
         let created_at = timestamp_to_datetime(message.created_at).map_err(|_| {
@@ -847,12 +865,13 @@ impl AggregatedMessage {
 
         if let Some(status) = &message.delivery_status {
             sqlx::query(
-                "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-                 VALUES (?, ?, ?)
-                 ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+                "INSERT INTO message_delivery_status (message_id, mls_group_id, account_pubkey, status)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(message_id, mls_group_id, account_pubkey) DO UPDATE SET status = excluded.status",
             )
             .bind(&message.id)
             .bind(group_id.as_slice())
+            .bind(account_pubkey.to_hex())
             .bind(serde_json::to_string(status)?)
             .execute(&mut *tx)
             .await?;
@@ -1017,6 +1036,7 @@ impl AggregatedMessage {
     pub async fn update_delivery_status(
         message_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         status: &DeliveryStatus,
         database: &Database,
     ) -> Result<ChatMessage> {
@@ -1038,12 +1058,13 @@ impl AggregatedMessage {
 
         // Upsert delivery status
         sqlx::query(
-            "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-             VALUES (?, ?, ?)
-             ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+            "INSERT INTO message_delivery_status (message_id, mls_group_id, account_pubkey, status)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(message_id, mls_group_id, account_pubkey) DO UPDATE SET status = excluded.status",
         )
         .bind(message_id)
         .bind(group_id.as_slice())
+        .bind(account_pubkey.to_hex())
         .bind(serde_json::to_string(status)?)
         .execute(&mut *tx)
         .await?;
@@ -1054,8 +1075,10 @@ impl AggregatedMessage {
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                  AND mds.account_pubkey = ?
              WHERE am.message_id = ? AND am.mls_group_id = ?",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_optional(&mut *tx)
@@ -1073,6 +1096,7 @@ impl AggregatedMessage {
     pub async fn update_delivery_status_with_retry(
         message_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         status: &DeliveryStatus,
         database: &Database,
     ) -> Result<ChatMessage> {
@@ -1081,7 +1105,15 @@ impl AggregatedMessage {
             .copied()
             .enumerate()
         {
-            match Self::update_delivery_status(message_id, group_id, status, database).await {
+            match Self::update_delivery_status(
+                message_id,
+                group_id,
+                account_pubkey,
+                status,
+                database,
+            )
+            .await
+            {
                 Ok(message) => return Ok(message),
                 Err(error) if Self::is_database_lock_error(&error) => {
                     tracing::debug!(
@@ -1096,7 +1128,7 @@ impl AggregatedMessage {
             }
         }
 
-        Self::update_delivery_status(message_id, group_id, status, database).await
+        Self::update_delivery_status(message_id, group_id, account_pubkey, status, database).await
     }
 
     /// Insert an initial delivery status row for an outgoing event.
@@ -1108,16 +1140,18 @@ impl AggregatedMessage {
     pub async fn insert_delivery_status(
         message_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         status: &DeliveryStatus,
         database: &Database,
     ) -> Result<()> {
         sqlx::query(
-            "INSERT INTO message_delivery_status (message_id, mls_group_id, status)
-             VALUES (?, ?, ?)
-             ON CONFLICT(message_id, mls_group_id) DO UPDATE SET status = excluded.status",
+            "INSERT INTO message_delivery_status (message_id, mls_group_id, account_pubkey, status)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(message_id, mls_group_id, account_pubkey) DO UPDATE SET status = excluded.status",
         )
         .bind(message_id)
         .bind(group_id.as_slice())
+        .bind(account_pubkey.to_hex())
         .bind(serde_json::to_string(status)?)
         .execute(&database.pool)
         .await?;
@@ -1130,14 +1164,16 @@ impl AggregatedMessage {
     pub async fn has_delivery_status(
         message_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         database: &Database,
     ) -> Result<bool> {
         let exists: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM message_delivery_status
-             WHERE message_id = ? AND mls_group_id = ?)",
+             WHERE message_id = ? AND mls_group_id = ? AND account_pubkey = ?)",
         )
         .bind(message_id)
         .bind(group_id.as_slice())
+        .bind(account_pubkey.to_hex())
         .fetch_one(&database.pool)
         .await?;
 
@@ -1165,6 +1201,7 @@ impl AggregatedMessage {
     pub async fn find_by_id(
         message_id: &str,
         group_id: &GroupId,
+        account_pubkey: &PublicKey,
         database: &Database,
     ) -> Result<Option<ChatMessage>> {
         let row: Option<AggregatedMessageRow> = sqlx::query_as(
@@ -1172,8 +1209,10 @@ impl AggregatedMessage {
              FROM aggregated_messages am
              LEFT JOIN message_delivery_status mds
                ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
+                  AND mds.account_pubkey = ?
              WHERE am.message_id = ? AND am.mls_group_id = ? AND am.kind = 9",
         )
+        .bind(account_pubkey.to_hex())
         .bind(message_id)
         .bind(group_id.as_slice())
         .fetch_optional(&database.pool)
@@ -1653,11 +1692,16 @@ mod tests {
     async fn test_find_messages_by_group_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
+        let author = Keys::generate().public_key();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(messages.is_empty());
     }
 
@@ -1672,7 +1716,8 @@ mod tests {
 
         // Insert message
         let result =
-            AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database).await;
+            AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
+                .await;
         assert!(result.is_ok());
 
         // Verify it was inserted
@@ -1682,10 +1727,14 @@ mod tests {
         assert_eq!(count, 1);
 
         // Verify we can retrieve it
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, message.id);
         assert_eq!(messages[0].content, message.content);
@@ -1704,7 +1753,7 @@ mod tests {
         for i in 1..=3 {
             let message = create_test_chat_message(i, author);
             message_ids.push(message.id.clone());
-            AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -1716,10 +1765,14 @@ mod tests {
         assert_eq!(count, 3);
 
         // Verify we can retrieve all messages
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 3);
 
         // Verify event IDs
@@ -1743,7 +1796,7 @@ mod tests {
 
         // Insert a message
         let message = create_test_chat_message(10, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1770,10 +1823,14 @@ mod tests {
         assert_eq!(count_after, 1);
 
         // But the message should have deletion_event_id set
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_deleted);
     }
@@ -1788,17 +1845,17 @@ mod tests {
 
         // Insert multiple messages
         let message1 = create_test_chat_message(20, author);
-        AggregatedMessage::insert_message(&message1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message1, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         let message2 = create_test_chat_message(21, author);
-        AggregatedMessage::insert_message(&message2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message2, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         let message3 = create_test_chat_message(22, author);
-        AggregatedMessage::insert_message(&message3, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message3, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1820,10 +1877,14 @@ mod tests {
         assert_eq!(count_after, 0);
 
         // No messages should be found
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(messages.is_empty());
 
         // No event IDs should be found
@@ -1846,13 +1907,13 @@ mod tests {
 
         // Insert message in group 1
         let message1 = create_test_chat_message(30, author);
-        AggregatedMessage::insert_message(&message1, &group_id_1, &whitenoise.database)
+        AggregatedMessage::insert_message(&message1, &group_id_1, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert message in group 2
         let message2 = create_test_chat_message(31, author);
-        AggregatedMessage::insert_message(&message2, &group_id_2, &whitenoise.database)
+        AggregatedMessage::insert_message(&message2, &group_id_2, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1884,7 +1945,7 @@ mod tests {
 
         // Insert a message with empty reactions
         let message = create_test_chat_message(40, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -1909,10 +1970,14 @@ mod tests {
         .unwrap();
 
         // Verify reactions were updated
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].reactions.by_emoji.len(), 1);
         assert!(messages[0].reactions.by_emoji.contains_key("👍"));
@@ -1988,31 +2053,51 @@ mod tests {
                 created_at: chrono::Utc::now(),
             },
         ];
-        AggregatedMessage::insert_message(&msg_with_media, &group_with_media, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_with_media,
+            &group_with_media,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Group 2: Message without media
         let mut msg_no_media = create_test_chat_message(51, author);
         msg_no_media.content = "Message without media".to_string();
-        AggregatedMessage::insert_message(&msg_no_media, &group_no_media, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_no_media,
+            &group_no_media,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Group 3: Has deleted newest message, should return older one
         let mut msg_older = create_test_chat_message(52, author);
         msg_older.content = "Older non-deleted".to_string();
         msg_older.created_at = Timestamp::from(1000);
-        AggregatedMessage::insert_message(&msg_older, &group_with_deletion, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_older,
+            &group_with_deletion,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         let mut msg_deleted = create_test_chat_message(53, author);
         msg_deleted.content = "Deleted message".to_string();
         msg_deleted.created_at = Timestamp::from(2000);
-        AggregatedMessage::insert_message(&msg_deleted, &group_with_deletion, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_deleted,
+            &group_with_deletion,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         AggregatedMessage::mark_deleted(
             &msg_deleted.id,
             &group_with_deletion,
@@ -2031,6 +2116,7 @@ mod tests {
         AggregatedMessage::insert_message(
             &msg_first,
             &group_multiple_messages,
+            &author,
             &whitenoise.database,
         )
         .await
@@ -2042,6 +2128,7 @@ mod tests {
         AggregatedMessage::insert_message(
             &msg_last,
             &group_multiple_messages,
+            &author,
             &whitenoise.database,
         )
         .await
@@ -2099,7 +2186,7 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(70, author);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2135,7 +2222,7 @@ mod tests {
         let author = Keys::generate().public_key();
         for i in 1..=3 {
             let msg = create_test_chat_message(80 + i, author);
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2159,7 +2246,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(90 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
             messages.push(msg);
@@ -2188,10 +2275,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(100, author);
         let msg2 = create_test_chat_message(101, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2241,7 +2328,7 @@ mod tests {
         // Group 1: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(110 + i, author);
-            AggregatedMessage::insert_message(&msg, &group1, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2249,7 +2336,7 @@ mod tests {
         // Group 2: 5 messages
         for i in 1..=5 {
             let msg = create_test_chat_message(120 + i, author);
-            AggregatedMessage::insert_message(&msg, &group2, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2290,7 +2377,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(130 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group1, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.database)
                 .await
                 .unwrap();
             group1_messages.push(msg);
@@ -2302,7 +2389,7 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(140 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group2, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.database)
                 .await
                 .unwrap();
             group2_messages.push(msg);
@@ -2342,9 +2429,14 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(150 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group_with_marker, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_with_marker,
+                &author,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
             messages.push(msg);
         }
         let marker = EventId::from_hex(&messages[1].id).unwrap();
@@ -2352,9 +2444,14 @@ mod tests {
         // Group without marker: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(160 + i, author);
-            AggregatedMessage::insert_message(&msg, &group_without_marker, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_without_marker,
+                &author,
+                &whitenoise.database,
+            )
+            .await
+            .unwrap();
         }
 
         let input = vec![
@@ -2384,21 +2481,23 @@ mod tests {
         // Insert a message with Sending status
         let mut message = create_test_chat_message(200, author);
         message.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Verify initial Sending status via find_by_id
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
 
         // Update to Sent(3) — returned message should have the updated status
         let updated = AggregatedMessage::update_delivery_status(
             &message.id,
             &group_id,
+            &author,
             &DeliveryStatus::Sent(3),
             &whitenoise.database,
         )
@@ -2407,16 +2506,18 @@ mod tests {
         assert_eq!(updated.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Verify via find_by_id as well
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Update to Failed
         let updated = AggregatedMessage::update_delivery_status(
             &message.id,
             &group_id,
+            &author,
             &DeliveryStatus::Failed("timeout".to_string()),
             &whitenoise.database,
         )
@@ -2432,10 +2533,12 @@ mod tests {
     async fn test_find_by_id_returns_none_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[201; 32]);
+        let author = Keys::generate().public_key();
 
-        let found = AggregatedMessage::find_by_id("nonexistent", &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id("nonexistent", &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap();
         assert!(found.is_none());
     }
 
@@ -2450,14 +2553,15 @@ mod tests {
         // delivery_status is None (incoming message)
         assert!(message.delivery_status.is_none());
 
-        AggregatedMessage::insert_message(&message, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
-        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, None);
     }
 
@@ -2471,21 +2575,25 @@ mod tests {
 
         // Insert incoming message (no delivery status)
         let msg_incoming = create_test_chat_message(203, author);
-        AggregatedMessage::insert_message(&msg_incoming, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_incoming, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert outgoing message with Sent status
         let mut msg_outgoing = create_test_chat_message(204, author);
         msg_outgoing.delivery_status = Some(DeliveryStatus::Sent(2));
-        AggregatedMessage::insert_message(&msg_outgoing, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_outgoing, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 2);
 
         let statuses: Vec<_> = messages.iter().map(|m| &m.delivery_status).collect();
@@ -2497,12 +2605,14 @@ mod tests {
     async fn test_update_delivery_status_returns_error_for_nonexistent_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[205; 32]);
+        let author = Keys::generate().public_key();
         setup_group(&group_id, &whitenoise.database).await;
 
         // Try to update delivery status for a message that doesn't exist
         let result = AggregatedMessage::update_delivery_status(
             &format!("{:0>64}", "ff"),
             &group_id,
+            &author,
             &DeliveryStatus::Sent(1),
             &whitenoise.database,
         )
@@ -2530,28 +2640,32 @@ mod tests {
 
         // Insert a normal message
         let msg_normal = create_test_chat_message(206, author);
-        AggregatedMessage::insert_message(&msg_normal, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_normal, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert a message with Retried status (simulating a retried failed message)
         let mut msg_retried = create_test_chat_message(207, author);
         msg_retried.delivery_status = Some(DeliveryStatus::Retried);
-        AggregatedMessage::insert_message(&msg_retried, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_retried, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Insert a message with Failed status (should still be visible)
         let mut msg_failed = create_test_chat_message(208, author);
         msg_failed.delivery_status = Some(DeliveryStatus::Failed("error".to_string()));
-        AggregatedMessage::insert_message(&msg_failed, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_failed, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Only normal and failed messages should appear, not retried
         assert_eq!(messages.len(), 2);
@@ -2574,7 +2688,7 @@ mod tests {
         let msg3 = create_test_chat_message(172, author);
 
         for msg in [&msg1, &msg2, &msg3] {
-            AggregatedMessage::insert_message(msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -2605,20 +2719,26 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(180, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         // Before inserting, has_delivery_status should return false
-        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            &msg.id,
+            &group_id,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(!has, "No delivery status should exist yet");
 
         // Insert delivery status
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
+            &author,
             &DeliveryStatus::Sending,
             &whitenoise.database,
         )
@@ -2626,16 +2746,22 @@ mod tests {
         .unwrap();
 
         // Now has_delivery_status should return true
-        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            &msg.id,
+            &group_id,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(has, "Delivery status should exist after insert");
 
         // Verify it shows up in find_by_id
-        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
     }
 
@@ -2647,7 +2773,7 @@ mod tests {
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(181, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2655,6 +2781,7 @@ mod tests {
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
+            &author,
             &DeliveryStatus::Sending,
             &whitenoise.database,
         )
@@ -2665,16 +2792,18 @@ mod tests {
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
+            &author,
             &DeliveryStatus::Sent(2),
             &whitenoise.database,
         )
         .await
         .unwrap();
 
-        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &whitenoise.database)
-            .await
-            .unwrap()
-            .unwrap();
+        let found =
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.database)
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(2)));
     }
 
@@ -2687,10 +2816,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(182, author);
         let msg2 = create_test_chat_message(183, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2705,10 +2834,14 @@ mod tests {
             .unwrap();
 
         // Both should have is_deleted=true
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(
             messages.iter().all(|m| m.is_deleted),
             "All messages should be marked as deleted"
@@ -2719,10 +2852,14 @@ mod tests {
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(messages.len(), 2, "Both messages should still be present");
         assert!(
             messages.iter().all(|m| !m.is_deleted),
@@ -2739,10 +2876,10 @@ mod tests {
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(184, author);
         let msg2 = create_test_chat_message(185, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -2761,10 +2898,14 @@ mod tests {
             .await
             .unwrap();
 
-        let messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &author,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         let not_deleted: Vec<_> = messages.iter().filter(|m| !m.is_deleted).collect();
         assert_eq!(not_deleted.len(), 1, "Only msg1 should be un-deleted");
         assert_eq!(not_deleted[0].id, msg1.id);
@@ -2831,11 +2972,16 @@ mod tests {
     async fn test_has_delivery_status_returns_false_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[188; 32]);
+        let author = Keys::generate().public_key();
 
-        let has =
-            AggregatedMessage::has_delivery_status("nonexistent", &group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let has = AggregatedMessage::has_delivery_status(
+            "nonexistent",
+            &group_id,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(!has);
     }
 
@@ -2865,7 +3011,7 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
-        AggregatedMessage::insert_message(&msg, group_id, database)
+        AggregatedMessage::insert_message(&msg, group_id, &author, database)
             .await
             .unwrap();
         msg
@@ -2875,9 +3021,11 @@ mod tests {
     async fn test_paginated_empty_group_returns_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[200; 32]);
+        let author = Keys::generate().public_key();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -2912,6 +3060,7 @@ mod tests {
         // Default (no cursor) should return the 50 newest
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -2970,6 +3119,7 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(cursor_ts),
@@ -3013,6 +3163,7 @@ mod tests {
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(3),
@@ -3058,6 +3209,7 @@ mod tests {
         // Requesting u32::MAX should be capped to 200
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(u32::MAX),
@@ -3093,6 +3245,7 @@ mod tests {
         // Page 1: newest 5 (seeds 6–10)
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(5),
@@ -3107,6 +3260,7 @@ mod tests {
         let cursor_id = page1[0].id.as_str();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(cursor_ts),
@@ -3135,6 +3289,7 @@ mod tests {
         let cursor_id2 = page2[0].id.as_str();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(cursor_ts2),
@@ -3177,6 +3332,7 @@ mod tests {
         // Page 1: newest 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             Some(3),
@@ -3191,6 +3347,7 @@ mod tests {
         let c1_id = page1[0].id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(c1_ts),
@@ -3209,6 +3366,7 @@ mod tests {
         let c2_id = page2[0].id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(c2_ts),
@@ -3231,6 +3389,7 @@ mod tests {
         let c3_id = page3[0].id.clone();
         let page4 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(c3_ts),
@@ -3276,11 +3435,13 @@ mod tests {
     async fn test_paginated_half_specified_cursor_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[207; 32]);
+        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_700_000_000u64);
 
         // before=Some, before_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(ts),
@@ -3299,6 +3460,7 @@ mod tests {
         // before=None, before_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before_message_id: Some(
@@ -3321,11 +3483,13 @@ mod tests {
     async fn test_paginated_invalid_before_message_id_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[208; 32]);
+        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_700_000_000u64);
 
         // Non-hex string → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(ts),
@@ -3345,6 +3509,7 @@ mod tests {
         // Valid hex but wrong length (32 chars instead of 64) → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(ts),
@@ -3390,6 +3555,7 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 2u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
@@ -3437,6 +3603,7 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
@@ -3483,6 +3650,7 @@ mod tests {
         // Page through with limit 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
@@ -3500,6 +3668,7 @@ mod tests {
         let c1_id = page1.last().unwrap().id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(c1_ts),
@@ -3517,6 +3686,7 @@ mod tests {
         let c2_id = page2.last().unwrap().id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(c2_ts),
@@ -3560,11 +3730,13 @@ mod tests {
     async fn test_paginated_both_before_and_after_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[223; 32]);
+        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_710_300_000u64);
         let id = "0000000000000000000000000000000000000000000000000000000000000001";
 
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(ts),
@@ -3587,11 +3759,13 @@ mod tests {
     async fn test_paginated_half_specified_after_cursor_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[224; 32]);
+        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_710_400_000u64);
 
         // after=Some, after_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(ts),
@@ -3610,6 +3784,7 @@ mod tests {
         // after=None, after_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after_message_id: Some(
@@ -3653,6 +3828,7 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 0xffu8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
@@ -3709,6 +3885,7 @@ mod tests {
 
         let results_a = AggregatedMessage::find_messages_by_group_paginated(
             &group_a,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -3718,6 +3895,7 @@ mod tests {
         .unwrap();
         let results_b = AggregatedMessage::find_messages_by_group_paginated(
             &group_b,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -3770,6 +3948,7 @@ mod tests {
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -3830,6 +4009,7 @@ mod tests {
         // LIMIT = MAX(2, 3) = 3, so all 3 rows (including the tombstone) are returned.
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
             &group_id,
+            &author,
             None,
             3,
             &whitenoise.database,
@@ -3894,6 +4074,7 @@ mod tests {
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -3946,6 +4127,7 @@ mod tests {
         // Should not error — uppercase is valid hex and gets canonicalized internally
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(Timestamp::from(base_ts + 3)),
@@ -3983,6 +4165,7 @@ mod tests {
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -4000,6 +4183,7 @@ mod tests {
         // Cursor from the only message → next page is empty
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
@@ -4041,6 +4225,7 @@ mod tests {
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -4057,6 +4242,7 @@ mod tests {
         // Cursor from the oldest (page1[0]) → no older messages exist
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
@@ -4112,6 +4298,7 @@ mod tests {
 
             let page = AggregatedMessage::find_messages_by_group_paginated(
                 &group_id,
+                &author,
                 &whitenoise.database,
                 &opts,
                 Some(1),
@@ -4172,6 +4359,7 @@ mod tests {
         // Full first page
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -4185,6 +4373,7 @@ mod tests {
         let oldest = &page1[0];
         let next_page = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions {
                 before: Some(oldest.created_at),
@@ -4233,12 +4422,13 @@ mod tests {
             media_attachments: vec![],
             delivery_status: Some(DeliveryStatus::Retried),
         };
-        AggregatedMessage::insert_message(&retried_msg, &group_id, &whitenoise.database)
+        AggregatedMessage::insert_message(&retried_msg, &group_id, &author, &whitenoise.database)
             .await
             .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -4304,7 +4494,7 @@ mod tests {
         ];
 
         for msg in &messages {
-            AggregatedMessage::insert_message(msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -4312,6 +4502,7 @@ mod tests {
         // Basic single-word search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "hello",
             50,
             &whitenoise.database,
@@ -4327,6 +4518,7 @@ mod tests {
         // Forward-order multi-word search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "big plans",
             50,
             &whitenoise.database,
@@ -4345,6 +4537,7 @@ mod tests {
         // Substring matching ("big" matches "bigger")
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "big",
             50,
             &whitenoise.database,
@@ -4357,6 +4550,7 @@ mod tests {
         // Case insensitive
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "MARMOT",
             50,
             &whitenoise.database,
@@ -4370,6 +4564,7 @@ mod tests {
         // CJK search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "日本語",
             50,
             &whitenoise.database,
@@ -4383,6 +4578,7 @@ mod tests {
         // Cyrillic search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "привет",
             50,
             &whitenoise.database,
@@ -4395,6 +4591,7 @@ mod tests {
         // Devanagari search (with combining marks)
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "नमस्ते",
             50,
             &whitenoise.database,
@@ -4408,6 +4605,7 @@ mod tests {
         // No match
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "nonexistent",
             50,
             &whitenoise.database,
@@ -4420,6 +4618,7 @@ mod tests {
         // Empty query matches all — positions are sequential newest-first
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "",
             50,
             &whitenoise.database,
@@ -4434,6 +4633,7 @@ mod tests {
         // Limit is respected
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "",
             2,
             &whitenoise.database,
@@ -4480,7 +4680,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -4488,6 +4688,7 @@ mod tests {
         // Search for all three: "same-ts" matches every message
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "same-ts",
             50,
             &whitenoise.database,
@@ -4560,24 +4761,29 @@ mod tests {
 
         // Insert messages: "marmot" in all three groups
         let msg_a = create_test_chat_message_with_content(1, author, "marmot in group A");
-        AggregatedMessage::insert_message(&msg_a, &group_a, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_a, &group_a, &author, &whitenoise.database)
             .await
             .unwrap();
 
         let msg_b = create_test_chat_message_with_content(2, author, "marmot in group B");
-        AggregatedMessage::insert_message(&msg_b, &group_b, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_b, &group_b, &author, &whitenoise.database)
             .await
             .unwrap();
 
         let msg_declined =
             create_test_chat_message_with_content(3, author, "marmot in declined group");
-        AggregatedMessage::insert_message(&msg_declined, &group_declined, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_declined,
+            &group_declined,
+            &author,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
 
         // Also add a second message in group A to verify per-group positions
         let msg_a2 = create_test_chat_message_with_content(4, author, "another marmot in group A");
-        AggregatedMessage::insert_message(&msg_a2, &group_a, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_a2, &group_a, &author, &whitenoise.database)
             .await
             .unwrap();
 
@@ -4687,6 +4893,7 @@ mod tests {
         // find_messages_by_group
         let messages = AggregatedMessage::find_messages_by_group(
             &group_id,
+            &author,
             Some(cleared_at_ms),
             &whitenoise.database,
         )
@@ -4699,6 +4906,7 @@ mod tests {
         // find_messages_by_group_paginated
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
+            &author,
             &whitenoise.database,
             &PaginationOptions::default(),
             None,
@@ -4711,6 +4919,7 @@ mod tests {
         // find_messages_with_unread_minimum
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
             &group_id,
+            &author,
             None,
             50,
             &whitenoise.database,
@@ -4804,7 +5013,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
                 .await
                 .unwrap();
         }
@@ -4814,6 +5023,7 @@ mod tests {
 
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
+            &author,
             "hello",
             50,
             &whitenoise.database,

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -5038,4 +5038,49 @@ mod tests {
         assert!(found_contents.contains(&"charlie hello"));
         assert!(found_contents.contains(&"delta hello"));
     }
+
+    /// Regression test for GitHub issue #739: delivery-status isolation between accounts.
+    ///
+    /// Two local accounts share a group. Account A sends a message (gets delivery
+    /// status `Sending`). Account B queries the same message and must see no
+    /// delivery status (NULL), because delivery tracking is sender-local.
+    #[tokio::test]
+    async fn test_delivery_status_isolated_between_accounts() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let group_id = GroupId::from_slice(&[42; 32]);
+        setup_group(&group_id, &whitenoise.database).await;
+
+        let account_a = Keys::generate().public_key();
+        let account_b = Keys::generate().public_key();
+
+        // Account A sends a message with delivery status
+        let mut msg = create_test_chat_message(1, account_a);
+        msg.delivery_status = Some(DeliveryStatus::Sending);
+        AggregatedMessage::insert_message(&msg, &group_id, &account_a, &whitenoise.database)
+            .await
+            .unwrap();
+
+        // Account A sees delivery status on their own message
+        let fetched_by_a =
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &account_a, &whitenoise.database)
+                .await
+                .unwrap()
+                .expect("message should exist");
+        assert_eq!(
+            fetched_by_a.delivery_status,
+            Some(DeliveryStatus::Sending),
+            "sender should see their own delivery status"
+        );
+
+        // Account B queries the same message — must NOT see A's delivery status
+        let fetched_by_b =
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &account_b, &whitenoise.database)
+                .await
+                .unwrap()
+                .expect("message should exist for any account");
+        assert_eq!(
+            fetched_by_b.delivery_status, None,
+            "other account must not see sender's delivery status (issue #739)"
+        );
+    }
 }

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -16,6 +16,7 @@ use crate::{
         chat_list_streaming::ChatListUpdateTrigger,
         error::{Result, WhitenoiseError},
         media_files::MediaFile,
+        message_aggregator::processor::{extract_deletion_target_ids, extract_reaction_target_id},
         message_aggregator::{ChatMessage, emoji_utils, reaction_handler},
         message_streaming::{MessageUpdate, UpdateTrigger},
         push_notifications::is_push_group_message_kind,
@@ -196,7 +197,9 @@ impl Whitenoise {
 
         match message.kind {
             Kind::ChatMessage => {
-                let msg = self.cache_chat_message(&group_id, &message).await?;
+                let msg = self
+                    .cache_chat_message(&account.pubkey, &group_id, &message)
+                    .await?;
                 let group_name = mdk.get_group(&group_id).ok().flatten().map(|g| g.name);
                 Whitenoise::spawn_new_message_notification_if_enabled(
                     account, &group_id, &msg, group_name,
@@ -210,12 +213,15 @@ impl Whitenoise {
                 .await;
             }
             Kind::Reaction => {
-                if let Some(target) = self.cache_reaction(&group_id, &message).await? {
+                if let Some(target) = self
+                    .cache_reaction(&account.pubkey, &group_id, &message)
+                    .await?
+                {
                     self.emit_message_update(&group_id, UpdateTrigger::ReactionAdded, target);
                 }
             }
             Kind::EventDeletion => {
-                self.handle_deletion_application_message(&group_id, &message)
+                self.handle_deletion_application_message(&account.pubkey, &group_id, &message)
                     .await?;
             }
             _ => {
@@ -228,12 +234,16 @@ impl Whitenoise {
 
     async fn handle_deletion_application_message(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<()> {
         let last_message_id = self.get_last_message_id(group_id).await;
 
-        for (trigger, msg) in self.cache_deletion(group_id, message).await? {
+        for (trigger, msg) in self
+            .cache_deletion(account_pubkey, group_id, message)
+            .await?
+        {
             self.emit_message_update(group_id, trigger, msg);
         }
 
@@ -243,7 +253,7 @@ impl Whitenoise {
         // modifies shared state). We emit for ALL subscribed accounts because
         // subsequent handlers will see incorrect post-deletion state.
         if let Some(last_message_id) = last_message_id {
-            let deleted_ids = Self::extract_deletion_target_ids(&message.tags);
+            let deleted_ids = extract_deletion_target_ids(&message.tags);
             if deleted_ids.contains(&last_message_id) {
                 self.emit_chat_list_update_for_group(
                     group_id,
@@ -469,6 +479,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_chat_message(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<ChatMessage> {
@@ -482,14 +493,20 @@ impl Whitenoise {
         // Preserve existing delivery status for relay echoes of locally-sent messages.
         // This keeps stream payloads aligned with the latest DB state instead of
         // regressing to `None` on reprocessing.
-        if let Some(existing_message) =
-            AggregatedMessage::find_by_id(&chat_message.id, group_id, &self.database).await?
+        if let Some(existing_message) = AggregatedMessage::find_by_id(
+            &chat_message.id,
+            group_id,
+            account_pubkey,
+            &self.database,
+        )
+        .await?
             && existing_message.delivery_status.is_some()
         {
             chat_message.delivery_status = existing_message.delivery_status;
         }
 
-        AggregatedMessage::insert_message(&chat_message, group_id, &self.database).await?;
+        AggregatedMessage::insert_message(&chat_message, group_id, account_pubkey, &self.database)
+            .await?;
 
         // Apply orphaned reactions/deletions - modifies in-place and returns final state
         let final_message = self
@@ -514,14 +531,20 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_reaction(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Option<ChatMessage>> {
         // If this reaction already has a delivery status, it was sent by us and already
         // applied to the parent — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(&message.id.to_string(), group_id, &self.database)
-            .await?
+        if AggregatedMessage::has_delivery_status(
+            &message.id.to_string(),
+            group_id,
+            account_pubkey,
+            &self.database,
+        )
+        .await?
         {
             tracing::debug!(
                 target: "whitenoise::cache",
@@ -534,7 +557,9 @@ impl Whitenoise {
 
         AggregatedMessage::insert_reaction(message, group_id, &self.database).await?;
 
-        let result = self.apply_reaction_to_target(message, group_id).await?;
+        let result = self
+            .apply_reaction_to_target(account_pubkey, message, group_id)
+            .await?;
 
         if result.is_none() {
             tracing::debug!(
@@ -560,13 +585,15 @@ impl Whitenoise {
     /// Returns `Err` for real failures (malformed tags, invalid emoji, DB errors).
     async fn apply_reaction_to_target(
         &self,
+        account_pubkey: &PublicKey,
         reaction: &Message,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
-        let target_id = Self::extract_reaction_target_id(&reaction.tags)?;
+        let target_id = extract_reaction_target_id(&reaction.tags)?;
 
         let Some(mut target) =
-            AggregatedMessage::find_by_id(&target_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(&target_id, group_id, account_pubkey, &self.database)
+                .await?
         else {
             return Ok(None); // True orphan: target not yet cached
         };
@@ -602,14 +629,20 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn cache_deletion(
         &self,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
         // If this deletion already has a delivery status, it was sent by us and already
         // applied to targets — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
-        if AggregatedMessage::has_delivery_status(&message.id.to_string(), group_id, &self.database)
-            .await?
+        if AggregatedMessage::has_delivery_status(
+            &message.id.to_string(),
+            group_id,
+            account_pubkey,
+            &self.database,
+        )
+        .await?
         {
             tracing::debug!(
                 target: "whitenoise::cache",
@@ -622,7 +655,9 @@ impl Whitenoise {
 
         AggregatedMessage::insert_deletion(message, group_id, &self.database).await?;
 
-        let updates = self.apply_deletions_to_targets(message, group_id).await?;
+        let updates = self
+            .apply_deletions_to_targets(account_pubkey, message, group_id)
+            .await?;
 
         tracing::debug!(
             target: "whitenoise::cache",
@@ -638,15 +673,16 @@ impl Whitenoise {
     /// Apply deletion to all targets and collect updates to emit.
     async fn apply_deletions_to_targets(
         &self,
+        account_pubkey: &PublicKey,
         deletion: &Message,
         group_id: &GroupId,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
-        let target_ids = Self::extract_deletion_target_ids(&deletion.tags);
+        let target_ids = extract_deletion_target_ids(&deletion.tags);
         let mut updates = Vec::with_capacity(target_ids.len());
 
         for target_id in target_ids {
             if let Some(update) = self
-                .apply_single_deletion(&target_id, &deletion.id, group_id)
+                .apply_single_deletion(account_pubkey, &target_id, &deletion.id, group_id)
                 .await?
             {
                 updates.push(update);
@@ -659,6 +695,7 @@ impl Whitenoise {
     /// Apply deletion to a single target, returning the appropriate update.
     async fn apply_single_deletion(
         &self,
+        account_pubkey: &PublicKey,
         target_id: &str,
         deletion_event_id: &EventId,
         group_id: &GroupId,
@@ -668,7 +705,7 @@ impl Whitenoise {
             AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.database).await?
         {
             let parent_update = self
-                .remove_reaction_from_parent(&reaction, group_id)
+                .remove_reaction_from_parent(account_pubkey, &reaction, group_id)
                 .await?;
             AggregatedMessage::mark_deleted(
                 target_id,
@@ -682,7 +719,8 @@ impl Whitenoise {
 
         // Check if target is a message
         if let Some(mut msg) =
-            AggregatedMessage::find_by_id(target_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(target_id, group_id, account_pubkey, &self.database)
+                .await?
         {
             msg.is_deleted = true;
             AggregatedMessage::mark_deleted(
@@ -709,15 +747,17 @@ impl Whitenoise {
     /// Remove a reaction from its parent message and return the updated parent.
     async fn remove_reaction_from_parent(
         &self,
+        account_pubkey: &PublicKey,
         reaction: &AggregatedMessage,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
-        let Ok(parent_id) = Self::extract_reaction_target_id(&reaction.tags) else {
+        let Ok(parent_id) = extract_reaction_target_id(&reaction.tags) else {
             return Ok(None);
         };
 
         let Some(mut parent) =
-            AggregatedMessage::find_by_id(&parent_id, group_id, &self.database).await?
+            AggregatedMessage::find_by_id(&parent_id, group_id, account_pubkey, &self.database)
+                .await?
         else {
             return Ok(None);
         };
@@ -742,20 +782,6 @@ impl Whitenoise {
         } else {
             Ok(None)
         }
-    }
-
-    pub(crate) fn extract_reaction_target_id(tags: &Tags) -> Result<String> {
-        tags.iter()
-            .find(|tag| tag.kind() == nostr_sdk::TagKind::e())
-            .and_then(|tag| tag.content().map(|s| s.to_string()))
-            .ok_or_else(|| WhitenoiseError::InvalidEvent("Reaction missing e-tag".to_string()))
-    }
-
-    pub(crate) fn extract_deletion_target_ids(tags: &Tags) -> Vec<String> {
-        tags.iter()
-            .filter(|tag| tag.kind() == nostr_sdk::TagKind::e())
-            .filter_map(|tag| tag.content().map(|s| s.to_string()))
-            .collect()
     }
 
     /// Apply any orphaned reactions/deletions to a newly cached message.
@@ -918,10 +944,14 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle regular message");
 
         // Verify message was cached
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            group_id,
+            &creator_account.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_msg.is_some(), "Message should be cached");
 
         // Test 2: Reaction message (Kind 7)
@@ -941,11 +971,15 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle reaction");
 
         // Verify reaction was applied to cached message
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            group_id,
+            &creator_account.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             !cached_msg.reactions.by_emoji.is_empty(),
             "Reaction should be applied"
@@ -968,11 +1002,15 @@ mod tests {
         assert!(result.is_ok(), "Failed to handle deletion");
 
         // Verify message was marked as deleted
-        let cached_msg =
-            AggregatedMessage::find_by_id(&message_id.to_string(), group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let cached_msg = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            group_id,
+            &creator_account.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(cached_msg.is_deleted, "Message should be marked as deleted");
     }
 
@@ -1018,7 +1056,7 @@ mod tests {
 
         // Initial cache pass creates the row without delivery status.
         let first = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&creator_account.pubkey, &group.mls_group_id, &message)
             .await
             .unwrap();
         assert_eq!(first.delivery_status, None);
@@ -1027,6 +1065,7 @@ mod tests {
         AggregatedMessage::update_delivery_status(
             &message_id.to_string(),
             &group.mls_group_id,
+            &creator_account.pubkey,
             &DeliveryStatus::Sent(1),
             &whitenoise.database,
         )
@@ -1035,7 +1074,7 @@ mod tests {
 
         // Relay echo reprocess should preserve the existing status.
         let second = whitenoise
-            .cache_chat_message(&group.mls_group_id, &message)
+            .cache_chat_message(&creator_account.pubkey, &group.mls_group_id, &message)
             .await
             .unwrap();
         assert_eq!(second.delivery_status, Some(DeliveryStatus::Sent(1)));
@@ -1043,6 +1082,7 @@ mod tests {
         let persisted = AggregatedMessage::find_by_id(
             &message_id.to_string(),
             &group.mls_group_id,
+            &creator_account.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1184,6 +1224,7 @@ mod tests {
         let cached_msg = AggregatedMessage::find_by_id(
             &future_message_id.to_string(),
             group_id,
+            &creator_account.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1290,6 +1331,7 @@ mod tests {
         let cached_msg = AggregatedMessage::find_by_id(
             &future_message_id.to_string(),
             group_id,
+            &creator_account.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1364,12 +1406,12 @@ mod tests {
         // Test extract_reaction_target_id
         let mut tags = Tags::new();
         tags.push(Tag::parse(vec!["e", "test_event_id"]).unwrap());
-        let target_id = Whitenoise::extract_reaction_target_id(&tags).unwrap();
+        let target_id = extract_reaction_target_id(&tags).unwrap();
         assert_eq!(target_id, "test_event_id");
 
         // Test extract_reaction_target_id with missing e-tag
         let empty_tags = Tags::new();
-        let result = Whitenoise::extract_reaction_target_id(&empty_tags);
+        let result = extract_reaction_target_id(&empty_tags);
         assert!(result.is_err(), "Should fail with missing e-tag");
 
         // Test extract_deletion_target_ids with multiple targets
@@ -1378,7 +1420,7 @@ mod tests {
         tags.push(Tag::parse(vec!["e", "id2"]).unwrap());
         tags.push(Tag::parse(vec!["p", "some_pubkey"]).unwrap()); // Should be ignored
 
-        let target_ids = Whitenoise::extract_deletion_target_ids(&tags);
+        let target_ids = extract_deletion_target_ids(&tags);
         assert_eq!(target_ids.len(), 2);
         assert!(target_ids.contains(&"id1".to_string()));
         assert!(target_ids.contains(&"id2".to_string()));
@@ -1434,6 +1476,7 @@ mod tests {
         // Verify all messages are in cache
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator_account.pubkey,
             None,
             &whitenoise.database,
         )
@@ -1504,10 +1547,14 @@ mod tests {
             token_tag.encrypted_token.to_base64()
         );
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &member_account.pubkey,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 
@@ -1575,10 +1622,14 @@ mod tests {
             leaf_one.encrypted_token.to_base64()
         );
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &member_account.pubkey,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 
@@ -1628,10 +1679,14 @@ mod tests {
         .unwrap();
         assert!(stored.is_empty());
 
-        let cached_messages =
-            AggregatedMessage::find_messages_by_group(&group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let cached_messages = AggregatedMessage::find_messages_by_group(
+            &group_id,
+            &member_account.pubkey,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
         assert!(cached_messages.is_empty());
     }
 

--- a/src/whitenoise/message_aggregator/mod.rs
+++ b/src/whitenoise/message_aggregator/mod.rs
@@ -5,7 +5,7 @@
 //! regular chat messages, reactions, deletions, and replies.
 
 pub(crate) mod emoji_utils;
-mod processor;
+pub(crate) mod processor;
 pub(crate) mod reaction_handler;
 mod types;
 // mod state;  // Future: For Phase 2 stateful implementation

--- a/src/whitenoise/message_aggregator/processor.rs
+++ b/src/whitenoise/message_aggregator/processor.rs
@@ -253,10 +253,24 @@ fn try_process_deletion(
     any_processed
 }
 
+/// Extract the reaction target event ID from an event's e-tags.
+pub(crate) fn extract_reaction_target_id(
+    tags: &Tags,
+) -> core::result::Result<String, crate::whitenoise::error::WhitenoiseError> {
+    tags.iter()
+        .find(|tag| tag.kind() == TagKind::e())
+        .and_then(|tag| tag.content().map(|s| s.to_string()))
+        .ok_or_else(|| {
+            crate::whitenoise::error::WhitenoiseError::InvalidEvent(
+                "Reaction missing e-tag".to_string(),
+            )
+        })
+}
+
 /// Extract target message IDs from deletion event e-tags
 pub(crate) fn extract_deletion_target_ids(tags: &Tags) -> Vec<String> {
     tags.iter()
-        .filter(|tag| tag.kind() == TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::E)))
+        .filter(|tag| tag.kind() == TagKind::e())
         .filter_map(|tag| tag.content().map(|s| s.to_string()))
         .collect()
 }

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -1,45 +1,22 @@
 pub use crate::whitenoise::database::aggregated_messages::PaginationOptions;
 
 use crate::{
-    perf_instrument, perf_span,
+    perf_instrument,
     types::MessageWithTokens,
     whitenoise::{
         Whitenoise,
         accounts::Account,
-        accounts_groups::AccountGroup,
         aggregated_message::AggregatedMessage,
         chat_list_streaming::ChatListUpdateTrigger,
-        database::{Database, retry_on_lock},
-        error::{Result, WhitenoiseError},
+        error::Result,
         media_files::MediaFile,
-        message_aggregator::{
-            ChatMessage, DeliveryStatus, SearchResult, emoji_utils, reaction_handler,
-        },
-        message_streaming::{MessageStreamManager, MessageUpdate, UpdateTrigger},
-        push_notifications::publish_notification_requests_after_delivery_with,
+        message_aggregator::{ChatMessage, SearchResult},
     },
 };
 use mdk_core::prelude::{message_types::Message, *};
 use nostr_sdk::prelude::*;
 
 impl Whitenoise {
-    /// Sends a message to a specific group and returns the message with parsed tokens.
-    ///
-    /// This method creates and sends a message to a group using the Nostr MLS protocol.
-    /// It handles the complete message lifecycle including event creation, MLS message
-    /// generation, publishing to relays, and token parsing. The message content is
-    /// automatically parsed for tokens (e.g., mentions, hashtags) before returning.
-    ///
-    /// # Arguments
-    ///
-    /// * `sender_pubkey` - The public key of the user sending the message. This is used
-    ///   to identify the sender and fetch their account for message creation.
-    /// * `group_id` - The unique identifier of the target group where the message will be sent.
-    /// * `message` - The content of the message to be sent as a string.
-    /// * `kind` - The Nostr event kind as a u16. This determines the type of event being created
-    ///   (e.g., text note, reaction, etc.).
-    /// * `tags` - Optional vector of Nostr tags to include with the message. If None, an empty
-    ///   tag list will be used.
     #[perf_instrument("messages")]
     pub async fn send_message_to_group(
         &self,
@@ -49,331 +26,39 @@ impl Whitenoise {
         kind: u16,
         tags: Option<Vec<Tag>>,
     ) -> Result<MessageWithTokens> {
-        let _build_span = perf_span!("messages::build_unsigned_event");
-        let (inner_event, event_id) =
-            self.create_unsigned_nostr_event(&account.pubkey, &message, kind, tags)?;
-        drop(_build_span);
-
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-
-        // Guard: fail immediately if no relays configured (before creating MLS message
-        // to avoid persisting a message in MDK storage that can never be delivered)
-        let _relay_check = perf_span!("messages::get_group_relays");
-        let group_relays: Vec<RelayUrl> = mdk.get_relays(group_id)?.into_iter().collect();
-        drop(_relay_check);
-        if group_relays.is_empty() {
-            return Err(WhitenoiseError::GroupMissingRelays);
-        }
-
-        let _mls_span = perf_span!("messages::mls_create_message");
-        let message_event = mdk.create_message(group_id, inner_event, None)?;
-        let mdk_message =
-            mdk.get_message(group_id, &event_id)?
-                .ok_or(WhitenoiseError::MdkCoreError(
-                    mdk_core::error::Error::MessageNotFound,
-                ))?;
-        drop(_mls_span);
-
-        let _parse_span = perf_span!("messages::parse_content_tokens");
-        let tokens = self.content_parser.parse(&mdk_message.content);
-        drop(_parse_span);
-
-        // Proactive caching + delivery tracking for all outgoing event kinds.
-        // Kind 9 (chat): full message processing + NewMessage emission
-        // Kind 7/5 (reaction/deletion): insert event + apply aggregated effect on parent
-        match kind {
-            9 => {
-                self.process_and_emit_outgoing_message(&mdk_message, group_id)
-                    .await?;
-            }
-            7 => {
-                self.cache_and_apply_outgoing_reaction(&mdk_message, group_id)
-                    .await?;
-            }
-            5 => {
-                self.cache_and_apply_outgoing_deletion(&mdk_message, group_id)
-                    .await?;
-            }
-            other => {
-                return Err(WhitenoiseError::Internal(format!(
-                    "Unsupported outgoing event kind: {other}"
-                )));
-            }
-        }
-
-        // Spawn background publish task with retries + delivery tracking for all kinds.
-        // Any successfully delivered outgoing event can fan out best-effort notification
-        // requests; receivers decide what to surface locally.
-        // On failure for kind 7/5, cascade by reversing the optimistic aggregated effect.
-        let ephemeral = self.relay_control.ephemeral();
-        let user_relay_sync = self.user_relay_sync_context();
-        let config = self.config.clone();
-        let event_id_str = event_id.to_string();
-        let account_pubkey = account.pubkey;
-        let database = self.database.clone();
-        let stream_manager = self.message_stream_manager.clone();
-        let group_id_clone = group_id.clone();
-        let tags_clone = mdk_message.tags.clone();
-        let message_author = mdk_message.pubkey;
-        let reaction_content = mdk_message.content.clone();
-
-        tokio::spawn(async move {
-            let publish_result = ephemeral
-                .publish_message_event(
-                    message_event,
-                    &account_pubkey,
-                    &group_relays,
-                    &event_id_str,
-                    &group_id_clone,
-                    &database,
-                    &stream_manager,
-                )
-                .await;
-
-            if publish_result.succeeded()
-                && let Err(error) = publish_notification_requests_after_delivery_with(
-                    &config,
-                    &database,
-                    &user_relay_sync,
-                    &ephemeral,
-                    account_pubkey,
-                    &group_id_clone,
-                )
-                .await
-            {
-                tracing::warn!(
-                    target: "whitenoise::push_notifications",
-                    account = %account_pubkey.to_hex(),
-                    error = %error,
-                    "Failed to publish best-effort notification requests after message delivery"
-                );
-            }
-
-            // On failure, reverse optimistic aggregated effects for reactions/deletions
-            if !publish_result.succeeded() {
-                Whitenoise::cascade_delivery_failure(
-                    kind,
-                    &event_id_str,
-                    &tags_clone,
-                    &message_author,
-                    &reaction_content,
-                    &group_id_clone,
-                    &database,
-                    &stream_manager,
-                )
-                .await;
-            }
-        });
-
-        Ok(MessageWithTokens::new(mdk_message, tokens))
-    }
-
-    /// Process an outgoing chat message for optimistic UI display.
-    ///
-    /// Aggregates the raw MDK message into a `ChatMessage`, sets its delivery
-    /// status to `Sending`, persists it in the cache, and emits a `NewMessage`
-    /// update so the UI shows it immediately.
-    #[perf_instrument("messages")]
-    async fn process_and_emit_outgoing_message(
-        &self,
-        mdk_message: &Message,
-        group_id: &GroupId,
-    ) -> Result<()> {
-        let chat_message = self
-            .message_aggregator
-            .process_single_message(
-                mdk_message,
-                &self.content_parser,
-                MediaFile::find_by_group(&self.database, group_id).await?,
-            )
-            .await
-            .map(|mut msg| {
-                msg.delivery_status = Some(DeliveryStatus::Sending);
-                msg
-            })?;
-
-        AggregatedMessage::insert_message(&chat_message, group_id, &self.database).await?;
-
-        // Emit NewMessage so the UI shows it immediately (optimistic)
-        self.message_stream_manager.emit(
-            group_id,
-            MessageUpdate {
-                trigger: UpdateTrigger::NewMessage,
-                message: chat_message,
-            },
-        );
-
-        Ok(())
-    }
-
-    /// Cache an outgoing reaction (kind 7) and optimistically apply it to the parent.
-    ///
-    /// Inserts the reaction event into `aggregated_messages`, sets delivery status
-    /// to `Sending`, applies the reaction to the target kind-9 message, and emits
-    /// a `ReactionAdded` update so the UI reflects the change immediately.
-    #[perf_instrument("messages")]
-    async fn cache_and_apply_outgoing_reaction(
-        &self,
-        mdk_message: &Message,
-        group_id: &GroupId,
-    ) -> Result<()> {
-        // Insert the reaction event row
-        AggregatedMessage::insert_reaction(mdk_message, group_id, &self.database).await?;
-
-        // Track delivery status for the reaction event (direct insert, not full
-        // update_delivery_status which opens a transaction that can contend with
-        // background publish_with_retries)
-        AggregatedMessage::insert_delivery_status(
-            &mdk_message.id.to_string(),
-            group_id,
-            &DeliveryStatus::Sending,
-            &self.database,
-        )
-        .await?;
-
-        // Apply reaction to the target kind-9 message (if e-tag is present and target cached)
-        if let Ok(target_id) = Self::extract_reaction_target_id(&mdk_message.tags)
-            && let Some(mut target) =
-                AggregatedMessage::find_by_id(&target_id, group_id, &self.database).await?
-        {
-            let emoji = emoji_utils::validate_and_normalize_reaction(
-                &mdk_message.content,
-                self.message_aggregator.config().normalize_emoji,
-            )?;
-
-            reaction_handler::add_reaction_to_message(
-                &mut target,
-                &mdk_message.pubkey,
-                &emoji,
-                mdk_message.created_at,
-                mdk_message.id,
-            );
-
-            AggregatedMessage::update_reactions(
-                &target.id,
-                group_id,
-                &target.reactions,
-                &self.database,
-            )
+        let session = self.require_session(&account.pubkey)?;
+        let result = session
+            .messages()
+            .for_group(group_id)
+            .send(message, kind, tags)
             .await?;
 
-            self.message_stream_manager.emit(
+        if result.last_message_deleted {
+            self.emit_chat_list_update_for_group(
                 group_id,
-                MessageUpdate {
-                    trigger: UpdateTrigger::ReactionAdded,
-                    message: target,
-                },
-            );
+                ChatListUpdateTrigger::LastMessageDeleted,
+            )
+            .await;
         }
 
-        Ok(())
+        Ok(result.message)
     }
 
-    /// Cache an outgoing deletion (kind 5) and optimistically apply it to the parent.
-    ///
-    /// Inserts the deletion event into `aggregated_messages`, sets delivery status
-    /// to `Sending`, marks the target message(s) as deleted, and emits appropriate
-    /// updates so the UI reflects the change immediately.
     #[perf_instrument("messages")]
-    async fn cache_and_apply_outgoing_deletion(
+    pub async fn retry_message_publish(
         &self,
-        mdk_message: &Message,
+        account: &Account,
         group_id: &GroupId,
+        event_id: &EventId,
     ) -> Result<()> {
-        // Insert the deletion event row
-        AggregatedMessage::insert_deletion(mdk_message, group_id, &self.database).await?;
-
-        // Track delivery status for the deletion event (direct insert, not full
-        // update_delivery_status which opens a transaction that can contend with
-        // background publish_with_retries)
-        AggregatedMessage::insert_delivery_status(
-            &mdk_message.id.to_string(),
-            group_id,
-            &DeliveryStatus::Sending,
-            &self.database,
-        )
-        .await?;
-
-        // Capture the last message ID *before* applying deletions so we can
-        // detect if the deletion removed it and emit a chat-list update.
-        let last_message_id = AggregatedMessage::find_last_by_group_ids(
-            std::slice::from_ref(group_id),
-            &self.database,
-        )
-        .await
-        .ok()
-        .and_then(|v| v.into_iter().next())
-        .map(|s| s.message_id.to_hex());
-
-        // Apply deletion to all targets (reactions and/or messages)
-        let deletion_event_id_str = mdk_message.id.to_string();
-        let target_ids = Self::extract_deletion_target_ids(&mdk_message.tags);
-        for target_id in &target_ids {
-            // Check if target is a reaction — must remove from parent's reaction summary
-            if let Some(reaction) =
-                AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.database).await?
-            {
-                // Remove reaction from parent message's summary
-                if let Ok(parent_id) = Self::extract_reaction_target_id(&reaction.tags)
-                    && let Some(mut parent) =
-                        AggregatedMessage::find_by_id(&parent_id, group_id, &self.database).await?
-                    && reaction_handler::remove_reaction_from_message(&mut parent, &reaction.author)
-                {
-                    AggregatedMessage::update_reactions(
-                        &parent_id,
-                        group_id,
-                        &parent.reactions,
-                        &self.database,
-                    )
-                    .await?;
-
-                    self.message_stream_manager.emit(
-                        group_id,
-                        MessageUpdate {
-                            trigger: UpdateTrigger::ReactionRemoved,
-                            message: parent,
-                        },
-                    );
-                }
-
-                AggregatedMessage::mark_deleted(
-                    target_id,
-                    group_id,
-                    &deletion_event_id_str,
-                    &self.database,
-                )
-                .await?;
-                continue;
-            }
-
-            // Target is a message — mark as deleted
-            AggregatedMessage::mark_deleted(
-                target_id,
-                group_id,
-                &deletion_event_id_str,
-                &self.database,
-            )
+        let session = self.require_session(&account.pubkey)?;
+        let result = session
+            .messages()
+            .for_group(group_id)
+            .retry_publish(event_id)
             .await?;
 
-            if let Some(mut msg) =
-                AggregatedMessage::find_by_id(target_id, group_id, &self.database).await?
-            {
-                msg.is_deleted = true;
-                self.message_stream_manager.emit(
-                    group_id,
-                    MessageUpdate {
-                        trigger: UpdateTrigger::MessageDeleted,
-                        message: msg,
-                    },
-                );
-            }
-        }
-
-        // If the deleted target was the last message in the group, emit a
-        // chat-list update so the UI shows the new last message.
-        if let Some(last_id) = last_message_id
-            && target_ids.contains(&last_id)
-        {
+        if result.last_message_deleted {
             self.emit_chat_list_update_for_group(
                 group_id,
                 ChatListUpdateTrigger::LastMessageDeleted,
@@ -384,247 +69,16 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Reverse optimistic aggregated effects when a reaction/deletion fails to publish.
-    ///
-    /// - **Kind 7 (reaction)**: Remove the reaction from the parent message's summary.
-    /// - **Kind 5 (deletion)**: Clear `deletion_event_id` on targets so they reappear.
-    /// - **Kind 9 / other**: No cascade needed — the message already shows Failed status.
-    #[perf_instrument("messages")]
-    async fn cascade_delivery_failure(
-        kind: u16,
-        event_id: &str,
-        tags: &Tags,
-        author: &PublicKey,
-        content: &str,
-        group_id: &GroupId,
-        database: &Database,
-        stream_manager: &MessageStreamManager,
-    ) {
-        match kind {
-            7 => {
-                // Reaction failed: remove from parent message's reaction summary
-                let target_id = match Self::extract_reaction_target_id(tags) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "whitenoise::messages::delivery",
-                            "Failed to extract reaction target for cascade: {e}",
-                        );
-                        return;
-                    }
-                };
-
-                let result = retry_on_lock(|| async {
-                    let Some(mut parent) =
-                        AggregatedMessage::find_by_id(&target_id, group_id, database).await?
-                    else {
-                        return Ok(None);
-                    };
-
-                    if !reaction_handler::remove_reaction_from_message(&mut parent, author) {
-                        return Ok(None);
-                    }
-
-                    AggregatedMessage::update_reactions(
-                        &target_id,
-                        group_id,
-                        &parent.reactions,
-                        database,
-                    )
-                    .await?;
-
-                    Ok(Some(parent))
-                })
-                .await;
-
-                match result {
-                    Ok(Some(parent)) => {
-                        stream_manager.emit(
-                            group_id,
-                            MessageUpdate {
-                                trigger: UpdateTrigger::ReactionRemoved,
-                                message: parent,
-                            },
-                        );
-                        tracing::info!(
-                            target: "whitenoise::messages::delivery",
-                            "Cascaded reaction failure: removed reaction \
-                             '{content}' from message {target_id}",
-                        );
-                    }
-                    Ok(None) => {}
-                    Err(e) => {
-                        tracing::error!(
-                            target: "whitenoise::messages::delivery",
-                            "Failed to cascade reaction failure after \
-                             retries: {e}",
-                        );
-                    }
-                }
-            }
-            5 => {
-                // Deletion failed: unmark targets so they reappear
-                let result = retry_on_lock(|| async {
-                    AggregatedMessage::unmark_deleted(event_id, group_id, database).await
-                })
-                .await;
-
-                if let Err(e) = result {
-                    tracing::error!(
-                        target: "whitenoise::messages::delivery",
-                        "Failed to cascade deletion failure after \
-                         retries: {e}",
-                    );
-                    return;
-                }
-
-                // Re-emit affected target messages so the UI reflects
-                // them as not deleted
-                let target_ids = Self::extract_deletion_target_ids(tags);
-                for target_id in target_ids {
-                    if let Ok(Some(msg)) =
-                        AggregatedMessage::find_by_id(&target_id, group_id, database).await
-                    {
-                        stream_manager.emit(
-                            group_id,
-                            MessageUpdate {
-                                trigger: UpdateTrigger::DeliveryStatusChanged,
-                                message: msg,
-                            },
-                        );
-                    }
-                }
-
-                tracing::info!(
-                    target: "whitenoise::messages::delivery",
-                    "Cascaded deletion failure: unmarked targets \
-                     of deletion {event_id}",
-                );
-            }
-            _ => {} // Kind 9 and others: no cascade needed
-        }
-    }
-
-    /// Retry publishing a failed message.
-    ///
-    /// Creates a brand new message with the same content, tags, and kind as the
-    /// original failed message but with a new event ID and `Timestamp::now()`.
-    /// The original message is marked as `Retried` so it's excluded from future
-    /// UI snapshots. The new message follows the normal `NewMessage` flow.
-    ///
-    /// Also emits `DeliveryStatusChanged` for the original message when it moves
-    /// to `Retried`, so subscribers can update immediately without a reload.
-    #[perf_instrument("messages")]
-    pub async fn retry_message_publish(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-        event_id: &EventId,
-    ) -> Result<()> {
-        // Guard: only retry messages that are in Failed state to prevent duplicate publishes
-        let event_id_str = event_id.to_string();
-        let original = match AggregatedMessage::find_by_id(&event_id_str, group_id, &self.database)
-            .await?
-        {
-            Some(cached) if matches!(cached.delivery_status, Some(DeliveryStatus::Failed(_))) => {
-                cached
-            }
-            Some(cached) => {
-                return Err(WhitenoiseError::Internal(format!(
-                    "Can only retry messages with Failed delivery status, got {:?}",
-                    cached.delivery_status
-                )));
-            }
-            None => {
-                return Err(WhitenoiseError::MessageNotFound);
-            }
-        };
-
-        // Create the new message FIRST — if this fails, the original stays visible as Failed
-        // rather than being hidden with no replacement.
-        let tags = original.tags.to_vec();
-        self.send_message_to_group(
-            account,
-            group_id,
-            original.content,
-            original.kind,
-            Some(tags),
-        )
-        .await?;
-
-        // Mark the original message as Retried so it's excluded from future snapshots.
-        // This is best-effort: if it fails, the user sees a duplicate (original Failed +
-        // new Sending) which is harmless and self-corrects on next app restart.
-        match AggregatedMessage::update_delivery_status_with_retry(
-            &event_id_str,
-            group_id,
-            &DeliveryStatus::Retried,
-            &self.database,
-        )
-        .await
-        {
-            Ok(updated_original) => {
-                self.message_stream_manager.emit(
-                    group_id,
-                    MessageUpdate {
-                        trigger: UpdateTrigger::DeliveryStatusChanged,
-                        message: updated_original,
-                    },
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::messages::delivery",
-                    "Failed to mark original message {} as Retried: {e}",
-                    event_id_str,
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Fetches all messages for a specific group with parsed tokens.
-    ///
-    /// This method retrieves all messages that have been sent to a particular group,
-    /// parsing the content of each message to extract tokens (e.g., mentions, hashtags).
-    /// The messages are returned with both the original message data and the parsed tokens.
-    ///
-    /// # Arguments
-    ///
-    /// * `pubkey` - The public key of the user requesting the messages. This is used to
-    ///   fetch the appropriate account and verify access permissions.
-    /// * `group_id` - The unique identifier of the group whose messages should be retrieved.
     #[perf_instrument("messages")]
     pub async fn fetch_messages_for_group(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Vec<MessageWithTokens>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let messages = mdk.get_messages(group_id, None)?;
-        let messages_with_tokens = messages
-            .iter()
-            .map(|message| MessageWithTokens {
-                message: message.clone(),
-                tokens: self.content_parser.parse(&message.content),
-            })
-            .collect::<Vec<MessageWithTokens>>();
-        Ok(messages_with_tokens)
+        let session = self.require_session(&account.pubkey)?;
+        session.messages().for_group(group_id).fetch().await
     }
 
-    /// Fetch and aggregate messages for a group - Main consumer API
-    ///
-    /// Returns pre-aggregated messages from the cache in oldest-first order. The cache is
-    /// kept up-to-date by:
-    /// - Event processor: Caches messages as they arrive (real-time updates)
-    /// - Startup sync: Populates cache with existing messages on initialization
-    ///
-    /// # Arguments
-    /// * `pubkey`   - The public key of the user requesting messages
-    /// * `group_id` - The group to fetch messages for
-    /// * `options`  - Pagination cursor and direction (see [`PaginationOptions`]).
-    /// * `limit`    - Maximum number of messages to return. Defaults to 50, capped at 200.
     #[perf_instrument("messages")]
     pub async fn fetch_aggregated_messages_for_group(
         &self,
@@ -633,44 +87,14 @@ impl Whitenoise {
         options: &PaginationOptions,
         limit: Option<u32>,
     ) -> Result<Vec<ChatMessage>> {
-        Account::find_by_pubkey(pubkey, &self.database).await?; // Verify account exists (security check)
-
-        let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
-
-        AggregatedMessage::find_messages_by_group_paginated(
-            group_id,
-            &self.database,
-            options,
-            limit,
-            cleared_at_ms,
-        )
-        .await
-        .map_err(|e| match e {
-            crate::whitenoise::database::DatabaseError::InvalidCursor { reason } => {
-                WhitenoiseError::InvalidCursor { reason }
-            }
-            other => {
-                WhitenoiseError::Internal(format!("Failed to read cached messages: {}", other))
-            }
-        })
+        let session = self.require_session(pubkey)?;
+        session
+            .messages()
+            .for_group(group_id)
+            .fetch_aggregated(options, limit)
+            .await
     }
 
-    /// Fetch the newest messages for a group, ensuring all unread messages are included
-    /// and at least `minimum` messages are returned.
-    ///
-    /// The effective fetch size is `max(unread_count, minimum)`, so the caller always
-    /// receives a full page even when there are no unread messages, and always receives
-    /// every unread message when there are more unreads than the minimum.
-    ///
-    /// Messages are returned in oldest-first order, ready for display in a chat view.
-    ///
-    /// # Arguments
-    /// * `pubkey`   - The public key of the requesting user (security check; must be a
-    ///                registered account).
-    /// * `group_id` - The MLS group to fetch messages for.
-    /// * `minimum`  - Floor on the number of messages to return. `None` defaults to 50.
-    ///                Values above 200 are clamped to 200.
     #[perf_instrument("messages")]
     pub async fn fetch_messages_unread_with_minimum(
         &self,
@@ -678,33 +102,14 @@ impl Whitenoise {
         group_id: &GroupId,
         minimum: Option<u32>,
     ) -> Result<Vec<ChatMessage>> {
-        let account = Account::find_by_pubkey(pubkey, &self.database).await?;
-
-        let read_marker = self.get_last_read_message_id(&account, group_id).await?;
-
-        let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
-
-        let minimum_val = minimum.unwrap_or(50);
-
-        Ok(AggregatedMessage::find_messages_with_unread_minimum(
-            group_id,
-            read_marker.as_ref(),
-            minimum_val,
-            &self.database,
-            cleared_at_ms,
-        )
-        .await?)
+        let session = self.require_session(pubkey)?;
+        session
+            .messages()
+            .for_group(group_id)
+            .fetch_unread_with_minimum(minimum)
+            .await
     }
 
-    /// Fetch a single aggregated message by its event ID.
-    ///
-    /// Returns `None` if the message does not exist in the cache or belongs to a different group.
-    ///
-    /// # Arguments
-    /// * `pubkey`   - The public key of the requesting user (security check)
-    /// * `group_id` - The group the message belongs to
-    /// * `message_id` - Hex-encoded event ID of the message
     #[perf_instrument("messages")]
     pub async fn fetch_message_by_id(
         &self,
@@ -712,17 +117,14 @@ impl Whitenoise {
         group_id: &GroupId,
         message_id: &str,
     ) -> Result<Option<ChatMessage>> {
-        Account::find_by_pubkey(pubkey, &self.database).await?;
-
-        Ok(AggregatedMessage::find_by_id(message_id, group_id, &self.database).await?)
+        let session = self.require_session(pubkey)?;
+        session
+            .messages()
+            .for_group(group_id)
+            .fetch_by_id(message_id)
+            .await
     }
 
-    /// Search messages within a group by content.
-    ///
-    /// Uses forward-order substring matching: query tokens must appear in
-    /// the message content in the same order as typed. Each result includes
-    /// `highlight_spans` — char-index `[start, end]` pairs for each token in
-    /// the order they appear in the message content, for frontend highlighting.
     pub async fn search_messages_in_group(
         &self,
         pubkey: &PublicKey,
@@ -730,57 +132,22 @@ impl Whitenoise {
         query: &str,
         limit: Option<u32>,
     ) -> Result<Vec<SearchResult>> {
-        Account::find_by_pubkey(pubkey, &self.database).await?;
-
-        let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(pubkey, group_id, &self.database).await?;
-
-        let limit_val = limit.unwrap_or(50);
-        Ok(AggregatedMessage::search_messages_in_group(
-            group_id,
-            query,
-            limit_val,
-            &self.database,
-            cleared_at_ms,
-        )
-        .await?)
+        let session = self.require_session(pubkey)?;
+        session
+            .messages()
+            .for_group(group_id)
+            .search(query, limit)
+            .await
     }
 
-    /// Search messages across all groups the account belongs to.
-    ///
-    /// Like [`search_messages_in_group`](Self::search_messages_in_group) but without
-    /// a group filter. Each result includes `mls_group_id` so callers can group
-    /// results by conversation.
     pub async fn search_messages(
         &self,
         pubkey: &PublicKey,
         query: &str,
         limit: Option<u32>,
     ) -> Result<Vec<SearchResult>> {
-        Account::find_by_pubkey(pubkey, &self.database).await?;
-
-        let limit_val = limit.unwrap_or(50);
-        Ok(AggregatedMessage::search_messages(pubkey, query, limit_val, &self.database).await?)
-    }
-
-    /// Creates an unsigned nostr event with the given parameters
-    fn create_unsigned_nostr_event(
-        &self,
-        pubkey: &PublicKey,
-        message: &String,
-        kind: u16,
-        tags: Option<Vec<Tag>>,
-    ) -> Result<(UnsignedEvent, EventId)> {
-        let final_tags = tags.unwrap_or_default();
-
-        let mut inner_event =
-            UnsignedEvent::new(*pubkey, Timestamp::now(), kind.into(), final_tags, message);
-
-        inner_event.ensure_id();
-
-        let event_id = inner_event.id.unwrap(); // This is guaranteed to be Some by ensure_id
-
-        Ok((inner_event, event_id))
+        let session = self.require_session(pubkey)?;
+        session.messages().search(query, limit).await
     }
 
     /// Synchronize message cache with MDK on startup
@@ -936,6 +303,10 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use crate::whitenoise::error::WhitenoiseError;
+    use crate::whitenoise::message_aggregator::DeliveryStatus;
+    use crate::whitenoise::message_streaming::{MessageStreamManager, UpdateTrigger};
+    use crate::whitenoise::session::messages::cascade_delivery_failure;
     use crate::whitenoise::test_utils::*;
 
     /// Test successful message sending with various scenarios:
@@ -1118,12 +489,13 @@ mod tests {
     /// Test helper method: create_unsigned_nostr_event
     #[tokio::test]
     async fn test_create_unsigned_nostr_event() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let test_keys = create_test_keys();
         let pubkey = test_keys.public_key();
 
+        use crate::whitenoise::session::messages::create_unsigned_nostr_event;
+
         // Test without tags
-        let result = whitenoise.create_unsigned_nostr_event(&pubkey, &"Test".to_string(), 1, None);
+        let result = create_unsigned_nostr_event(&pubkey, "Test", 1, None);
         assert!(result.is_ok());
         let (event, event_id) = result.unwrap();
         assert_eq!(event.pubkey, pubkey);
@@ -1133,7 +505,7 @@ mod tests {
 
         // Test with tags
         let tags = Some(vec![Tag::parse(vec!["e", "test_id"]).unwrap()]);
-        let result = whitenoise.create_unsigned_nostr_event(&pubkey, &"Test".to_string(), 1, tags);
+        let result = create_unsigned_nostr_event(&pubkey, "Test", 1, tags);
         assert!(result.is_ok());
         let (event, _) = result.unwrap();
         assert_eq!(event.tags.len(), 1);
@@ -1296,6 +668,7 @@ mod tests {
         // Verify we can fetch the messages from cache
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -1367,6 +740,7 @@ mod tests {
         // Verify all messages are retrievable
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -1432,6 +806,7 @@ mod tests {
         // Verify messages are correct
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -1664,6 +1039,7 @@ mod tests {
         let parent = AggregatedMessage::find_by_id(
             &chat_result.message.id.to_string(),
             &group.mls_group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1710,6 +1086,7 @@ mod tests {
         let msg = AggregatedMessage::find_by_id(
             &event_id.to_string(),
             &group.mls_group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1810,6 +1187,7 @@ mod tests {
         AggregatedMessage::update_delivery_status(
             &original_event_id.to_string(),
             &group.mls_group_id,
+            &creator.pubkey,
             &DeliveryStatus::Failed("simulated failure".to_string()),
             &whitenoise.database,
         )
@@ -1820,6 +1198,7 @@ mod tests {
         let msg = AggregatedMessage::find_by_id(
             &original_event_id.to_string(),
             &group.mls_group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1851,6 +1230,7 @@ mod tests {
         let original_msg = AggregatedMessage::find_by_id(
             &original_event_id.to_string(),
             &group.mls_group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await
@@ -1867,6 +1247,7 @@ mod tests {
         // The background publish may complete before we read, so accept Sending OR Sent.
         let all_messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -1939,11 +1320,15 @@ mod tests {
         let event_id = result.message.id.to_string();
 
         // Verify initial status is Sending
-        let msg =
-            AggregatedMessage::find_by_id(&event_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &event_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(msg.delivery_status, Some(DeliveryStatus::Sending));
 
         // Build a test event for bounded relay-control publish
@@ -1984,11 +1369,15 @@ mod tests {
             .await;
 
         // Verify status transitioned to Failed
-        let msg =
-            AggregatedMessage::find_by_id(&event_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &event_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             matches!(msg.delivery_status, Some(DeliveryStatus::Failed(_))),
             "Expected Failed status after exhausting retries, got {:?}",
@@ -2126,6 +1515,7 @@ mod tests {
         // Verify messages were recovered
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -2223,6 +1613,7 @@ mod tests {
         // Verify all messages were recovered
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -2293,16 +1684,21 @@ mod tests {
         );
 
         // find_by_id should return the message but with is_deleted=true
-        let target =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let target = AggregatedMessage::find_by_id(
+            &target_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(target.is_deleted, "Message should be marked as deleted");
 
         // Also verify via find_messages_by_group — message should have is_deleted flag
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -2319,6 +1715,7 @@ mod tests {
         let has_status = AggregatedMessage::has_delivery_status(
             &del_event_id,
             &group.mls_group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await
@@ -2371,11 +1768,15 @@ mod tests {
             .unwrap();
 
         // Verify reaction was applied to parent
-        let parent =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let parent = AggregatedMessage::find_by_id(
+            &target_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             !parent.reactions.by_emoji.is_empty(),
             "Parent should have reaction applied"
@@ -2386,7 +1787,7 @@ mod tests {
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &target_id]).unwrap()]);
         let stream_manager = MessageStreamManager::new();
 
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             7,
             &reaction_event_id,
             &tags,
@@ -2399,11 +1800,15 @@ mod tests {
         .await;
 
         // Parent should no longer have the reaction
-        let parent =
-            AggregatedMessage::find_by_id(&target_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let parent = AggregatedMessage::find_by_id(
+            &target_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             parent.reactions.by_emoji.is_empty(),
             "Reaction should be removed after cascade failure"
@@ -2458,6 +1863,7 @@ mod tests {
         // Verify message is marked as deleted
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -2471,7 +1877,7 @@ mod tests {
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &target_id]).unwrap()]);
         let stream_manager = MessageStreamManager::new();
 
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             5,
             &del_event_id,
             &tags,
@@ -2486,6 +1892,7 @@ mod tests {
         // Message should no longer be deleted after cascade
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
+            &creator.pubkey,
             None,
             &whitenoise.database,
         )
@@ -2507,7 +1914,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         // Should not panic or error — just a no-op
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             9,
             "some_event_id",
             &Tags::from_list(vec![]),
@@ -2568,7 +1975,7 @@ mod tests {
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &nonexistent_target]).unwrap()]);
 
         // Should return cleanly without panic — parent not found is handled
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             7,
             "some_reaction_id",
             &tags,
@@ -2591,7 +1998,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         // Empty tags — no e-tag to extract
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             7,
             "some_reaction_id",
             &Tags::new(),
@@ -2664,11 +2071,15 @@ mod tests {
         assert!(del_result.is_ok(), "Deletion should succeed");
 
         // The second message should be marked deleted
-        let msg =
-            AggregatedMessage::find_by_id(&last_id, &group.mls_group_id, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let msg = AggregatedMessage::find_by_id(
+            &last_id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(msg.is_deleted, "Last message should be marked deleted");
     }
 
@@ -2685,7 +2096,7 @@ mod tests {
         // Close the pool to force DB errors on find_by_id
         whitenoise.database.pool.close().await;
 
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             7,
             "reaction_event_id",
             &tags,
@@ -2712,7 +2123,7 @@ mod tests {
         // Close the pool to force DB errors on unmark_deleted
         whitenoise.database.pool.close().await;
 
-        Whitenoise::cascade_delivery_failure(
+        cascade_delivery_failure(
             5,
             "deletion_event_id",
             &tags,

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -1905,6 +1905,118 @@ mod tests {
         );
     }
 
+    /// Regression: deleting a reaction then failing to publish must restore
+    /// the reaction on the parent message's summary.
+    #[tokio::test]
+    async fn test_cascade_deletion_failure_restores_reaction_on_parent() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_pubkey = members[0].0.pubkey;
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let config = create_nostr_group_config_data(vec![creator.pubkey]);
+        let group = whitenoise
+            .create_group(&creator, vec![member_pubkey], config, None)
+            .await
+            .unwrap();
+
+        // Send a chat message (the parent)
+        let chat_result = whitenoise
+            .send_message_to_group(
+                &creator,
+                &group.mls_group_id,
+                "React to me".to_string(),
+                9,
+                None,
+            )
+            .await
+            .unwrap();
+        let parent_id = chat_result.message.id.to_hex();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Send a reaction targeting the parent
+        let reaction_tags = Some(vec![Tag::parse(vec!["e", &parent_id]).unwrap()]);
+        let reaction_result = whitenoise
+            .send_message_to_group(
+                &creator,
+                &group.mls_group_id,
+                "\u{1f44d}".to_string(), // thumbs up
+                7,
+                reaction_tags,
+            )
+            .await
+            .unwrap();
+        let reaction_id = reaction_result.message.id.to_hex();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Verify parent has the reaction
+        let parent = whitenoise
+            .fetch_message_by_id(&creator.pubkey, &group.mls_group_id, &parent_id)
+            .await
+            .unwrap()
+            .expect("parent should exist");
+        assert!(
+            !parent.reactions.by_emoji.is_empty(),
+            "parent should have a reaction before deletion"
+        );
+
+        // Send a kind-5 deletion targeting the reaction
+        let deletion_tags = Some(vec![Tag::parse(vec!["e", &reaction_id]).unwrap()]);
+        let del_result = whitenoise
+            .send_message_to_group(
+                &creator,
+                &group.mls_group_id,
+                String::new(),
+                5,
+                deletion_tags,
+            )
+            .await
+            .unwrap();
+
+        // Verify parent's reaction was removed by the optimistic deletion
+        let parent_after_delete = whitenoise
+            .fetch_message_by_id(&creator.pubkey, &group.mls_group_id, &parent_id)
+            .await
+            .unwrap()
+            .expect("parent should exist");
+        assert!(
+            parent_after_delete.reactions.by_emoji.is_empty(),
+            "parent should have no reactions after deletion"
+        );
+
+        // Cascade the deletion failure — should restore the reaction
+        let del_event_id = del_result.message.id.to_string();
+        let tags = Tags::from_list(vec![Tag::parse(vec!["e", &reaction_id]).unwrap()]);
+        let stream_manager = MessageStreamManager::new();
+
+        cascade_delivery_failure(
+            5,
+            &del_event_id,
+            &tags,
+            &creator.pubkey,
+            "",
+            &group.mls_group_id,
+            &whitenoise.database,
+            &stream_manager,
+        )
+        .await;
+
+        // Parent should have the reaction back
+        let parent_after_cascade = whitenoise
+            .fetch_message_by_id(&creator.pubkey, &group.mls_group_id, &parent_id)
+            .await
+            .unwrap()
+            .expect("parent should exist");
+        assert!(
+            !parent_after_cascade.reactions.by_emoji.is_empty(),
+            "parent should have reaction restored after cascade failure"
+        );
+    }
+
     /// Test cascade_delivery_failure is a no-op for kind 9.
     #[tokio::test]
     async fn test_cascade_kind9_is_noop() {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1612,6 +1612,7 @@ mod tests {
             aggregated_message::AggregatedMessage::insert_message(
                 &msg1,
                 &group_id,
+                &test_pubkey,
                 &whitenoise.database,
             )
             .await
@@ -1619,6 +1620,7 @@ mod tests {
             aggregated_message::AggregatedMessage::insert_message(
                 &msg2,
                 &group_id,
+                &test_pubkey,
                 &whitenoise.database,
             )
             .await
@@ -1726,6 +1728,7 @@ mod tests {
             aggregated_message::AggregatedMessage::insert_message(
                 &msg,
                 group_id,
+                &author,
                 &whitenoise.database,
             )
             .await
@@ -3274,6 +3277,7 @@ mod tests {
                 aggregated_message::AggregatedMessage::insert_message(
                     &msg,
                     &group.mls_group_id,
+                    &creator.pubkey,
                     &whitenoise.database,
                 )
                 .await

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1524,6 +1524,7 @@ mod tests {
 
     async fn wait_for_message_sent_status(
         whitenoise: &Whitenoise,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
         message_id: &EventId,
     ) {
@@ -1532,6 +1533,7 @@ mod tests {
                 let message = AggregatedMessage::find_by_id(
                     &message_id.to_string(),
                     group_id,
+                    account_pubkey,
                     &whitenoise.database,
                 )
                 .await
@@ -2066,7 +2068,13 @@ mod tests {
             )
             .await
             .unwrap();
-        wait_for_message_sent_status(&whitenoise, &group_id, &chat_result.message.id).await;
+        wait_for_message_sent_status(
+            &whitenoise,
+            &admin_account.pubkey,
+            &group_id,
+            &chat_result.message.id,
+        )
+        .await;
 
         let admin_mdk = whitenoise
             .create_mdk_for_account(admin_account.pubkey)
@@ -2227,7 +2235,13 @@ mod tests {
             .await
             .unwrap();
 
-        wait_for_message_sent_status(&whitenoise, &group_id, &send_result.message.id).await;
+        wait_for_message_sent_status(
+            &whitenoise,
+            &creator.pubkey,
+            &group_id,
+            &send_result.message.id,
+        )
+        .await;
 
         let creator_mdk = whitenoise.create_mdk_for_account(creator.pubkey).unwrap();
         let active_leaf_map = creator_mdk.group_leaf_map(&group_id).unwrap();
@@ -2267,6 +2281,7 @@ mod tests {
         let cached_message = AggregatedMessage::find_by_id(
             &send_result.message.id.to_string(),
             &group_id,
+            &creator.pubkey,
             &whitenoise.database,
         )
         .await

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -265,6 +265,9 @@ impl<'a> MessageOpsForGroup<'a> {
 
     // ── Private helpers ────────────────────────────────────────────
 
+    // TODO(durable-task-runtime): Move spawn to caller. Views should not call
+    // tokio::spawn internally per the session-projection architecture rules.
+    // Blocked on the durable task runtime that replaces fire-and-forget publishing.
     fn spawn_publish_task(
         &self,
         message_event: Event,
@@ -283,9 +286,17 @@ impl<'a> MessageOpsForGroup<'a> {
         let author = mdk_message.pubkey;
         let content = mdk_message.content.clone();
 
+        // TODO: Push config and relay sync context should live on AccountSession
+        // instead of reaching back to the singleton. Tracked for Phase 16b.
         let (push_config, push_relay_sync) = match crate::whitenoise::Whitenoise::get_instance() {
             Ok(wn) => (Some(wn.config.clone()), Some(wn.user_relay_sync_context())),
-            Err(_) => (None, None),
+            Err(_) => {
+                tracing::debug!(
+                    target: "whitenoise::messages",
+                    "Whitenoise singleton unavailable, push notifications skipped"
+                );
+                (None, None)
+            }
         };
 
         tokio::spawn(async move {

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -175,8 +175,36 @@ impl<'a> MessageOpsForGroup<'a> {
         kind: u16,
         tags: Option<Vec<Tag>>,
     ) -> Result<SendResult> {
+        let tags_vec = tags.unwrap_or_default();
+
+        // Validate kind + tag invariants before any MDK/DB writes.
+        // Reactions require an e-tag (target message), deletions require at
+        // least one e-tag (target messages/reactions).
+        match kind {
+            9 => {}
+            7 => {
+                if !tags_vec.iter().any(|t| t.kind() == TagKind::e()) {
+                    return Err(WhitenoiseError::Internal(
+                        "Reaction event missing e-tag".to_string(),
+                    ));
+                }
+            }
+            5 => {
+                if !tags_vec.iter().any(|t| t.kind() == TagKind::e()) {
+                    return Err(WhitenoiseError::Internal(
+                        "Deletion event requires at least one e-tag".to_string(),
+                    ));
+                }
+            }
+            other => {
+                return Err(WhitenoiseError::Internal(format!(
+                    "Unsupported outgoing event kind: {other}"
+                )));
+            }
+        }
+
         let (inner_event, event_id) =
-            create_unsigned_nostr_event(self.pubkey(), &message, kind, tags)?;
+            create_unsigned_nostr_event(self.pubkey(), &message, kind, Some(tags_vec))?;
 
         let mdk = &self.session.mdk;
 
@@ -201,11 +229,7 @@ impl<'a> MessageOpsForGroup<'a> {
             5 => {
                 last_message_deleted = self.cache_and_apply_outgoing_deletion(&mdk_message).await?
             }
-            other => {
-                return Err(WhitenoiseError::Internal(format!(
-                    "Unsupported outgoing event kind: {other}"
-                )));
-            }
+            _ => unreachable!("validated above"),
         }
 
         self.spawn_publish_task(message_event, group_relays, event_id, kind, &mdk_message);
@@ -622,7 +646,50 @@ async fn cascade_deletion_failure(
         return;
     }
 
+    // Restore each target. For reactions, re-add them to the parent's summary
+    // (the optimistic delete path removed them). For messages, just re-emit.
     for target_id in extract_deletion_target_ids(tags) {
+        // Check if the restored target is a reaction — if so, re-attach to parent
+        if let Ok(Some(reaction)) =
+            AggregatedMessage::find_reaction_by_id(&target_id, group_id, database).await
+        {
+            if let Ok(parent_id) = extract_reaction_target_id(&reaction.tags)
+                && let Ok(Some(mut parent)) =
+                    AggregatedMessage::find_by_id(&parent_id, group_id, author, database).await
+            {
+                reaction_handler::add_reaction_to_message(
+                    &mut parent,
+                    &reaction.author,
+                    &reaction.content,
+                    Timestamp::from(reaction.created_at.timestamp() as u64),
+                    reaction.event_id,
+                );
+                if let Err(e) = AggregatedMessage::update_reactions(
+                    &parent_id,
+                    group_id,
+                    &parent.reactions,
+                    database,
+                )
+                .await
+                {
+                    tracing::error!(
+                        target: "whitenoise::messages::delivery",
+                        "Failed to restore reaction on parent {parent_id}: {e}",
+                    );
+                } else {
+                    stream_manager.emit(
+                        group_id,
+                        MessageUpdate {
+                            trigger: UpdateTrigger::ReactionAdded,
+                            message: parent,
+                        },
+                    );
+                }
+            }
+            continue;
+        }
+
+        // Regular message target — just re-emit so UI reflects it as not deleted
         if let Ok(Some(msg)) =
             AggregatedMessage::find_by_id(&target_id, group_id, author, database).await
         {

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -1,0 +1,632 @@
+use std::sync::Arc;
+
+use mdk_core::prelude::*;
+use nostr_sdk::prelude::*;
+
+use crate::nostr_manager::parser::ContentParser;
+use crate::types::MessageWithTokens;
+use crate::whitenoise::accounts_groups::AccountGroup;
+use crate::whitenoise::aggregated_message::AggregatedMessage;
+use crate::whitenoise::database::aggregated_messages::PaginationOptions;
+use crate::whitenoise::database::{Database, retry_on_lock};
+use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::message_aggregator::processor::{
+    extract_deletion_target_ids, extract_reaction_target_id,
+};
+use crate::whitenoise::message_aggregator::{
+    ChatMessage, DeliveryStatus, MessageAggregator, SearchResult, emoji_utils, reaction_handler,
+};
+use crate::whitenoise::message_streaming::{MessageStreamManager, MessageUpdate, UpdateTrigger};
+use crate::whitenoise::push_notifications::publish_notification_requests_after_delivery_with;
+use crate::whitenoise::session::AccountSession;
+
+/// Account-scoped message view. Constructed via [`AccountSession::messages()`].
+pub struct MessageOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> MessageOps<'a> {
+    pub(crate) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Narrow to a specific group.
+    pub fn for_group(&self, group_id: &'a GroupId) -> MessageOpsForGroup<'a> {
+        MessageOpsForGroup {
+            session: self.session,
+            group_id,
+        }
+    }
+
+    /// Search messages across all groups.
+    pub async fn search(&self, query: &str, limit: Option<u32>) -> Result<Vec<SearchResult>> {
+        let limit_val = limit.unwrap_or(50);
+        Ok(AggregatedMessage::search_messages(self.pubkey(), query, limit_val, self.db()).await?)
+    }
+
+    fn pubkey(&self) -> &PublicKey {
+        &self.session.account_pubkey
+    }
+
+    fn db(&self) -> &Arc<Database> {
+        &self.session.database
+    }
+}
+
+/// Group-scoped message view. Both account and group identity are baked in.
+pub struct MessageOpsForGroup<'a> {
+    session: &'a AccountSession,
+    group_id: &'a GroupId,
+}
+
+impl<'a> MessageOpsForGroup<'a> {
+    fn pubkey(&self) -> &PublicKey {
+        &self.session.account_pubkey
+    }
+
+    fn db(&self) -> &Arc<Database> {
+        &self.session.database
+    }
+
+    fn emit(&self, trigger: UpdateTrigger, message: ChatMessage) {
+        self.session
+            .message_stream_manager
+            .emit(self.group_id, MessageUpdate { trigger, message });
+    }
+
+    // ── Read operations ────────────────────────────────────────────
+
+    /// Fetch raw MLS messages from MDK storage with parsed content tokens.
+    pub async fn fetch(&self) -> Result<Vec<MessageWithTokens>> {
+        let parser = ContentParser::new();
+        let messages = self.session.mdk.get_messages(self.group_id, None)?;
+        Ok(messages
+            .iter()
+            .map(|m| MessageWithTokens {
+                message: m.clone(),
+                tokens: parser.parse(&m.content),
+            })
+            .collect())
+    }
+
+    /// Fetch aggregated messages with cursor-based pagination (oldest-first).
+    pub async fn fetch_aggregated(
+        &self,
+        options: &PaginationOptions,
+        limit: Option<u32>,
+    ) -> Result<Vec<ChatMessage>> {
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.db()).await?;
+
+        AggregatedMessage::find_messages_by_group_paginated(
+            self.group_id,
+            self.pubkey(),
+            self.db(),
+            options,
+            limit,
+            cleared_at_ms,
+        )
+        .await
+        .map_err(|e| match e {
+            crate::whitenoise::database::DatabaseError::InvalidCursor { reason } => {
+                WhitenoiseError::InvalidCursor { reason }
+            }
+            other => {
+                WhitenoiseError::Internal(format!("Failed to read cached messages: {}", other))
+            }
+        })
+    }
+
+    /// Fetch newest messages ensuring all unreads are included, with a minimum floor.
+    pub async fn fetch_unread_with_minimum(
+        &self,
+        minimum: Option<u32>,
+    ) -> Result<Vec<ChatMessage>> {
+        let account_group =
+            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+                .await?
+                .ok_or(WhitenoiseError::GroupNotFound)?;
+
+        Ok(AggregatedMessage::find_messages_with_unread_minimum(
+            self.group_id,
+            self.pubkey(),
+            account_group.last_read_message_id.as_ref(),
+            minimum.unwrap_or(50),
+            self.db(),
+            account_group
+                .chat_cleared_at
+                .map(|dt| dt.timestamp_millis()),
+        )
+        .await?)
+    }
+
+    /// Fetch a single aggregated message by event ID.
+    pub async fn fetch_by_id(&self, message_id: &str) -> Result<Option<ChatMessage>> {
+        Ok(
+            AggregatedMessage::find_by_id(message_id, self.group_id, self.pubkey(), self.db())
+                .await?,
+        )
+    }
+
+    /// Search messages by content within this group.
+    pub async fn search(&self, query: &str, limit: Option<u32>) -> Result<Vec<SearchResult>> {
+        let cleared_at_ms =
+            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.db()).await?;
+
+        Ok(AggregatedMessage::search_messages_in_group(
+            self.group_id,
+            self.pubkey(),
+            query,
+            limit.unwrap_or(50),
+            self.db(),
+            cleared_at_ms,
+        )
+        .await?)
+    }
+
+    // ── Write operations ───────────────────────────────────────────
+
+    /// Send a message (chat, reaction, or deletion) to this group.
+    ///
+    /// Returns the sent message and whether the last group message was deleted.
+    pub async fn send(
+        &self,
+        message: String,
+        kind: u16,
+        tags: Option<Vec<Tag>>,
+    ) -> Result<SendResult> {
+        let (inner_event, event_id) =
+            create_unsigned_nostr_event(self.pubkey(), &message, kind, tags)?;
+
+        let mdk = &self.session.mdk;
+
+        let group_relays: Vec<RelayUrl> = mdk.get_relays(self.group_id)?.into_iter().collect();
+        if group_relays.is_empty() {
+            return Err(WhitenoiseError::GroupMissingRelays);
+        }
+
+        let message_event = mdk.create_message(self.group_id, inner_event, None)?;
+        let mdk_message =
+            mdk.get_message(self.group_id, &event_id)?
+                .ok_or(WhitenoiseError::MdkCoreError(
+                    mdk_core::error::Error::MessageNotFound,
+                ))?;
+
+        let tokens = ContentParser::new().parse(&mdk_message.content);
+
+        let mut last_message_deleted = false;
+        match kind {
+            9 => self.process_and_emit_outgoing_message(&mdk_message).await?,
+            7 => self.cache_and_apply_outgoing_reaction(&mdk_message).await?,
+            5 => {
+                last_message_deleted = self.cache_and_apply_outgoing_deletion(&mdk_message).await?
+            }
+            other => {
+                return Err(WhitenoiseError::Internal(format!(
+                    "Unsupported outgoing event kind: {other}"
+                )));
+            }
+        }
+
+        self.spawn_publish_task(message_event, group_relays, event_id, kind, &mdk_message);
+
+        Ok(SendResult {
+            message: MessageWithTokens::new(mdk_message, tokens),
+            last_message_deleted,
+        })
+    }
+
+    /// Retry publishing a failed message.
+    pub async fn retry_publish(&self, event_id: &EventId) -> Result<SendResult> {
+        let event_id_str = event_id.to_string();
+        let original = match AggregatedMessage::find_by_id(
+            &event_id_str,
+            self.group_id,
+            self.pubkey(),
+            self.db(),
+        )
+        .await?
+        {
+            Some(c) if matches!(c.delivery_status, Some(DeliveryStatus::Failed(_))) => c,
+            Some(c) => {
+                return Err(WhitenoiseError::Internal(format!(
+                    "Can only retry messages with Failed delivery status, got {:?}",
+                    c.delivery_status
+                )));
+            }
+            None => return Err(WhitenoiseError::MessageNotFound),
+        };
+
+        let tags = original.tags.to_vec();
+        let result = self
+            .send(original.content, original.kind, Some(tags))
+            .await?;
+
+        // Mark original as Retried (best-effort)
+        match AggregatedMessage::update_delivery_status_with_retry(
+            &event_id_str,
+            self.group_id,
+            self.pubkey(),
+            &DeliveryStatus::Retried,
+            self.db(),
+        )
+        .await
+        {
+            Ok(updated) => self.emit(UpdateTrigger::DeliveryStatusChanged, updated),
+            Err(e) => tracing::warn!(
+                target: "whitenoise::messages::delivery",
+                "Failed to mark original message {} as Retried: {e}",
+                event_id_str,
+            ),
+        }
+
+        Ok(result)
+    }
+
+    // ── Private helpers ────────────────────────────────────────────
+
+    fn spawn_publish_task(
+        &self,
+        message_event: Event,
+        group_relays: Vec<RelayUrl>,
+        event_id: EventId,
+        kind: u16,
+        mdk_message: &mdk_core::prelude::message_types::Message,
+    ) {
+        let ephemeral = self.session.ephemeral.clone_inner();
+        let account_pubkey = *self.pubkey();
+        let database = self.session.database.clone();
+        let stream_manager = self.session.message_stream_manager.clone();
+        let group_id = self.group_id.clone();
+        let event_id_str = event_id.to_string();
+        let tags = mdk_message.tags.clone();
+        let author = mdk_message.pubkey;
+        let content = mdk_message.content.clone();
+
+        let (push_config, push_relay_sync) = match crate::whitenoise::Whitenoise::get_instance() {
+            Ok(wn) => (Some(wn.config.clone()), Some(wn.user_relay_sync_context())),
+            Err(_) => (None, None),
+        };
+
+        tokio::spawn(async move {
+            let ok = ephemeral
+                .publish_message_event(
+                    message_event,
+                    &account_pubkey,
+                    &group_relays,
+                    &event_id_str,
+                    &group_id,
+                    &database,
+                    &stream_manager,
+                )
+                .await
+                .succeeded();
+
+            if ok {
+                if let Some(config) = &push_config
+                    && let Some(sync) = &push_relay_sync
+                    && let Err(e) = publish_notification_requests_after_delivery_with(
+                        config,
+                        &database,
+                        sync,
+                        &ephemeral,
+                        account_pubkey,
+                        &group_id,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        target: "whitenoise::push_notifications",
+                        account = %account_pubkey.to_hex(),
+                        error = %e,
+                        "Best-effort push notification failed after delivery"
+                    );
+                }
+            } else {
+                cascade_delivery_failure(
+                    kind,
+                    &event_id_str,
+                    &tags,
+                    &author,
+                    &content,
+                    &group_id,
+                    &database,
+                    &stream_manager,
+                )
+                .await;
+            }
+        });
+    }
+
+    async fn process_and_emit_outgoing_message(
+        &self,
+        mdk_message: &mdk_core::prelude::message_types::Message,
+    ) -> Result<()> {
+        let media_files =
+            crate::whitenoise::media_files::MediaFile::find_by_group(self.db(), self.group_id)
+                .await?;
+
+        let aggregator = MessageAggregator::with_config(self.session.aggregator_config.clone());
+        let chat_message = aggregator
+            .process_single_message(mdk_message, &ContentParser::new(), media_files)
+            .await
+            .map(|mut msg| {
+                msg.delivery_status = Some(DeliveryStatus::Sending);
+                msg
+            })?;
+
+        AggregatedMessage::insert_message(&chat_message, self.group_id, self.pubkey(), self.db())
+            .await?;
+
+        self.emit(UpdateTrigger::NewMessage, chat_message);
+        Ok(())
+    }
+
+    async fn cache_and_apply_outgoing_reaction(
+        &self,
+        mdk_message: &mdk_core::prelude::message_types::Message,
+    ) -> Result<()> {
+        AggregatedMessage::insert_reaction(mdk_message, self.group_id, self.db()).await?;
+        AggregatedMessage::insert_delivery_status(
+            &mdk_message.id.to_string(),
+            self.group_id,
+            self.pubkey(),
+            &DeliveryStatus::Sending,
+            self.db(),
+        )
+        .await?;
+
+        if let Ok(target_id) = extract_reaction_target_id(&mdk_message.tags)
+            && let Some(mut target) =
+                AggregatedMessage::find_by_id(&target_id, self.group_id, self.pubkey(), self.db())
+                    .await?
+        {
+            let emoji = emoji_utils::validate_and_normalize_reaction(
+                &mdk_message.content,
+                self.session.aggregator_config.normalize_emoji,
+            )?;
+            reaction_handler::add_reaction_to_message(
+                &mut target,
+                &mdk_message.pubkey,
+                &emoji,
+                mdk_message.created_at,
+                mdk_message.id,
+            );
+            AggregatedMessage::update_reactions(
+                &target.id,
+                self.group_id,
+                &target.reactions,
+                self.db(),
+            )
+            .await?;
+            self.emit(UpdateTrigger::ReactionAdded, target);
+        }
+
+        Ok(())
+    }
+
+    /// Returns `true` if the deletion removed the last message in the group.
+    async fn cache_and_apply_outgoing_deletion(
+        &self,
+        mdk_message: &mdk_core::prelude::message_types::Message,
+    ) -> Result<bool> {
+        AggregatedMessage::insert_deletion(mdk_message, self.group_id, self.db()).await?;
+        AggregatedMessage::insert_delivery_status(
+            &mdk_message.id.to_string(),
+            self.group_id,
+            self.pubkey(),
+            &DeliveryStatus::Sending,
+            self.db(),
+        )
+        .await?;
+
+        let last_message_id = AggregatedMessage::find_last_by_group_ids(
+            std::slice::from_ref(self.group_id),
+            self.db(),
+        )
+        .await
+        .ok()
+        .and_then(|v| v.into_iter().next())
+        .map(|s| s.message_id.to_hex());
+
+        let deletion_id = mdk_message.id.to_string();
+        let target_ids = extract_deletion_target_ids(&mdk_message.tags);
+
+        for target_id in &target_ids {
+            if let Some(reaction) =
+                AggregatedMessage::find_reaction_by_id(target_id, self.group_id, self.db()).await?
+            {
+                if let Ok(parent_id) = extract_reaction_target_id(&reaction.tags)
+                    && let Some(mut parent) = AggregatedMessage::find_by_id(
+                        &parent_id,
+                        self.group_id,
+                        self.pubkey(),
+                        self.db(),
+                    )
+                    .await?
+                    && reaction_handler::remove_reaction_from_message(&mut parent, &reaction.author)
+                {
+                    AggregatedMessage::update_reactions(
+                        &parent_id,
+                        self.group_id,
+                        &parent.reactions,
+                        self.db(),
+                    )
+                    .await?;
+                    self.emit(UpdateTrigger::ReactionRemoved, parent);
+                }
+                AggregatedMessage::mark_deleted(target_id, self.group_id, &deletion_id, self.db())
+                    .await?;
+                continue;
+            }
+
+            AggregatedMessage::mark_deleted(target_id, self.group_id, &deletion_id, self.db())
+                .await?;
+
+            if let Some(mut msg) =
+                AggregatedMessage::find_by_id(target_id, self.group_id, self.pubkey(), self.db())
+                    .await?
+            {
+                msg.is_deleted = true;
+                self.emit(UpdateTrigger::MessageDeleted, msg);
+            }
+        }
+
+        Ok(last_message_id.is_some_and(|id| target_ids.contains(&id)))
+    }
+}
+
+/// Result of a send operation.
+pub struct SendResult {
+    pub message: MessageWithTokens,
+    pub last_message_deleted: bool,
+}
+
+// ── Free functions ─────────────────────────────────────────────────
+
+pub(crate) fn create_unsigned_nostr_event(
+    pubkey: &PublicKey,
+    message: &str,
+    kind: u16,
+    tags: Option<Vec<Tag>>,
+) -> Result<(UnsignedEvent, EventId)> {
+    let mut inner_event = UnsignedEvent::new(
+        *pubkey,
+        Timestamp::now(),
+        kind.into(),
+        tags.unwrap_or_default(),
+        message,
+    );
+    inner_event.ensure_id();
+    let event_id = inner_event.id.unwrap();
+    Ok((inner_event, event_id))
+}
+
+/// Reverse optimistic aggregated effects when a reaction/deletion fails to publish.
+pub(crate) async fn cascade_delivery_failure(
+    kind: u16,
+    event_id: &str,
+    tags: &Tags,
+    author: &PublicKey,
+    content: &str,
+    group_id: &GroupId,
+    database: &Database,
+    stream_manager: &MessageStreamManager,
+) {
+    match kind {
+        7 => {
+            cascade_reaction_failure(
+                event_id,
+                tags,
+                author,
+                content,
+                group_id,
+                database,
+                stream_manager,
+            )
+            .await
+        }
+        5 => {
+            cascade_deletion_failure(event_id, tags, author, group_id, database, stream_manager)
+                .await
+        }
+        _ => {}
+    }
+}
+
+async fn cascade_reaction_failure(
+    _event_id: &str,
+    tags: &Tags,
+    author: &PublicKey,
+    content: &str,
+    group_id: &GroupId,
+    database: &Database,
+    stream_manager: &MessageStreamManager,
+) {
+    let target_id = match extract_reaction_target_id(tags) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                target: "whitenoise::messages::delivery",
+                "Failed to extract reaction target for cascade: {e}",
+            );
+            return;
+        }
+    };
+
+    let result = retry_on_lock(|| async {
+        let Some(mut parent) =
+            AggregatedMessage::find_by_id(&target_id, group_id, author, database).await?
+        else {
+            return Ok(None);
+        };
+        if !reaction_handler::remove_reaction_from_message(&mut parent, author) {
+            return Ok(None);
+        }
+        AggregatedMessage::update_reactions(&target_id, group_id, &parent.reactions, database)
+            .await?;
+        Ok(Some(parent))
+    })
+    .await;
+
+    match result {
+        Ok(Some(parent)) => {
+            stream_manager.emit(
+                group_id,
+                MessageUpdate {
+                    trigger: UpdateTrigger::ReactionRemoved,
+                    message: parent,
+                },
+            );
+            tracing::info!(
+                target: "whitenoise::messages::delivery",
+                "Cascaded reaction failure: removed '{content}' from {target_id}",
+            );
+        }
+        Ok(None) => {}
+        Err(e) => tracing::error!(
+            target: "whitenoise::messages::delivery",
+            "Failed to cascade reaction failure after retries: {e}",
+        ),
+    }
+}
+
+async fn cascade_deletion_failure(
+    event_id: &str,
+    tags: &Tags,
+    author: &PublicKey,
+    group_id: &GroupId,
+    database: &Database,
+    stream_manager: &MessageStreamManager,
+) {
+    if let Err(e) = retry_on_lock(|| async {
+        AggregatedMessage::unmark_deleted(event_id, group_id, database).await
+    })
+    .await
+    {
+        tracing::error!(
+            target: "whitenoise::messages::delivery",
+            "Failed to cascade deletion failure after retries: {e}",
+        );
+        return;
+    }
+
+    for target_id in extract_deletion_target_ids(tags) {
+        if let Ok(Some(msg)) =
+            AggregatedMessage::find_by_id(&target_id, group_id, author, database).await
+        {
+            stream_manager.emit(
+                group_id,
+                MessageUpdate {
+                    trigger: UpdateTrigger::DeliveryStatusChanged,
+                    message: msg,
+                },
+            );
+        }
+    }
+
+    tracing::info!(
+        target: "whitenoise::messages::delivery",
+        "Cascaded deletion failure: unmarked targets of deletion {event_id}",
+    );
+}

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod messages;
 pub(crate) mod relay_handles;
 
 use std::sync::Arc;
@@ -20,6 +21,7 @@ use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
 use crate::whitenoise::database::Database;
 use crate::whitenoise::database::account::AccountRepositories;
 use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::message_aggregator::AggregatorConfig;
 
 /// Signer slot shared between `AccountSession` and its relay handles.
 ///
@@ -56,6 +58,10 @@ pub struct AccountSession {
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
     #[expect(dead_code, reason = "used in Phase 5 view-pattern callers")]
     pub(crate) repos: AccountRepositories,
+    pub(crate) database: Arc<Database>,
+    pub(crate) message_stream_manager:
+        Arc<crate::whitenoise::message_streaming::MessageStreamManager>,
+    pub(crate) aggregator_config: AggregatorConfig,
     pub(crate) signer: SharedSigner,
     contact_list_guard: Arc<Semaphore>,
     cancellation: watch::Sender<bool>,
@@ -71,10 +77,12 @@ impl AccountSession {
     pub(crate) async fn new(
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
+        database: Arc<Database>,
+        message_stream_manager: Arc<crate::whitenoise::message_streaming::MessageStreamManager>,
+        aggregator_config: AggregatorConfig,
         signer: Option<Arc<dyn NostrSigner>>,
         ephemeral_plane: crate::relay_control::ephemeral::EphemeralPlane,
         relay_control: Arc<crate::relay_control::RelayControlPlane>,
-        db: Arc<Database>,
     ) -> Result<Self> {
         let (cancellation, _) = watch::channel(false);
         let signer: SharedSigner = Arc::new(RwLock::new(signer));
@@ -85,9 +93,12 @@ impl AccountSession {
         );
         let group_handle = relay_handles::AccountGroupHandle::new(account_pubkey, relay_control);
         Ok(Self {
-            repos: AccountRepositories::new(account_pubkey, db).await?,
+            repos: AccountRepositories::new(account_pubkey, database.clone()).await?,
             account_pubkey,
             mdk: Arc::new(mdk),
+            database,
+            message_stream_manager,
+            aggregator_config,
             signer,
             contact_list_guard: Arc::new(Semaphore::new(1)),
             cancellation,
@@ -110,10 +121,12 @@ impl AccountSession {
         Self::new(
             account.pubkey,
             mdk,
+            wn.database.clone(),
+            wn.message_stream_manager.clone(),
+            wn.message_aggregator.config().clone(),
             signer,
             wn.relay_control.ephemeral(),
             wn.relay_control.clone(),
-            wn.database.clone(),
         )
         .await
     }
@@ -140,6 +153,11 @@ impl AccountSession {
     /// Signal cancellation to all background tasks associated with this session.
     pub(crate) fn cancel(&self) {
         let _ = self.cancellation.send(true);
+    }
+
+    /// Return a lightweight view for message read/search operations.
+    pub fn messages(&self) -> messages::MessageOps<'_> {
+        messages::MessageOps::new(self)
     }
 
     /// Acquire the contact-list processing permit for this session.
@@ -425,6 +443,11 @@ impl Whitenoise {
     pub fn session(&self, pubkey: &PublicKey) -> Option<Arc<AccountSession>> {
         self.account_manager.get_session(pubkey)
     }
+
+    /// Look up an active session, returning an error if none exists.
+    pub(crate) fn require_session(&self, pubkey: &PublicKey) -> Result<Arc<AccountSession>> {
+        self.session(pubkey).ok_or(WhitenoiseError::AccountNotFound)
+    }
 }
 
 #[cfg(test)]
@@ -479,10 +502,21 @@ pub(crate) mod test_helpers {
             event_sender,
             [0u8; 16],
         ));
+        let stream_manager =
+            Arc::new(crate::whitenoise::message_streaming::MessageStreamManager::default());
         Arc::new(
-            AccountSession::new(pubkey, mdk, None, ephemeral, relay_control, db)
-                .await
-                .expect("create test session"),
+            AccountSession::new(
+                pubkey,
+                mdk,
+                db,
+                stream_manager,
+                AggregatorConfig::default(),
+                None,
+                ephemeral,
+                relay_control,
+            )
+            .await
+            .expect("create test session"),
         )
     }
 }

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::*;
 use nostr_sdk::{PublicKey, RelayUrl};
 
@@ -8,11 +7,9 @@ use super::SharedSigner;
 use crate::RelayType;
 use crate::nostr_manager::Result as NostrResult;
 use crate::relay_control::RelayControlPlane;
-use crate::relay_control::ephemeral::{EphemeralPlane, MessagePublishResult};
+use crate::relay_control::ephemeral::EphemeralPlane;
 use crate::relay_control::groups::GroupSubscriptionSpec;
-use crate::whitenoise::database::Database;
 use crate::whitenoise::error::{Result, WhitenoiseError};
-use crate::whitenoise::message_streaming::MessageStreamManager;
 
 /// Scoped handle into the shared ephemeral relay plane.
 ///
@@ -174,27 +171,9 @@ impl AccountEphemeralHandle {
         }
     }
 
-    #[expect(dead_code, reason = "phase 7+")]
-    pub(crate) async fn publish_message_event(
-        &self,
-        event: Event,
-        relays: &[RelayUrl],
-        event_id: &str,
-        group_id: &GroupId,
-        database: &Database,
-        stream_manager: &Arc<MessageStreamManager>,
-    ) -> MessagePublishResult {
-        self.ephemeral
-            .publish_message_event(
-                event,
-                &self.account_pubkey,
-                relays,
-                event_id,
-                group_id,
-                database,
-                stream_manager,
-            )
-            .await
+    /// Clone the underlying `EphemeralPlane` for use in spawned background tasks.
+    pub(crate) fn clone_inner(&self) -> crate::relay_control::ephemeral::EphemeralPlane {
+        self.ephemeral.clone()
     }
 
     // ── Fetch helpers (anonymous scope, no signer needed) ───────────
@@ -314,6 +293,7 @@ mod tests {
 
     use super::*;
     use crate::relay_control::observability::{RelayObservability, RelayObservabilityConfig};
+    use crate::whitenoise::database::Database;
     use crate::whitenoise::session::test_helpers::test_db;
 
     fn test_ephemeral_plane(database: Arc<Database>) -> EphemeralPlane {

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -57,6 +57,7 @@ impl Whitenoise {
         let fetched_messages =
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(
                 group_id,
+                account_pubkey,
                 &self.database,
                 &PaginationOptions::default(),
                 limit,


### PR DESCRIPTION
![marmot](https://blossom.primal.net/d05b67f740ea84c8ff97a2ace1af819ac50d14bf82af8430aa550bb0c787de62.jpg)

## What

Migrates message read, search, send, and retry operations from the `Whitenoise` singleton into session-scoped views (`MessageOps` / `MessageOpsForGroup`), and fixes the delivery-status account isolation bug (#739).

## Why

The `message_delivery_status` table was keyed by `(message_id, mls_group_id)` with no `account_pubkey`. When two local accounts shared a group on the same device, sender-local delivery state bled between them. A message sent by account A showed "Sending" status when viewed as account B.

The session rearchitecture (Phases 6+7 of the implementation plan) moves message operations behind `AccountSession`, where account identity is baked in at construction time. With identity always present, the delivery-status scope fix becomes a natural part of the migration: every query now carries `account_pubkey`.

## How

**Session views (new file: `session/messages.rs`)**

Two-level API that bakes in identity:
```rust
session.messages()                          // MessageOps: account-scoped
    .for_group(&group_id)                   // MessageOpsForGroup: account+group scoped
    .fetch_aggregated(&options, limit)      // no pubkey argument needed
```

Methods on `Whitenoise` become thin delegation wrappers that resolve the session and forward the call.

**Delivery-status scope fix (migration 0045)**

- Adds `account_pubkey` to the `message_delivery_status` primary key
- Backfills existing rows from `aggregated_messages.author`
- All LEFT JOIN reads now filter by the requesting account's pubkey
- All delivery-status writes carry account identity

**What moved to `MessageOpsForGroup`**

| Read | Write |
|------|-------|
| `fetch` (raw MDK messages) | `send` (chat/reaction/deletion) |
| `fetch_aggregated` (paginated cache) | `retry_publish` |
| `fetch_unread_with_minimum` | optimistic cache helpers |
| `fetch_by_id` | `cascade_delivery_failure` |
| `search` (per-group and cross-group) | delivery-status tracking |

**Shared helpers consolidated**

`extract_reaction_target_id` and `extract_deletion_target_ids` had three copies across the codebase. Now one canonical pair in `message_aggregator/processor.rs`.

**Other cleanup**

- Removed redundant `Account::find_by_pubkey` calls from session views (session existence proves account validity)
- Fixed double `AccountGroup` query in `fetch_unread_with_minimum` (was 3 DB calls, now 1)
- `AggregatorConfig` flows through `AccountSession` instead of hardcoded `normalize_emoji: true`
- Singleton access moved outside spawn boundaries in the publish task

## Validation

- `just check` passes (fmt, docs, clippy, dead_code)
- Existing unit tests updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delivery-status is now account-scoped (DB migration applied) to prevent cross-account status conflicts.

* **New Features**
  * New session-based message API for account-scoped sending, retrying, fetching, searching, and group-scoped operations.
  * Optimistic message/reaction/deletion behavior with retry and failure-cascade handling.

* **Tests**
  * Added regression tests for delivery-status isolation and reaction-restoration on deletion failure.

* **Documentation**
  * Updated migration/projection implementation plan to mark relevant phases complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->