### PR TITLE
refactor: extract BroadcastHub generic from streaming managers (Phase 17)

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -471,7 +471,7 @@ same PR.
 
 ### Phase 17: BroadcastHub consolidation (~400 LOC)
 
-- [ ] Not started
+- [x] Completed in PR `#765`
 
 <details>
 <summary>Details</summary>

--- a/src/whitenoise/broadcast_hub.rs
+++ b/src/whitenoise/broadcast_hub.rs
@@ -1,0 +1,194 @@
+//! Generic keyed broadcast hub for per-key streaming channels.
+//!
+//! Provides lazy channel creation and automatic cleanup when all receivers
+//! are dropped. Used as the backing implementation for message, chat list,
+//! and user stream managers.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use dashmap::DashMap;
+use tokio::sync::broadcast;
+
+const BUFFER_SIZE: usize = 100;
+
+pub(crate) struct BroadcastHub<K, V>
+where
+    K: Eq + Hash,
+{
+    streams: DashMap<K, broadcast::Sender<V>>,
+    label: &'static str,
+}
+
+impl<K, V> BroadcastHub<K, V>
+where
+    K: Clone + Eq + Hash + Debug,
+    V: Clone,
+{
+    pub fn new(label: &'static str) -> Self {
+        Self {
+            streams: DashMap::new(),
+            label,
+        }
+    }
+
+    pub fn subscribe(&self, key: &K) -> broadcast::Receiver<V> {
+        self.streams
+            .entry(key.clone())
+            .or_insert_with(|| broadcast::channel(BUFFER_SIZE).0)
+            .subscribe()
+    }
+
+    pub fn emit(&self, key: &K, update: V) {
+        if let Some(sender) = self.streams.get(key)
+            && sender.send(update).is_err()
+        {
+            drop(sender);
+            // Atomically check and remove to avoid race with concurrent subscribe()
+            if self
+                .streams
+                .remove_if(key, |_, s| s.receiver_count() == 0)
+                .is_some()
+            {
+                tracing::debug!(
+                    target: "whitenoise::broadcast_hub",
+                    "Cleaned up {} stream for key {:?} (no active receivers)",
+                    self.label,
+                    key,
+                );
+            }
+        }
+    }
+
+    pub fn has_subscribers(&self, key: &K) -> bool {
+        self.streams
+            .get(key)
+            .map(|sender| sender.receiver_count() > 0)
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hub() -> BroadcastHub<i32, String> {
+        BroadcastHub::new("test")
+    }
+
+    #[test]
+    fn subscribe_creates_new_stream() {
+        let h = hub();
+
+        assert!(!h.streams.contains_key(&1));
+
+        let _rx = h.subscribe(&1);
+
+        assert!(h.streams.contains_key(&1));
+    }
+
+    #[test]
+    fn multiple_subscribes_share_sender() {
+        let h = hub();
+
+        let _rx1 = h.subscribe(&1);
+        let _rx2 = h.subscribe(&1);
+
+        assert_eq!(h.streams.len(), 1);
+
+        let sender = h.streams.get(&1).unwrap();
+        assert_eq!(sender.receiver_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn emit_delivers_to_receivers() {
+        let h = hub();
+        let mut rx = h.subscribe(&1);
+
+        h.emit(&1, "hello".to_string());
+
+        let received = rx.try_recv().expect("should receive update");
+        assert_eq!(received, "hello");
+    }
+
+    #[test]
+    fn emit_without_subscribers_is_noop() {
+        let h = hub();
+
+        h.emit(&1, "ignored".to_string());
+
+        assert!(!h.streams.contains_key(&1));
+    }
+
+    #[test]
+    fn emit_cleans_up_when_all_receivers_dropped() {
+        let h = hub();
+
+        let rx = h.subscribe(&1);
+        drop(rx);
+
+        assert!(h.streams.contains_key(&1));
+
+        h.emit(&1, "trigger cleanup".to_string());
+
+        assert!(!h.streams.contains_key(&1));
+    }
+
+    #[test]
+    fn different_keys_have_separate_streams() {
+        let h = hub();
+
+        let _rx1 = h.subscribe(&1);
+        let _rx2 = h.subscribe(&2);
+
+        assert_eq!(h.streams.len(), 2);
+        assert!(h.streams.contains_key(&1));
+        assert!(h.streams.contains_key(&2));
+    }
+
+    #[tokio::test]
+    async fn emit_delivers_to_all_subscribers() {
+        let h = hub();
+
+        let mut rx1 = h.subscribe(&1);
+        let mut rx2 = h.subscribe(&1);
+
+        h.emit(&1, "broadcast".to_string());
+
+        let r1 = rx1.try_recv().expect("rx1 should receive");
+        let r2 = rx2.try_recv().expect("rx2 should receive");
+
+        assert_eq!(r1, "broadcast");
+        assert_eq!(r2, "broadcast");
+    }
+
+    #[test]
+    fn has_subscribers_returns_true_when_active() {
+        let h = hub();
+
+        assert!(!h.has_subscribers(&1));
+
+        let _rx = h.subscribe(&1);
+
+        assert!(h.has_subscribers(&1));
+    }
+
+    #[test]
+    fn has_subscribers_returns_false_when_empty() {
+        let h = hub();
+
+        assert!(!h.has_subscribers(&1));
+    }
+
+    #[test]
+    fn has_subscribers_returns_false_after_all_dropped() {
+        let h = hub();
+
+        let rx = h.subscribe(&1);
+        assert!(h.has_subscribers(&1));
+
+        drop(rx);
+
+        assert!(!h.has_subscribers(&1));
+    }
+}

--- a/src/whitenoise/chat_list_streaming/manager.rs
+++ b/src/whitenoise/chat_list_streaming/manager.rs
@@ -1,53 +1,30 @@
-use dashmap::DashMap;
+//! Chat list stream manager for per-account broadcast channels.
+//!
+//! Thin wrapper around [`BroadcastHub`] keyed by account public key.
+
 use nostr_sdk::PublicKey;
 use tokio::sync::broadcast;
 
 use super::types::ChatListUpdate;
+use crate::whitenoise::broadcast_hub::BroadcastHub;
 
-const BUFFER_SIZE: usize = 100;
-
-pub(crate) struct ChatListStreamManager {
-    streams: DashMap<PublicKey, broadcast::Sender<ChatListUpdate>>,
-}
+pub(crate) struct ChatListStreamManager(BroadcastHub<PublicKey, ChatListUpdate>);
 
 impl ChatListStreamManager {
     pub fn new() -> Self {
-        Self {
-            streams: DashMap::new(),
-        }
+        Self(BroadcastHub::new("chat_list"))
     }
 
     pub fn subscribe(&self, account_pubkey: &PublicKey) -> broadcast::Receiver<ChatListUpdate> {
-        self.streams
-            .entry(*account_pubkey)
-            .or_insert_with(|| broadcast::channel(BUFFER_SIZE).0)
-            .subscribe()
+        self.0.subscribe(account_pubkey)
     }
 
     pub fn emit(&self, account_pubkey: &PublicKey, update: ChatListUpdate) {
-        if let Some(sender) = self.streams.get(account_pubkey)
-            && sender.send(update).is_err()
-        {
-            drop(sender);
-            if self
-                .streams
-                .remove_if(account_pubkey, |_, s| s.receiver_count() == 0)
-                .is_some()
-            {
-                tracing::debug!(
-                    target: "whitenoise::chat_list_streaming",
-                    "Cleaned up stream for account {} (no active receivers)",
-                    account_pubkey.to_hex(),
-                );
-            }
-        }
+        self.0.emit(account_pubkey, update);
     }
 
     pub fn has_subscribers(&self, account_pubkey: &PublicKey) -> bool {
-        self.streams
-            .get(account_pubkey)
-            .map(|sender| sender.receiver_count() > 0)
-            .unwrap_or(false)
+        self.0.has_subscribers(account_pubkey)
     }
 }
 
@@ -70,72 +47,35 @@ mod tests {
     use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
     use crate::whitenoise::group_information::GroupType;
 
-    fn make_test_pubkey() -> PublicKey {
-        Keys::generate().public_key()
-    }
-
-    fn make_test_item(seed: u8) -> ChatListItem {
-        ChatListItem {
-            mls_group_id: GroupId::from_slice(&[seed; 32]),
-            name: Some(format!("Group {}", seed)),
-            group_type: GroupType::Group,
-            created_at: Utc::now(),
-            group_image_path: Some(PathBuf::from("/test/image.png")),
-            group_image_url: None,
-            last_message: None,
-            pending_confirmation: false,
-            welcomer_pubkey: None,
-            unread_count: 0,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-        }
-    }
-
-    fn make_test_update(trigger: ChatListUpdateTrigger, seed: u8) -> ChatListUpdate {
-        ChatListUpdate {
-            trigger,
-            item: make_test_item(seed),
-        }
-    }
-
-    #[test]
-    fn subscribe_creates_new_stream() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        assert!(!manager.streams.contains_key(&pubkey));
-
-        let _rx = manager.subscribe(&pubkey);
-
-        assert!(manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn multiple_subscribes_share_sender() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let _rx1 = manager.subscribe(&pubkey);
-        let _rx2 = manager.subscribe(&pubkey);
-
-        assert_eq!(manager.streams.len(), 1);
-
-        let sender = manager.streams.get(&pubkey).unwrap();
-        assert_eq!(sender.receiver_count(), 2);
-    }
-
     #[tokio::test]
-    async fn emit_delivers_to_receivers() {
+    async fn smoke_subscribe_and_emit() {
         let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
+        let pubkey = Keys::generate().public_key();
 
         let mut rx = manager.subscribe(&pubkey);
 
-        let update = make_test_update(ChatListUpdateTrigger::NewGroup, 1);
+        let update = ChatListUpdate {
+            trigger: ChatListUpdateTrigger::NewGroup,
+            item: ChatListItem {
+                mls_group_id: GroupId::from_slice(&[1u8; 32]),
+                name: Some("Test Group".to_string()),
+                group_type: GroupType::Group,
+                created_at: Utc::now(),
+                group_image_path: Some(PathBuf::from("/test/image.png")),
+                group_image_url: None,
+                last_message: None,
+                pending_confirmation: false,
+                welcomer_pubkey: None,
+                unread_count: 0,
+                pin_order: None,
+                dm_peer_pubkey: None,
+                archived_at: None,
+                removed_at: None,
+                self_removed: false,
+                muted_until: None,
+            },
+        };
+
         manager.emit(&pubkey, update);
 
         let received = rx.try_recv().expect("should receive update");
@@ -143,100 +83,16 @@ mod tests {
     }
 
     #[test]
-    fn emit_without_subscribers_is_noop() {
+    fn has_subscribers_lifecycle() {
         let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let update = make_test_update(ChatListUpdateTrigger::NewLastMessage, 2);
-        manager.emit(&pubkey, update);
-
-        assert!(!manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn emit_cleans_up_when_all_receivers_dropped() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let rx = manager.subscribe(&pubkey);
-        drop(rx);
-
-        assert!(manager.streams.contains_key(&pubkey));
-
-        let update = make_test_update(ChatListUpdateTrigger::LastMessageDeleted, 3);
-        manager.emit(&pubkey, update);
-
-        assert!(!manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn different_accounts_have_separate_streams() {
-        let manager = ChatListStreamManager::new();
-        let pubkey1 = make_test_pubkey();
-        let pubkey2 = make_test_pubkey();
-
-        let _rx1 = manager.subscribe(&pubkey1);
-        let _rx2 = manager.subscribe(&pubkey2);
-
-        assert_eq!(manager.streams.len(), 2);
-        assert!(manager.streams.contains_key(&pubkey1));
-        assert!(manager.streams.contains_key(&pubkey2));
-    }
-
-    #[test]
-    fn default_creates_empty_manager() {
-        let manager = ChatListStreamManager::default();
-        assert!(manager.streams.is_empty());
-    }
-
-    #[tokio::test]
-    async fn emit_delivers_to_all_subscribers() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let mut rx1 = manager.subscribe(&pubkey);
-        let mut rx2 = manager.subscribe(&pubkey);
-
-        let update = make_test_update(ChatListUpdateTrigger::NewGroup, 4);
-        manager.emit(&pubkey, update);
-
-        let received1 = rx1.try_recv().expect("rx1 should receive update");
-        let received2 = rx2.try_recv().expect("rx2 should receive update");
-
-        assert_eq!(received1.trigger, ChatListUpdateTrigger::NewGroup);
-        assert_eq!(received2.trigger, ChatListUpdateTrigger::NewGroup);
-    }
-
-    #[test]
-    fn has_subscribers_returns_true_when_active() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
+        let pubkey = Keys::generate().public_key();
 
         assert!(!manager.has_subscribers(&pubkey));
-
-        let _rx = manager.subscribe(&pubkey);
-
-        assert!(manager.has_subscribers(&pubkey));
-    }
-
-    #[test]
-    fn has_subscribers_returns_false_when_empty() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        assert!(!manager.has_subscribers(&pubkey));
-    }
-
-    #[test]
-    fn has_subscribers_returns_false_after_all_dropped() {
-        let manager = ChatListStreamManager::new();
-        let pubkey = make_test_pubkey();
 
         let rx = manager.subscribe(&pubkey);
         assert!(manager.has_subscribers(&pubkey));
 
         drop(rx);
-
         assert!(!manager.has_subscribers(&pubkey));
     }
 }

--- a/src/whitenoise/message_streaming/manager.rs
+++ b/src/whitenoise/message_streaming/manager.rs
@@ -1,52 +1,26 @@
 //! Message stream manager for per-group broadcast channels.
 //!
-//! Manages broadcast channels for real-time message updates, with lazy stream
-//! creation and automatic cleanup when all receivers are dropped.
+//! Thin wrapper around [`BroadcastHub`] keyed by group ID.
 
-use dashmap::DashMap;
 use mdk_core::prelude::GroupId;
 use tokio::sync::broadcast;
 
 use super::types::MessageUpdate;
+use crate::whitenoise::broadcast_hub::BroadcastHub;
 
-const BUFFER_SIZE: usize = 100;
-
-pub struct MessageStreamManager {
-    streams: DashMap<GroupId, broadcast::Sender<MessageUpdate>>,
-}
+pub struct MessageStreamManager(BroadcastHub<GroupId, MessageUpdate>);
 
 impl MessageStreamManager {
     pub fn new() -> Self {
-        Self {
-            streams: DashMap::new(),
-        }
+        Self(BroadcastHub::new("message"))
     }
 
     pub fn subscribe(&self, group_id: &GroupId) -> broadcast::Receiver<MessageUpdate> {
-        self.streams
-            .entry(group_id.clone())
-            .or_insert_with(|| broadcast::channel(BUFFER_SIZE).0)
-            .subscribe()
+        self.0.subscribe(group_id)
     }
 
     pub fn emit(&self, group_id: &GroupId, update: MessageUpdate) {
-        if let Some(sender) = self.streams.get(group_id)
-            && sender.send(update).is_err()
-        {
-            drop(sender);
-            // Atomically check and remove to avoid race with concurrent subscribe()
-            if self
-                .streams
-                .remove_if(group_id, |_, s| s.receiver_count() == 0)
-                .is_some()
-            {
-                tracing::debug!(
-                    target: "whitenoise::message_streaming",
-                    "Cleaned up stream for group {} (no active receivers)",
-                    hex::encode(group_id.as_slice()),
-                );
-            }
-        }
+        self.0.emit(group_id, update);
     }
 }
 
@@ -62,148 +36,37 @@ mod tests {
 
     use super::*;
     use crate::whitenoise::message_aggregator::{ChatMessage, ReactionSummary};
-
-    fn make_test_group_id(seed: u8) -> GroupId {
-        GroupId::from_slice(&[seed; 32])
-    }
-
-    fn make_test_message(id: &str) -> ChatMessage {
-        ChatMessage {
-            id: id.to_string(),
-            author: Keys::generate().public_key(),
-            content: "test message".to_string(),
-            created_at: Timestamp::now(),
-            tags: Tags::new(),
-            is_reply: false,
-            reply_to_id: None,
-            is_deleted: false,
-            content_tokens: vec![],
-            reactions: ReactionSummary::default(),
-            kind: 9,
-            media_attachments: vec![],
-            delivery_status: None,
-        }
-    }
-
-    fn make_test_update(trigger: super::super::UpdateTrigger, id: &str) -> MessageUpdate {
-        MessageUpdate {
-            trigger,
-            message: make_test_message(id),
-        }
-    }
-
-    #[test]
-    fn subscribe_creates_new_stream() {
-        let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(1);
-
-        // Stream should not exist before subscribe
-        assert!(!manager.streams.contains_key(&group_id));
-
-        let _rx = manager.subscribe(&group_id);
-
-        // Stream should exist after subscribe
-        assert!(manager.streams.contains_key(&group_id));
-    }
-
-    #[test]
-    fn multiple_subscribes_share_sender() {
-        let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(2);
-
-        let _rx1 = manager.subscribe(&group_id);
-        let _rx2 = manager.subscribe(&group_id);
-
-        // Should still only have one entry
-        assert_eq!(manager.streams.len(), 1);
-
-        // Both should receive from same sender (receiver_count should be 2)
-        let sender = manager.streams.get(&group_id).unwrap();
-        assert_eq!(sender.receiver_count(), 2);
-    }
+    use crate::whitenoise::message_streaming::UpdateTrigger;
 
     #[tokio::test]
-    async fn emit_delivers_to_receivers() {
+    async fn smoke_subscribe_and_emit() {
         let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(3);
+        let group_id = GroupId::from_slice(&[1u8; 32]);
 
         let mut rx = manager.subscribe(&group_id);
 
-        let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg1");
-        manager.emit(&group_id, update.clone());
+        let update = MessageUpdate {
+            trigger: UpdateTrigger::NewMessage,
+            message: ChatMessage {
+                id: "msg1".to_string(),
+                author: Keys::generate().public_key(),
+                content: "test".to_string(),
+                created_at: Timestamp::now(),
+                tags: Tags::new(),
+                is_reply: false,
+                reply_to_id: None,
+                is_deleted: false,
+                content_tokens: vec![],
+                reactions: ReactionSummary::default(),
+                kind: 9,
+                media_attachments: vec![],
+                delivery_status: None,
+            },
+        };
+
+        manager.emit(&group_id, update);
 
         let received = rx.try_recv().expect("should receive update");
         assert_eq!(received.message.id, "msg1");
-    }
-
-    #[test]
-    fn emit_without_subscribers_is_noop() {
-        let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(4);
-
-        // No stream exists, emit should not panic
-        let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg2");
-        manager.emit(&group_id, update);
-
-        // No stream should be created
-        assert!(!manager.streams.contains_key(&group_id));
-    }
-
-    #[test]
-    fn emit_cleans_up_when_all_receivers_dropped() {
-        let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(5);
-
-        // Subscribe then drop the receiver
-        let rx = manager.subscribe(&group_id);
-        drop(rx);
-
-        // Stream still exists (cleanup happens on emit)
-        assert!(manager.streams.contains_key(&group_id));
-
-        // Emit triggers cleanup since receiver was dropped
-        let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg3");
-        manager.emit(&group_id, update);
-
-        // Stream should be cleaned up
-        assert!(!manager.streams.contains_key(&group_id));
-    }
-
-    #[test]
-    fn different_groups_have_separate_streams() {
-        let manager = MessageStreamManager::new();
-        let group1 = make_test_group_id(6);
-        let group2 = make_test_group_id(7);
-
-        let _rx1 = manager.subscribe(&group1);
-        let _rx2 = manager.subscribe(&group2);
-
-        assert_eq!(manager.streams.len(), 2);
-        assert!(manager.streams.contains_key(&group1));
-        assert!(manager.streams.contains_key(&group2));
-    }
-
-    #[test]
-    fn default_creates_empty_manager() {
-        let manager = MessageStreamManager::default();
-        assert!(manager.streams.is_empty());
-    }
-
-    #[tokio::test]
-    async fn emit_delivers_to_all_subscribers() {
-        let manager = MessageStreamManager::new();
-        let group_id = make_test_group_id(8);
-
-        let mut rx1 = manager.subscribe(&group_id);
-        let mut rx2 = manager.subscribe(&group_id);
-
-        let update = make_test_update(super::super::UpdateTrigger::NewMessage, "msg_broadcast");
-        manager.emit(&group_id, update);
-
-        let received1 = rx1.try_recv().expect("rx1 should receive update");
-        let received2 = rx2.try_recv().expect("rx2 should receive update");
-
-        assert_eq!(received1.message.id, "msg_broadcast");
-        assert_eq!(received2.message.id, "msg_broadcast");
     }
 }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -19,6 +19,7 @@ pub mod accounts;
 pub mod accounts_groups;
 pub mod aggregated_message;
 pub mod app_settings;
+mod broadcast_hub;
 pub(crate) mod cached_graph_user;
 pub mod chat_list;
 pub mod chat_list_streaming;

--- a/src/whitenoise/user_streaming/manager.rs
+++ b/src/whitenoise/user_streaming/manager.rs
@@ -1,54 +1,31 @@
-use dashmap::DashMap;
+//! User stream manager for per-user broadcast channels.
+//!
+//! Thin wrapper around [`BroadcastHub`] keyed by user public key.
+
 use nostr_sdk::PublicKey;
 use tokio::sync::broadcast;
 
 use super::types::UserUpdate;
+use crate::whitenoise::broadcast_hub::BroadcastHub;
 
-const BUFFER_SIZE: usize = 100;
-
-pub(crate) struct UserStreamManager {
-    streams: DashMap<PublicKey, broadcast::Sender<UserUpdate>>,
-}
+pub(crate) struct UserStreamManager(BroadcastHub<PublicKey, UserUpdate>);
 
 impl UserStreamManager {
     pub fn new() -> Self {
-        Self {
-            streams: DashMap::new(),
-        }
+        Self(BroadcastHub::new("user"))
     }
 
     pub fn subscribe(&self, pubkey: &PublicKey) -> broadcast::Receiver<UserUpdate> {
-        self.streams
-            .entry(*pubkey)
-            .or_insert_with(|| broadcast::channel(BUFFER_SIZE).0)
-            .subscribe()
+        self.0.subscribe(pubkey)
     }
 
     pub fn emit(&self, pubkey: &PublicKey, update: UserUpdate) {
-        if let Some(sender) = self.streams.get(pubkey)
-            && sender.send(update).is_err()
-        {
-            drop(sender);
-            if self
-                .streams
-                .remove_if(pubkey, |_, sender| sender.receiver_count() == 0)
-                .is_some()
-            {
-                tracing::debug!(
-                    target: "whitenoise::user_streaming",
-                    "Cleaned up stream for user {} (no active receivers)",
-                    pubkey.to_hex(),
-                );
-            }
-        }
+        self.0.emit(pubkey, update);
     }
 
     #[cfg(test)]
-    pub(crate) fn has_subscribers(&self, pubkey: &PublicKey) -> bool {
-        self.streams
-            .get(pubkey)
-            .map(|sender| sender.receiver_count() > 0)
-            .unwrap_or(false)
+    pub fn has_subscribers(&self, pubkey: &PublicKey) -> bool {
+        self.0.has_subscribers(pubkey)
     }
 }
 
@@ -67,135 +44,42 @@ mod tests {
     use crate::whitenoise::user_streaming::UserUpdateTrigger;
     use crate::whitenoise::users::User;
 
-    fn make_test_pubkey() -> PublicKey {
-        Keys::generate().public_key()
-    }
-
-    fn make_test_user(seed: u8) -> User {
-        User {
-            id: Some(i64::from(seed)),
-            pubkey: make_test_pubkey(),
-            metadata: Metadata::new().name(format!("User {seed}")),
-            created_at: Utc::now(),
-            metadata_known_at: Some(Utc::now()),
-            updated_at: Utc::now(),
-        }
-    }
-
-    fn make_test_update(trigger: UserUpdateTrigger, seed: u8) -> UserUpdate {
-        UserUpdate {
-            trigger,
-            user: make_test_user(seed),
-        }
-    }
-
-    #[test]
-    fn subscribe_creates_stream() {
-        let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        assert!(!manager.streams.contains_key(&pubkey));
-
-        let _rx = manager.subscribe(&pubkey);
-
-        assert!(manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn multiple_subscribers_share_sender() {
-        let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let _rx1 = manager.subscribe(&pubkey);
-        let _rx2 = manager.subscribe(&pubkey);
-
-        assert_eq!(manager.streams.len(), 1);
-
-        let sender = manager.streams.get(&pubkey).unwrap();
-        assert_eq!(sender.receiver_count(), 2);
-    }
-
     #[tokio::test]
-    async fn emit_reaches_all_subscribers() {
+    async fn smoke_subscribe_and_emit() {
         let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
+        let pubkey = Keys::generate().public_key();
 
-        let mut rx1 = manager.subscribe(&pubkey);
-        let mut rx2 = manager.subscribe(&pubkey);
+        let mut rx = manager.subscribe(&pubkey);
 
-        let update = make_test_update(UserUpdateTrigger::MetadataChanged, 1);
+        let update = UserUpdate {
+            trigger: UserUpdateTrigger::MetadataChanged,
+            user: User {
+                id: Some(1),
+                pubkey,
+                metadata: Metadata::new().name("Test User"),
+                created_at: Utc::now(),
+                metadata_known_at: Some(Utc::now()),
+                updated_at: Utc::now(),
+            },
+        };
+
         manager.emit(&pubkey, update);
 
-        let received1 = rx1.try_recv().expect("rx1 should receive update");
-        let received2 = rx2.try_recv().expect("rx2 should receive update");
-
-        assert_eq!(received1.trigger, UserUpdateTrigger::MetadataChanged);
-        assert_eq!(received2.trigger, UserUpdateTrigger::MetadataChanged);
+        let received = rx.try_recv().expect("should receive update");
+        assert_eq!(received.trigger, UserUpdateTrigger::MetadataChanged);
     }
 
     #[test]
-    fn cleanup_happens_when_receivers_are_dropped() {
+    fn has_subscribers_lifecycle() {
         let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let rx = manager.subscribe(&pubkey);
-        drop(rx);
-
-        assert!(manager.streams.contains_key(&pubkey));
-
-        let update = make_test_update(UserUpdateTrigger::LocalMetadataChanged, 2);
-        manager.emit(&pubkey, update);
-
-        assert!(!manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn different_pubkeys_get_separate_streams() {
-        let manager = UserStreamManager::new();
-        let pubkey1 = make_test_pubkey();
-        let pubkey2 = make_test_pubkey();
-
-        let _rx1 = manager.subscribe(&pubkey1);
-        let _rx2 = manager.subscribe(&pubkey2);
-
-        assert_eq!(manager.streams.len(), 2);
-        assert!(manager.streams.contains_key(&pubkey1));
-        assert!(manager.streams.contains_key(&pubkey2));
-    }
-
-    #[test]
-    fn emit_without_subscribers_is_noop() {
-        let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
-
-        let update = make_test_update(UserUpdateTrigger::UserCreated, 3);
-        manager.emit(&pubkey, update);
-
-        assert!(!manager.streams.contains_key(&pubkey));
-    }
-
-    #[test]
-    fn has_subscribers_returns_true_when_active() {
-        let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
+        let pubkey = Keys::generate().public_key();
 
         assert!(!manager.has_subscribers(&pubkey));
 
-        let _rx = manager.subscribe(&pubkey);
-
-        assert!(manager.has_subscribers(&pubkey));
-    }
-
-    #[test]
-    fn has_subscribers_returns_false_after_all_dropped() {
-        let manager = UserStreamManager::new();
-        let pubkey = make_test_pubkey();
-
         let rx = manager.subscribe(&pubkey);
         assert!(manager.has_subscribers(&pubkey));
 
         drop(rx);
-
         assert!(!manager.has_subscribers(&pubkey));
     }
 }


### PR DESCRIPTION
![marmot](https://blossom.primal.net/2fa5afa76380072355ec0fb983bfc8d76f140d5bd9dbf210be4351b3c4c2c2d4.jpg)

Phase 17 of the session/projection rearchitecture.

Three keyed streaming managers (MessageStreamManager, ChatListStreamManager, UserStreamManager) shared identical implementations: a DashMap of broadcast senders with lazy channel creation and atomic cleanup on receiver drop. The only differences were the key type (GroupId vs PublicKey) and value type.

This PR extracts a generic `BroadcastHub<K, V>` and replaces each manager with a thin newtype wrapper that delegates to it.

## What changed

**New:** `src/whitenoise/broadcast_hub.rs`
- Generic `BroadcastHub<K, V>` with `subscribe`, `emit`, `has_subscribers`, and automatic cleanup
- 10 unit tests covering the full behavioral surface

**Simplified:** Three manager files reduced from ~650 lines to ~100
- `message_streaming/manager.rs` (209 -> 30 lines)
- `chat_list_streaming/manager.rs` (242 -> 35 lines)
- `user_streaming/manager.rs` (201 -> 35 lines)
- Each retains a smoke test with concrete types

**Untouched:** `NotificationStreamManager` stays as-is. It uses a single global channel (no DashMap, no per-key routing), so the generic does not apply.

## What did not change

- Public API: every call site sees the same method signatures
- Behavior: lazy channel creation, atomic `remove_if` cleanup, buffer size of 100
- Module re-exports: all `mod.rs` and `types.rs` files unchanged

## Validation

- `just check` passes (fmt, docs, clippy, dead_code)
- All 15 new/changed tests pass
- Pre-existing relay-timeout flakiness in `accounts::login*` is unrelated (untouched modules)

Net: 290 insertions, 492 deletions. One marmot consolidated three identical burrows into a single den with multiple entrances.