### PR TITLE
Phase 12: Migrate memberships to session-scoped MembershipOps

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1282,6 +1282,7 @@ async fn chats_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Resp
     Ok(to_response(&clean))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn archive_chat(
     wn: &Whitenoise,
@@ -1296,6 +1297,7 @@ async fn archive_chat(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn unarchive_chat(
     wn: &Whitenoise,
@@ -1310,6 +1312,7 @@ async fn unarchive_chat(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn mute_chat(
     wn: &Whitenoise,
@@ -1325,6 +1328,7 @@ async fn mute_chat(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn unmute_chat(
     wn: &Whitenoise,

--- a/src/integration_tests/test_cases/chat_list/mark_message_read.rs
+++ b/src/integration_tests/test_cases/chat_list/mark_message_read.rs
@@ -18,6 +18,7 @@ impl MarkMessageReadTestCase {
     }
 }
 
+#[allow(deprecated)]
 #[async_trait]
 impl TestCase for MarkMessageReadTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {

--- a/src/integration_tests/test_cases/shared/set_chat_pin_order.rs
+++ b/src/integration_tests/test_cases/shared/set_chat_pin_order.rs
@@ -31,6 +31,7 @@ impl SetChatPinOrderTestCase {
     }
 }
 
+#[allow(deprecated)]
 #[async_trait]
 impl TestCase for SetChatPinOrderTestCase {
     async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -8,8 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::perf_instrument;
 use crate::whitenoise::{
-    Whitenoise, accounts::Account, aggregated_message::AggregatedMessage,
-    chat_list_streaming::ChatListUpdateTrigger, database::Database, drafts::Draft,
+    Whitenoise, accounts::Account, chat_list_streaming::ChatListUpdateTrigger, database::Database,
     error::WhitenoiseError,
 };
 
@@ -375,10 +374,10 @@ impl AccountGroup {
 }
 
 impl Whitenoise {
-    /// Gets or creates an AccountGroup for the given account and MLS group.
-    ///
-    /// For DM groups, pass the other participant's pubkey as `dm_peer_pubkey`
-    /// so it can be persisted for efficient lookups.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().get_or_create() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn get_or_create_account_group(
         &self,
@@ -386,38 +385,58 @@ impl Whitenoise {
         mls_group_id: &GroupId,
         dm_peer_pubkey: Option<&PublicKey>,
     ) -> Result<(AccountGroup, bool), WhitenoiseError> {
-        AccountGroup::get_or_create(self, &account.pubkey, mls_group_id, dm_peer_pubkey).await
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .get_or_create(dm_peer_pubkey)
+            .await
     }
 
-    /// Gets all visible AccountGroups for the given account.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().visible_groups() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn get_visible_account_groups(
         &self,
         account: &Account,
     ) -> Result<Vec<AccountGroup>, WhitenoiseError> {
-        AccountGroup::visible_for_account(self, &account.pubkey).await
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().visible_groups().await
     }
 
-    /// Gets all pending AccountGroups for the given account.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().pending_groups() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn get_pending_account_groups(
         &self,
         account: &Account,
     ) -> Result<Vec<AccountGroup>, WhitenoiseError> {
-        AccountGroup::pending_for_account(self, &account.pubkey).await
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().pending_groups().await
     }
 
-    /// Accepts a group invite for the given account and MLS group.
+    /// Accepts a group invite and best-effort shares the local push token.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().accept() for DB ops; \
+                this facade also handles push-token sharing."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn accept_account_group(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-        let accepted = account_group.accept(self).await?;
+        let session = self.require_session(&account.pubkey)?;
+        let accepted = session
+            .membership()
+            .for_group(mls_group_id)
+            .accept()
+            .await?;
 
         // Best-effort: share the local push token now that the group is accepted.
         if let Err(error) = self
@@ -436,17 +455,24 @@ impl Whitenoise {
         Ok(accepted)
     }
 
-    /// Declines a group invite for the given account and MLS group.
+    /// Declines a group invite and best-effort removes the local push token.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().decline() for DB ops; \
+                this facade also handles push-token removal."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn decline_account_group(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-        let declined = account_group.decline(self).await?;
+        let session = self.require_session(&account.pubkey)?;
+        let declined = session
+            .membership()
+            .for_group(mls_group_id)
+            .decline()
+            .await?;
 
         // Best-effort: remove any push token previously shared under the old behavior.
         if let Err(error) = self
@@ -465,54 +491,42 @@ impl Whitenoise {
         Ok(declined)
     }
 
-    /// Marks a message as read for the given account.
-    ///
-    /// Looks up the message to find its group, then atomically updates the
-    /// last_read_message_id only if the new message is newer than the current
-    /// read marker. This prevents regression when messages arrive out of order
-    /// or when the UI marks an older message as read after a newer one.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().mark_message_read() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn mark_message_read(
         &self,
         account: &Account,
         message_id: &EventId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let message = AggregatedMessage::find_by_message_id(message_id, &self.database)
-            .await?
-            .ok_or(WhitenoiseError::MessageNotFound)?;
-
-        let account_group = AccountGroup::get(self, &account.pubkey, &message.mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        // Atomic compare-and-update: only advances if newer
-        let message_created_at_ms = message.created_at.timestamp_millis();
-        if let Some(updated) = account_group
-            .update_last_read_if_newer(message_id, message_created_at_ms, &self.database)
-            .await?
-        {
-            return Ok(updated);
-        }
-
-        // Update was skipped (message not newer), return current state
-        Ok(account_group)
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().mark_message_read(message_id).await
     }
 
-    /// Gets the last read message ID for an account in a group.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().last_read_message_id() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn get_last_read_message_id(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Option<EventId>, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, group_id).await?;
-        Ok(account_group.and_then(|ag| ag.last_read_message_id))
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(group_id)
+            .last_read_message_id()
+            .await
     }
 
-    /// Sets the pin order for a chat.
-    ///
-    /// - `None` = unpin the chat
-    /// - `Some(n)` = pin the chat with order n (lower values appear first)
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().set_pin_order() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn set_chat_pin_order(
         &self,
@@ -520,77 +534,50 @@ impl Whitenoise {
         mls_group_id: &GroupId,
         pin_order: Option<i64>,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let updated = account_group
-            .update_pin_order(pin_order, &self.database)
-            .await?;
-
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .set_pin_order(pin_order)
+            .await
     }
 
-    /// Archives a chat for the given account.
-    ///
-    /// Idempotent: if already archived, returns the existing state unchanged.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().archive() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn archive_chat(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        if account_group.is_archived() {
-            return Ok(account_group);
-        }
-
-        let updated = account_group.archive(self).await?;
-        self.emit_chat_list_update(
-            account,
-            mls_group_id,
-            ChatListUpdateTrigger::ChatArchiveChanged,
-        )
-        .await;
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().for_group(mls_group_id).archive().await
     }
 
-    /// Unarchives a chat for the given account.
-    ///
-    /// Idempotent: if not archived, returns the existing state unchanged.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().unarchive() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn unarchive_chat(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        if !account_group.is_archived() {
-            return Ok(account_group);
-        }
-
-        let updated = account_group.unarchive(self).await?;
-        self.emit_chat_list_update(
-            account,
-            mls_group_id,
-            ChatListUpdateTrigger::ChatArchiveChanged,
-        )
-        .await;
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .unarchive()
+            .await
     }
 
-    /// Mutes a chat for the given account for the specified duration.
-    ///
-    /// Re-muting with a different duration always overwrites the previous
-    /// `muted_until` value. Use [`MuteDuration::Forever`] to mute indefinitely.
-    /// Returns [`WhitenoiseError::InvalidInput`] if [`MuteDuration::Custom`] carries
-    /// a timestamp that is not in the future.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().mute() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn mute_chat(
         &self,
@@ -598,184 +585,90 @@ impl Whitenoise {
         mls_group_id: &GroupId,
         duration: MuteDuration,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let until = duration.to_expiry();
-        if until <= Utc::now() {
-            return Err(WhitenoiseError::InvalidInput(
-                "mute_chat: `until` must be in the future".to_string(),
-            ));
-        }
-
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let updated = account_group.mute(until, self).await?;
-        self.emit_chat_list_update(
-            account,
-            mls_group_id,
-            ChatListUpdateTrigger::ChatMuteChanged,
-        )
-        .await;
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .mute(duration)
+            .await
     }
 
-    /// Unmutes a chat for the given account.
-    ///
-    /// Always clears `muted_until` and emits `ChatMuteChanged`, even if the
-    /// mute has already expired. This ensures an explicit "Unmute" action is
-    /// immediate rather than waiting for the background cleanup task.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().unmute() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn unmute_chat(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let updated = account_group.unmute(self).await?;
-        self.emit_chat_list_update(
-            account,
-            mls_group_id,
-            ChatListUpdateTrigger::ChatMuteChanged,
-        )
-        .await;
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().for_group(mls_group_id).unmute().await
     }
 
-    /// Marks a group as voluntarily departed for the given account.
-    ///
-    /// Idempotent. Emits [`ChatListUpdateTrigger::LeftGroup`] when the row changes.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().mark_as_left() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub(crate) async fn mark_as_left(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let Some(updated) = account_group.mark_left(self).await? else {
-            // Already departed (left or removed) — reload current state.
-            let current = AccountGroup::get(self, &account.pubkey, mls_group_id)
-                .await?
-                .ok_or(WhitenoiseError::GroupNotFound)?;
-            return Ok(current);
-        };
-
-        self.emit_chat_list_update(account, mls_group_id, ChatListUpdateTrigger::LeftGroup)
-            .await;
-
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .mark_as_left()
+            .await
     }
 
-    /// Marks a group as removed for the given account.
-    ///
-    /// Idempotent. Emits [`ChatListUpdateTrigger::RemovedFromGroup`] when the row changes.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().mark_as_removed() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub(crate) async fn mark_as_removed(
         &self,
         account: &Account,
         mls_group_id: &GroupId,
     ) -> Result<AccountGroup, WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, mls_group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let Some(updated) = account_group.mark_removed(self).await? else {
-            // Another task won the atomic update — reload the current row so
-            // we return the persisted removed_at rather than the stale pre-load value.
-            let current = AccountGroup::get(self, &account.pubkey, mls_group_id)
-                .await?
-                .ok_or(WhitenoiseError::GroupNotFound)?;
-            return Ok(current);
-        };
-
-        self.emit_chat_list_update(
-            account,
-            mls_group_id,
-            ChatListUpdateTrigger::RemovedFromGroup,
-        )
-        .await;
-
-        Ok(updated)
+        let session = self.require_session(&account.pubkey)?;
+        session
+            .membership()
+            .for_group(mls_group_id)
+            .mark_as_removed()
+            .await
     }
 
-    /// Returns the group ID of the latest DM group between the account and the
-    /// given peer, or `None` if no DM group exists between them.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().dm_group_with_peer() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn get_dm_group_with_peer(
         &self,
         account: &Account,
         peer_pubkey: &PublicKey,
     ) -> Result<Option<GroupId>, WhitenoiseError> {
-        AccountGroup::find_latest_dm_group_with_peer(self, &account.pubkey, peer_pubkey).await
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().dm_group_with_peer(peer_pubkey).await
     }
 
-    /// Clears all messages from this account's view by setting a per-account
-    /// timestamp floor. Messages at or before the current time are hidden.
-    ///
-    /// The group remains in the chat list with no visible messages. This is a
-    /// local-only operation with no protocol-level side effects.
-    ///
-    /// Works correctly in multi-account scenarios: each account's
-    /// `chat_cleared_at` is independent. Messages are only physically deleted
-    /// when all accounts sharing the group have cleared.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::membership().for_group().clear_chat() instead."
+    )]
     #[perf_instrument("account_groups")]
     pub async fn clear_chat(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) -> Result<(), WhitenoiseError> {
-        let account_group = AccountGroup::get(self, &account.pubkey, group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        account_group
-            .clear_chat_state(Utc::now(), &self.database)
-            .await?;
-
-        if let Err(e) = Draft::delete(&account.pubkey, group_id, &self.database).await {
-            tracing::warn!(
-                target: "whitenoise::accounts_groups",
-                "Failed to delete draft during clear_chat: {}",
-                e
-            );
-        }
-
-        if let Err(e) = self.database.try_cleanup_cleared_messages(group_id).await {
-            tracing::warn!(
-                target: "whitenoise::accounts_groups",
-                "Failed to cleanup cleared messages: {}",
-                e
-            );
-        }
-
-        match self.create_mdk_for_account(account.pubkey) {
-            Ok(mdk) => {
-                if let Err(e) = mdk.delete_messages_for_group(group_id) {
-                    tracing::warn!(
-                        target: "whitenoise::accounts_groups",
-                        "Failed to delete MDK messages during clear_chat: {}",
-                        e
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::accounts_groups",
-                    "Failed to create MDK for clear_chat message cleanup: {}",
-                    e
-                );
-            }
-        }
-
-        self.emit_chat_list_update(account, group_id, ChatListUpdateTrigger::ChatCleared)
-            .await;
-
-        Ok(())
+        let session = self.require_session(&account.pubkey)?;
+        session.membership().for_group(group_id).clear_chat().await
     }
 
     /// Deletes all local data for a group from this account's perspective.
@@ -920,8 +813,10 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
+    use crate::whitenoise::aggregated_message::AggregatedMessage;
     use crate::whitenoise::group_information::{GroupInformation, GroupType};
     use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
 

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -747,6 +747,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::whitenoise::aggregated_message::AggregatedMessage;

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -406,6 +406,7 @@ impl Whitenoise {
                 account.pubkey.to_hex(),
                 hex::encode(mls_group_id.as_slice())
             );
+            #[allow(deprecated)]
             self.mark_as_removed(account, mls_group_id).await?;
         }
 

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -845,6 +845,7 @@ impl Whitenoise {
         // Optimistic local update is best-effort after publish success.
         // When the auto-committed removal commit arrives later,
         // mark_as_removed() will converge the local state regardless.
+        #[allow(deprecated)]
         if let Err(error) = self.mark_as_left(account, group_id).await {
             tracing::warn!(
                 target: "whitenoise::groups",
@@ -862,6 +863,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::whitenoise::Whitenoise;

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -299,6 +299,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::time::Duration;
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1324,6 +1324,7 @@ pub mod test_utils {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::test_utils::*;
     use super::*;

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -128,6 +128,11 @@ impl<'a> MembershipOpsForGroup<'a> {
             return;
         };
         let Ok(account) = Account::find_by_pubkey(self.pubkey(), self.db()).await else {
+            tracing::debug!(
+                target: "whitenoise::membership",
+                account = %self.pubkey().to_hex(),
+                "Account row not found for chat list emit"
+            );
             return;
         };
         wn.emit_chat_list_update(&account, self.group_id, trigger)
@@ -161,6 +166,10 @@ impl<'a> MembershipOpsForGroup<'a> {
     // ── Accept / decline ──────────────────────────────────────────
 
     /// Accept a group invite (DB-only, no push-token side effects).
+    ///
+    /// Callers that need push-token sharing should use
+    /// `Whitenoise::accept_account_group` until push ops move to the session
+    /// in Phase 13.
     pub async fn accept(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
         Ok(account_group
@@ -169,6 +178,10 @@ impl<'a> MembershipOpsForGroup<'a> {
     }
 
     /// Decline a group invite (DB-only, no push-token side effects).
+    ///
+    /// Callers that need push-token removal should use
+    /// `Whitenoise::decline_account_group` until push ops move to the session
+    /// in Phase 13.
     pub async fn decline(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
         Ok(account_group

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -1,0 +1,325 @@
+//! Group membership operations scoped to an [`AccountSession`].
+//!
+//! Provides [`MembershipOps`] (account-wide) and [`MembershipOpsForGroup`]
+//! (narrowed to a single group) for managing the account↔group relationship:
+//! acceptance/decline, read markers, pinning, archiving, muting, departure
+//! tracking, DM peer lookup, and chat clearing.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use mdk_core::prelude::GroupId;
+use nostr_sdk::{EventId, PublicKey};
+
+use super::AccountSession;
+use crate::whitenoise::accounts::Account;
+use crate::whitenoise::accounts_groups::{AccountGroup, MuteDuration};
+use crate::whitenoise::aggregated_message::AggregatedMessage;
+use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
+use crate::whitenoise::database::Database;
+use crate::whitenoise::error::{Result, WhitenoiseError};
+
+/// Account-scoped membership view. Constructed via [`AccountSession::membership`].
+pub struct MembershipOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> MembershipOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    /// Narrow to a specific group.
+    pub fn for_group(&self, group_id: &'a GroupId) -> MembershipOpsForGroup<'a> {
+        MembershipOpsForGroup {
+            session: self.session,
+            group_id,
+        }
+    }
+
+    fn pubkey(&self) -> &PublicKey {
+        &self.session.account_pubkey
+    }
+
+    fn db(&self) -> &Arc<Database> {
+        &self.session.database
+    }
+
+    /// Return all visible (pending + accepted) account-group memberships.
+    pub async fn visible_groups(&self) -> Result<Vec<AccountGroup>> {
+        Ok(AccountGroup::find_visible_for_account(self.pubkey(), self.db()).await?)
+    }
+
+    /// Return all pending (awaiting user confirmation) account-group memberships.
+    pub async fn pending_groups(&self) -> Result<Vec<AccountGroup>> {
+        Ok(AccountGroup::find_pending_for_account(self.pubkey(), self.db()).await?)
+    }
+
+    /// Mark a message as read for this account.
+    ///
+    /// Looks up the message to find its group, then atomically advances the
+    /// read marker only if the new message is newer than the current one.
+    pub async fn mark_message_read(&self, message_id: &EventId) -> Result<AccountGroup> {
+        let message = AggregatedMessage::find_by_message_id(message_id, self.db())
+            .await?
+            .ok_or(WhitenoiseError::MessageNotFound)?;
+
+        let account_group = AccountGroup::find_by_account_and_group(
+            self.pubkey(),
+            &message.mls_group_id,
+            self.db(),
+        )
+        .await?
+        .ok_or(WhitenoiseError::GroupNotFound)?;
+
+        let message_created_at_ms = message.created_at.timestamp_millis();
+        if let Some(updated) = account_group
+            .update_last_read_if_newer(message_id, message_created_at_ms, self.db())
+            .await?
+        {
+            return Ok(updated);
+        }
+
+        // Update was skipped (message not newer), return current state.
+        Ok(account_group)
+    }
+
+    /// Return the group ID of the latest DM group with `peer_pubkey`, if any.
+    pub async fn dm_group_with_peer(&self, peer_pubkey: &PublicKey) -> Result<Option<GroupId>> {
+        Ok(AccountGroup::find_dm_group_id_by_peer(self.pubkey(), peer_pubkey, self.db()).await?)
+    }
+}
+
+/// Group-scoped membership view. Both account and group identity are baked in.
+///
+/// Constructed via [`MembershipOps::for_group`].
+pub struct MembershipOpsForGroup<'a> {
+    session: &'a AccountSession,
+    group_id: &'a GroupId,
+}
+
+impl<'a> MembershipOpsForGroup<'a> {
+    fn pubkey(&self) -> &PublicKey {
+        &self.session.account_pubkey
+    }
+
+    fn db(&self) -> &Arc<Database> {
+        &self.session.database
+    }
+
+    /// Load the account-group row, returning `GroupNotFound` if absent.
+    async fn require_account_group(&self) -> Result<AccountGroup> {
+        AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+            .await?
+            .ok_or(WhitenoiseError::GroupNotFound)
+    }
+
+    /// Best-effort chat list stream notification.
+    ///
+    /// Reaches back to the `Whitenoise` singleton for the stream managers that
+    /// are not yet session-scoped.
+    // TODO(phase-16): Move chat list stream managers to AccountSession.
+    async fn emit_chat_list_update(&self, trigger: ChatListUpdateTrigger) {
+        let Ok(wn) = crate::whitenoise::Whitenoise::get_instance() else {
+            tracing::debug!(
+                target: "whitenoise::membership",
+                "Whitenoise singleton unavailable for chat list emit"
+            );
+            return;
+        };
+        let Ok(account) = Account::find_by_pubkey(self.pubkey(), self.db()).await else {
+            return;
+        };
+        wn.emit_chat_list_update(&account, self.group_id, trigger)
+            .await;
+    }
+
+    // ── Create / query ────────────────────────────────────────────
+
+    /// Get or create the account-group membership.
+    ///
+    /// For DM groups, pass the peer's pubkey so it is persisted for efficient
+    /// lookups. Returns `(AccountGroup, was_created)`.
+    pub async fn get_or_create(
+        &self,
+        dm_peer_pubkey: Option<&PublicKey>,
+    ) -> Result<(AccountGroup, bool)> {
+        Ok(
+            AccountGroup::find_or_create(self.pubkey(), self.group_id, dm_peer_pubkey, self.db())
+                .await?,
+        )
+    }
+
+    /// Return the last-read message ID for this account in this group.
+    pub async fn last_read_message_id(&self) -> Result<Option<EventId>> {
+        let account_group =
+            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+                .await?;
+        Ok(account_group.and_then(|ag| ag.last_read_message_id))
+    }
+
+    // ── Accept / decline ──────────────────────────────────────────
+
+    /// Accept a group invite (DB-only, no push-token side effects).
+    pub async fn accept(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        Ok(account_group
+            .update_user_confirmation(true, self.db())
+            .await?)
+    }
+
+    /// Decline a group invite (DB-only, no push-token side effects).
+    pub async fn decline(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        Ok(account_group
+            .update_user_confirmation(false, self.db())
+            .await?)
+    }
+
+    // ── Pin ───────────────────────────────────────────────────────
+
+    /// Set or clear the pin order for this chat.
+    ///
+    /// `None` = unpin, `Some(n)` = pin at order n (lower values first).
+    pub async fn set_pin_order(&self, pin_order: Option<i64>) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        Ok(account_group.update_pin_order(pin_order, self.db()).await?)
+    }
+
+    // ── Archive ───────────────────────────────────────────────────
+
+    /// Archive this chat. Idempotent.
+    pub async fn archive(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        if account_group.is_archived() {
+            return Ok(account_group);
+        }
+        let updated = account_group
+            .update_archived_at(Some(Utc::now()), self.db())
+            .await?;
+        self.emit_chat_list_update(ChatListUpdateTrigger::ChatArchiveChanged)
+            .await;
+        Ok(updated)
+    }
+
+    /// Unarchive this chat. Idempotent.
+    pub async fn unarchive(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        if !account_group.is_archived() {
+            return Ok(account_group);
+        }
+        let updated = account_group.update_archived_at(None, self.db()).await?;
+        self.emit_chat_list_update(ChatListUpdateTrigger::ChatArchiveChanged)
+            .await;
+        Ok(updated)
+    }
+
+    // ── Mute ──────────────────────────────────────────────────────
+
+    /// Mute this chat for the specified duration.
+    ///
+    /// Re-muting overwrites the previous expiry. Returns
+    /// [`WhitenoiseError::InvalidInput`] if the resolved expiry is not in
+    /// the future.
+    pub async fn mute(&self, duration: MuteDuration) -> Result<AccountGroup> {
+        let until = duration.to_expiry();
+        if until <= Utc::now() {
+            return Err(WhitenoiseError::InvalidInput(
+                "mute_chat: `until` must be in the future".to_string(),
+            ));
+        }
+        let account_group = self.require_account_group().await?;
+        let updated = account_group
+            .update_muted_until(Some(until), self.db())
+            .await?;
+        self.emit_chat_list_update(ChatListUpdateTrigger::ChatMuteChanged)
+            .await;
+        Ok(updated)
+    }
+
+    /// Unmute this chat. Always clears `muted_until` and emits, even if the
+    /// mute already expired.
+    pub async fn unmute(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        let updated = account_group.update_muted_until(None, self.db()).await?;
+        self.emit_chat_list_update(ChatListUpdateTrigger::ChatMuteChanged)
+            .await;
+        Ok(updated)
+    }
+
+    // ── Departure ─────────────────────────────────────────────────
+
+    /// Mark this group as voluntarily departed.
+    ///
+    /// Idempotent. Emits [`ChatListUpdateTrigger::LeftGroup`] when the row
+    /// changes.
+    pub(crate) async fn mark_as_left(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        let Some(updated) = account_group.mark_left_atomic(self.db()).await? else {
+            // Already departed — reload current state.
+            return self.require_account_group().await;
+        };
+        self.emit_chat_list_update(ChatListUpdateTrigger::LeftGroup)
+            .await;
+        Ok(updated)
+    }
+
+    /// Mark this group as removed by an admin.
+    ///
+    /// Idempotent. Emits [`ChatListUpdateTrigger::RemovedFromGroup`] when
+    /// the row changes.
+    pub(crate) async fn mark_as_removed(&self) -> Result<AccountGroup> {
+        let account_group = self.require_account_group().await?;
+        let Some(updated) = account_group.mark_removed_atomic(self.db()).await? else {
+            // Another task won the atomic update — reload persisted state.
+            return self.require_account_group().await;
+        };
+        self.emit_chat_list_update(ChatListUpdateTrigger::RemovedFromGroup)
+            .await;
+        Ok(updated)
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────
+
+    /// Clear all messages from this account's view by setting a per-account
+    /// timestamp floor.
+    ///
+    /// The group remains in the chat list with no visible messages. This is
+    /// a local-only operation with no protocol-level side effects.
+    pub async fn clear_chat(&self) -> Result<()> {
+        let account_group = self.require_account_group().await?;
+
+        account_group
+            .clear_chat_state(Utc::now(), self.db())
+            .await?;
+
+        // Delete draft (best-effort).
+        if let Err(e) = self.session.repos.drafts.delete(self.group_id).await {
+            tracing::warn!(
+                target: "whitenoise::membership",
+                "Failed to delete draft during clear_chat: {e}"
+            );
+        }
+
+        // Cleanup aggregated messages that all accounts have cleared (best-effort).
+        if let Err(e) = self.db().try_cleanup_cleared_messages(self.group_id).await {
+            tracing::warn!(
+                target: "whitenoise::membership",
+                "Failed to cleanup cleared messages: {e}"
+            );
+        }
+
+        // Delete MDK message state (best-effort).
+        if let Err(e) = self.session.mdk.delete_messages_for_group(self.group_id) {
+            tracing::warn!(
+                target: "whitenoise::membership",
+                "Failed to delete MDK messages during clear_chat: {e}"
+            );
+        }
+
+        self.emit_chat_list_update(ChatListUpdateTrigger::ChatCleared)
+            .await;
+
+        Ok(())
+    }
+}

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -2,10 +2,12 @@ pub(crate) mod messages;
 pub(crate) mod relay_handles;
 
 mod drafts;
+mod membership;
 mod settings;
 mod social;
 
 pub use self::drafts::DraftOps;
+pub use self::membership::{MembershipOps, MembershipOpsForGroup};
 pub use self::settings::SettingsOps;
 pub use self::social::SocialOps;
 
@@ -193,6 +195,11 @@ impl AccountSession {
     /// Return a view for follow/social operations scoped to this session.
     pub fn social(&self) -> SocialOps<'_> {
         SocialOps::new(self)
+    }
+
+    /// Return a view for group membership operations scoped to this session.
+    pub fn membership(&self) -> MembershipOps<'_> {
+        MembershipOps::new(self)
     }
 
     // ── Inbox plane lifecycle ──────────────────────────────────────


### PR DESCRIPTION
![marmot](https://blossom.primal.net/2073f4500fded7489cab1fc045effa653e513d7ecacb228ce5f5e8c8390518e7.jpg)

## Phase 12: Migrate memberships (accounts_groups) to MembershipOps

Migrates 16 account-group membership methods from the `Whitenoise` singleton to session-scoped `MembershipOps` and `MembershipOpsForGroup` on `AccountSession`. This marmot sorted every membership card into its proper filing cabinet.

### What changed

**New file: `session/membership.rs`**: Two-level view pattern matching `MessageOps`.
- `MembershipOps` (account-wide): `visible_groups`, `pending_groups`, `mark_message_read`, `dm_group_with_peer`
- `MembershipOpsForGroup` (group-scoped): `get_or_create`, `accept`, `decline`, `last_read_message_id`, `set_pin_order`, `archive`, `unarchive`, `mute`, `unmute`, `mark_as_left`, `mark_as_removed`, `clear_chat`

**Deprecation facades on `accounts_groups.rs`**: All 16 `impl Whitenoise` methods now delegate to session ops. `accept`/`decline` facades retain push-token side effects until push ops are session-scoped.

**Chat list emit bridge**: Methods that emit chat list updates reach back to `Whitenoise::get_instance()` for the stream managers not yet on `AccountSession`. Same pattern as `MessageOpsForGroup::spawn_publish_task`.

### Design decisions

- **No `AccountGroupsRepo`**: `AccountGroup` already has well-structured static DB methods. Ops delegate directly, same as `MessageOps`.
- **`clear_chat` in scope, `delete_chat` deferred**: `clear_chat` dependencies (MDK, database, drafts repo) are all on `AccountSession`. `delete_chat` needs `storage` and `build_chat_list_item` which are not session-scoped yet.
- **`backfill_dm_peer_pubkeys` stays on `Whitenoise`**: Global startup operation iterating all accounts.

### Files touched

| File | Change |
|------|--------|
| `session/membership.rs` | New: `MembershipOps` + `MembershipOpsForGroup` |
| `session/mod.rs` | Module wiring + `membership()` factory |
| `accounts_groups.rs` | 16 deprecated facades |
| `dispatch.rs`, `groups.rs`, `handle_mls_message.rs` | `#[allow(deprecated)]` at call sites |
| `messages.rs`, `chat_list.rs`, `mod.rs`, `push_notifications.rs` | `#[allow(deprecated)]` on test modules |
| 2 integration test files | `#[allow(deprecated)]` on impl blocks |

### Validation

- `just precommit-quick`: fmt, docs, clippy, dead_code all pass. Unit test failures are pre-existing relay-connection timeouts unrelated to this change.