### PR TITLE
feat: migrate key packages and chat list reads to session ops (Phase 14)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1272,6 +1272,7 @@ async fn follows_check(
     Ok(Response::ok(serde_json::json!({ "following": following })))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn chats_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
@@ -1348,6 +1349,7 @@ async fn unmute_chat(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 #[perf_instrument("dispatch")]
 async fn archived_chats_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
@@ -2163,6 +2165,7 @@ async fn demote_admin(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 async fn keys_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
     let packages = wn
@@ -2182,6 +2185,7 @@ async fn keys_list(wn: &Whitenoise, account_str: &str) -> Result<Response, Respo
     Ok(Response::ok(serde_json::json!({ "key_packages": items })))
 }
 
+#[allow(deprecated)]
 async fn keys_publish(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
     wn.publish_key_package_for_account(&account)
@@ -2190,6 +2194,7 @@ async fn keys_publish(wn: &Whitenoise, account_str: &str) -> Result<Response, Re
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[allow(deprecated)]
 async fn keys_delete(
     wn: &Whitenoise,
     account_str: &str,
@@ -2205,6 +2210,7 @@ async fn keys_delete(
     Ok(Response::ok(serde_json::json!({ "deleted": deleted })))
 }
 
+#[allow(deprecated)]
 async fn keys_delete_all(wn: &Whitenoise, account_str: &str) -> Result<Response, Response> {
     let account = find_account(wn, account_str).await?;
     let count = wn

--- a/src/integration_tests/test_cases/chat_list/mod.rs
+++ b/src/integration_tests/test_cases/chat_list/mod.rs
@@ -1,8 +1,12 @@
 mod create_dm;
 mod mark_message_read;
+#[allow(deprecated)]
 mod verify_chat_list;
+#[allow(deprecated)]
 mod verify_chat_list_item;
+#[allow(deprecated)]
 mod verify_chat_list_order;
+#[allow(deprecated)]
 mod verify_dm_chat_list_item;
 
 pub use create_dm::CreateDmTestCase;

--- a/src/integration_tests/test_cases/scheduler/mod.rs
+++ b/src/integration_tests/test_cases/scheduler/mod.rs
@@ -1,4 +1,6 @@
+#[allow(deprecated)]
 mod key_package_lifecycle;
+#[allow(deprecated)]
 mod key_package_maintenance;
 mod verify_scheduler_running;
 

--- a/src/integration_tests/test_cases/shared/mod.rs
+++ b/src/integration_tests/test_cases/shared/mod.rs
@@ -1,3 +1,4 @@
+#[allow(deprecated)]
 pub mod create_accounts;
 pub mod create_group;
 pub mod delete_message;

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -683,6 +683,7 @@ impl Whitenoise {
     /// (`removed_at.is_none()`), they remain a member in the protocol -- other
     /// members continue encrypting messages for them, and their key packages
     /// remain published. The recommended flow is `leave_group` -> `delete_chat`.
+    #[allow(deprecated)]
     #[perf_instrument("account_groups")]
     pub async fn delete_chat(
         &self,

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -722,7 +722,7 @@ impl Whitenoise {
     /// Groups without images return None (not an error).
     /// Download failures are logged but don't fail the batch.
     #[perf_instrument("chat_list")]
-    async fn resolve_group_image_paths(
+    pub(crate) async fn resolve_group_image_paths(
         &self,
         account: &Account,
         groups: &[group_types::Group],

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -118,7 +118,7 @@ impl ChatListItem {
 ///
 /// Fallback chain: display_name -> name -> None
 /// Does not fall back to truncated pubkey.
-fn resolve_display_name(user: Option<&User>) -> Option<String> {
+pub(crate) fn resolve_display_name(user: Option<&User>) -> Option<String> {
     user.and_then(|u| {
         u.metadata
             .display_name
@@ -133,7 +133,7 @@ fn resolve_display_name(user: Option<&User>) -> Option<String> {
 ///
 /// - Groups: Returns the group name from MDK (may be empty string)
 /// - DMs: Returns the other user's display name (None if no metadata)
-fn resolve_chat_name(
+pub(crate) fn resolve_chat_name(
     group: &group_types::Group,
     group_type: &GroupType,
     dm_other_user: Option<&User>,
@@ -153,7 +153,7 @@ fn get_dm_other_user(group_members: &[PublicKey], account_pubkey: &PublicKey) ->
 }
 
 /// Collects all pubkeys that need metadata lookup (DM participants + message authors).
-fn collect_pubkeys_to_fetch(
+pub(crate) fn collect_pubkeys_to_fetch(
     dm_other_users: &HashMap<GroupId, PublicKey>,
     last_message_map: &HashMap<GroupId, ChatMessageSummary>,
 ) -> Vec<PublicKey> {
@@ -167,7 +167,7 @@ fn collect_pubkeys_to_fetch(
 }
 
 /// Assembles ChatListItems from all the collected data.
-fn assemble_chat_list_items(
+pub(crate) fn assemble_chat_list_items(
     groups: &[group_types::Group],
     group_info_map: &HashMap<GroupId, GroupInformation>,
     dm_other_users: &HashMap<GroupId, PublicKey>,
@@ -247,11 +247,16 @@ pub(crate) fn sort_chat_list(items: &mut [ChatListItem]) {
     items.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 }
 
+#[allow(deprecated)]
 impl Whitenoise {
     /// Retrieves the active (non-archived) chat list for an account.
     ///
     /// Returns a list of chat summaries sorted by last activity (most recent first).
     /// Declined and archived groups are filtered out.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::chat_list().active() instead."
+    )]
     #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
@@ -266,6 +271,10 @@ impl Whitenoise {
     /// Retrieves the archived chat list for an account.
     ///
     /// Returns only archived chats, sorted by last activity.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::chat_list().archived() instead."
+    )]
     #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_archived_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
@@ -347,6 +356,10 @@ impl Whitenoise {
     /// - Group doesn't exist in MDK
     /// - GroupInformation doesn't exist (group not fully initialized)
     /// - AccountGroup is declined
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::chat_list().build_item() instead."
+    )]
     #[perf_instrument("chat_list")]
     pub(crate) async fn build_chat_list_item(
         &self,

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -269,6 +269,12 @@ impl Whitenoise {
     /// Called from the emit path which runs inside `tokio::spawn`. Cannot
     /// delegate to session ops without hitting the compiler recursion limit
     /// (the extra async indirection pushes h2/hyper trait evaluation past 128).
+    ///
+    /// NOTE: This implementation resolves DM peers via MDK group membership,
+    /// while `ChatListOps::build_item` uses `AccountGroup::find_dm_peers_for_account`
+    /// (batch SQL). The two paths can diverge in edge cases where MDK membership
+    /// and the DB are transiently inconsistent. Tracked for removal in phase 15
+    /// (session-scoped event dispatch) when emit paths use session directly.
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::chat_list().build_item() instead."

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -17,7 +17,6 @@ use crate::whitenoise::{
     chat_list_streaming::{ChatListUpdate, ChatListUpdateTrigger},
     error::Result,
     group_information::{GroupInformation, GroupType},
-    groups::GroupWithMembership,
     message_aggregator::ChatMessageSummary,
     users::User,
 };
@@ -144,14 +143,6 @@ pub(crate) fn resolve_chat_name(
     }
 }
 
-/// Finds the "other user" in a DM group (the participant who isn't the account owner).
-fn get_dm_other_user(group_members: &[PublicKey], account_pubkey: &PublicKey) -> Option<PublicKey> {
-    group_members
-        .iter()
-        .find(|pk| *pk != account_pubkey)
-        .copied()
-}
-
 /// Collects all pubkeys that need metadata lookup (DM participants + message authors).
 pub(crate) fn collect_pubkeys_to_fetch(
     dm_other_users: &HashMap<GroupId, PublicKey>,
@@ -249,113 +240,35 @@ pub(crate) fn sort_chat_list(items: &mut [ChatListItem]) {
 
 #[allow(deprecated)]
 impl Whitenoise {
-    /// Retrieves the active (non-archived) chat list for an account.
-    ///
-    /// Returns a list of chat summaries sorted by last activity (most recent first).
-    /// Declined and archived groups are filtered out.
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::chat_list().active() instead."
     )]
-    #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
-        let visible = self.visible_groups(account).await?;
-        let active: Vec<_> = visible
-            .into_iter()
-            .filter(|gwm| !gwm.membership.is_archived())
-            .collect();
-        self.build_chat_list_for(account, active).await
+        self.require_session(&account.pubkey)?
+            .chat_list()
+            .active()
+            .await
     }
 
-    /// Retrieves the archived chat list for an account.
-    ///
-    /// Returns only archived chats, sorted by last activity.
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::chat_list().archived() instead."
     )]
-    #[allow(deprecated)]
     #[perf_instrument("chat_list")]
     pub async fn get_archived_chat_list(&self, account: &Account) -> Result<Vec<ChatListItem>> {
-        let visible = self.visible_groups(account).await?;
-        let archived: Vec<_> = visible
-            .into_iter()
-            .filter(|gwm| gwm.membership.is_archived())
-            .collect();
-        self.build_chat_list_for(account, archived).await
-    }
-
-    /// Builds a sorted chat list from a pre-filtered set of groups.
-    ///
-    /// Handles the expensive batch pipeline: group info, messages, users, images,
-    /// unread counts, assembly, and sorting.
-    #[perf_instrument("chat_list")]
-    async fn build_chat_list_for(
-        &self,
-        account: &Account,
-        groups_with_membership: Vec<GroupWithMembership>,
-    ) -> Result<Vec<ChatListItem>> {
-        if groups_with_membership.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let groups: Vec<_> = groups_with_membership
-            .iter()
-            .map(|gwm| gwm.group.clone())
-            .collect();
-        let group_ids: Vec<GroupId> = groups.iter().map(|g| g.mls_group_id.clone()).collect();
-
-        let membership_map: HashMap<GroupId, AccountGroup> = groups_with_membership
-            .iter()
-            .map(|gwm| (gwm.group.mls_group_id.clone(), gwm.membership.clone()))
-            .collect();
-
-        let group_info_map = self
-            .build_group_info_map(account.pubkey, &group_ids)
-            .await?;
-        let dm_other_users = self.identify_dm_participants(account).await?;
-        let last_message_map = self.build_last_message_map(&group_ids).await?;
-        let pubkeys_to_fetch = collect_pubkeys_to_fetch(&dm_other_users, &last_message_map);
-        let users_by_pubkey = self.build_users_by_pubkey(&pubkeys_to_fetch).await?;
-        let image_paths = self
-            .resolve_group_images(account, &groups, &group_info_map)
-            .await;
-
-        let group_markers: Vec<_> = membership_map
-            .iter()
-            .map(|(gid, ag)| {
-                let cleared_ms = ag.chat_cleared_at.map(|dt| dt.timestamp_millis());
-                (gid.clone(), ag.last_read_message_id, cleared_ms)
-            })
-            .collect();
-        let unread_counts =
-            AggregatedMessage::count_unread_for_groups(&group_markers, &self.database).await?;
-
-        let mut items = assemble_chat_list_items(
-            &groups,
-            &group_info_map,
-            &dm_other_users,
-            &last_message_map,
-            &users_by_pubkey,
-            &image_paths,
-            &membership_map,
-            &unread_counts,
-        );
-        sort_chat_list(&mut items);
-
-        Ok(items)
+        self.require_session(&account.pubkey)?
+            .chat_list()
+            .archived()
+            .await
     }
 
     /// Builds a single ChatListItem for a specific group.
     ///
-    /// Used by the streaming system to construct updates without re-fetching the entire chat list.
-    /// Performs individual queries rather than batch operations.
-    ///
-    /// Returns `Ok(None)` if:
-    /// - Group doesn't exist in MDK
-    /// - GroupInformation doesn't exist (group not fully initialized)
-    /// - AccountGroup is declined
+    /// Called from the emit path which runs inside `tokio::spawn`. Cannot
+    /// delegate to session ops without hitting the compiler recursion limit
+    /// (the extra async indirection pushes h2/hyper trait evaluation past 128).
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::chat_list().build_item() instead."
@@ -366,56 +279,50 @@ impl Whitenoise {
         account: &Account,
         group_id: &GroupId,
     ) -> Result<Option<ChatListItem>> {
-        // 1. Get group from MDK
         let mdk = self.create_mdk_for_account(account.pubkey)?;
         let Some(group) = mdk.get_group(group_id)? else {
             return Ok(None);
         };
 
-        // 2. Get GroupInformation (returns error if not found)
         let group_info =
             match GroupInformation::find_by_mls_group_id(group_id, &self.database).await {
                 Ok(info) => info,
-                Err(_) => return Ok(None), // Group not fully initialized
+                Err(_) => return Ok(None),
             };
 
-        // 3. Get AccountGroup for visibility/pending status and welcomer pubkey
-        let account_group = AccountGroup::get(self, &account.pubkey, group_id).await?;
+        let account_group =
+            AccountGroup::find_by_account_and_group(&account.pubkey, group_id, &self.database)
+                .await?;
         let Some(account_group) = account_group else {
-            return Ok(None); // No AccountGroup record
+            return Ok(None);
         };
         if !account_group.is_visible() {
-            return Ok(None); // Declined
+            return Ok(None);
         }
-        let pending_confirmation = account_group.is_pending();
-        let welcomer_pubkey = account_group.welcomer_pubkey;
 
-        // 4. For DMs: get members, find other user, lookup metadata
         let (dm_peer_pubkey, dm_other_user) = if group_info.group_type == GroupType::DirectMessage {
             let members: Vec<PublicKey> = mdk.get_members(group_id)?.into_iter().collect();
-            if let Some(other_pk) = get_dm_other_user(&members, &account.pubkey) {
-                let user = User::find_by_pubkey(&other_pk, &self.database).await.ok();
-                (Some(other_pk), user)
-            } else {
-                (None, None)
+            let other_pk = members.iter().find(|pk| *pk != &account.pubkey).copied();
+            match other_pk {
+                Some(pk) => {
+                    let user = User::find_by_pubkey(&pk, &self.database).await.ok();
+                    (Some(pk), user)
+                }
+                None => (None, None),
             }
         } else {
             (None, None)
         };
 
-        // 5. Get last message
-        let last_message_summaries = AggregatedMessage::find_last_by_group_ids(
+        let last_message_summary = AggregatedMessage::find_last_by_group_ids(
             std::slice::from_ref(group_id),
             &self.database,
         )
-        .await?;
-        let last_message_summary = last_message_summaries.into_iter().next();
+        .await?
+        .into_iter()
+        .next()
+        .filter(|s| account_group.is_message_visible(s.created_at));
 
-        // 6. Lookup message author metadata and build final last_message.
-        //    Filter out messages at or before chat_cleared_at so the chat list
-        //    preview does not show a message the user explicitly cleared.
-        let last_message_summary = last_message_summary
-            .filter(|summary| account_group.is_message_visible(summary.created_at));
         let last_message = if let Some(mut summary) = last_message_summary {
             let author_user = User::find_by_pubkey(&summary.author, &self.database)
                 .await
@@ -426,9 +333,7 @@ impl Whitenoise {
             None
         };
 
-        // 7. Resolve name and image based on group type
         let name = resolve_chat_name(&group, &group_info.group_type, dm_other_user.as_ref());
-
         let (group_image_path, group_image_url) = match group_info.group_type {
             GroupType::Group => {
                 let path = self
@@ -446,7 +351,6 @@ impl Whitenoise {
             }
         };
 
-        // 8. Compute unread count
         let cleared_ms = account_group
             .chat_cleared_at
             .map(|dt| dt.timestamp_millis());
@@ -458,14 +362,6 @@ impl Whitenoise {
         )
         .await?;
 
-        // 9. Get pin order, archived_at, removed_at, self_removed, and muted_until
-        let pin_order = account_group.pin_order;
-        let archived_at = account_group.archived_at;
-        let removed_at = account_group.removed_at;
-        let self_removed = account_group.self_removed;
-        let muted_until = account_group.muted_until;
-
-        // 10. Assemble and return ChatListItem
         Ok(Some(ChatListItem {
             mls_group_id: group_id.clone(),
             name,
@@ -474,15 +370,15 @@ impl Whitenoise {
             group_image_path,
             group_image_url,
             last_message,
-            pending_confirmation,
-            welcomer_pubkey,
+            pending_confirmation: account_group.is_pending(),
+            welcomer_pubkey: account_group.welcomer_pubkey,
             unread_count,
-            pin_order,
+            pin_order: account_group.pin_order,
             dm_peer_pubkey,
-            archived_at,
-            removed_at,
-            self_removed,
-            muted_until,
+            archived_at: account_group.archived_at,
+            removed_at: account_group.removed_at,
+            self_removed: account_group.self_removed,
+            muted_until: account_group.muted_until,
         }))
     }
 
@@ -641,77 +537,6 @@ impl Whitenoise {
                 );
             }
         }
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn build_group_info_map(
-        &self,
-        account_pubkey: PublicKey,
-        group_ids: &[GroupId],
-    ) -> Result<HashMap<GroupId, GroupInformation>> {
-        let group_infos =
-            GroupInformation::get_by_mls_group_ids(account_pubkey, group_ids, self).await?;
-        Ok(group_infos
-            .into_iter()
-            .map(|gi| (gi.mls_group_id.clone(), gi))
-            .collect())
-    }
-
-    /// Identifies the "other user" in each DM group using the persisted
-    /// `dm_peer_pubkey` column, avoiding per-group MDK membership lookups.
-    #[perf_instrument("chat_list")]
-    async fn identify_dm_participants(
-        &self,
-        account: &Account,
-    ) -> Result<HashMap<GroupId, PublicKey>> {
-        let pairs =
-            AccountGroup::find_dm_peers_for_account(&account.pubkey, &self.database).await?;
-        Ok(pairs.into_iter().collect())
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn build_last_message_map(
-        &self,
-        group_ids: &[GroupId],
-    ) -> Result<HashMap<GroupId, ChatMessageSummary>> {
-        let summaries =
-            AggregatedMessage::find_last_by_group_ids(group_ids, &self.database).await?;
-        Ok(summaries
-            .into_iter()
-            .map(|s| (s.mls_group_id.clone(), s))
-            .collect())
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn build_users_by_pubkey(
-        &self,
-        pubkeys: &[PublicKey],
-    ) -> Result<HashMap<PublicKey, User>> {
-        let users = User::find_by_pubkeys(pubkeys, &self.database).await?;
-        Ok(users.into_iter().map(|u| (u.pubkey, u)).collect())
-    }
-
-    /// Resolves image paths for Group-type chats only (DMs use profile picture URLs).
-    #[perf_instrument("chat_list")]
-    async fn resolve_group_images(
-        &self,
-        account: &Account,
-        groups: &[group_types::Group],
-        group_info_map: &HashMap<GroupId, GroupInformation>,
-    ) -> HashMap<GroupId, PathBuf> {
-        let group_type_groups: Vec<_> = groups
-            .iter()
-            .filter(|g| {
-                group_info_map
-                    .get(&g.mls_group_id)
-                    .map(|info| info.group_type == GroupType::Group)
-                    .unwrap_or(false)
-            })
-            .cloned()
-            .collect();
-
-        self.resolve_group_image_paths(account, &group_type_groups)
-            .await
     }
 
     /// Resolves image paths for multiple groups in parallel.

--- a/src/whitenoise/database/account/mod.rs
+++ b/src/whitenoise/database/account/mod.rs
@@ -10,6 +10,7 @@
 
 mod drafts;
 mod follows;
+mod published_key_packages;
 mod settings;
 
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use nostr_sdk::PublicKey;
 
 pub use self::drafts::DraftsRepo;
 pub use self::follows::AccountFollowsRepo;
+pub use self::published_key_packages::PublishedKeyPackagesRepo;
 pub use self::settings::AccountSettingsRepo;
 
 use crate::whitenoise::database::Database;
@@ -32,6 +34,8 @@ pub struct AccountRepositories {
     pub settings: AccountSettingsRepo,
     /// Follow relationship repository for this account.
     pub follows: AccountFollowsRepo,
+    /// Published key package lifecycle tracking repository for this account.
+    pub published_key_packages: PublishedKeyPackagesRepo,
 }
 
 impl AccountRepositories {
@@ -46,7 +50,8 @@ impl AccountRepositories {
         Ok(Self {
             drafts: DraftsRepo::new(account_pubkey, db.clone()),
             settings: AccountSettingsRepo::new(account_pubkey, db.clone()),
-            follows: AccountFollowsRepo::new(account_pubkey, db).await?,
+            follows: AccountFollowsRepo::new(account_pubkey, db.clone()).await?,
+            published_key_packages: PublishedKeyPackagesRepo::new(account_pubkey, db),
         })
     }
 }

--- a/src/whitenoise/database/account/mod.rs
+++ b/src/whitenoise/database/account/mod.rs
@@ -59,7 +59,7 @@ impl AccountRepositories {
             drafts: DraftsRepo::new(account_pubkey, db.clone()),
             settings: AccountSettingsRepo::new(account_pubkey, db.clone()),
             follows: AccountFollowsRepo::new(account_pubkey, db.clone()).await?,
-            published_key_packages: PublishedKeyPackagesRepo::new(account_pubkey, db),
+            published_key_packages: PublishedKeyPackagesRepo::new(account_pubkey, db.clone()),
             push_registrations: PushRegistrationsRepo::new(account_pubkey, db.clone()),
             group_push_tokens: GroupPushTokensRepo::new(account_pubkey, db),
         })

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -72,4 +72,20 @@ impl PublishedKeyPackagesRepo {
     pub async fn mark_key_material_deleted(&self, id: i64) -> Result<()> {
         Ok(PublishedKeyPackage::mark_key_material_deleted(id, &self.db).await?)
     }
+
+    /// Backdate `consumed_at` into the past for testing cleanup eligibility.
+    #[cfg(feature = "integration-tests")]
+    pub async fn backdate_consumed_at(&self, event_id: &str, age_secs: i64) -> Result<()> {
+        sqlx::query(
+            "UPDATE published_key_packages SET consumed_at = unixepoch() - ?
+             WHERE account_pubkey = ? AND event_id = ?",
+        )
+        .bind(age_secs)
+        .bind(self.account_pubkey.to_hex())
+        .bind(event_id)
+        .execute(&self.db.pool)
+        .await
+        .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
+        Ok(())
+    }
 }

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -1,0 +1,75 @@
+//! Per-account repository for published key package lifecycle tracking.
+//!
+//! Wraps the existing [`PublishedKeyPackage`] DB functions so that callers do not
+//! need to thread an `account_pubkey` argument through every call — the pubkey
+//! is baked in at construction time.
+
+use std::sync::Arc;
+
+use nostr_sdk::PublicKey;
+
+use crate::whitenoise::database::Database;
+use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
+use crate::whitenoise::error::Result;
+
+/// Repository for published key package lifecycle records scoped to a single account.
+#[derive(Clone, Debug)]
+pub struct PublishedKeyPackagesRepo {
+    account_pubkey: PublicKey,
+    db: Arc<Database>,
+}
+
+impl PublishedKeyPackagesRepo {
+    /// Construct a new [`PublishedKeyPackagesRepo`] for `account_pubkey`.
+    pub(crate) fn new(account_pubkey: PublicKey, db: Arc<Database>) -> Self {
+        Self { account_pubkey, db }
+    }
+
+    /// Record a successfully published key package for lifecycle tracking.
+    ///
+    /// Delegates to `PublishedKeyPackage::create`.
+    pub async fn create(&self, hash_ref: &[u8], event_id: &str) -> Result<()> {
+        Ok(PublishedKeyPackage::create(&self.account_pubkey, hash_ref, event_id, &self.db).await?)
+    }
+
+    /// Look up a published key package by its event ID.
+    ///
+    /// Delegates to `PublishedKeyPackage::find_by_event_id`.
+    pub async fn find_by_event_id(&self, event_id: &str) -> Result<Option<PublishedKeyPackage>> {
+        Ok(PublishedKeyPackage::find_by_event_id(&self.account_pubkey, event_id, &self.db).await?)
+    }
+
+    /// Mark a published key package as consumed (used by a Welcome).
+    ///
+    /// Returns `false` if no matching row exists or key material is already deleted.
+    ///
+    /// Delegates to `PublishedKeyPackage::mark_consumed`.
+    pub async fn mark_consumed(&self, event_id: &str) -> Result<bool> {
+        Ok(PublishedKeyPackage::mark_consumed(&self.account_pubkey, event_id, &self.db).await?)
+    }
+
+    /// Return all published key packages eligible for key material cleanup.
+    ///
+    /// A package is eligible when all consumed packages for this account have
+    /// `consumed_at` older than `quiet_period_secs`.
+    ///
+    /// Delegates to `PublishedKeyPackage::find_eligible_for_cleanup`.
+    pub async fn find_eligible_for_cleanup(
+        &self,
+        quiet_period_secs: i64,
+    ) -> Result<Vec<PublishedKeyPackage>> {
+        Ok(PublishedKeyPackage::find_eligible_for_cleanup(
+            &self.account_pubkey,
+            quiet_period_secs,
+            &self.db,
+        )
+        .await?)
+    }
+
+    /// Mark a published key package's key material as deleted.
+    ///
+    /// Delegates to `PublishedKeyPackage::mark_key_material_deleted`.
+    pub async fn mark_key_material_deleted(&self, id: i64) -> Result<()> {
+        Ok(PublishedKeyPackage::mark_key_material_deleted(id, &self.db).await?)
+    }
+}

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -392,6 +392,7 @@ impl Whitenoise {
     ///
     /// Marks the consumed key package in the published_key_packages table,
     /// then deletes it from relays and publishes a fresh replacement.
+    #[allow(deprecated)]
     #[perf_instrument("event_handlers")]
     async fn rotate_key_package(
         whitenoise: &Whitenoise,

--- a/src/whitenoise/group_information.rs
+++ b/src/whitenoise/group_information.rs
@@ -122,7 +122,7 @@ impl GroupInformation {
         mdk: &MDK<MdkSqliteStorage>,
         database: &Database,
     ) -> Result<Vec<GroupInformation>, WhitenoiseError> {
-        let existing = GroupInformation::find_by_mls_group_ids(mls_group_ids, database).await?;
+        let existing = Self::find_by_mls_group_ids(mls_group_ids, database).await?;
 
         let mut existing_map: std::collections::HashMap<GroupId, GroupInformation> = existing
             .into_iter()
@@ -138,12 +138,9 @@ impl GroupInformation {
                     .get_group(mls_group_id)?
                     .ok_or(WhitenoiseError::GroupNotFound)?;
                 let group_type = Self::infer_group_type_from_group_name(&group.name);
-                let (new_info, _was_created) = GroupInformation::find_or_create_by_mls_group_id(
-                    mls_group_id,
-                    Some(group_type),
-                    database,
-                )
-                .await?;
+                let (new_info, _was_created) =
+                    Self::find_or_create_by_mls_group_id(mls_group_id, Some(group_type), database)
+                        .await?;
                 results.push(new_info);
             }
         }

--- a/src/whitenoise/group_information.rs
+++ b/src/whitenoise/group_information.rs
@@ -2,10 +2,13 @@ use std::{fmt, str::FromStr};
 
 use chrono::{DateTime, Utc};
 use mdk_core::prelude::GroupId;
+use mdk_core::prelude::MDK;
+use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::PublicKey;
 use serde::{Deserialize, Serialize};
 
 use crate::perf_instrument;
+use crate::whitenoise::database::Database;
 use crate::whitenoise::{Whitenoise, WhitenoiseError};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -105,24 +108,32 @@ impl GroupInformation {
         mls_group_ids: &[GroupId],
         whitenoise: &Whitenoise,
     ) -> Result<Vec<GroupInformation>, WhitenoiseError> {
-        // First try to get existing records
-        let existing =
-            GroupInformation::find_by_mls_group_ids(mls_group_ids, &whitenoise.database).await?;
+        let mdk = whitenoise.create_mdk_for_account(account_pubkey)?;
+        Self::get_by_mls_group_ids_with_mdk(mls_group_ids, &mdk, &whitenoise.database).await
+    }
 
-        // Create a map for quick lookups, but continue to preserve input order
+    /// Get group information for multiple MLS group IDs using an existing MDK instance.
+    ///
+    /// Session-compatible variant that avoids requiring `&Whitenoise`. Missing
+    /// groups will be created with a type inferred from the group name.
+    #[perf_instrument("group_info")]
+    pub(crate) async fn get_by_mls_group_ids_with_mdk(
+        mls_group_ids: &[GroupId],
+        mdk: &MDK<MdkSqliteStorage>,
+        database: &Database,
+    ) -> Result<Vec<GroupInformation>, WhitenoiseError> {
+        let existing = GroupInformation::find_by_mls_group_ids(mls_group_ids, database).await?;
+
         let mut existing_map: std::collections::HashMap<GroupId, GroupInformation> = existing
             .into_iter()
             .map(|gi| (gi.mls_group_id.clone(), gi))
             .collect();
-
-        let mdk = whitenoise.create_mdk_for_account(account_pubkey)?;
 
         let mut results = Vec::new();
         for mls_group_id in mls_group_ids {
             if let Some(existing_info) = existing_map.remove(mls_group_id) {
                 results.push(existing_info);
             } else {
-                // Create missing record with a type inferred from the group name
                 let group = mdk
                     .get_group(mls_group_id)?
                     .ok_or(WhitenoiseError::GroupNotFound)?;
@@ -130,7 +141,7 @@ impl GroupInformation {
                 let (new_info, _was_created) = GroupInformation::find_or_create_by_mls_group_id(
                     mls_group_id,
                     Some(group_type),
-                    &whitenoise.database,
+                    database,
                 )
                 .await?;
                 results.push(new_info);

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -12,9 +12,6 @@ use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::relays::Relay;
 
-/// Maximum number of relay publish attempts before giving up.
-const MAX_PUBLISH_ATTEMPTS: u32 = 3;
-
 /// Maximum number of fetch-delete rounds before giving up. This prevents
 /// infinite loops when relays keep returning the same key packages after
 /// deletion (e.g., because they don't support NIP-09 deletion).
@@ -187,66 +184,10 @@ impl Whitenoise {
     )]
     #[perf_instrument("key_packages")]
     pub async fn publish_key_package_for_account(&self, account: &Account) -> Result<()> {
-        let relays = account.key_package_relays(self).await?;
-
-        if relays.is_empty() {
-            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
-        }
-
-        // Create the key package once — retries below only re-publish the same payload
-        let key_package_data = self.encoded_key_package(account, &relays).await?;
-        let relay_urls = Relay::urls(&relays);
-        let signer = self.get_signer_for_account(account)?;
-
-        let mut last_error = None;
-
-        for attempt in 0..MAX_PUBLISH_ATTEMPTS {
-            if attempt > 0 {
-                let delay = Duration::from_secs(1 << attempt);
-                tracing::warn!(
-                    target: "whitenoise::key_packages",
-                    "Retrying key package publish for account {} (attempt {}/{})",
-                    account.pubkey.to_hex(),
-                    attempt + 1,
-                    MAX_PUBLISH_ATTEMPTS,
-                );
-                tokio::time::sleep(delay).await;
-            }
-
-            match self
-                .publish_key_package_to_relays(
-                    &key_package_data.content,
-                    &relay_urls,
-                    &key_package_data.tags_443,
-                    signer.clone(),
-                )
-                .await
-            {
-                Ok(event_id) => {
-                    self.track_published_key_package(
-                        account,
-                        &key_package_data.hash_ref,
-                        &event_id,
-                    )
-                    .await;
-                    return Ok(());
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "whitenoise::key_packages",
-                        "Key package publish attempt {}/{} failed for account {}: {}",
-                        attempt + 1,
-                        MAX_PUBLISH_ATTEMPTS,
-                        account.pubkey.to_hex(),
-                        e,
-                    );
-                    last_error = Some(e);
-                }
-            }
-        }
-
-        // `last_error` is always `Some` here because the loop runs at least once
-        Err(last_error.expect("loop ran at least once"))
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .publish()
+            .await
     }
 
     /// Publishes the MLS key package using an external signer.
@@ -296,20 +237,10 @@ impl Whitenoise {
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
-        let key_package_data = self.encoded_key_package(account, relays).await?;
-        let relay_urls = Relay::urls(relays);
-        let signer = self.get_signer_for_account(account)?;
-        let event_id = self
-            .publish_key_package_to_relays(
-                &key_package_data.content,
-                &relay_urls,
-                &key_package_data.tags_443,
-                signer,
-            )
-            .await?;
-        self.track_published_key_package(account, &key_package_data.hash_ref, &event_id)
-            .await;
-        Ok(())
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .create_and_publish(relays)
+            .await
     }
 
     /// Like [`Self::create_and_publish_key_package`], but the relay publish
@@ -478,14 +409,10 @@ impl Whitenoise {
         event_id: &EventId,
         delete_mls_stored_keys: bool,
     ) -> Result<bool> {
-        let signer = self.get_signer_for_account(account)?;
-        self.delete_key_package_for_account_internal(
-            account,
-            event_id,
-            delete_mls_stored_keys,
-            signer,
-        )
-        .await
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .delete(event_id, delete_mls_stored_keys)
+            .await
     }
 
     /// Deletes the key package from the relays using an external signer.
@@ -613,48 +540,10 @@ impl Whitenoise {
         &self,
         account: &Account,
     ) -> Result<Vec<Event>> {
-        let key_package_relays = account.key_package_relays(self).await?;
-        let relay_urls: Vec<RelayUrl> = Relay::urls(&key_package_relays);
-
-        if relay_urls.is_empty() {
-            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
-        }
-
-        let key_package_filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
-            .author(account.pubkey);
-
-        let fetched = self
-            .relay_control
-            .ephemeral()
-            .fetch_events_from(&relay_urls, key_package_filter)
-            .await?;
-        let key_package_events: Vec<Event> = fetched.into_iter().collect();
-
-        let (key_package_events, dropped_wrong_kind, dropped_wrong_author) =
-            filter_key_package_events_for_account(account.pubkey, key_package_events);
-
-        let total_dropped = dropped_wrong_kind + dropped_wrong_author;
-        if total_dropped > 0 {
-            tracing::warn!(
-                target: "whitenoise::key_packages",
-                "Dropped {} off-filter event(s) while fetching key packages for account {} \
-                 (wrong kind: {}, wrong author: {})",
-                total_dropped,
-                account.pubkey.to_hex(),
-                dropped_wrong_kind,
-                dropped_wrong_author,
-            );
-        }
-
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Found {} valid key package event(s) for account {}",
-            key_package_events.len(),
-            account.pubkey.to_hex()
-        );
-
-        Ok(key_package_events)
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .fetch_all()
+            .await
     }
 
     /// Deletes all key package events from relays for the given account.
@@ -680,11 +569,6 @@ impl Whitenoise {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - Account has no key package relays configured
-    /// - Failed to retrieve account's key package relays
-    /// - Failed to get signing keys for the account
-    /// - Network error while fetching or publishing events
-    /// - Batch deletion event publishing failed
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::key_packages().delete_all() instead."
@@ -695,8 +579,9 @@ impl Whitenoise {
         account: &Account,
         delete_mls_stored_keys: bool,
     ) -> Result<usize> {
-        let signer = self.get_signer_for_account(account)?;
-        self.delete_all_key_packages_loop(account, delete_mls_stored_keys, signer)
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .delete_all(delete_mls_stored_keys)
             .await
     }
 
@@ -828,15 +713,10 @@ impl Whitenoise {
         delete_mls_stored_keys: bool,
         max_retries: u32,
     ) -> Result<usize> {
-        let signer = self.get_signer_for_account(account)?;
-        self.delete_key_packages_for_account_internal(
-            account,
-            key_package_events,
-            delete_mls_stored_keys,
-            max_retries,
-            signer,
-        )
-        .await
+        self.require_session(&account.pubkey)?
+            .key_packages()
+            .delete_batch(key_package_events, delete_mls_stored_keys, max_retries)
+            .await
     }
 
     #[perf_instrument("key_packages")]

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -153,6 +153,7 @@ pub(crate) fn filter_key_package_events_for_account(
     (valid_events, dropped_wrong_kind, dropped_wrong_author)
 }
 
+#[allow(deprecated)]
 impl Whitenoise {
     /// Helper method to create and encode a key package for the given account.
     ///
@@ -180,6 +181,10 @@ impl Whitenoise {
     /// 3 times with exponential backoff (2s, 4s) if publishing fails. The key
     /// package is created only once to avoid orphaning unused key material in
     /// local MLS storage.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().publish() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub async fn publish_key_package_for_account(&self, account: &Account) -> Result<()> {
         let relays = account.key_package_relays(self).await?;
@@ -281,6 +286,10 @@ impl Whitenoise {
     /// This is a convenience wrapper that calls [`Self::encoded_key_package`] followed by
     /// [`Self::publish_key_package_to_relays`]. If you need retry semantics, prefer calling
     /// those two methods separately so the key package is only created once.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().create_and_publish() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub(crate) async fn create_and_publish_key_package(
         &self,
@@ -458,6 +467,10 @@ impl Whitenoise {
     /// - For local accounts: uses keys from the secrets store
     ///
     /// Returns `true` if a key package was found and deleted, `false` if no key package was found.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().delete() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub async fn delete_key_package_for_account(
         &self,
@@ -591,6 +604,10 @@ impl Whitenoise {
     /// - Failed to retrieve account's key package relays
     /// - Network error while fetching events from relays
     /// - NostrSDK error during event streaming
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().fetch_all() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub async fn fetch_all_key_packages_for_account(
         &self,
@@ -668,6 +685,10 @@ impl Whitenoise {
     /// - Failed to get signing keys for the account
     /// - Network error while fetching or publishing events
     /// - Batch deletion event publishing failed
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().delete_all() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub async fn delete_all_key_packages_for_account(
         &self,
@@ -795,6 +816,10 @@ impl Whitenoise {
     /// # Returns
     ///
     /// Returns the number of key packages that were successfully deleted.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().delete_batch() instead."
+    )]
     #[perf_instrument("key_packages")]
     pub(crate) async fn delete_key_packages_for_account(
         &self,
@@ -1011,6 +1036,10 @@ impl Whitenoise {
     ///
     /// Integration-test helper for verifying lifecycle states (consumed_at,
     /// key_material_deleted) without exposing the raw database handle.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().find_published_for_testing() instead."
+    )]
     #[cfg(feature = "integration-tests")]
     pub async fn find_published_key_package_for_testing(
         &self,
@@ -1027,6 +1056,10 @@ impl Whitenoise {
     /// Integration-test helper for cases that manually publish custom key
     /// package events (for example with a backdated timestamp) and still need
     /// maintenance to treat them as locally-owned packages.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().track_published_for_testing() instead."
+    )]
     #[cfg(feature = "integration-tests")]
     pub async fn track_published_key_package_for_testing(
         &self,
@@ -1044,6 +1077,10 @@ impl Whitenoise {
     /// Integration-test helper that shifts `consumed_at` into the past so the
     /// maintenance task considers it eligible for cleanup without waiting the
     /// full quiet period.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use AccountSession::key_packages().backdate_consumed_at_for_testing() instead."
+    )]
     #[cfg(feature = "integration-tests")]
     pub async fn backdate_consumed_at_for_testing(
         &self,
@@ -1074,6 +1111,7 @@ impl Whitenoise {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use chrono::Utc;
     use nostr_sdk::{EventBuilder, Keys, Kind, Tag, TagKind};

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1114,6 +1114,7 @@ pub mod test_utils {
         )
     }
 
+    #[allow(deprecated)]
     pub(crate) async fn setup_multiple_test_accounts(
         whitenoise: &Whitenoise,
         count: usize,

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -136,6 +136,7 @@ fn summarize_maintenance_results(results: Vec<MaintenanceResult>) -> Maintenance
     summary
 }
 
+#[allow(deprecated)]
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> MaintenanceResult {
     let packages = match whitenoise.fetch_all_key_packages_for_account(account).await {
@@ -305,6 +306,7 @@ async fn find_live_published_key_packages(
 }
 
 /// Publishes a new key package when the account has no usable local one.
+#[allow(deprecated)]
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn publish_new_key_package(whitenoise: &Whitenoise, account: &Account) -> MaintenanceResult {
     tracing::info!(
@@ -332,6 +334,7 @@ async fn publish_new_key_package(whitenoise: &Whitenoise, account: &Account) -> 
 /// If the account would be left with zero key packages after deletion, a new one is
 /// published first to avoid a gap. Otherwise, only the expired packages are deleted
 /// without republishing, since the account already has a valid package.
+#[allow(deprecated)]
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn rotate_expired_packages(
     whitenoise: &Whitenoise,
@@ -391,6 +394,7 @@ async fn rotate_expired_packages(
 /// was enforced. They cause interop failures with newer MDK versions. We only delete
 /// them (without republishing) because the account already has at least one valid key
 /// package. This avoids unnecessary key package churn.
+#[allow(deprecated)]
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn delete_outdated_packages(
     whitenoise: &Whitenoise,
@@ -415,6 +419,7 @@ async fn delete_outdated_packages(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use nostr_sdk::{
         Client, EventBuilder, EventId, FromBech32, Keys, Kind, SecretKey, Tag, TagKind,

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -176,13 +176,13 @@ impl<'a> ChatListOps<'a> {
         Ok(items)
     }
 
-    /// Transitionally calls `Whitenoise::get_instance()` for media resolution.
     /// Returns an empty map if the singleton is unavailable (e.g. in tests).
     async fn resolve_group_images(
         &self,
         groups: &[group_types::Group],
         group_info_map: &HashMap<GroupId, GroupInformation>,
     ) -> HashMap<GroupId, PathBuf> {
+        // TODO(phase-16b): remove singleton access once media services move to session scope.
         let wn = match Whitenoise::get_instance() {
             Ok(wn) => wn,
             Err(_) => return HashMap::new(),
@@ -208,5 +208,44 @@ impl<'a> ChatListOps<'a> {
 
         wn.resolve_group_image_paths(&account, &group_type_groups)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::Keys;
+
+    use crate::whitenoise::session::test_helpers::test_session;
+
+    #[tokio::test]
+    async fn active_returns_empty_for_new_session() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let items = session.chat_list().active().await.unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn archived_returns_empty_for_new_session() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let items = session.chat_list().archived().await.unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_item_returns_none_for_nonexistent_group() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+        let fake_group_id = mdk_core::prelude::GroupId::from_slice(&[0xAB; 32]);
+
+        let result = session
+            .chat_list()
+            .build_item(&fake_group_id)
+            .await
+            .unwrap();
+        assert!(result.is_none());
     }
 }

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use futures::future::join_all;
 use mdk_core::prelude::*;
 use nostr_sdk::PublicKey;
 
@@ -215,11 +214,42 @@ impl<'a> ChatListOps<'a> {
             .map(|gwm| (gwm.group.mls_group_id.clone(), gwm.membership.clone()))
             .collect();
 
-        let group_info_map = self.build_group_info_map(&group_ids).await?;
-        let dm_other_users = self.identify_dm_participants().await?;
-        let last_message_map = self.build_last_message_map(&group_ids).await?;
+        let group_info_map = {
+            let infos = GroupInformation::get_by_mls_group_ids_with_mdk(
+                &group_ids,
+                &self.session.mdk,
+                &self.session.database,
+            )
+            .await?;
+            infos
+                .into_iter()
+                .map(|gi| (gi.mls_group_id.clone(), gi))
+                .collect::<HashMap<_, _>>()
+        };
+
+        let dm_other_users: HashMap<GroupId, PublicKey> = AccountGroup::find_dm_peers_for_account(
+            &self.session.account_pubkey,
+            &self.session.database,
+        )
+        .await?
+        .into_iter()
+        .collect();
+
+        let last_message_map: HashMap<GroupId, ChatMessageSummary> =
+            AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.database)
+                .await?
+                .into_iter()
+                .map(|s| (s.mls_group_id.clone(), s))
+                .collect();
+
         let pubkeys_to_fetch = collect_pubkeys_to_fetch(&dm_other_users, &last_message_map);
-        let users_by_pubkey = self.build_users_by_pubkey(&pubkeys_to_fetch).await?;
+        let users_by_pubkey: HashMap<PublicKey, User> =
+            User::find_by_pubkeys(&pubkeys_to_fetch, &self.session.database)
+                .await?
+                .into_iter()
+                .map(|u| (u.pubkey, u))
+                .collect();
+
         let image_paths = self.resolve_group_images(&groups, &group_info_map).await;
 
         let group_markers: Vec<_> = membership_map
@@ -248,60 +278,8 @@ impl<'a> ChatListOps<'a> {
         Ok(items)
     }
 
-    #[perf_instrument("chat_list")]
-    async fn build_group_info_map(
-        &self,
-        group_ids: &[GroupId],
-    ) -> Result<HashMap<GroupId, GroupInformation>> {
-        let group_infos = GroupInformation::get_by_mls_group_ids_with_mdk(
-            group_ids,
-            &self.session.mdk,
-            &self.session.database,
-        )
-        .await?;
-        Ok(group_infos
-            .into_iter()
-            .map(|gi| (gi.mls_group_id.clone(), gi))
-            .collect())
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn identify_dm_participants(&self) -> Result<HashMap<GroupId, PublicKey>> {
-        let pairs = AccountGroup::find_dm_peers_for_account(
-            &self.session.account_pubkey,
-            &self.session.database,
-        )
-        .await?;
-        Ok(pairs.into_iter().collect())
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn build_last_message_map(
-        &self,
-        group_ids: &[GroupId],
-    ) -> Result<HashMap<GroupId, ChatMessageSummary>> {
-        let summaries =
-            AggregatedMessage::find_last_by_group_ids(group_ids, &self.session.database).await?;
-        Ok(summaries
-            .into_iter()
-            .map(|s| (s.mls_group_id.clone(), s))
-            .collect())
-    }
-
-    #[perf_instrument("chat_list")]
-    async fn build_users_by_pubkey(
-        &self,
-        pubkeys: &[PublicKey],
-    ) -> Result<HashMap<PublicKey, User>> {
-        let users = User::find_by_pubkeys(pubkeys, &self.session.database).await?;
-        Ok(users.into_iter().map(|u| (u.pubkey, u)).collect())
-    }
-
-    /// Resolve image paths for Group-type chats.
-    ///
     /// Transitionally calls `Whitenoise::get_instance()` for media resolution.
     /// Returns an empty map if the singleton is unavailable (e.g. in tests).
-    #[perf_instrument("chat_list")]
     async fn resolve_group_images(
         &self,
         groups: &[group_types::Group],
@@ -311,7 +289,6 @@ impl<'a> ChatListOps<'a> {
             Ok(wn) => wn,
             Err(_) => return HashMap::new(),
         };
-
         let account =
             match Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
                 .await
@@ -331,38 +308,10 @@ impl<'a> ChatListOps<'a> {
             .cloned()
             .collect();
 
-        let futures = group_type_groups.iter().map(|group| {
-            let group_id = group.mls_group_id.clone();
-            async {
-                let result = wn.resolve_group_image_path(&account, group).await;
-                (group_id, result)
-            }
-        });
-
-        let results = join_all(futures).await;
-
-        let mut paths = HashMap::new();
-        for (group_id, result) in results {
-            match result {
-                Ok(Some(path)) => {
-                    paths.insert(group_id, path);
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        target: "whitenoise::chat_list",
-                        "Failed to resolve image for group {}: {}",
-                        hex::encode(group_id.as_slice()),
-                        e
-                    );
-                }
-            }
-        }
-
-        paths
+        wn.resolve_group_image_paths(&account, &group_type_groups)
+            .await
     }
 
-    /// Resolve a single group image path (used by `build_item`).
     async fn resolve_single_group_image(&self, group: &group_types::Group) -> Option<PathBuf> {
         let wn = Whitenoise::get_instance().ok()?;
         let account = Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -1,0 +1,373 @@
+//! Chat list read operations scoped to an [`AccountSession`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use futures::future::join_all;
+use mdk_core::prelude::*;
+use nostr_sdk::PublicKey;
+
+use super::AccountSession;
+use crate::perf_instrument;
+use crate::whitenoise::Whitenoise;
+use crate::whitenoise::accounts::Account;
+use crate::whitenoise::accounts_groups::AccountGroup;
+use crate::whitenoise::aggregated_message::AggregatedMessage;
+use crate::whitenoise::chat_list::{
+    ChatListItem, assemble_chat_list_items, collect_pubkeys_to_fetch, resolve_chat_name,
+    resolve_display_name, sort_chat_list,
+};
+use crate::whitenoise::error::Result;
+use crate::whitenoise::group_information::{GroupInformation, GroupType};
+use crate::whitenoise::groups::GroupWithMembership;
+use crate::whitenoise::message_aggregator::ChatMessageSummary;
+use crate::whitenoise::users::User;
+
+/// View over [`AccountSession`] for chat list read operations.
+///
+/// Obtain via [`AccountSession::chat_list`].
+pub struct ChatListOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> ChatListOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    // ── Public API ─────────────────────────────────────────────────────
+
+    /// Retrieve the active (non-archived) chat list for this account.
+    ///
+    /// Returns a list of chat summaries sorted by last activity (most recent
+    /// first). Declined and archived groups are filtered out.
+    #[perf_instrument("chat_list")]
+    pub async fn active(&self) -> Result<Vec<ChatListItem>> {
+        let visible = self.session.groups().visible().await?;
+        let active: Vec<_> = visible
+            .into_iter()
+            .filter(|gwm| !gwm.membership.is_archived())
+            .collect();
+        self.build_for(active).await
+    }
+
+    /// Retrieve the archived chat list for this account.
+    ///
+    /// Returns only archived chats, sorted by last activity.
+    #[perf_instrument("chat_list")]
+    pub async fn archived(&self) -> Result<Vec<ChatListItem>> {
+        let visible = self.session.groups().visible().await?;
+        let archived: Vec<_> = visible
+            .into_iter()
+            .filter(|gwm| gwm.membership.is_archived())
+            .collect();
+        self.build_for(archived).await
+    }
+
+    /// Build a single [`ChatListItem`] for a specific group.
+    ///
+    /// Used by the streaming system to construct updates without re-fetching
+    /// the entire chat list. Returns `Ok(None)` if the group is not visible
+    /// or not fully initialized.
+    #[perf_instrument("chat_list")]
+    pub(crate) async fn build_item(&self, group_id: &GroupId) -> Result<Option<ChatListItem>> {
+        // 1. Get group from MDK
+        let Some(group) = self.session.mdk.get_group(group_id)? else {
+            return Ok(None);
+        };
+
+        // 2. Get GroupInformation
+        let group_info =
+            match GroupInformation::find_by_mls_group_id(group_id, &self.session.database).await {
+                Ok(info) => info,
+                Err(_) => return Ok(None),
+            };
+
+        // 3. Get AccountGroup for visibility/pending status
+        let account_group = AccountGroup::find_by_account_and_group(
+            &self.session.account_pubkey,
+            group_id,
+            &self.session.database,
+        )
+        .await?;
+        let Some(account_group) = account_group else {
+            return Ok(None);
+        };
+        if !account_group.is_visible() {
+            return Ok(None);
+        }
+        let pending_confirmation = account_group.is_pending();
+        let welcomer_pubkey = account_group.welcomer_pubkey;
+
+        // 4. For DMs: get members, find other user, lookup metadata
+        let (dm_peer_pubkey, dm_other_user) = if group_info.group_type == GroupType::DirectMessage {
+            let members: Vec<PublicKey> = self
+                .session
+                .mdk
+                .get_members(group_id)?
+                .into_iter()
+                .collect();
+            if let Some(other_pk) = members
+                .iter()
+                .find(|pk| *pk != &self.session.account_pubkey)
+                .copied()
+            {
+                let user = User::find_by_pubkey(&other_pk, &self.session.database)
+                    .await
+                    .ok();
+                (Some(other_pk), user)
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // 5. Get last message
+        let last_message_summaries = AggregatedMessage::find_last_by_group_ids(
+            std::slice::from_ref(group_id),
+            &self.session.database,
+        )
+        .await?;
+        let last_message_summary = last_message_summaries.into_iter().next();
+
+        // 6. Filter by visibility and resolve author display name
+        let last_message_summary = last_message_summary
+            .filter(|summary| account_group.is_message_visible(summary.created_at));
+        let last_message = if let Some(mut summary) = last_message_summary {
+            let author_user = User::find_by_pubkey(&summary.author, &self.session.database)
+                .await
+                .ok();
+            summary.author_display_name = resolve_display_name(author_user.as_ref());
+            Some(summary)
+        } else {
+            None
+        };
+
+        // 7. Resolve name and image
+        let name = resolve_chat_name(&group, &group_info.group_type, dm_other_user.as_ref());
+
+        let (group_image_path, group_image_url) = match group_info.group_type {
+            GroupType::Group => {
+                let path = self.resolve_single_group_image(&group).await;
+                (path, None)
+            }
+            GroupType::DirectMessage => {
+                let url = dm_other_user
+                    .as_ref()
+                    .and_then(|u| u.metadata.picture.as_ref().map(|url| url.to_string()));
+                (None, url)
+            }
+        };
+
+        // 8. Compute unread count
+        let cleared_ms = account_group
+            .chat_cleared_at
+            .map(|dt| dt.timestamp_millis());
+        let unread_count = AggregatedMessage::count_unread_for_group(
+            group_id,
+            account_group.last_read_message_id.as_ref(),
+            &self.session.database,
+            cleared_ms,
+        )
+        .await?;
+
+        Ok(Some(ChatListItem {
+            mls_group_id: group_id.clone(),
+            name,
+            group_type: group_info.group_type,
+            created_at: group_info.created_at,
+            group_image_path,
+            group_image_url,
+            last_message,
+            pending_confirmation,
+            welcomer_pubkey,
+            unread_count,
+            pin_order: account_group.pin_order,
+            dm_peer_pubkey,
+            archived_at: account_group.archived_at,
+            removed_at: account_group.removed_at,
+            self_removed: account_group.self_removed,
+            muted_until: account_group.muted_until,
+        }))
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────
+
+    /// Build a sorted chat list from a pre-filtered set of groups.
+    #[perf_instrument("chat_list")]
+    async fn build_for(
+        &self,
+        groups_with_membership: Vec<GroupWithMembership>,
+    ) -> Result<Vec<ChatListItem>> {
+        if groups_with_membership.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let groups: Vec<_> = groups_with_membership
+            .iter()
+            .map(|gwm| gwm.group.clone())
+            .collect();
+        let group_ids: Vec<GroupId> = groups.iter().map(|g| g.mls_group_id.clone()).collect();
+
+        let membership_map: HashMap<GroupId, AccountGroup> = groups_with_membership
+            .iter()
+            .map(|gwm| (gwm.group.mls_group_id.clone(), gwm.membership.clone()))
+            .collect();
+
+        let group_info_map = self.build_group_info_map(&group_ids).await?;
+        let dm_other_users = self.identify_dm_participants().await?;
+        let last_message_map = self.build_last_message_map(&group_ids).await?;
+        let pubkeys_to_fetch = collect_pubkeys_to_fetch(&dm_other_users, &last_message_map);
+        let users_by_pubkey = self.build_users_by_pubkey(&pubkeys_to_fetch).await?;
+        let image_paths = self.resolve_group_images(&groups, &group_info_map).await;
+
+        let group_markers: Vec<_> = membership_map
+            .iter()
+            .map(|(gid, ag)| {
+                let cleared_ms = ag.chat_cleared_at.map(|dt| dt.timestamp_millis());
+                (gid.clone(), ag.last_read_message_id, cleared_ms)
+            })
+            .collect();
+        let unread_counts =
+            AggregatedMessage::count_unread_for_groups(&group_markers, &self.session.database)
+                .await?;
+
+        let mut items = assemble_chat_list_items(
+            &groups,
+            &group_info_map,
+            &dm_other_users,
+            &last_message_map,
+            &users_by_pubkey,
+            &image_paths,
+            &membership_map,
+            &unread_counts,
+        );
+        sort_chat_list(&mut items);
+
+        Ok(items)
+    }
+
+    #[perf_instrument("chat_list")]
+    async fn build_group_info_map(
+        &self,
+        group_ids: &[GroupId],
+    ) -> Result<HashMap<GroupId, GroupInformation>> {
+        let group_infos = GroupInformation::get_by_mls_group_ids_with_mdk(
+            group_ids,
+            &self.session.mdk,
+            &self.session.database,
+        )
+        .await?;
+        Ok(group_infos
+            .into_iter()
+            .map(|gi| (gi.mls_group_id.clone(), gi))
+            .collect())
+    }
+
+    #[perf_instrument("chat_list")]
+    async fn identify_dm_participants(&self) -> Result<HashMap<GroupId, PublicKey>> {
+        let pairs = AccountGroup::find_dm_peers_for_account(
+            &self.session.account_pubkey,
+            &self.session.database,
+        )
+        .await?;
+        Ok(pairs.into_iter().collect())
+    }
+
+    #[perf_instrument("chat_list")]
+    async fn build_last_message_map(
+        &self,
+        group_ids: &[GroupId],
+    ) -> Result<HashMap<GroupId, ChatMessageSummary>> {
+        let summaries =
+            AggregatedMessage::find_last_by_group_ids(group_ids, &self.session.database).await?;
+        Ok(summaries
+            .into_iter()
+            .map(|s| (s.mls_group_id.clone(), s))
+            .collect())
+    }
+
+    #[perf_instrument("chat_list")]
+    async fn build_users_by_pubkey(
+        &self,
+        pubkeys: &[PublicKey],
+    ) -> Result<HashMap<PublicKey, User>> {
+        let users = User::find_by_pubkeys(pubkeys, &self.session.database).await?;
+        Ok(users.into_iter().map(|u| (u.pubkey, u)).collect())
+    }
+
+    /// Resolve image paths for Group-type chats.
+    ///
+    /// Transitionally calls `Whitenoise::get_instance()` for media resolution.
+    /// Returns an empty map if the singleton is unavailable (e.g. in tests).
+    #[perf_instrument("chat_list")]
+    async fn resolve_group_images(
+        &self,
+        groups: &[group_types::Group],
+        group_info_map: &HashMap<GroupId, GroupInformation>,
+    ) -> HashMap<GroupId, PathBuf> {
+        let wn = match Whitenoise::get_instance() {
+            Ok(wn) => wn,
+            Err(_) => return HashMap::new(),
+        };
+
+        let account =
+            match Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
+                .await
+            {
+                Ok(account) => account,
+                Err(_) => return HashMap::new(),
+            };
+
+        let group_type_groups: Vec<_> = groups
+            .iter()
+            .filter(|g| {
+                group_info_map
+                    .get(&g.mls_group_id)
+                    .map(|info| info.group_type == GroupType::Group)
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+
+        let futures = group_type_groups.iter().map(|group| {
+            let group_id = group.mls_group_id.clone();
+            async {
+                let result = wn.resolve_group_image_path(&account, group).await;
+                (group_id, result)
+            }
+        });
+
+        let results = join_all(futures).await;
+
+        let mut paths = HashMap::new();
+        for (group_id, result) in results {
+            match result {
+                Ok(Some(path)) => {
+                    paths.insert(group_id, path);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::chat_list",
+                        "Failed to resolve image for group {}: {}",
+                        hex::encode(group_id.as_slice()),
+                        e
+                    );
+                }
+            }
+        }
+
+        paths
+    }
+
+    /// Resolve a single group image path (used by `build_item`).
+    async fn resolve_single_group_image(&self, group: &group_types::Group) -> Option<PathBuf> {
+        let wn = Whitenoise::get_instance().ok()?;
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
+            .await
+            .ok()?;
+        wn.resolve_group_image_path(&account, group).await.ok()?
+    }
+}

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -13,8 +13,7 @@ use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::aggregated_message::AggregatedMessage;
 use crate::whitenoise::chat_list::{
-    ChatListItem, assemble_chat_list_items, collect_pubkeys_to_fetch, resolve_chat_name,
-    resolve_display_name, sort_chat_list,
+    ChatListItem, assemble_chat_list_items, collect_pubkeys_to_fetch, sort_chat_list,
 };
 use crate::whitenoise::error::Result;
 use crate::whitenoise::group_information::{GroupInformation, GroupType};
@@ -65,130 +64,29 @@ impl<'a> ChatListOps<'a> {
 
     /// Build a single [`ChatListItem`] for a specific group.
     ///
-    /// Used by the streaming system to construct updates without re-fetching
-    /// the entire chat list. Returns `Ok(None)` if the group is not visible
-    /// or not fully initialized.
+    /// Returns `Ok(None)` if the group is not visible or not fully initialized.
     #[perf_instrument("chat_list")]
     pub(crate) async fn build_item(&self, group_id: &GroupId) -> Result<Option<ChatListItem>> {
-        // 1. Get group from MDK
         let Some(group) = self.session.mdk.get_group(group_id)? else {
             return Ok(None);
         };
 
-        // 2. Get GroupInformation
-        let group_info =
-            match GroupInformation::find_by_mls_group_id(group_id, &self.session.database).await {
-                Ok(info) => info,
-                Err(_) => return Ok(None),
-            };
-
-        // 3. Get AccountGroup for visibility/pending status
         let account_group = AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
             &self.session.database,
         )
         .await?;
-        let Some(account_group) = account_group else {
+        let Some(membership) = account_group else {
             return Ok(None);
         };
-        if !account_group.is_visible() {
+        if !membership.is_visible() {
             return Ok(None);
         }
-        let pending_confirmation = account_group.is_pending();
-        let welcomer_pubkey = account_group.welcomer_pubkey;
 
-        // 4. For DMs: get members, find other user, lookup metadata
-        let (dm_peer_pubkey, dm_other_user) = if group_info.group_type == GroupType::DirectMessage {
-            let members: Vec<PublicKey> = self
-                .session
-                .mdk
-                .get_members(group_id)?
-                .into_iter()
-                .collect();
-            if let Some(other_pk) = members
-                .iter()
-                .find(|pk| *pk != &self.session.account_pubkey)
-                .copied()
-            {
-                let user = User::find_by_pubkey(&other_pk, &self.session.database)
-                    .await
-                    .ok();
-                (Some(other_pk), user)
-            } else {
-                (None, None)
-            }
-        } else {
-            (None, None)
-        };
-
-        // 5. Get last message
-        let last_message_summaries = AggregatedMessage::find_last_by_group_ids(
-            std::slice::from_ref(group_id),
-            &self.session.database,
-        )
-        .await?;
-        let last_message_summary = last_message_summaries.into_iter().next();
-
-        // 6. Filter by visibility and resolve author display name
-        let last_message_summary = last_message_summary
-            .filter(|summary| account_group.is_message_visible(summary.created_at));
-        let last_message = if let Some(mut summary) = last_message_summary {
-            let author_user = User::find_by_pubkey(&summary.author, &self.session.database)
-                .await
-                .ok();
-            summary.author_display_name = resolve_display_name(author_user.as_ref());
-            Some(summary)
-        } else {
-            None
-        };
-
-        // 7. Resolve name and image
-        let name = resolve_chat_name(&group, &group_info.group_type, dm_other_user.as_ref());
-
-        let (group_image_path, group_image_url) = match group_info.group_type {
-            GroupType::Group => {
-                let path = self.resolve_single_group_image(&group).await;
-                (path, None)
-            }
-            GroupType::DirectMessage => {
-                let url = dm_other_user
-                    .as_ref()
-                    .and_then(|u| u.metadata.picture.as_ref().map(|url| url.to_string()));
-                (None, url)
-            }
-        };
-
-        // 8. Compute unread count
-        let cleared_ms = account_group
-            .chat_cleared_at
-            .map(|dt| dt.timestamp_millis());
-        let unread_count = AggregatedMessage::count_unread_for_group(
-            group_id,
-            account_group.last_read_message_id.as_ref(),
-            &self.session.database,
-            cleared_ms,
-        )
-        .await?;
-
-        Ok(Some(ChatListItem {
-            mls_group_id: group_id.clone(),
-            name,
-            group_type: group_info.group_type,
-            created_at: group_info.created_at,
-            group_image_path,
-            group_image_url,
-            last_message,
-            pending_confirmation,
-            welcomer_pubkey,
-            unread_count,
-            pin_order: account_group.pin_order,
-            dm_peer_pubkey,
-            archived_at: account_group.archived_at,
-            removed_at: account_group.removed_at,
-            self_removed: account_group.self_removed,
-            muted_until: account_group.muted_until,
-        }))
+        let gwm = GroupWithMembership { group, membership };
+        let mut items = self.build_for(vec![gwm]).await?;
+        Ok(items.pop())
     }
 
     // ── Private helpers ────────────────────────────────────────────────
@@ -310,13 +208,5 @@ impl<'a> ChatListOps<'a> {
 
         wn.resolve_group_image_paths(&account, &group_type_groups)
             .await
-    }
-
-    async fn resolve_single_group_image(&self, group: &group_types::Group) -> Option<PathBuf> {
-        let wn = Whitenoise::get_instance().ok()?;
-        let account = Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
-            .await
-            .ok()?;
-        wn.resolve_group_image_path(&account, group).await.ok()?
     }
 }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -35,22 +35,18 @@ impl<'a> KeyPackageOps<'a> {
 
     // ── Public API ─────────────────────────────────────────────────────
 
-    /// Publish a new key package for this account with retry (up to 3 attempts).
-    ///
     /// Creates a single MLS key package, then retries relay publishing with
     /// exponential backoff if publishing fails. The key package is created
     /// only once to avoid orphaning unused key material in local MLS storage.
     #[perf_instrument("key_packages")]
     pub async fn publish(&self) -> Result<()> {
         let relays = self.prepare_relays().await?;
-
         if relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
         let key_package_data = self.encoded_key_package(&relays).await?;
         let relay_urls = Relay::urls(&relays);
-
         let mut last_error = None;
 
         for attempt in 0..MAX_PUBLISH_ATTEMPTS {
@@ -113,11 +109,9 @@ impl<'a> KeyPackageOps<'a> {
         Ok(())
     }
 
-    /// Fetch all key package events for this account from its key package relays.
     #[perf_instrument("key_packages")]
     pub async fn fetch_all(&self) -> Result<Vec<Event>> {
         let relays = self.prepare_relays().await?;
-
         if relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
@@ -145,18 +139,9 @@ impl<'a> KeyPackageOps<'a> {
             );
         }
 
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Found {} valid key package event(s) for account {}",
-            key_package_events.len(),
-            self.session.account_pubkey.to_hex()
-        );
-
         Ok(key_package_events)
     }
 
-    /// Delete a single key package from relays, optionally deleting local key material.
-    ///
     /// Returns `true` if the deletion event was accepted by at least one relay.
     #[perf_instrument("key_packages")]
     pub async fn delete(&self, event_id: &EventId, delete_mls_stored_keys: bool) -> Result<bool> {
@@ -178,8 +163,6 @@ impl<'a> KeyPackageOps<'a> {
         Ok(!result.success.is_empty())
     }
 
-    /// Delete all key packages for this account with convergence loop.
-    ///
     /// Fetches and deletes in rounds until no key packages remain on relays,
     /// up to 10 rounds.
     #[perf_instrument("key_packages")]
@@ -192,8 +175,7 @@ impl<'a> KeyPackageOps<'a> {
             if key_package_events.is_empty() {
                 tracing::info!(
                     target: "whitenoise::key_packages",
-                    "All key packages deleted for account {} \
-                     ({} total across {} round(s))",
+                    "All key packages deleted for account {} ({} total across {} round(s))",
                     self.session.account_pubkey.to_hex(),
                     total_deleted,
                     round + 1,
@@ -201,18 +183,9 @@ impl<'a> KeyPackageOps<'a> {
                 return Ok(total_deleted);
             }
 
-            tracing::debug!(
-                target: "whitenoise::key_packages",
-                "Round {}: found {} remaining key package(s) for account {}",
-                round + 1,
-                key_package_events.len(),
-                self.session.account_pubkey.to_hex(),
-            );
-
             let batch_size = key_package_events.len();
-
             let deleted = self
-                .delete_batch_internal(key_package_events, delete_mls_stored_keys, 1)
+                .delete_batch(key_package_events, delete_mls_stored_keys, 1)
                 .await?;
 
             total_deleted += deleted;
@@ -220,8 +193,7 @@ impl<'a> KeyPackageOps<'a> {
             if deleted == 0 {
                 tracing::warn!(
                     target: "whitenoise::key_packages",
-                    "Round {} deleted 0 key packages despite {} found \
-                     — relays may not support deletion",
+                    "Round {} deleted 0 key packages despite {} found — relays may not support deletion",
                     round + 1,
                     batch_size,
                 );
@@ -233,7 +205,6 @@ impl<'a> KeyPackageOps<'a> {
     }
 
     /// Delete specific key package events from relays with retry.
-    ///
     /// Storage deletion happens only on the initial attempt.
     #[perf_instrument("key_packages")]
     pub(crate) async fn delete_batch(
@@ -242,13 +213,69 @@ impl<'a> KeyPackageOps<'a> {
         delete_mls_stored_keys: bool,
         max_retries: u32,
     ) -> Result<usize> {
-        self.delete_batch_internal(key_package_events, delete_mls_stored_keys, max_retries)
-            .await
+        if key_package_events.is_empty() {
+            return Ok(0);
+        }
+
+        let original_count = key_package_events.len();
+        let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
+
+        let relays = self.prepare_relays().await?;
+        if relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+        let relay_urls = Relay::urls(&relays);
+
+        if delete_mls_stored_keys {
+            self.delete_from_storage(&key_package_events)?;
+        }
+
+        let mut pending_ids: Vec<EventId> = key_package_events.iter().map(|e| e.id).collect();
+
+        for attempt in 0..=max_retries {
+            if attempt > 0 {
+                tracing::debug!(
+                    target: "whitenoise::key_packages",
+                    "Retry {}/{} for {} remaining key package(s)",
+                    attempt,
+                    max_retries,
+                    pending_ids.len()
+                );
+            }
+
+            self.publish_deletion(&pending_ids, &relay_urls).await?;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let remaining_events = self.fetch_all().await?;
+            pending_ids = remaining_events
+                .iter()
+                .filter(|e| original_ids.contains(&e.id))
+                .map(|e| e.id)
+                .collect();
+
+            if pending_ids.is_empty() {
+                break;
+            }
+        }
+
+        let deleted_count = original_count - pending_ids.len();
+
+        if !pending_ids.is_empty() {
+            tracing::warn!(
+                target: "whitenoise::key_packages",
+                "After {} retries, {} of {} key package(s) still not deleted for account {}",
+                max_retries,
+                pending_ids.len(),
+                original_count,
+                self.session.account_pubkey.to_hex()
+            );
+        }
+
+        Ok(deleted_count)
     }
 
     // ── Private helpers ────────────────────────────────────────────────
 
-    /// Create and encode a key package for this account.
     #[perf_instrument("key_packages")]
     async fn encoded_key_package(&self, relays: &[Relay]) -> Result<KeyPackageEventData> {
         let key_package_relay_urls = Relay::urls(relays);
@@ -257,11 +284,9 @@ impl<'a> KeyPackageOps<'a> {
             .mdk
             .create_key_package_for_event(&self.session.account_pubkey, key_package_relay_urls)
             .map_err(|e| WhitenoiseError::Configuration(format!("NostrMls error: {}", e)))?;
-
         Ok(data)
     }
 
-    /// Publish an encoded key package to relays. Returns the event ID on success.
     #[perf_instrument("key_packages")]
     async fn publish_to_relays(
         &self,
@@ -281,16 +306,9 @@ impl<'a> KeyPackageOps<'a> {
             ));
         }
 
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Published key package to {} relay(s)",
-            result.success.len(),
-        );
-
         Ok(*result.id())
     }
 
-    /// Record a published key package in the lifecycle tracking table.
     #[perf_instrument("key_packages")]
     async fn track_published(&self, hash_ref: &[u8], event_id: &EventId) {
         if let Err(e) = self
@@ -308,7 +326,6 @@ impl<'a> KeyPackageOps<'a> {
         }
     }
 
-    /// Resolve key package relay URLs for this account.
     async fn prepare_relays(&self) -> Result<Vec<Relay>> {
         let user = User::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
             .await
@@ -317,7 +334,6 @@ impl<'a> KeyPackageOps<'a> {
             .await
     }
 
-    /// Delete local MLS key material for a single key package event.
     async fn delete_local_key_material(&self, event_id: &EventId) {
         match self
             .session
@@ -355,17 +371,11 @@ impl<'a> KeyPackageOps<'a> {
                     );
                 }
             }
-            Ok(Some(_)) => {
-                tracing::debug!(
-                    target: "whitenoise::key_packages",
-                    "Key material already deleted for event {}, skipping local deletion",
-                    event_id
-                );
-            }
+            Ok(Some(_)) => {}
             Ok(None) => {
                 tracing::warn!(
                     target: "whitenoise::key_packages",
-                    "No published key package record found for event {}, cannot delete local key material",
+                    "No published key package record for event {}, cannot delete local key material",
                     event_id
                 );
             }
@@ -380,31 +390,21 @@ impl<'a> KeyPackageOps<'a> {
         }
     }
 
-    /// Delete key packages from local MLS storage by parsing them from events.
-    fn delete_from_storage(
-        &self,
-        key_package_events: &[Event],
-        initial_count: usize,
-    ) -> Result<()> {
-        let mut storage_delete_count = 0;
-
+    fn delete_from_storage(&self, key_package_events: &[Event]) -> Result<()> {
         for event in key_package_events {
             match self.session.mdk.parse_key_package(event) {
                 Ok(key_package) => {
-                    match self
+                    if let Err(e) = self
                         .session
                         .mdk
                         .delete_key_package_from_storage(&key_package)
                     {
-                        Ok(_) => storage_delete_count += 1,
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "whitenoise::key_packages",
-                                "Failed to delete key package from storage for event {}: {}",
-                                event.id,
-                                e
-                            );
-                        }
+                        tracing::warn!(
+                            target: "whitenoise::key_packages",
+                            "Failed to delete key package from storage for event {}: {}",
+                            event.id,
+                            e
+                        );
                     }
                 }
                 Err(e) => {
@@ -417,147 +417,27 @@ impl<'a> KeyPackageOps<'a> {
                 }
             }
         }
-
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Deleted {} out of {} key packages from MLS storage",
-            storage_delete_count,
-            initial_count
-        );
-
         Ok(())
     }
 
-    /// Publish a batch deletion event for the given event IDs.
     #[perf_instrument("key_packages")]
     async fn publish_deletion(&self, event_ids: &[EventId], relay_urls: &[RelayUrl]) -> Result<()> {
-        match self
+        let result = self
             .session
             .ephemeral
             .publish_event_deletion(event_ids, relay_urls)
-            .await
-        {
-            Ok(result) => {
-                if result.success.is_empty() {
-                    tracing::error!(
-                        target: "whitenoise::key_packages",
-                        "Batch deletion event was not accepted by any relay",
-                    );
-                } else {
-                    tracing::info!(
-                        target: "whitenoise::key_packages",
-                        "Published batch deletion event to {} relay(s) for {} key packages",
-                        result.success.len(),
-                        event_ids.len()
-                    );
-                }
-                Ok(())
-            }
-            Err(e) => {
-                tracing::error!(
-                    target: "whitenoise::key_packages",
-                    "Failed to publish batch deletion event: {}",
-                    e
-                );
-                Err(e)
-            }
-        }
-    }
-
-    /// Internal batch delete with retry logic.
-    async fn delete_batch_internal(
-        &self,
-        key_package_events: Vec<Event>,
-        delete_mls_stored_keys: bool,
-        max_retries: u32,
-    ) -> Result<usize> {
-        if key_package_events.is_empty() {
-            tracing::debug!(
+            .await?;
+        if result.success.is_empty() {
+            tracing::error!(
                 target: "whitenoise::key_packages",
-                "No key package events to delete for account {}",
-                self.session.account_pubkey.to_hex()
-            );
-            return Ok(0);
-        }
-
-        let original_count = key_package_events.len();
-        let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
-
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Deleting {} key package events for account {}",
-            original_count,
-            self.session.account_pubkey.to_hex()
-        );
-
-        let relays = self.prepare_relays().await?;
-        if relays.is_empty() {
-            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
-        }
-        let relay_urls = Relay::urls(&relays);
-
-        // Delete from local storage on initial attempt only
-        if delete_mls_stored_keys {
-            self.delete_from_storage(&key_package_events, original_count)?;
-        }
-
-        let mut pending_ids: Vec<EventId> = key_package_events.iter().map(|e| e.id).collect();
-
-        for attempt in 0..=max_retries {
-            if attempt > 0 {
-                tracing::debug!(
-                    target: "whitenoise::key_packages",
-                    "Retry {}/{} for {} remaining key package(s)",
-                    attempt,
-                    max_retries,
-                    pending_ids.len()
-                );
-            }
-
-            self.publish_deletion(&pending_ids, &relay_urls).await?;
-
-            // Wait for relays to process
-            tokio::time::sleep(Duration::from_millis(500)).await;
-
-            // Check which of our original packages are still present
-            let remaining_events = self.fetch_all().await?;
-            pending_ids = remaining_events
-                .iter()
-                .filter(|e| original_ids.contains(&e.id))
-                .map(|e| e.id)
-                .collect();
-
-            if pending_ids.is_empty() {
-                break;
-            }
-        }
-
-        let deleted_count = original_count - pending_ids.len();
-
-        if pending_ids.is_empty() {
-            tracing::info!(
-                target: "whitenoise::key_packages",
-                "Successfully deleted {} key package(s) for account {}",
-                deleted_count,
-                self.session.account_pubkey.to_hex()
-            );
-        } else {
-            tracing::warn!(
-                target: "whitenoise::key_packages",
-                "After {} retries, {} of {} key package(s) still not deleted for account {}",
-                max_retries,
-                pending_ids.len(),
-                original_count,
-                self.session.account_pubkey.to_hex()
+                "Batch deletion event was not accepted by any relay"
             );
         }
-
-        Ok(deleted_count)
+        Ok(())
     }
 
     // ── Testing helpers ────────────────────────────────────────────────
 
-    /// Look up a published key package record by event ID (test helper).
     #[cfg(feature = "integration-tests")]
     pub async fn find_published_for_testing(
         &self,
@@ -570,7 +450,6 @@ impl<'a> KeyPackageOps<'a> {
             .await
     }
 
-    /// Record a published key package for lifecycle tracking (test helper).
     #[cfg(feature = "integration-tests")]
     pub async fn track_published_for_testing(&self, hash_ref: &[u8], event_id: &str) -> Result<()> {
         self.session
@@ -580,7 +459,6 @@ impl<'a> KeyPackageOps<'a> {
             .await
     }
 
-    /// Backdate `consumed_at` for a published key package (test helper).
     #[cfg(feature = "integration-tests")]
     pub async fn backdate_consumed_at_for_testing(
         &self,
@@ -597,14 +475,6 @@ impl<'a> KeyPackageOps<'a> {
         .execute(&self.session.database.pool)
         .await
         .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
-
-        tracing::debug!(
-            target: "whitenoise::key_packages",
-            "Backdated consumed_at by {}s for KP event {} (TEST ONLY)",
-            age_secs,
-            event_id
-        );
-
         Ok(())
     }
 }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -465,16 +465,49 @@ impl<'a> KeyPackageOps<'a> {
         event_id: &str,
         age_secs: i64,
     ) -> Result<()> {
-        sqlx::query(
-            "UPDATE published_key_packages SET consumed_at = unixepoch() - ?
-             WHERE account_pubkey = ? AND event_id = ?",
-        )
-        .bind(age_secs)
-        .bind(self.session.account_pubkey.to_hex())
-        .bind(event_id)
-        .execute(&self.session.database.pool)
-        .await
-        .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
-        Ok(())
+        self.session
+            .repos
+            .published_key_packages
+            .backdate_consumed_at(event_id, age_secs)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::Keys;
+
+    use crate::whitenoise::session::test_helpers::test_session;
+
+    #[tokio::test]
+    async fn publish_fails_with_no_relays() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let result = session.key_packages().publish().await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("key package relay") || err_msg.contains("AccountNotFound"),
+            "Expected relay or account error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_all_fails_with_no_relays() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let result = session.key_packages().fetch_all().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_batch_empty_returns_zero() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let result = session.key_packages().delete_batch(vec![], false, 0).await;
+        assert_eq!(result.unwrap(), 0);
     }
 }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -1,0 +1,610 @@
+//! Key package lifecycle operations scoped to an [`AccountSession`].
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use mdk_core::key_packages::KeyPackageEventData;
+use nostr_sdk::prelude::*;
+
+use super::AccountSession;
+use crate::RelayType;
+use crate::perf_instrument;
+use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
+use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::key_packages::filter_key_package_events_for_account;
+use crate::whitenoise::relays::Relay;
+use crate::whitenoise::users::User;
+
+/// Maximum number of relay publish attempts before giving up.
+const MAX_PUBLISH_ATTEMPTS: u32 = 3;
+
+/// Maximum number of fetch-delete rounds before giving up.
+const MAX_DELETE_ROUNDS: u32 = 10;
+
+/// View over [`AccountSession`] for key package lifecycle operations.
+///
+/// Obtain via [`AccountSession::key_packages`].
+pub struct KeyPackageOps<'a> {
+    session: &'a AccountSession,
+}
+
+impl<'a> KeyPackageOps<'a> {
+    pub(super) fn new(session: &'a AccountSession) -> Self {
+        Self { session }
+    }
+
+    // ── Public API ─────────────────────────────────────────────────────
+
+    /// Publish a new key package for this account with retry (up to 3 attempts).
+    ///
+    /// Creates a single MLS key package, then retries relay publishing with
+    /// exponential backoff if publishing fails. The key package is created
+    /// only once to avoid orphaning unused key material in local MLS storage.
+    #[perf_instrument("key_packages")]
+    pub async fn publish(&self) -> Result<()> {
+        let relays = self.prepare_relays().await?;
+
+        if relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+
+        let key_package_data = self.encoded_key_package(&relays).await?;
+        let relay_urls = Relay::urls(&relays);
+
+        let mut last_error = None;
+
+        for attempt in 0..MAX_PUBLISH_ATTEMPTS {
+            if attempt > 0 {
+                let delay = Duration::from_secs(1 << attempt);
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Retrying key package publish for account {} (attempt {}/{})",
+                    self.session.account_pubkey.to_hex(),
+                    attempt + 1,
+                    MAX_PUBLISH_ATTEMPTS,
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            match self
+                .publish_to_relays(
+                    &key_package_data.content,
+                    &relay_urls,
+                    &key_package_data.tags_443,
+                )
+                .await
+            {
+                Ok(event_id) => {
+                    self.track_published(&key_package_data.hash_ref, &event_id)
+                        .await;
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Key package publish attempt {}/{} failed for account {}: {}",
+                        attempt + 1,
+                        MAX_PUBLISH_ATTEMPTS,
+                        self.session.account_pubkey.to_hex(),
+                        e,
+                    );
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        Err(last_error.expect("loop ran at least once"))
+    }
+
+    /// Create a new key package and publish it (single attempt, no retry).
+    #[perf_instrument("key_packages")]
+    pub(crate) async fn create_and_publish(&self, relays: &[Relay]) -> Result<()> {
+        let key_package_data = self.encoded_key_package(relays).await?;
+        let relay_urls = Relay::urls(relays);
+        let event_id = self
+            .publish_to_relays(
+                &key_package_data.content,
+                &relay_urls,
+                &key_package_data.tags_443,
+            )
+            .await?;
+        self.track_published(&key_package_data.hash_ref, &event_id)
+            .await;
+        Ok(())
+    }
+
+    /// Fetch all key package events for this account from its key package relays.
+    #[perf_instrument("key_packages")]
+    pub async fn fetch_all(&self) -> Result<Vec<Event>> {
+        let relays = self.prepare_relays().await?;
+
+        if relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+
+        let relay_urls = Relay::urls(&relays);
+        let key_package_events = self
+            .session
+            .ephemeral
+            .fetch_key_packages_from_relays(&relay_urls)
+            .await?;
+
+        let (key_package_events, dropped_wrong_kind, dropped_wrong_author) =
+            filter_key_package_events_for_account(self.session.account_pubkey, key_package_events);
+
+        let total_dropped = dropped_wrong_kind + dropped_wrong_author;
+        if total_dropped > 0 {
+            tracing::warn!(
+                target: "whitenoise::key_packages",
+                "Dropped {} off-filter event(s) while fetching key packages for account {} \
+                 (wrong kind: {}, wrong author: {})",
+                total_dropped,
+                self.session.account_pubkey.to_hex(),
+                dropped_wrong_kind,
+                dropped_wrong_author,
+            );
+        }
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Found {} valid key package event(s) for account {}",
+            key_package_events.len(),
+            self.session.account_pubkey.to_hex()
+        );
+
+        Ok(key_package_events)
+    }
+
+    /// Delete a single key package from relays, optionally deleting local key material.
+    ///
+    /// Returns `true` if the deletion event was accepted by at least one relay.
+    #[perf_instrument("key_packages")]
+    pub async fn delete(&self, event_id: &EventId, delete_mls_stored_keys: bool) -> Result<bool> {
+        if delete_mls_stored_keys {
+            self.delete_local_key_material(event_id).await;
+        }
+
+        let relays = self.prepare_relays().await?;
+        if relays.is_empty() {
+            return Ok(false);
+        }
+
+        let relay_urls = Relay::urls(&relays);
+        let result = self
+            .session
+            .ephemeral
+            .publish_event_deletion(&[*event_id], &relay_urls)
+            .await?;
+        Ok(!result.success.is_empty())
+    }
+
+    /// Delete all key packages for this account with convergence loop.
+    ///
+    /// Fetches and deletes in rounds until no key packages remain on relays,
+    /// up to 10 rounds.
+    #[perf_instrument("key_packages")]
+    pub async fn delete_all(&self, delete_mls_stored_keys: bool) -> Result<usize> {
+        let mut total_deleted = 0;
+
+        for round in 0..MAX_DELETE_ROUNDS {
+            let key_package_events = self.fetch_all().await?;
+
+            if key_package_events.is_empty() {
+                tracing::info!(
+                    target: "whitenoise::key_packages",
+                    "All key packages deleted for account {} \
+                     ({} total across {} round(s))",
+                    self.session.account_pubkey.to_hex(),
+                    total_deleted,
+                    round + 1,
+                );
+                return Ok(total_deleted);
+            }
+
+            tracing::debug!(
+                target: "whitenoise::key_packages",
+                "Round {}: found {} remaining key package(s) for account {}",
+                round + 1,
+                key_package_events.len(),
+                self.session.account_pubkey.to_hex(),
+            );
+
+            let batch_size = key_package_events.len();
+
+            let deleted = self
+                .delete_batch_internal(key_package_events, delete_mls_stored_keys, 1)
+                .await?;
+
+            total_deleted += deleted;
+
+            if deleted == 0 {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Round {} deleted 0 key packages despite {} found \
+                     — relays may not support deletion",
+                    round + 1,
+                    batch_size,
+                );
+                break;
+            }
+        }
+
+        Ok(total_deleted)
+    }
+
+    /// Delete specific key package events from relays with retry.
+    ///
+    /// Storage deletion happens only on the initial attempt.
+    #[perf_instrument("key_packages")]
+    pub(crate) async fn delete_batch(
+        &self,
+        key_package_events: Vec<Event>,
+        delete_mls_stored_keys: bool,
+        max_retries: u32,
+    ) -> Result<usize> {
+        self.delete_batch_internal(key_package_events, delete_mls_stored_keys, max_retries)
+            .await
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────
+
+    /// Create and encode a key package for this account.
+    #[perf_instrument("key_packages")]
+    async fn encoded_key_package(&self, relays: &[Relay]) -> Result<KeyPackageEventData> {
+        let key_package_relay_urls = Relay::urls(relays);
+        let data = self
+            .session
+            .mdk
+            .create_key_package_for_event(&self.session.account_pubkey, key_package_relay_urls)
+            .map_err(|e| WhitenoiseError::Configuration(format!("NostrMls error: {}", e)))?;
+
+        Ok(data)
+    }
+
+    /// Publish an encoded key package to relays. Returns the event ID on success.
+    #[perf_instrument("key_packages")]
+    async fn publish_to_relays(
+        &self,
+        encoded_key_package: &str,
+        relay_urls: &[RelayUrl],
+        tags: &[Tag],
+    ) -> Result<EventId> {
+        let result = self
+            .session
+            .ephemeral
+            .publish_key_package(encoded_key_package, relay_urls, tags)
+            .await?;
+
+        if result.success.is_empty() {
+            return Err(WhitenoiseError::KeyPackagePublishFailed(
+                "no relay accepted the key package event".to_string(),
+            ));
+        }
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Published key package to {} relay(s)",
+            result.success.len(),
+        );
+
+        Ok(*result.id())
+    }
+
+    /// Record a published key package in the lifecycle tracking table.
+    #[perf_instrument("key_packages")]
+    async fn track_published(&self, hash_ref: &[u8], event_id: &EventId) {
+        if let Err(e) = self
+            .session
+            .repos
+            .published_key_packages
+            .create(hash_ref, &event_id.to_hex())
+            .await
+        {
+            tracing::warn!(
+                target: "whitenoise::key_packages",
+                "Published key package but failed to track it: {}",
+                e
+            );
+        }
+    }
+
+    /// Resolve key package relay URLs for this account.
+    async fn prepare_relays(&self) -> Result<Vec<Relay>> {
+        let user = User::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
+            .await
+            .map_err(|_| WhitenoiseError::AccountNotFound)?;
+        user.relays(RelayType::KeyPackage, &self.session.database)
+            .await
+    }
+
+    /// Delete local MLS key material for a single key package event.
+    async fn delete_local_key_material(&self, event_id: &EventId) {
+        match self
+            .session
+            .repos
+            .published_key_packages
+            .find_by_event_id(&event_id.to_hex())
+            .await
+        {
+            Ok(Some(pkg)) if !pkg.key_material_deleted => {
+                if let Err(e) = self
+                    .session
+                    .mdk
+                    .delete_key_package_from_storage_by_hash_ref(&pkg.key_package_hash_ref)
+                {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Failed to delete key material for event {}: {}",
+                        event_id,
+                        e
+                    );
+                    return;
+                }
+                if let Err(e) = self
+                    .session
+                    .repos
+                    .published_key_packages
+                    .mark_key_material_deleted(pkg.id)
+                    .await
+                {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Deleted key material but failed to mark record {}: {}",
+                        pkg.id,
+                        e
+                    );
+                }
+            }
+            Ok(Some(_)) => {
+                tracing::debug!(
+                    target: "whitenoise::key_packages",
+                    "Key material already deleted for event {}, skipping local deletion",
+                    event_id
+                );
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "No published key package record found for event {}, cannot delete local key material",
+                    event_id
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Failed to look up published key package for event {}: {}",
+                    event_id,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Delete key packages from local MLS storage by parsing them from events.
+    fn delete_from_storage(
+        &self,
+        key_package_events: &[Event],
+        initial_count: usize,
+    ) -> Result<()> {
+        let mut storage_delete_count = 0;
+
+        for event in key_package_events {
+            match self.session.mdk.parse_key_package(event) {
+                Ok(key_package) => {
+                    match self
+                        .session
+                        .mdk
+                        .delete_key_package_from_storage(&key_package)
+                    {
+                        Ok(_) => storage_delete_count += 1,
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "whitenoise::key_packages",
+                                "Failed to delete key package from storage for event {}: {}",
+                                event.id,
+                                e
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Failed to parse key package for event {}: {}",
+                        event.id,
+                        e
+                    );
+                }
+            }
+        }
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Deleted {} out of {} key packages from MLS storage",
+            storage_delete_count,
+            initial_count
+        );
+
+        Ok(())
+    }
+
+    /// Publish a batch deletion event for the given event IDs.
+    #[perf_instrument("key_packages")]
+    async fn publish_deletion(&self, event_ids: &[EventId], relay_urls: &[RelayUrl]) -> Result<()> {
+        match self
+            .session
+            .ephemeral
+            .publish_event_deletion(event_ids, relay_urls)
+            .await
+        {
+            Ok(result) => {
+                if result.success.is_empty() {
+                    tracing::error!(
+                        target: "whitenoise::key_packages",
+                        "Batch deletion event was not accepted by any relay",
+                    );
+                } else {
+                    tracing::info!(
+                        target: "whitenoise::key_packages",
+                        "Published batch deletion event to {} relay(s) for {} key packages",
+                        result.success.len(),
+                        event_ids.len()
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "whitenoise::key_packages",
+                    "Failed to publish batch deletion event: {}",
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+
+    /// Internal batch delete with retry logic.
+    async fn delete_batch_internal(
+        &self,
+        key_package_events: Vec<Event>,
+        delete_mls_stored_keys: bool,
+        max_retries: u32,
+    ) -> Result<usize> {
+        if key_package_events.is_empty() {
+            tracing::debug!(
+                target: "whitenoise::key_packages",
+                "No key package events to delete for account {}",
+                self.session.account_pubkey.to_hex()
+            );
+            return Ok(0);
+        }
+
+        let original_count = key_package_events.len();
+        let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Deleting {} key package events for account {}",
+            original_count,
+            self.session.account_pubkey.to_hex()
+        );
+
+        let relays = self.prepare_relays().await?;
+        if relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+        let relay_urls = Relay::urls(&relays);
+
+        // Delete from local storage on initial attempt only
+        if delete_mls_stored_keys {
+            self.delete_from_storage(&key_package_events, original_count)?;
+        }
+
+        let mut pending_ids: Vec<EventId> = key_package_events.iter().map(|e| e.id).collect();
+
+        for attempt in 0..=max_retries {
+            if attempt > 0 {
+                tracing::debug!(
+                    target: "whitenoise::key_packages",
+                    "Retry {}/{} for {} remaining key package(s)",
+                    attempt,
+                    max_retries,
+                    pending_ids.len()
+                );
+            }
+
+            self.publish_deletion(&pending_ids, &relay_urls).await?;
+
+            // Wait for relays to process
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Check which of our original packages are still present
+            let remaining_events = self.fetch_all().await?;
+            pending_ids = remaining_events
+                .iter()
+                .filter(|e| original_ids.contains(&e.id))
+                .map(|e| e.id)
+                .collect();
+
+            if pending_ids.is_empty() {
+                break;
+            }
+        }
+
+        let deleted_count = original_count - pending_ids.len();
+
+        if pending_ids.is_empty() {
+            tracing::info!(
+                target: "whitenoise::key_packages",
+                "Successfully deleted {} key package(s) for account {}",
+                deleted_count,
+                self.session.account_pubkey.to_hex()
+            );
+        } else {
+            tracing::warn!(
+                target: "whitenoise::key_packages",
+                "After {} retries, {} of {} key package(s) still not deleted for account {}",
+                max_retries,
+                pending_ids.len(),
+                original_count,
+                self.session.account_pubkey.to_hex()
+            );
+        }
+
+        Ok(deleted_count)
+    }
+
+    // ── Testing helpers ────────────────────────────────────────────────
+
+    /// Look up a published key package record by event ID (test helper).
+    #[cfg(feature = "integration-tests")]
+    pub async fn find_published_for_testing(
+        &self,
+        event_id: &str,
+    ) -> Result<Option<PublishedKeyPackage>> {
+        self.session
+            .repos
+            .published_key_packages
+            .find_by_event_id(event_id)
+            .await
+    }
+
+    /// Record a published key package for lifecycle tracking (test helper).
+    #[cfg(feature = "integration-tests")]
+    pub async fn track_published_for_testing(&self, hash_ref: &[u8], event_id: &str) -> Result<()> {
+        self.session
+            .repos
+            .published_key_packages
+            .create(hash_ref, event_id)
+            .await
+    }
+
+    /// Backdate `consumed_at` for a published key package (test helper).
+    #[cfg(feature = "integration-tests")]
+    pub async fn backdate_consumed_at_for_testing(
+        &self,
+        event_id: &str,
+        age_secs: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE published_key_packages SET consumed_at = unixepoch() - ?
+             WHERE account_pubkey = ? AND event_id = ?",
+        )
+        .bind(age_secs)
+        .bind(self.session.account_pubkey.to_hex())
+        .bind(event_id)
+        .execute(&self.session.database.pool)
+        .await
+        .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
+
+        tracing::debug!(
+            target: "whitenoise::key_packages",
+            "Backdated consumed_at by {}s for KP event {} (TEST ONLY)",
+            age_secs,
+            event_id
+        );
+
+        Ok(())
+    }
+}

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -145,13 +145,17 @@ impl<'a> KeyPackageOps<'a> {
     /// Returns `true` if the deletion event was accepted by at least one relay.
     #[perf_instrument("key_packages")]
     pub async fn delete(&self, event_id: &EventId, delete_mls_stored_keys: bool) -> Result<bool> {
-        if delete_mls_stored_keys {
-            self.delete_local_key_material(event_id).await;
-        }
-
+        // Resolve relays before wiping local MLS key material. If this step
+        // fails, the relay-side key package event is still live, so wiping
+        // local material would leave peers with a key package pointing at
+        // nonexistent local keys. Matches `delete_batch` ordering.
         let relays = self.prepare_relays().await?;
         if relays.is_empty() {
             return Ok(false);
+        }
+
+        if delete_mls_stored_keys {
+            self.delete_local_key_material(event_id).await;
         }
 
         let relay_urls = Relay::urls(&relays);
@@ -475,9 +479,51 @@ impl<'a> KeyPackageOps<'a> {
 
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::Keys;
+    use nostr_sdk::{EventId, Keys, RelayUrl};
 
     use crate::whitenoise::session::test_helpers::test_session;
+
+    #[tokio::test]
+    async fn delete_keeps_local_material_when_no_relays() {
+        // Regression: when `prepare_relays` yields no relays, `delete()` must
+        // short-circuit BEFORE wiping local MLS key material. Otherwise the
+        // relay-side KP event stays live while local material is gone, leaving
+        // peers with a broken key package.
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        // Create real MLS key material so that an incorrectly-ordered wipe
+        // would actually succeed. Without this, the MDK delete would no-op on
+        // a missing hash_ref and the test couldn't distinguish old from new.
+        let dummy_url = RelayUrl::parse("wss://test.invalid").unwrap();
+        let kp_data = session
+            .mdk
+            .create_key_package_for_event(&pk, vec![dummy_url])
+            .expect("create key package");
+
+        let event_id = EventId::all_zeros();
+        session
+            .repos
+            .published_key_packages
+            .create(&kp_data.hash_ref, &event_id.to_hex())
+            .await
+            .expect("seed published_key_packages row");
+
+        let result = session.key_packages().delete(&event_id, true).await;
+        assert!(matches!(result, Ok(false)));
+
+        let pkg = session
+            .repos
+            .published_key_packages
+            .find_by_event_id(&event_id.to_hex())
+            .await
+            .expect("lookup")
+            .expect("record exists");
+        assert!(
+            !pkg.key_material_deleted,
+            "delete() wiped local key material despite relay check yielding no relays"
+        );
+    }
 
     #[tokio::test]
     async fn publish_fails_with_no_relays() {

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -1,4 +1,6 @@
+mod chat_list;
 mod groups;
+mod key_packages;
 pub(crate) mod messages;
 pub(crate) mod relay_handles;
 
@@ -7,8 +9,10 @@ mod membership;
 mod settings;
 mod social;
 
+pub use self::chat_list::ChatListOps;
 pub use self::drafts::DraftOps;
 pub use self::groups::GroupOps;
+pub use self::key_packages::KeyPackageOps;
 pub use self::membership::{MembershipOps, MembershipOpsForGroup};
 pub use self::settings::SettingsOps;
 pub use self::social::SocialOps;
@@ -203,10 +207,20 @@ impl AccountSession {
     pub fn membership(&self) -> MembershipOps<'_> {
         MembershipOps::new(self)
     }
-  
+
     /// Return a view for group read operations scoped to this session.
     pub fn groups(&self) -> GroupOps<'_> {
         GroupOps::new(self)
+    }
+
+    /// Return a view for key package lifecycle operations scoped to this session.
+    pub fn key_packages(&self) -> KeyPackageOps<'_> {
+        KeyPackageOps::new(self)
+    }
+
+    /// Return a view for chat list read operations scoped to this session.
+    pub fn chat_list(&self) -> ChatListOps<'_> {
+        ChatListOps::new(self)
     }
 
     // ── Inbox plane lifecycle ──────────────────────────────────────

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -227,7 +227,7 @@ impl AccountSession {
     pub fn chat_list(&self) -> ChatListOps<'_> {
         ChatListOps::new(self)
     }
-  
+
     /// Return a view for push notification operations scoped to this session.
     pub fn push(&self) -> PushOps<'_> {
         PushOps::new(self)

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -109,7 +109,6 @@ impl AccountEphemeralHandle {
             .await?)
     }
 
-    #[expect(dead_code, reason = "phase 14")]
     pub(crate) async fn publish_key_package(
         &self,
         encoded_key_package: &str,
@@ -123,7 +122,6 @@ impl AccountEphemeralHandle {
             .await?)
     }
 
-    #[expect(dead_code, reason = "phase 7+")]
     pub(crate) async fn publish_event_deletion(
         &self,
         event_ids: &[EventId],
@@ -146,6 +144,19 @@ impl AccountEphemeralHandle {
                 .publish_batch_event_deletion_with_signer(event_ids, relays, signer)
                 .await?)
         }
+    }
+
+    /// Fetch all key package events for this account from the given relays.
+    pub(crate) async fn fetch_key_packages_from_relays(
+        &self,
+        relays: &[RelayUrl],
+    ) -> Result<Vec<Event>> {
+        let filter = Filter::new()
+            .kind(Kind::MlsKeyPackage)
+            .author(self.account_pubkey);
+
+        let fetched = self.ephemeral.fetch_events_from(relays, filter).await?;
+        Ok(fetched.into_iter().collect())
     }
 
     // ── Publish helpers (event already signed) ──────────────────────

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -193,6 +193,7 @@ impl Whitenoise {
     /// - Subscription is established BEFORE fetching to capture concurrent updates
     /// - Any updates that arrived during fetch are merged into `initial_items`
     /// - The receiver only yields updates AFTER the initial snapshot
+    #[allow(deprecated)]
     #[perf_instrument("whitenoise")]
     pub async fn subscribe_to_chat_list(
         &self,
@@ -246,6 +247,7 @@ impl Whitenoise {
     ///
     /// Same race-condition-free design as `subscribe_to_chat_list`, but uses
     /// `get_archived_chat_list` and the archived stream manager.
+    #[allow(deprecated)]
     #[perf_instrument("whitenoise")]
     pub async fn subscribe_to_archived_chat_list(
         &self,


### PR DESCRIPTION
![marmot](https://blossom.primal.net/d2e0eecc61dd1df500ecac16b75c39c0b34bf5295a44a420c7cfb4b57a25a1d9.jpg)

## Phase 14: Key Packages and Chat List Reads

This marmot sorted its keyring and pinned its favorite chats. Phase 14 moves key package lifecycle operations and chat list reads into session-scoped ops, continuing the session/projection rearchitecture.

### What moved

**KeyPackageOps** (session.key_packages()):
- Publish with retry (3 attempts, exponential backoff)
- Fetch all from relay
- Delete single, batch, or all with convergence loop
- Lifecycle tracking via new PublishedKeyPackagesRepo

**ChatListOps** (session.chat_list()):
- Active and archived chat list assembly
- Single-item build for streaming updates
- Batch pipeline: group info, DM peers, last messages, unread counts, image resolution

### New infrastructure

- `PublishedKeyPackagesRepo` wraps the lifecycle tracking DB with account_pubkey baked in
- `AccountEphemeralHandle.fetch_key_packages_from_relays()` for relay queries
- `GroupInformation.get_by_mls_group_ids_with_mdk()` avoids requiring &Whitenoise

### Design decisions

- KeyPackageOps reads the session's SharedSigner. The `_with_signer` variants stay on Whitenoise for pre-session login flows.
- ChatListOps calls `Whitenoise::get_instance()` for image resolution only (media services haven't moved to session scope yet).
- The emit_chat_list_update methods stay on Whitenoise because they broadcast across accounts.
- No spawning in ops (no-spawn rule). `create_key_package_and_background_publish` remains on Whitenoise as a spawning wrapper.

### Validation

- `just check` passes (fmt, docs, clippy, dead_code)
- All session tests pass
- Test failures are pre-existing relay connectivity flakiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-based key package operations for publishing, creating, fetching, and deleting key packages.
  * Added session-based chat list operations for retrieving active and archived chat lists.

* **Refactor**
  * Refactored chat list and key package management to use centralized session APIs.
  * Added published key packages repository for better data organization.
  * Simplified chat list assembly and key package lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->