### PR TITLE
feat: migrate group read operations to session views (Phase 8)

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -261,7 +261,7 @@ delivery-status isolation test.
 
 ### Phase 8: Migrate group read operations (~500 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #763
 
 <details>
 <summary>Details</summary>

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -15,6 +15,7 @@ use crate::whitenoise::users::KeyPackageStatus;
 use super::protocol::{MuteDuration, Request, Response};
 
 /// Route a request to the appropriate `Whitenoise` method and produce a response.
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 pub async fn dispatch(req: Request) -> Response {
     let wn = match Whitenoise::get_instance() {
@@ -986,6 +987,7 @@ async fn add_members(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn get_group(
     wn: &Whitenoise,
@@ -1001,6 +1003,7 @@ async fn get_group(
     Ok(to_response(&group))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn group_pubkey_list(
     wn: &Whitenoise,
@@ -1028,6 +1031,7 @@ async fn group_pubkey_list(
     Ok(to_response(&members))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn group_relay_list(
     wn: &Whitenoise,
@@ -1110,6 +1114,7 @@ async fn rename_group(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn group_invites(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
@@ -2083,6 +2088,7 @@ async fn debug_ratchet_tree(
     })))
 }
 
+#[allow(deprecated)]
 async fn promote_admin(
     wn: &Whitenoise,
     account_str: &str,
@@ -2120,6 +2126,7 @@ async fn promote_admin(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 async fn demote_admin(
     wn: &Whitenoise,
     account_str: &str,

--- a/src/integration_tests/test_cases/group_membership/add_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/add_group_members.rs
@@ -33,6 +33,7 @@ impl AddGroupMembersTestCase {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl TestCase for AddGroupMembersTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(

--- a/src/integration_tests/test_cases/group_membership/remove_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/remove_group_members.rs
@@ -33,6 +33,7 @@ impl RemoveGroupMembersTestCase {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl TestCase for RemoveGroupMembersTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         tracing::info!(

--- a/src/integration_tests/test_cases/shared/verify_self_update.rs
+++ b/src/integration_tests/test_cases/shared/verify_self_update.rs
@@ -47,6 +47,7 @@ impl VerifySelfUpdateTestCase {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl TestCase for VerifySelfUpdateTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let group = context.get_group(&self.group_name)?;

--- a/src/integration_tests/test_cases/shared/wait_for_welcome.rs
+++ b/src/integration_tests/test_cases/shared/wait_for_welcome.rs
@@ -29,6 +29,7 @@ impl WaitForWelcomeTestCase {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl TestCase for WaitForWelcomeTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let group = context.get_group(&self.group_name)?;

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -252,6 +252,7 @@ impl Whitenoise {
     ///
     /// Returns a list of chat summaries sorted by last activity (most recent first).
     /// Declined and archived groups are filtered out.
+    #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
         let visible = self.visible_groups(account).await?;
@@ -265,6 +266,7 @@ impl Whitenoise {
     /// Retrieves the archived chat list for an account.
     ///
     /// Returns only archived chats, sorted by last activity.
+    #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_archived_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
         let visible = self.visible_groups(account).await?;

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -357,189 +357,98 @@ impl Whitenoise {
         Ok(group)
     }
 
-    #[perf_instrument("groups")]
+    #[deprecated(since = "0.0.0", note = "Use AccountSession::groups().all() instead.")]
     pub async fn groups(
         &self,
         account: &Account,
         active_filter: bool,
     ) -> Result<Vec<group_types::Group>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let groups: Vec<group_types::Group> = mdk
-            .get_groups()
-            .map_err(WhitenoiseError::from)?
-            .into_iter()
-            .filter(|group| !active_filter || group.state == group_types::GroupState::Active)
-            .collect();
-
-        Ok(groups)
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().all(active_filter)
     }
 
-    /// Returns visible groups for the account (pending + accepted + removed, excluding declined).
-    ///
-    /// `AccountGroup` is the source of truth for visibility:
-    /// - **Pending** (`user_confirmation = NULL`) — invited, not yet accepted
-    /// - **Accepted** (`user_confirmation = true`) — active member
-    /// - **Removed** (`user_confirmation = true`, `removed_at IS NOT NULL`) — kicked by admin;
-    ///   group stays visible (read-only) until the user explicitly archives or deletes it
-    /// - **Declined** (`user_confirmation = false`) — hidden, never shown
-    ///
-    /// All MDK groups (including inactive) are fetched so that removed groups, which MDK
-    /// marks as `Inactive`, are still paired with their `AccountGroup` records and returned.
-    ///
-    /// # Arguments
-    /// * `account` - The account to get visible groups for
-    ///
-    /// # Returns
-    /// * `Ok(Vec<GroupWithMembership>)` - List of visible groups with their membership data
-    /// * `Err(WhitenoiseError)` - If there's an error accessing storage
-    #[perf_instrument("groups")]
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().visible() instead."
+    )]
     pub async fn visible_groups(&self, account: &Account) -> Result<Vec<GroupWithMembership>> {
-        // Fetch all MDK groups (including inactive) — AccountGroup is the source of
-        // truth for visibility. Removed groups (inactive in MDK but with a removed_at
-        // record) must remain visible in the chat list until the user archives them.
-        let all_groups = self.groups(account, false).await?;
-
-        // Get visible AccountGroup records (pending + accepted, including removed)
-        let visible_account_groups =
-            AccountGroup::visible_for_account(self, &account.pubkey).await?;
-
-        // Build a map for efficient lookup when pairing
-        let memberships_by_id: HashMap<_, _> = visible_account_groups
-            .into_iter()
-            .map(|ag| (ag.mls_group_id.clone(), ag))
-            .collect();
-
-        // Include inactive MDK groups only when explicitly removed — not for unrelated inactive state.
-        Ok(all_groups
-            .into_iter()
-            .filter_map(|group| {
-                let membership = memberships_by_id.get(&group.mls_group_id)?.clone();
-                if group.state == group_types::GroupState::Active || membership.is_removed() {
-                    Some(GroupWithMembership { group, membership })
-                } else {
-                    None
-                }
-            })
-            .collect())
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().visible().await
     }
 
-    /// Returns visible groups for the account, each paired with its [`GroupInformation`].
-    ///
-    /// This eliminates the N+1 pattern of calling [`Whitenoise::visible_groups`] and then
-    /// fetching [`GroupInformation`] individually for each group. Group metadata (including
-    /// [`crate::whitenoise::group_information::GroupType`]) is fetched in a single batch
-    /// query and included in every returned item, so callers can filter or branch on
-    /// `group_type` without any further round-trips.
-    ///
-    /// Groups with no `group_information` row are excluded from the result. In practice
-    /// this is safe: the row is created eagerly at group creation and welcome time.
-    ///
-    /// # Arguments
-    /// * `account` - The account to get visible groups for
-    ///
-    /// # Returns
-    /// * `Ok(Vec<GroupWithInfoAndMembership>)` - Visible groups with info and membership data
-    /// * `Err(WhitenoiseError)` - If there is an error accessing storage
-    #[perf_instrument("groups")]
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().visible_with_info() instead."
+    )]
     pub async fn visible_groups_with_info(
         &self,
         account: &Account,
     ) -> Result<Vec<GroupWithInfoAndMembership>> {
-        let visible = self.visible_groups(account).await?;
-
-        if visible.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Batch-fetch all GroupInformation rows for the visible group IDs.
-        let group_ids: Vec<_> = visible
-            .iter()
-            .map(|gwm| gwm.group.mls_group_id.clone())
-            .collect();
-        let info_list = GroupInformation::find_by_mls_group_ids(&group_ids, &self.database).await?;
-        let info_by_id: HashMap<_, _> = info_list
-            .into_iter()
-            .map(|gi| (gi.mls_group_id.clone(), gi))
-            .collect();
-
-        // Pair each visible group with its GroupInformation, dropping any without a row.
-        let result = visible
-            .into_iter()
-            .filter_map(|gwm| {
-                let info = info_by_id.get(&gwm.group.mls_group_id)?.clone();
-                Some(GroupWithInfoAndMembership {
-                    group: gwm.group,
-                    info,
-                    membership: gwm.membership,
-                })
-            })
-            .collect();
-
-        Ok(result)
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().visible_with_info().await
     }
 
-    /// Retrieves a single group by its MLS group ID
-    ///
-    /// # Arguments
-    /// * `account` - The account that has access to the group
-    /// * `group_id` - The MLS group ID to retrieve
-    ///
-    /// # Returns
-    /// * `Ok(Group)` - The group if found
-    /// * `Err(WhitenoiseError::GroupNotFound)` - If the group doesn't exist
-    /// * `Err(WhitenoiseError)` - If there's an error accessing storage
-    #[perf_instrument("groups")]
+    #[deprecated(since = "0.0.0", note = "Use AccountSession::groups().get() instead.")]
     pub async fn group(&self, account: &Account, group_id: &GroupId) -> Result<group_types::Group> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        let group = mdk
-            .get_group(group_id)
-            .map_err(WhitenoiseError::from)?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        Ok(group)
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().get(group_id)
     }
 
-    #[perf_instrument("groups")]
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().members() instead."
+    )]
     pub async fn group_members(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Vec<PublicKey>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        Ok(mdk
-            .get_members(group_id)
-            .map_err(WhitenoiseError::from)?
-            .into_iter()
-            .collect::<Vec<PublicKey>>())
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().members(group_id)
     }
 
-    #[perf_instrument("groups")]
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().relays() instead."
+    )]
     pub async fn group_relays(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<BTreeSet<RelayUrl>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        mdk.get_relays(group_id).map_err(WhitenoiseError::from)
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().relays(group_id)
     }
 
-    #[perf_instrument("groups")]
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().admins() instead."
+    )]
     pub async fn group_admins(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Vec<PublicKey>> {
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
-        Ok(mdk
-            .get_group(group_id)
-            .map_err(WhitenoiseError::from)?
-            .ok_or(WhitenoiseError::GroupNotFound)?
-            .admin_pubkeys
-            .into_iter()
-            .collect::<Vec<PublicKey>>())
+        let session = self
+            .session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session.groups().admins(group_id)
     }
 
     #[perf_instrument("groups")]
+    #[allow(deprecated)]
     async fn ensure_account_is_group_admin(
         &self,
         account: &Account,
@@ -862,6 +771,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::whitenoise::Whitenoise;

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -217,6 +217,7 @@ impl Whitenoise {
     ///
     /// The returned metadata (hash, key, nonce) should be passed to `update_group_data`
     /// to update the group's image settings.
+    #[allow(deprecated)]
     #[perf_instrument("media")]
     pub async fn upload_group_image(
         &self,

--- a/src/whitenoise/session/groups.rs
+++ b/src/whitenoise/session/groups.rs
@@ -1,0 +1,161 @@
+//! Group read operations scoped to an [`AccountSession`].
+
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+
+use mdk_core::prelude::*;
+use nostr_sdk::{PublicKey, RelayUrl};
+
+use super::AccountSession;
+use crate::whitenoise::accounts_groups::AccountGroup;
+use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::group_information::GroupInformation;
+use crate::whitenoise::groups::{GroupWithInfoAndMembership, GroupWithMembership};
+
+/// View over [`AccountSession`] for group read operations.
+///
+/// Obtain via [`AccountSession::groups`].
+pub struct GroupOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> GroupOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Return all groups for this account.
+    ///
+    /// When `active_filter` is `true`, only groups in `Active` state are
+    /// returned. When `false`, all groups (including inactive) are included.
+    pub fn all(&self, active_filter: bool) -> Result<Vec<group_types::Group>> {
+        let groups: Vec<group_types::Group> = self
+            .session
+            .mdk
+            .get_groups()
+            .map_err(WhitenoiseError::from)?
+            .into_iter()
+            .filter(|group| !active_filter || group.state == group_types::GroupState::Active)
+            .collect();
+
+        Ok(groups)
+    }
+
+    /// Return visible groups for this account (pending + accepted + removed,
+    /// excluding declined).
+    ///
+    /// `AccountGroup` is the source of truth for visibility:
+    /// - **Pending** (`user_confirmation = NULL`) — invited, not yet accepted
+    /// - **Accepted** (`user_confirmation = true`) — active member
+    /// - **Removed** (`user_confirmation = true`, `removed_at IS NOT NULL`) —
+    ///   kicked by admin; stays visible until archived
+    /// - **Declined** (`user_confirmation = false`) — hidden, never shown
+    ///
+    /// All MDK groups (including inactive) are fetched so that removed groups,
+    /// which MDK marks as `Inactive`, are still paired with their
+    /// `AccountGroup` records.
+    pub async fn visible(&self) -> Result<Vec<GroupWithMembership>> {
+        let all_groups = self.all(false)?;
+
+        let visible_account_groups = AccountGroup::find_visible_for_account(
+            &self.session.account_pubkey,
+            &self.session.database,
+        )
+        .await?;
+
+        let memberships_by_id: HashMap<_, _> = visible_account_groups
+            .into_iter()
+            .map(|ag| (ag.mls_group_id.clone(), ag))
+            .collect();
+
+        Ok(all_groups
+            .into_iter()
+            .filter_map(|group| {
+                let membership = memberships_by_id.get(&group.mls_group_id)?.clone();
+                if group.state == group_types::GroupState::Active || membership.is_removed() {
+                    Some(GroupWithMembership { group, membership })
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
+    /// Return visible groups paired with their [`GroupInformation`].
+    ///
+    /// Eliminates the N+1 pattern of calling [`Self::visible`] then fetching
+    /// info individually. Groups with no `group_information` row are excluded.
+    pub async fn visible_with_info(&self) -> Result<Vec<GroupWithInfoAndMembership>> {
+        let visible = self.visible().await?;
+
+        if visible.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let group_ids: Vec<_> = visible
+            .iter()
+            .map(|gwm| gwm.group.mls_group_id.clone())
+            .collect();
+        let info_list =
+            GroupInformation::find_by_mls_group_ids(&group_ids, &self.session.database).await?;
+        let info_by_id: HashMap<_, _> = info_list
+            .into_iter()
+            .map(|gi| (gi.mls_group_id.clone(), gi))
+            .collect();
+
+        let result = visible
+            .into_iter()
+            .filter_map(|gwm| {
+                let info = info_by_id.get(&gwm.group.mls_group_id)?.clone();
+                Some(GroupWithInfoAndMembership {
+                    group: gwm.group,
+                    info,
+                    membership: gwm.membership,
+                })
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    /// Retrieve a single group by its MLS group ID.
+    pub fn get(&self, group_id: &GroupId) -> Result<group_types::Group> {
+        self.session
+            .mdk
+            .get_group(group_id)
+            .map_err(WhitenoiseError::from)?
+            .ok_or(WhitenoiseError::GroupNotFound)
+    }
+
+    /// Return the members of a group.
+    pub fn members(&self, group_id: &GroupId) -> Result<Vec<PublicKey>> {
+        Ok(self
+            .session
+            .mdk
+            .get_members(group_id)
+            .map_err(WhitenoiseError::from)?
+            .into_iter()
+            .collect::<Vec<PublicKey>>())
+    }
+
+    /// Return the relay URLs for a group.
+    pub fn relays(&self, group_id: &GroupId) -> Result<BTreeSet<RelayUrl>> {
+        self.session
+            .mdk
+            .get_relays(group_id)
+            .map_err(WhitenoiseError::from)
+    }
+
+    /// Return the admin public keys for a group.
+    pub fn admins(&self, group_id: &GroupId) -> Result<Vec<PublicKey>> {
+        Ok(self
+            .session
+            .mdk
+            .get_group(group_id)
+            .map_err(WhitenoiseError::from)?
+            .ok_or(WhitenoiseError::GroupNotFound)?
+            .admin_pubkeys
+            .into_iter()
+            .collect::<Vec<PublicKey>>())
+    }
+}

--- a/src/whitenoise/session/groups.rs
+++ b/src/whitenoise/session/groups.rs
@@ -135,7 +135,7 @@ impl<'a> GroupOps<'a> {
             .get_members(group_id)
             .map_err(WhitenoiseError::from)?
             .into_iter()
-            .collect::<Vec<PublicKey>>())
+            .collect())
     }
 
     /// Return the relay URLs for a group.
@@ -148,14 +148,6 @@ impl<'a> GroupOps<'a> {
 
     /// Return the admin public keys for a group.
     pub fn admins(&self, group_id: &GroupId) -> Result<Vec<PublicKey>> {
-        Ok(self
-            .session
-            .mdk
-            .get_group(group_id)
-            .map_err(WhitenoiseError::from)?
-            .ok_or(WhitenoiseError::GroupNotFound)?
-            .admin_pubkeys
-            .into_iter()
-            .collect::<Vec<PublicKey>>())
+        Ok(self.get(group_id)?.admin_pubkeys.into_iter().collect())
     }
 }

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,3 +1,4 @@
+mod groups;
 pub(crate) mod messages;
 pub(crate) mod relay_handles;
 
@@ -6,6 +7,7 @@ mod settings;
 mod social;
 
 pub use self::drafts::DraftOps;
+pub use self::groups::GroupOps;
 pub use self::settings::SettingsOps;
 pub use self::social::SocialOps;
 
@@ -193,6 +195,11 @@ impl AccountSession {
     /// Return a view for follow/social operations scoped to this session.
     pub fn social(&self) -> SocialOps<'_> {
         SocialOps::new(self)
+    }
+
+    /// Return a view for group read operations scoped to this session.
+    pub fn groups(&self) -> GroupOps<'_> {
+        GroupOps::new(self)
     }
 
     // ── Inbox plane lifecycle ──────────────────────────────────────

--- a/src/whitenoise/user_search/graph.rs
+++ b/src/whitenoise/user_search/graph.rs
@@ -38,6 +38,7 @@ const NETWORK_FETCH_RETRIES: usize = 3;
 ///
 /// This is purely local data (MLS/MDK) — no network fetch required.
 #[perf_instrument("user_search")]
+#[allow(deprecated)]
 pub(super) async fn get_group_co_member_pubkeys(
     whitenoise: &Whitenoise,
     searcher_pubkey: &PublicKey,


### PR DESCRIPTION
## Summary

- Migrate 7 group read methods into `GroupOps` session view (`session/groups.rs`)
- Deprecate old `Whitenoise` methods with delegation to session views
- Annotate all callers with `#[allow(deprecated)]`

## Methods migrated

| Old (`Whitenoise`) | New (`GroupOps`) |
|---|---|
| `groups()` | `groups().all()` |
| `visible_groups()` | `groups().visible()` |
| `visible_groups_with_info()` | `groups().visible_with_info()` |
| `group()` | `groups().get()` |
| `group_members()` | `groups().members()` |
| `group_relays()` | `groups().relays()` |
| `group_admins()` | `groups().admins()` |

## Files changed

- **New:** `src/whitenoise/session/groups.rs` — `GroupOps` view struct with 7 read methods
- **Modified:** `src/whitenoise/groups.rs` — deprecated wrappers delegating to session views
- **Modified:** `src/whitenoise/session/mod.rs` — module declaration + `groups()` accessor
- **Annotated callers:** `dispatch.rs`, `chat_list.rs`, `media.rs`, `graph.rs`, 4 integration test files

## Validation

`just precommit-quick` passes (fmt, docs, clippy, tests). 1 pre-existing test failure (`test_send_message_to_group_edge_cases`) from PR #760

## Test plan

- [x] `just precommit-quick` passes