### PR TITLE
feat: migrate group mutation operations to session views (Phase 9)

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -283,7 +283,7 @@ Create only the repos needed for group membership reads. Leave mutation-heavy pa
 
 ### Phase 9: Migrate group member/data mutation operations (~800 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #766
 
 <details>
 <summary>Details</summary>

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -966,6 +966,7 @@ async fn create_group(
     Ok(to_response(&group))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn add_members(
     wn: &Whitenoise,
@@ -1049,6 +1050,7 @@ async fn group_relay_list(
     Ok(to_response(&urls))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn remove_members(
     wn: &Whitenoise,
@@ -1070,6 +1072,7 @@ async fn remove_members(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn leave_group(
     wn: &Whitenoise,
@@ -1084,6 +1087,7 @@ async fn leave_group(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn self_demote(
     wn: &Whitenoise,
@@ -1098,6 +1102,7 @@ async fn self_demote(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn rename_group(
     wn: &Whitenoise,

--- a/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs
@@ -40,6 +40,7 @@ impl AddMembersBenchmark {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl BenchmarkTestCase for AddMembersBenchmark {
     async fn run_iteration(
         &self,

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -484,6 +484,7 @@ impl Whitenoise {
     /// advance local state after confirming the relay accepted the event.
     /// If all publish attempts fail, the pending commit is never merged and
     /// the group state remains unchanged.
+    #[allow(deprecated)]
     #[perf_instrument("event_handlers")]
     async fn perform_self_update(
         whitenoise: &Whitenoise,

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -338,6 +338,7 @@ impl Whitenoise {
         }
     }
 
+    #[allow(deprecated)]
     #[perf_instrument("event_handlers")]
     async fn handle_auto_committed_proposal(
         &self,

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -29,7 +29,7 @@ pub use membership::{GroupWithInfoAndMembership, GroupWithMembership};
 
 impl Whitenoise {
     #[perf_instrument("groups")]
-    async fn resolve_member_delivery_relays(
+    pub(crate) async fn resolve_member_delivery_relays(
         &self,
         member: &User,
         fallback_account: &Account,
@@ -447,8 +447,8 @@ impl Whitenoise {
         session.groups().admins(group_id)
     }
 
-    #[perf_instrument("groups")]
     #[allow(deprecated)]
+    #[perf_instrument("groups")]
     async fn ensure_account_is_group_admin(
         &self,
         account: &Account,
@@ -462,23 +462,11 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Adds new members to an existing MLS group
-    ///
-    /// This method performs the complete workflow for adding members to a group:
-    /// 1. Fetches key packages for all new members from their configured relays
-    /// 2. Creates an MLS add members proposal and generates welcome messages
-    /// 3. Publishes the evolution event to relays (with retry)
-    /// 4. Only after relay acceptance, merges the pending commit locally
-    /// 5. Sends welcome messages to each new member via gift wrap
-    ///
-    /// Per MIP-03, the evolution event is published to relays *before* merging
-    /// the pending commit locally. This ensures we only advance local state
-    /// after confirming the relay accepted the event.
-    ///
-    /// # Arguments
-    /// * `account` - The account performing the member addition (must be group admin)
-    /// * `group_id` - The ID of the group to add members to
-    /// * `members` - Vector of public keys for the new members to add
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().add_members() instead."
+    )]
+    #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn add_members_to_group(
         &self,
@@ -494,24 +482,17 @@ impl Whitenoise {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
         let mut users = Vec::new();
 
-        // Fetch key packages for all members
         for pk in members.iter() {
             let (user, newly_created) = User::find_or_create_by_pubkey(pk, &self.database).await?;
 
-            if newly_created {
-                // Sync relay lists synchronously so that the key package relay lookup below
-                // has a chance to find the user's relays before falling back to account defaults.
-                // Metadata is not needed to add a member to a group; skip it on the critical path.
-                if let Err(e) = user.update_relay_lists(self).await {
-                    tracing::warn!(
-                        target: "whitenoise::accounts::groups::add_members_to_group",
-                        "Failed to update relay lists for new user {}: {}",
-                        user.pubkey,
-                        e
-                    );
-                }
+            if newly_created && let Err(e) = user.update_relay_lists(self).await {
+                tracing::warn!(
+                    target: "whitenoise::accounts::groups::add_members_to_group",
+                    "Failed to update relay lists for new user {}: {}",
+                    user.pubkey,
+                    e
+                );
             }
-            // Try and get user's key package relays, if they don't have any, use account's default relays
             let mut relays_to_use = user.relays(RelayType::KeyPackage, &self.database).await?;
             if relays_to_use.is_empty() {
                 tracing::warn!(
@@ -543,9 +524,7 @@ impl Whitenoise {
         drop(_mls_add);
 
         let evolution_event = update_result.evolution_event;
-        let welcome_rumors = update_result.welcome_rumors;
-
-        let welcome_rumors = match welcome_rumors {
+        let welcome_rumors = match update_result.welcome_rumors {
             None => {
                 return Err(WhitenoiseError::MdkCoreError(mdk_core::Error::Group(
                     "Missing welcome message".to_owned(),
@@ -563,10 +542,7 @@ impl Whitenoise {
         self.publish_and_merge_commit(evolution_event, &account.pubkey, group_id, &relay_urls)
             .await?;
 
-        // Evolution event published and commit merged successfully
-        // Fan out the welcome message to all members
         for (welcome_rumor, user) in welcome_rumors.iter().zip(users) {
-            // Get the public key of the member from the key package event
             let key_package_event_id =
                 welcome_rumor
                     .tags
@@ -584,7 +560,6 @@ impl Whitenoise {
                     "No public key found in key package event".to_string(),
                 ))?;
 
-            // Create a timestamp 1 month in the future
             let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
             let relays_to_use = self
@@ -613,21 +588,11 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Removes members from an existing MLS group
-    ///
-    /// This method performs the complete workflow for removing members from a group:
-    /// 1. Creates an MLS remove members proposal
-    /// 2. Publishes the evolution event to relays (with retry)
-    /// 3. Only after relay acceptance, merges the pending commit locally
-    ///
-    /// Per MIP-03, the evolution event is published to relays *before* merging
-    /// the pending commit locally. This ensures we only advance local state
-    /// after confirming the relay accepted the event.
-    ///
-    /// # Arguments
-    /// * `account` - The account performing the member removal (must be group admin)
-    /// * `group_id` - The ID of the group to remove members from
-    /// * `members` - Vector of public keys for the members to remove
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().remove_members() instead."
+    )]
+    #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn remove_members_from_group(
         &self,
@@ -641,9 +606,7 @@ impl Whitenoise {
         let (relay_urls, evolution_event) = {
             let mdk = self.create_mdk_for_account(account.pubkey)?;
             let relay_urls = Self::ensure_group_relays(&mdk, group_id)?;
-
             let update_result = mdk.remove_members(group_id, &members)?;
-
             (relay_urls, update_result.evolution_event)
         };
 
@@ -651,21 +614,11 @@ impl Whitenoise {
             .await
     }
 
-    /// Updates group metadata and publishes the change to group relays.
-    ///
-    /// This method performs the complete workflow for updating group data:
-    /// 1. Creates an MLS group data update proposal
-    /// 2. Publishes the evolution event to relays (with retry)
-    /// 3. Only after relay acceptance, merges the pending commit locally
-    ///
-    /// Per MIP-03, the evolution event is published to relays *before* merging
-    /// the pending commit locally. This ensures we only advance local state
-    /// after confirming the relay accepted the event.
-    ///
-    /// # Arguments
-    /// * `account` - The account performing the group data update (must be group admin)
-    /// * `group_id` - The ID of the group to update
-    /// * `group_data` - The new group data to update
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().update_group_data() instead."
+    )]
+    #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn update_group_data(
         &self,
@@ -679,9 +632,7 @@ impl Whitenoise {
         let (relay_urls, evolution_event) = {
             let mdk = self.create_mdk_for_account(account.pubkey)?;
             let relay_urls = Self::ensure_group_relays(&mdk, group_id)?;
-
             let update_result = mdk.update_group_data(group_id, group_data)?;
-
             (relay_urls, update_result.evolution_event)
         };
 
@@ -691,12 +642,11 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Removes the caller from the group's `admin_pubkeys` list.
-    ///
-    /// This is a prerequisite for `leave_group()` — the MIP-03 protocol requires
-    /// admins to relinquish admin status before sending a SelfRemove proposal.
-    /// If the caller is the last admin, they must designate another admin first
-    /// via `update_group_data()`.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().self_demote() instead."
+    )]
+    #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn self_demote(&self, account: &Account, group_id: &GroupId) -> Result<()> {
         self.ensure_account_is_group_admin(account, group_id)
@@ -713,25 +663,13 @@ impl Whitenoise {
             .await
     }
 
-    /// Leaves a group by creating a SelfRemove proposal and publishing it.
-    ///
-    /// After the proposal is successfully published, the group is optimistically
-    /// marked as departed locally (`removed_at` + `self_removed`). When another
-    /// member auto-commits the proposal, the resulting commit will trigger
-    /// `mark_as_removed()` which no-ops idempotently since `removed_at` is
-    /// already set.
-    ///
-    /// # Arguments
-    /// * `account` - The account that wants to leave the group
-    /// * `group_id` - The ID of the group to leave
-    ///
-    /// # Errors
-    /// * `AlreadyDepartedFromGroup` if the account has already departed
-    /// * MDK errors if the caller is still an admin (must call `self_demote()` first)
-    /// * Relay errors if the proposal cannot be published
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::groups().leave() instead."
+    )]
+    #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn leave_group(&self, account: &Account, group_id: &GroupId) -> Result<()> {
-        // Guard: can't leave a group you've already departed from
         let account_group = AccountGroup::get(self, &account.pubkey, group_id)
             .await?
             .ok_or(WhitenoiseError::GroupNotFound)?;
@@ -747,7 +685,6 @@ impl Whitenoise {
             (relay_urls, update_result.evolution_event)
         };
 
-        // Publish the SelfRemove proposal to the group relays
         self.publish_event_with_retry(evolution_event, &account.pubkey, &relay_urls)
             .await?;
 
@@ -764,7 +701,6 @@ impl Whitenoise {
             );
         }
 
-        // Always refresh subscriptions after publish
         self.background_refresh_account_group_subscriptions(account);
 
         Ok(())

--- a/src/whitenoise/groups/publish.rs
+++ b/src/whitenoise/groups/publish.rs
@@ -72,6 +72,10 @@ impl Whitenoise {
     /// state. This ensures a failed publish never leaves the group stuck with
     /// a dangling pending commit that would block all subsequent operations.
     /// The error from the publish attempt is returned to the caller.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use GroupOps::publish_and_merge_commit() instead."
+    )]
     pub(crate) async fn publish_and_merge_commit(
         &self,
         evolution_event: Event,
@@ -108,6 +112,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use nostr_sdk::prelude::*;
 

--- a/src/whitenoise/session/groups.rs
+++ b/src/whitenoise/session/groups.rs
@@ -1,18 +1,27 @@
-//! Group read operations scoped to an [`AccountSession`].
+//! Group read and mutation operations scoped to an [`AccountSession`].
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::time::Duration;
 
 use mdk_core::prelude::*;
+use nostr_sdk::prelude::*;
 use nostr_sdk::{PublicKey, RelayUrl};
 
 use super::AccountSession;
+use crate::whitenoise::Whitenoise;
+use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::group_information::GroupInformation;
 use crate::whitenoise::groups::{GroupWithInfoAndMembership, GroupWithMembership};
+use crate::whitenoise::key_packages::{
+    REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_tags,
+};
+use crate::whitenoise::relays::{Relay, RelayType};
+use crate::whitenoise::users::User;
 
-/// View over [`AccountSession`] for group read operations.
+/// View over [`AccountSession`] for group operations.
 ///
 /// Obtain via [`AccountSession::groups`].
 pub struct GroupOps<'a> {
@@ -23,6 +32,21 @@ impl<'a> GroupOps<'a> {
     pub(super) fn new(session: &'a AccountSession) -> Self {
         Self { session }
     }
+
+    // ── Singleton bridge ──────────────────────────────────────────────
+
+    /// Obtain a `&'static Whitenoise` reference via the global singleton.
+    ///
+    /// Several mutation methods need access to relay control, user relay
+    /// lookups, and account-group records that still live on `Whitenoise`.
+    /// This bridge keeps the session API functional while ownership migrates.
+    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
+    fn wn() -> Result<&'static Whitenoise> {
+        Whitenoise::get_instance()
+            .map_err(|_| WhitenoiseError::Internal("Whitenoise singleton unavailable".to_string()))
+    }
+
+    // ── Read operations ───────────────────────────────────────────────
 
     /// Return all groups for this account.
     ///
@@ -149,5 +173,316 @@ impl<'a> GroupOps<'a> {
     /// Return the admin public keys for a group.
     pub fn admins(&self, group_id: &GroupId) -> Result<Vec<PublicKey>> {
         Ok(self.get(group_id)?.admin_pubkeys.into_iter().collect())
+    }
+
+    // ── Mutation helpers ──────────────────────────────────────────────
+
+    /// Verify the current account is an admin of the given group.
+    fn ensure_admin(&self, group_id: &GroupId) -> Result<()> {
+        let admins = self.admins(group_id)?;
+        if !admins.contains(&self.session.account_pubkey) {
+            return Err(WhitenoiseError::AccountNotAuthorized);
+        }
+        Ok(())
+    }
+
+    /// Return the relay URLs configured for the group, or error if none.
+    fn ensure_relays(&self, group_id: &GroupId) -> Result<Vec<RelayUrl>> {
+        let relays = self
+            .session
+            .mdk
+            .get_relays(group_id)
+            .map_err(WhitenoiseError::from)?;
+        if relays.is_empty() {
+            return Err(WhitenoiseError::GroupMissingRelays);
+        }
+        Ok(relays.into_iter().collect())
+    }
+
+    /// Publish an evolution event and merge the pending commit on success.
+    ///
+    /// Per MIP-03 this is the canonical ordering for MLS state evolution:
+    /// 1. Caller creates the pending commit via an MDK operation
+    /// 2. This method publishes the evolution event (with retry)
+    /// 3. Only after at least one relay accepts, the pending commit is merged
+    ///
+    /// If all publish attempts fail, the pending commit is cleared via
+    /// `clear_pending_commit`, rolling back the MLS group to its pre-commit
+    /// state.
+    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
+    async fn publish_and_merge_commit(
+        &self,
+        evolution_event: Event,
+        group_id: &GroupId,
+        relay_urls: &[RelayUrl],
+    ) -> Result<()> {
+        let wn = Self::wn()?;
+        if let Err(publish_err) = wn
+            .publish_event_with_retry(evolution_event, &self.session.account_pubkey, relay_urls)
+            .await
+        {
+            if let Err(clear_err) = self.session.mdk.clear_pending_commit(group_id) {
+                tracing::warn!(
+                    target: "whitenoise::session::groups",
+                    "Failed to clear pending commit after publish failure for group {}: {}",
+                    hex::encode(group_id.as_slice()),
+                    clear_err,
+                );
+            }
+            return Err(publish_err);
+        }
+        self.session.mdk.merge_pending_commit(group_id)?;
+        Ok(())
+    }
+
+    // ── Mutation operations ───────────────────────────────────────────
+
+    /// Adds new members to an existing MLS group.
+    ///
+    /// Performs the complete workflow: fetch key packages, add members via MDK,
+    /// publish evolution event, merge commit, and send welcome messages.
+    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
+    pub async fn add_members(
+        &self,
+        group_id: &GroupId,
+        member_pubkeys: Vec<PublicKey>,
+    ) -> Result<()> {
+        self.ensure_admin(group_id)?;
+
+        let wn = Self::wn()?;
+        let signer = self
+            .session
+            .get_signer()
+            .ok_or(WhitenoiseError::SignerUnavailable(
+                self.session.account_pubkey,
+            ))?;
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+
+        let mut key_package_events: Vec<Event> = Vec::new();
+        let mut users = Vec::new();
+
+        for pk in member_pubkeys.iter() {
+            let (user, newly_created) = User::find_or_create_by_pubkey(pk, &wn.database).await?;
+
+            if newly_created && let Err(e) = user.update_relay_lists(wn).await {
+                tracing::warn!(
+                    target: "whitenoise::session::groups",
+                    "Failed to update relay lists for new user {}: {}",
+                    user.pubkey,
+                    e
+                );
+            }
+
+            let mut relays_to_use = user.relays(RelayType::KeyPackage, &wn.database).await?;
+            if relays_to_use.is_empty() {
+                tracing::warn!(
+                    target: "whitenoise::session::groups",
+                    "User {} has no relays configured, using account's default relays",
+                    user.pubkey
+                );
+                relays_to_use = account.nip65_relays(wn).await?;
+            }
+            let relays_to_use_urls = Relay::urls(&relays_to_use);
+            let some_event = wn
+                .relay_control
+                .fetch_user_key_package(*pk, &relays_to_use_urls)
+                .await?;
+            let event = some_event.ok_or(WhitenoiseError::MdkCoreError(
+                mdk_core::Error::KeyPackage("Does not exist".to_owned()),
+            ))?;
+
+            Self::validate_fetched_member_key_package(&event, pk)?;
+
+            key_package_events.push(event);
+            users.push(user);
+        }
+
+        let relay_urls = self.ensure_relays(group_id)?;
+
+        let update_result = self
+            .session
+            .mdk
+            .add_members(group_id, &key_package_events)?;
+
+        let evolution_event = update_result.evolution_event;
+        let welcome_rumors = match update_result.welcome_rumors {
+            None => {
+                return Err(WhitenoiseError::MdkCoreError(mdk_core::Error::Group(
+                    "Missing welcome message".to_owned(),
+                )));
+            }
+            Some(wr) => wr,
+        };
+
+        if welcome_rumors.len() != users.len() {
+            return Err(WhitenoiseError::Internal(
+                "Welcome rumours are missing for some of the members".to_string(),
+            ));
+        }
+
+        self.publish_and_merge_commit(evolution_event, group_id, &relay_urls)
+            .await?;
+
+        for (welcome_rumor, user) in welcome_rumors.iter().zip(users) {
+            let key_package_event_id =
+                welcome_rumor
+                    .tags
+                    .event_ids()
+                    .next()
+                    .ok_or(WhitenoiseError::Internal(
+                        "No event ID found in welcome rumor".to_string(),
+                    ))?;
+
+            let member_pubkey = key_package_events
+                .iter()
+                .find(|event| event.id == *key_package_event_id)
+                .map(|event| event.pubkey)
+                .ok_or(WhitenoiseError::Internal(
+                    "No public key found in key package event".to_string(),
+                ))?;
+
+            let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
+
+            let relays_to_use = wn
+                .resolve_member_delivery_relays(
+                    &user,
+                    &account,
+                    "whitenoise::session::groups::add_members",
+                )
+                .await?;
+
+            let relay_urls = Relay::urls(&relays_to_use);
+
+            wn.relay_control
+                .publish_welcome(
+                    &member_pubkey,
+                    welcome_rumor.clone(),
+                    &[Tag::expiration(one_month_future)],
+                    account.pubkey,
+                    &relay_urls,
+                    signer.clone(),
+                )
+                .await
+                .map_err(WhitenoiseError::from)?;
+        }
+
+        Ok(())
+    }
+
+    /// Removes members from an existing MLS group.
+    ///
+    /// Creates an MLS remove-members proposal, publishes the evolution event,
+    /// and merges the pending commit on success.
+    pub async fn remove_members(&self, group_id: &GroupId, members: Vec<PublicKey>) -> Result<()> {
+        self.ensure_admin(group_id)?;
+
+        let relay_urls = self.ensure_relays(group_id)?;
+        let update_result = self.session.mdk.remove_members(group_id, &members)?;
+
+        self.publish_and_merge_commit(update_result.evolution_event, group_id, &relay_urls)
+            .await
+    }
+
+    /// Updates group metadata and publishes the change to group relays.
+    ///
+    /// Creates an MLS group-data update proposal, publishes the evolution
+    /// event, merges the pending commit, and refreshes subscriptions.
+    // TODO(phase-16): Remove singleton bridge when background_refresh moves to session.
+    pub async fn update_group_data(
+        &self,
+        group_id: &GroupId,
+        group_data: NostrGroupDataUpdate,
+    ) -> Result<()> {
+        self.ensure_admin(group_id)?;
+
+        let relay_urls = self.ensure_relays(group_id)?;
+        let update_result = self.session.mdk.update_group_data(group_id, group_data)?;
+
+        self.publish_and_merge_commit(update_result.evolution_event, group_id, &relay_urls)
+            .await?;
+
+        let wn = Self::wn()?;
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+        wn.background_refresh_account_group_subscriptions(&account);
+        Ok(())
+    }
+
+    /// Removes the caller from the group's admin list.
+    ///
+    /// This is a prerequisite for [`Self::leave`] — the MIP-03 protocol
+    /// requires admins to relinquish admin status before sending a SelfRemove
+    /// proposal.
+    pub async fn self_demote(&self, group_id: &GroupId) -> Result<()> {
+        self.ensure_admin(group_id)?;
+
+        let relay_urls = self.ensure_relays(group_id)?;
+        let update_result = self.session.mdk.self_demote(group_id)?;
+
+        self.publish_and_merge_commit(update_result.evolution_event, group_id, &relay_urls)
+            .await
+    }
+
+    /// Leaves a group by creating a SelfRemove proposal and publishing it.
+    ///
+    /// After the proposal is successfully published, the group is
+    /// optimistically marked as departed locally. When another member
+    /// auto-commits the proposal, the resulting commit converges local state.
+    // TODO(phase-16): Remove singleton bridge when mark_as_left moves to session.
+    #[allow(deprecated)] // wn.mark_as_left() deprecated in Phase 12
+    pub async fn leave(&self, group_id: &GroupId) -> Result<()> {
+        let wn = Self::wn()?;
+
+        let account_group = AccountGroup::get(wn, &self.session.account_pubkey, group_id)
+            .await?
+            .ok_or(WhitenoiseError::GroupNotFound)?;
+
+        if account_group.is_removed() {
+            return Err(WhitenoiseError::AlreadyDepartedFromGroup);
+        }
+
+        let relay_urls = self.ensure_relays(group_id)?;
+        let update_result = self.session.mdk.leave_group(group_id)?;
+
+        wn.publish_event_with_retry(
+            update_result.evolution_event,
+            &self.session.account_pubkey,
+            &relay_urls,
+        )
+        .await?;
+
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+
+        if let Err(error) = wn.mark_as_left(&account, group_id).await {
+            tracing::warn!(
+                target: "whitenoise::session::groups",
+                account_pubkey = %self.session.account_pubkey,
+                group_id = %hex::encode(group_id.as_slice()),
+                "SelfRemove published but failed to mark local departure: {error}",
+            );
+        }
+
+        wn.background_refresh_account_group_subscriptions(&account);
+
+        Ok(())
+    }
+
+    // ── Static helpers ────────────────────────────────────────────────
+
+    fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey) -> Result<()> {
+        if event.pubkey != *pk {
+            return Err(WhitenoiseError::InvalidInput(format!(
+                "Fetched key package event {} signed by {} instead of expected {}",
+                event.id, event.pubkey, pk
+            )));
+        }
+
+        validate_marmot_key_package_tags(event, REQUIRED_MLS_CIPHERSUITE_TAG).map_err(|e| {
+            WhitenoiseError::InvalidInput(format!(
+                "Incompatible key package event {} for member {}: {}",
+                event.id, pk, e
+            ))
+        })?;
+
+        Ok(())
     }
 }

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -203,7 +203,7 @@ impl AccountSession {
     pub fn membership(&self) -> MembershipOps<'_> {
         MembershipOps::new(self)
     }
-  
+
     /// Return a view for group read operations scoped to this session.
     pub fn groups(&self) -> GroupOps<'_> {
         GroupOps::new(self)


### PR DESCRIPTION
## Summary

Migrates the 5 group mutation operations from `Whitenoise` impl to session-scoped `GroupOps` view, continuing the session/projection rearchitecture (Phase 9).

**Methods migrated to `GroupOps`:**
- `add_members` — full workflow: fetch key packages, validate, add via MDK, publish evolution event, merge commit, send welcome messages
- `remove_members` — create MLS remove proposal, publish, merge
- `update_group_data` — update group metadata, publish, merge, refresh subscriptions
- `self_demote` — remove self from admin list (prerequisite for leave)
- `leave` — create SelfRemove proposal, publish (no merge — it's a proposal, not a commit), mark local departure

**Supporting helpers added to `GroupOps`:**
- `wn()` — singleton bridge for relay_control/DB access (annotated `TODO(phase-16)`)
- `ensure_admin()` — verify current account is group admin
- `ensure_relays()` — validate group has configured relays
- `publish_and_merge_commit()` — MIP-03 publish-then-merge with rollback on failure
- `validate_fetched_member_key_package()` — key package event validation

## Architecture Decisions

**Deprecated wrappers retain original implementations** — Unlike Phase 8 (read ops) where deprecated wrappers safely delegated to session methods, mutation ops cannot delegate because session methods use the singleton bridge (`Self::wn()`) which fails in unit tests where no global singleton exists. The deprecated `Whitenoise` methods keep their original `&self`-based logic for backward compatibility.

**Singleton bridge pattern** — Session mutation methods access `relay_control`, user relay lookups, and account-group records through `Whitenoise::get_instance()`. Each usage is annotated with `// TODO(phase-16)` for removal when these services move to session ownership.

**`leave()` uses `publish_event_with_retry` directly** — Unlike other mutations that use `publish_and_merge_commit`, leaving creates a PROPOSAL (not a commit). The proposal is published and the group is optimistically marked as departed; another member's auto-commit will finalize the state change.

## Files Changed

| File | Change |
|------|--------|
| `src/whitenoise/session/groups.rs` | +333 lines: mutation methods, helpers, singleton bridge |
| `src/whitenoise/groups.rs` | Deprecated wrappers with `#[deprecated]` + `#[allow(deprecated)]` on all 5 methods |
| `src/whitenoise/groups/publish.rs` | Deprecated `Whitenoise::publish_and_merge_commit` (session has its own) |
| `src/cli/dispatch.rs` | `#[allow(deprecated)]` on caller functions |
| `src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs` | `#[allow(deprecated)]` on `perform_self_update` |
| `src/whitenoise/event_processor/event_handlers/handle_mls_message.rs` | `#[allow(deprecated)]` on `handle_auto_committed_proposal` |
| `src/integration_tests/benchmarks/test_cases/groups/add_members_benchmark.rs` | `#[allow(deprecated)]` |
| `docs/session-projection-implementation-plan.md` | Phase 9 marked completed with PR #766 |

## Test Results

All checks pass (fmt, docs, clippy, dead_code, tests) except 1 pre-existing failure from PR #760:
- `test_send_message_to_group_edge_cases` — broken by e-tag validation for kind 5 deletion events (Danny's phases 6+7, not related to this PR)

## Test plan

- [x] `just precommit-quick` passes (1213/1213 tests pass, 1 pre-existing failure from #760)
- [x] Verify deprecated wrappers still work for existing callers (dispatch, event handlers)
- [x] `just int-test basic-messaging` (requires Docker)