### PR TITLE
feat: migrate drafts, follows, and settings to session view pattern (Phase 5)

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -109,7 +109,7 @@ transitional lookup.
 
 ### Phase 3: Scoped relay handles (~700 LOC)
 
-- [ ] Not started
+- [x] Completed in PRs #753, #755, #756
 
 <details>
 <summary>Details</summary>
@@ -158,7 +158,7 @@ exposing a pubkey argument. Add the remaining repos when their domains migrate r
 
 ### Phase 5: View pattern + migrate drafts/follows/settings (~700 LOC)
 
-- [ ] Not started
+- [x] Completed on branch `phase-5-view-pattern-migrate-ops`
 
 <details>
 <summary>Details</summary>

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -249,6 +249,7 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
 }
 
 #[tokio::main]
+#[allow(deprecated)]
 async fn main() -> Result<(), WhitenoiseError> {
     let args = Args::parse();
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1208,6 +1208,7 @@ async fn profile_update(
     Ok(to_response(&metadata))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn follows_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
@@ -1232,6 +1233,7 @@ enum FollowAction {
     Remove,
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn follows_mutate(
     wn: &Whitenoise,
@@ -1249,6 +1251,7 @@ async fn follows_mutate(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn follows_check(
     wn: &Whitenoise,

--- a/src/integration_tests/benchmarks/scenarios/user_search.rs
+++ b/src/integration_tests/benchmarks/scenarios/user_search.rs
@@ -78,6 +78,7 @@ impl BenchmarkScenario for UserSearchBenchmark {
         unreachable!()
     }
 
+    #[allow(deprecated)]
     async fn run_benchmark(
         &mut self,
         whitenoise: &'static Whitenoise,

--- a/src/integration_tests/test_cases/drafts/delete_draft.rs
+++ b/src/integration_tests/test_cases/drafts/delete_draft.rs
@@ -26,6 +26,7 @@ impl DeleteDraftTestCase {
 
 #[async_trait]
 impl TestCase for DeleteDraftTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(
             "Deleting draft for account '{}' in group '{}'...",

--- a/src/integration_tests/test_cases/drafts/load_draft.rs
+++ b/src/integration_tests/test_cases/drafts/load_draft.rs
@@ -33,6 +33,7 @@ impl LoadDraftTestCase {
 
 #[async_trait]
 impl TestCase for LoadDraftTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(
             "Loading draft for account '{}' in group '{}'...",

--- a/src/integration_tests/test_cases/drafts/save_draft.rs
+++ b/src/integration_tests/test_cases/drafts/save_draft.rs
@@ -28,6 +28,7 @@ impl SaveDraftTestCase {
 
 #[async_trait]
 impl TestCase for SaveDraftTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(
             "Saving draft for account '{}' in group '{}'...",

--- a/src/integration_tests/test_cases/follow_management/follow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/follow_user.rs
@@ -20,6 +20,7 @@ impl FollowUserTestCase {
 
 #[async_trait]
 impl TestCase for FollowUserTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(
             "Following user {} from account: {}",

--- a/src/integration_tests/test_cases/follow_management/unfollow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/unfollow_user.rs
@@ -20,6 +20,7 @@ impl UnfollowUserTestCase {
 
 #[async_trait]
 impl TestCase for UnfollowUserTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(
             "Unfollowing user {} from account: {}",

--- a/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
+++ b/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
@@ -322,6 +322,7 @@ impl PublishSubscriptionUpdateTestCase {
     }
 
     /// Verify follow list processed into follows (account-based)
+    #[allow(deprecated)]
     async fn verify_follow_list(
         &self,
         context: &mut ScenarioContext,
@@ -363,6 +364,7 @@ impl PublishSubscriptionUpdateTestCase {
 
 #[async_trait]
 impl TestCase for PublishSubscriptionUpdateTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let has_metadata = self.metadata.is_some();
         let has_relay = self.new_relay_url.is_some();

--- a/src/integration_tests/test_cases/user_search/search_direct_follows.rs
+++ b/src/integration_tests/test_cases/user_search/search_direct_follows.rs
@@ -32,6 +32,7 @@ impl SearchDirectFollowsTestCase {
 
 #[async_trait]
 impl TestCase for SearchDirectFollowsTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let account = context.get_account(&self.account_name)?;
         let searcher_pubkey = account.pubkey;

--- a/src/integration_tests/test_cases/user_search/search_empty_metadata.rs
+++ b/src/integration_tests/test_cases/user_search/search_empty_metadata.rs
@@ -37,6 +37,7 @@ impl SearchEmptyMetadataTestCase {
 
 #[async_trait]
 impl TestCase for SearchEmptyMetadataTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let account = context.get_account(&self.account_name)?;
         let searcher_pubkey = account.pubkey;

--- a/src/integration_tests/test_cases/user_search/search_follows_of_follows.rs
+++ b/src/integration_tests/test_cases/user_search/search_follows_of_follows.rs
@@ -39,6 +39,7 @@ impl SearchFollowsOfFollowsTestCase {
 
 #[async_trait]
 impl TestCase for SearchFollowsOfFollowsTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let account = context.get_account(&self.account_name)?;
         let searcher_pubkey = account.pubkey;

--- a/src/integration_tests/test_cases/user_search/search_incremental_radius.rs
+++ b/src/integration_tests/test_cases/user_search/search_incremental_radius.rs
@@ -34,6 +34,7 @@ impl SearchIncrementalRadiusTestCase {
 
 #[async_trait]
 impl TestCase for SearchIncrementalRadiusTestCase {
+    #[allow(deprecated)]
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let account = context.get_account(&self.account_name)?;
         let searcher_pubkey = account.pubkey;

--- a/src/whitenoise/account_settings.rs
+++ b/src/whitenoise/account_settings.rs
@@ -21,11 +21,18 @@ pub struct AccountSettings {
 
 impl Whitenoise {
     /// Returns the settings for `account`, creating a default row if none exists.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::settings().get() instead."
+    )]
     pub async fn account_settings(
         &self,
         account: &Account,
     ) -> Result<AccountSettings, WhitenoiseError> {
-        Ok(AccountSettings::find_or_create_for_pubkey(&account.pubkey, &self.database).await?)
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.settings().get().await
     }
 
     /// Sets the notification preference for `account` and returns the updated settings.
@@ -33,14 +40,23 @@ impl Whitenoise {
     /// Disabling notifications here does not clear any locally stored push
     /// registration. MIP-05 sharing/removal decisions are handled separately by
     /// the push-notifications subsystem.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::settings().update_notifications_enabled() for DB ops; \
+                this facade also handles push-token reconciliation."
+    )]
     pub async fn update_notifications_enabled(
         &self,
         account: &Account,
         enabled: bool,
     ) -> Result<AccountSettings, WhitenoiseError> {
-        let settings =
-            AccountSettings::update_notifications_enabled(&account.pubkey, enabled, &self.database)
-                .await?;
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        let settings = session
+            .settings()
+            .update_notifications_enabled(enabled)
+            .await?;
 
         let result = match enabled {
             true => self.share_local_push_token_to_joined_groups(account).await,
@@ -65,6 +81,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use crate::whitenoise::test_utils::*;
 

--- a/src/whitenoise/database/account/follows.rs
+++ b/src/whitenoise/database/account/follows.rs
@@ -89,6 +89,9 @@ impl AccountFollowsRepo {
 
     /// Record that this account follows `user`.
     pub async fn add(&self, user: &User) -> Result<()> {
+        let user_id = user
+            .id
+            .ok_or_else(|| DatabaseError::MissingUserId(user.pubkey.to_hex()))?;
         let now = chrono::Utc::now().timestamp_millis();
         sqlx::query(
             "INSERT INTO account_follows (account_id, user_id, created_at, updated_at)
@@ -96,7 +99,7 @@ impl AccountFollowsRepo {
              ON CONFLICT(account_id, user_id) DO UPDATE SET updated_at = ?",
         )
         .bind(self.account_id)
-        .bind(user.id)
+        .bind(user_id)
         .bind(now)
         .bind(now)
         .bind(now)
@@ -108,9 +111,12 @@ impl AccountFollowsRepo {
 
     /// Remove the follow relationship between this account and `user`.
     pub async fn remove(&self, user: &User) -> Result<()> {
+        let user_id = user
+            .id
+            .ok_or_else(|| DatabaseError::MissingUserId(user.pubkey.to_hex()))?;
         sqlx::query("DELETE FROM account_follows WHERE account_id = ? AND user_id = ?")
             .bind(self.account_id)
-            .bind(user.id)
+            .bind(user_id)
             .execute(&self.db.pool)
             .await
             .map_err(DatabaseError::Sqlx)?;

--- a/src/whitenoise/database/account/settings.rs
+++ b/src/whitenoise/database/account/settings.rs
@@ -54,8 +54,7 @@ impl AccountSettingsRepo {
     /// push-token reconciliation (sharing or removing the local push token
     /// from joined groups). Callers that need the full side-effectful behaviour
     /// should use `Whitenoise::update_notifications_enabled` instead, or handle
-    /// push-token sync separately. Phase 5 callers must account for this when
-    /// migrating away from the `Whitenoise` facade.
+    /// push-token sync separately.
     pub async fn update_notifications_enabled(&self, enabled: bool) -> Result<AccountSettings> {
         Ok(
             AccountSettings::update_notifications_enabled(&self.account_pubkey, enabled, &self.db)

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -56,6 +56,8 @@ pub enum DatabaseError {
     Serialization(#[from] serde_json::Error),
     #[error("Search query did not return a position column for message {message_id}")]
     MissingSearchPosition { message_id: String },
+    #[error("User {0} has no database id; pass a persisted User from find_or_create_by_pubkey")]
+    MissingUserId(String),
 }
 
 impl DatabaseError {

--- a/src/whitenoise/drafts.rs
+++ b/src/whitenoise/drafts.rs
@@ -32,6 +32,7 @@ impl Whitenoise {
     ///
     /// Uses upsert semantics: creates a new draft or updates an existing one.
     /// Returns the persisted draft.
+    #[deprecated(since = "0.0.0", note = "Use AccountSession::drafts().save() instead.")]
     pub async fn save_draft(
         &self,
         account: &Account,
@@ -40,37 +41,47 @@ impl Whitenoise {
         reply_to_id: Option<&EventId>,
         media_attachments: &[MediaFile],
     ) -> Result<Draft, WhitenoiseError> {
-        Draft::save(
-            &account.pubkey,
-            group_id,
-            content,
-            reply_to_id,
-            media_attachments,
-            &self.database,
-        )
-        .await
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session
+            .drafts()
+            .save(group_id, content, reply_to_id, media_attachments)
+            .await
     }
 
     /// Loads the draft for (account, group), if any.
+    #[deprecated(since = "0.0.0", note = "Use AccountSession::drafts().load() instead.")]
     pub async fn load_draft(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Option<Draft>, WhitenoiseError> {
-        Draft::find(&account.pubkey, group_id, &self.database).await
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.drafts().load(group_id).await
     }
 
     /// Deletes the draft for (account, group).
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::drafts().delete() instead."
+    )]
     pub async fn delete_draft(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<(), WhitenoiseError> {
-        Draft::delete(&account.pubkey, group_id, &self.database).await
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.drafts().delete(group_id).await
     }
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use mdk_core::prelude::GroupId;
 

--- a/src/whitenoise/follows.rs
+++ b/src/whitenoise/follows.rs
@@ -19,6 +19,11 @@ impl Whitenoise {
     ///
     /// * `account` - The account that will follow the user (must exist in database with valid ID)
     /// * `pubkey` - The public key of the user to be followed
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::social().add_follow() / remove_follow() for DB ops; \
+                this facade also handles Nostr publish and user resolution."
+    )]
     #[perf_instrument("follows")]
     pub async fn follow_user(&self, account: &Account, pubkey: &PublicKey) -> Result<()> {
         let (user, newly_created) = User::find_or_create_by_pubkey(pubkey, &self.database).await?;
@@ -28,7 +33,10 @@ impl Whitenoise {
             self.discovery_sync_worker.request_rebuild();
         }
 
-        account.follow_user(&user, &self.database).await?;
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.social().add_follow(&user).await?;
         self.background_publish_account_follow_list(account).await?;
         Ok(())
     }
@@ -43,6 +51,11 @@ impl Whitenoise {
     ///
     /// * `account` - The account that will unfollow the user (must exist in database with valid ID)
     /// * `pubkey` - The public key of the user to be unfollowed
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::social().remove_follow() for DB ops; \
+                this facade also handles Nostr publish."
+    )]
     #[perf_instrument("follows")]
     pub async fn unfollow_user(&self, account: &Account, pubkey: &PublicKey) -> Result<()> {
         let user = match self.find_user_by_pubkey(pubkey).await {
@@ -50,7 +63,10 @@ impl Whitenoise {
             Err(WhitenoiseError::UserNotFound) => return Ok(()),
             Err(e) => return Err(e),
         };
-        account.unfollow_user(&user, &self.database).await?;
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.social().remove_follow(&user).await?;
         self.background_publish_account_follow_list(account).await?;
         Ok(())
     }
@@ -65,14 +81,16 @@ impl Whitenoise {
     ///
     /// * `account` - The account to check (must exist in database with valid ID)
     /// * `pubkey` - The public key of the user to check if followed
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::social().is_following() instead."
+    )]
     #[perf_instrument("follows")]
     pub async fn is_following_user(&self, account: &Account, pubkey: &PublicKey) -> Result<bool> {
-        let user = match self.find_user_by_pubkey(pubkey).await {
-            Ok(user) => user,
-            Err(WhitenoiseError::UserNotFound) => return Ok(false),
-            Err(e) => return Err(e),
-        };
-        account.is_following_user(&user, &self.database).await
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.social().is_following(pubkey).await
     }
 
     /// Retrieves all users that an account follows.
@@ -84,13 +102,21 @@ impl Whitenoise {
     /// # Arguments
     ///
     /// * `account` - The account whose follows to retrieve (must exist in database with valid ID)
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::social().follows() instead."
+    )]
     #[perf_instrument("follows")]
     pub async fn follows(&self, account: &Account) -> Result<Vec<User>> {
-        account.follows(&self.database).await
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.social().follows().await
     }
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use nostr_sdk::Keys;
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1387,6 +1387,7 @@ impl PushRegistration {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::{collections::BTreeMap, time::Duration};
 

--- a/src/whitenoise/session/drafts.rs
+++ b/src/whitenoise/session/drafts.rs
@@ -1,0 +1,47 @@
+//! Draft operations scoped to an [`AccountSession`].
+
+use mdk_core::prelude::GroupId;
+use nostr_sdk::EventId;
+
+use super::AccountSession;
+use crate::whitenoise::drafts::Draft;
+use crate::whitenoise::error::Result;
+use crate::whitenoise::media_files::MediaFile;
+
+/// View over [`AccountSession`] for draft message operations.
+///
+/// Obtain via [`AccountSession::drafts`].
+pub struct DraftOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> DraftOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Upsert the draft for `(account, group_id)`.
+    pub async fn save(
+        &self,
+        group_id: &GroupId,
+        content: &str,
+        reply_to_id: Option<&EventId>,
+        media_attachments: &[MediaFile],
+    ) -> Result<Draft> {
+        self.session
+            .repos
+            .drafts
+            .save(group_id, content, reply_to_id, media_attachments)
+            .await
+    }
+
+    /// Load the draft for `(account, group_id)`, or `None` if absent.
+    pub async fn load(&self, group_id: &GroupId) -> Result<Option<Draft>> {
+        self.session.repos.drafts.find(group_id).await
+    }
+
+    /// Delete the draft for `(account, group_id)`. No-op if absent.
+    pub async fn delete(&self, group_id: &GroupId) -> Result<()> {
+        self.session.repos.drafts.delete(group_id).await
+    }
+}

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,5 +1,13 @@
 pub(crate) mod relay_handles;
 
+mod drafts;
+mod settings;
+mod social;
+
+pub use self::drafts::DraftOps;
+pub use self::settings::SettingsOps;
+pub use self::social::SocialOps;
+
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -54,7 +62,6 @@ impl AccountInboxState {
 pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
-    #[expect(dead_code, reason = "used in Phase 5 view-pattern callers")]
     pub(crate) repos: AccountRepositories,
     pub(crate) signer: SharedSigner,
     contact_list_guard: Arc<Semaphore>,
@@ -153,6 +160,21 @@ impl AccountSession {
                     "Failed to acquire contact list processing permit".to_string(),
                 )
             })
+    }
+
+    /// Return a view for draft message operations scoped to this session.
+    pub fn drafts(&self) -> DraftOps<'_> {
+        DraftOps::new(self)
+    }
+
+    /// Return a view for per-account settings operations scoped to this session.
+    pub fn settings(&self) -> SettingsOps<'_> {
+        SettingsOps::new(self)
+    }
+
+    /// Return a view for follow/social operations scoped to this session.
+    pub fn social(&self) -> SocialOps<'_> {
+        SocialOps::new(self)
     }
 
     // ── Inbox plane lifecycle ──────────────────────────────────────

--- a/src/whitenoise/session/settings.rs
+++ b/src/whitenoise/session/settings.rs
@@ -1,0 +1,37 @@
+//! Account settings operations scoped to an [`AccountSession`].
+
+use super::AccountSession;
+use crate::whitenoise::account_settings::AccountSettings;
+use crate::whitenoise::error::Result;
+
+/// View over [`AccountSession`] for per-account settings operations.
+///
+/// Obtain via [`AccountSession::settings`].
+pub struct SettingsOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> SettingsOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Return the settings for this account, creating a default row if none exists.
+    pub async fn get(&self) -> Result<AccountSettings> {
+        self.session.repos.settings.find_or_create().await
+    }
+
+    /// Set `notifications_enabled` and return the updated settings.
+    ///
+    /// **Note:** this only updates the database row. It does **not** perform
+    /// push-token reconciliation. Callers that need the full side-effectful
+    /// behaviour should use `Whitenoise::update_notifications_enabled` (which
+    /// delegates here and then handles push-token sync separately).
+    pub async fn update_notifications_enabled(&self, enabled: bool) -> Result<AccountSettings> {
+        self.session
+            .repos
+            .settings
+            .update_notifications_enabled(enabled)
+            .await
+    }
+}

--- a/src/whitenoise/session/social.rs
+++ b/src/whitenoise/session/social.rs
@@ -1,0 +1,48 @@
+//! Social/follow operations scoped to an [`AccountSession`].
+
+use nostr_sdk::PublicKey;
+
+use super::AccountSession;
+use crate::whitenoise::error::Result;
+use crate::whitenoise::users::User;
+
+/// View over [`AccountSession`] for follow/unfollow operations.
+///
+/// Obtain via [`AccountSession::social`].
+pub struct SocialOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> SocialOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Return all users this account follows.
+    pub async fn follows(&self) -> Result<Vec<User>> {
+        self.session.repos.follows.all().await
+    }
+
+    /// Return whether this account follows `target_pubkey`.
+    pub async fn is_following(&self, target_pubkey: &PublicKey) -> Result<bool> {
+        self.session.repos.follows.is_following(target_pubkey).await
+    }
+
+    /// Record that this account follows `user`.
+    ///
+    /// This is the low-level DB operation only. Callers that need the full
+    /// side-effectful behaviour (user metadata resolution, Nostr follow-list
+    /// publish) should use `Whitenoise::follow_user` instead.
+    pub async fn add_follow(&self, user: &User) -> Result<()> {
+        self.session.repos.follows.add(user).await
+    }
+
+    /// Remove the follow relationship between this account and `user`.
+    ///
+    /// This is the low-level DB operation only. Callers that need the full
+    /// side-effectful behaviour (Nostr follow-list publish) should use
+    /// `Whitenoise::unfollow_user` instead.
+    pub async fn remove_follow(&self, user: &User) -> Result<()> {
+        self.session.repos.follows.remove(user).await
+    }
+}

--- a/src/whitenoise/user_search/graph.rs
+++ b/src/whitenoise/user_search/graph.rs
@@ -605,6 +605,7 @@ async fn fetch_events_with_retries(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::whitenoise::test_utils::create_mock_whitenoise;

--- a/src/whitenoise/user_search/mod.rs
+++ b/src/whitenoise/user_search/mod.rs
@@ -1579,6 +1579,7 @@ async fn build_network_layer_from_follows(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::whitenoise::cached_graph_user::CachedGraphUser;


### PR DESCRIPTION
## Context

Part of the session/projection refactor ([plan](docs/session-projection-implementation-plan.md)). Phase 5 introduces the **view pattern** and migrates the first three operation domains — drafts, follows, and settings — out of the \`Whitenoise\` singleton and into \`AccountSession\`-scoped view types.

Prior phases (1–4) scaffolded \`AccountSession\`, \`AccountManager\`, relay handles, and \`AccountRepositories\`. This phase builds on that scaffold and is the first to move real business logic into it.

## What changed

**New view types** (\`src/whitenoise/session/\`):

- \`SocialOps<'a>\` — follow/unfollow/is_following/follows, backed by \`AccountFollowsRepo\`
- \`DraftOps<'a>\` — save/load/delete drafts, backed by \`DraftsRepo\`
- \`SettingsOps<'a>\` — get/update_notifications_enabled, backed by \`AccountSettingsRepo\`

Views borrow \`&AccountSession\` and are obtained via \`session.social()\`, \`session.drafts()\`, \`session.settings()\`. They never spawn \`tokio::spawn\` internally — all work is awaited inline.

**Deprecated facades** (\`Whitenoise::follow_user\`, \`save_draft\`, \`account_settings\`, etc.):

The original \`Whitenoise\` methods are marked \`#[deprecated]\` and now delegate DB operations to the view types. Side effects that belong on the facade are kept there:
- \`follow_user\` / \`unfollow_user\`: Nostr follow-list publish + user metadata resolution stay on facade
- \`update_notifications_enabled\`: push-token reconciliation stays on facade
- Drafts: pure DB ops, no side effects to retain

**Caller suppressions**: 15 existing callers across integration tests, CLI, and benchmarks get \`#[allow(deprecated)]\`. This is intentional — each suppression is removed when that call site is migrated in a later phase. The deprecation signal is there to guide future work, not demand immediate migration.

## What this is NOT

- Does not touch messages, groups, relays, or any other domain
- Does not remove any existing functionality
- Does not change any public API behaviour

## Test plan

- [x] \`just precommit-quick\` passes (fmt, docs, clippy, dead_code, tests)
- [x] \`just int-test follow-management\` passes (per plan validation requirement)
- [x] No regressions on drafts or settings paths