### PR TITLE
Phase 15: session-scoped event dispatch

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -407,7 +407,7 @@ split phase.
 
 ### Phase 15: Session-scoped event dispatch (~800 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #770
 
 <details>
 <summary>Details</summary>

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -626,6 +626,7 @@ impl Whitenoise {
             .await
     }
 
+    #[cfg(test)]
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::membership().for_group().mark_as_removed() instead."

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -359,17 +359,18 @@ impl Whitenoise {
 
     /// Extract rumor timestamp from giftwrap event for sync advancement.
     ///
-    /// Only called after `handle_giftwrap` succeeds, so the session signer
-    /// is guaranteed to exist (giftwrap decryption already used it).
+    /// Only called after `handle_giftwrap` succeeds. A missing signer here
+    /// is surfaced as `SignerUnavailable` so it is distinguishable from an
+    /// actual rumor-extraction failure in the caller's logs.
     #[perf_instrument("event_processor")]
     async fn extract_rumor_timestamp_for_advancement(
         &self,
         event: &Event,
         session: &Arc<AccountSession>,
     ) -> Result<Option<Timestamp>> {
-        let Some(signer) = session.get_signer() else {
-            return Ok(None);
-        };
+        let signer = session
+            .get_signer()
+            .ok_or(WhitenoiseError::SignerUnavailable(session.account_pubkey))?;
 
         match extract_rumor(&signer, event).await {
             Ok(unwrapped) => Ok(Some(unwrapped.rumor.created_at)),

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -589,4 +589,52 @@ mod tests {
             "Error should describe missing p tag, got: {err_msg}"
         );
     }
+
+    /// When the session is removed (account logged out) between event receipt
+    /// and processing, the event is silently discarded and not tracked.
+    #[tokio::test]
+    async fn test_process_account_event_discards_when_session_missing() {
+        let (whitenoise, _d, _l) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let keys = whitenoise
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&account.pubkey)
+            .unwrap();
+
+        // Build a contact-list event for this account
+        let event = EventBuilder::new(Kind::ContactList, "")
+            .sign(&keys)
+            .await
+            .unwrap();
+
+        // Remove the session to simulate logout
+        whitenoise.account_manager.remove_session(&account.pubkey);
+        assert!(whitenoise.session(&account.pubkey).is_none());
+
+        // Process the event; it should be silently discarded
+        let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
+        whitenoise
+            .process_account_event(
+                event.clone(),
+                EventSource::RelaySubscription(SubscriptionContext {
+                    plane: RelayPlane::Discovery,
+                    account_pubkey: Some(account.pubkey),
+                    relay_url,
+                    stream: SubscriptionStream::DiscoveryFollowLists,
+                    group_ids: Vec::new(),
+                }),
+                Default::default(),
+            )
+            .await;
+
+        // Event must NOT be tracked as processed
+        assert!(
+            !whitenoise
+                .event_tracker
+                .already_processed_account_event(&event.id, &account.pubkey)
+                .await
+                .unwrap(),
+            "Event should not be tracked when session is missing"
+        );
+    }
 }

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -91,7 +91,7 @@ impl Whitenoise {
         );
 
         let result = self
-            .route_account_event_for_processing(&event, &session, &account)
+            .route_account_event_for_processing(&session, &account, &event)
             .await;
 
         // Handle the result - success, retry, or give up
@@ -145,7 +145,7 @@ impl Whitenoise {
                     Kind::GiftWrap => {
                         // Use rumor timestamp for advancement per NIP-59
                         match self
-                            .extract_rumor_timestamp_for_advancement(&event, &session, &account)
+                            .extract_rumor_timestamp_for_advancement(&event, &session)
                             .await
                         {
                             Ok(Some(rumor_timestamp)) => {
@@ -325,9 +325,9 @@ impl Whitenoise {
     #[perf_instrument("event_processor")]
     async fn route_account_event_for_processing(
         &self,
-        event: &Event,
         session: &Arc<AccountSession>,
         account: &Account,
+        event: &Event,
     ) -> Result<()> {
         match event.kind {
             Kind::GiftWrap => match validate_giftwrap_target(account, event) {
@@ -357,19 +357,18 @@ impl Whitenoise {
         }
     }
 
-    /// Extract rumor timestamp from giftwrap event for sync advancement
+    /// Extract rumor timestamp from giftwrap event for sync advancement.
+    ///
+    /// Only called after `handle_giftwrap` succeeds, so the session signer
+    /// is guaranteed to exist (giftwrap decryption already used it).
     #[perf_instrument("event_processor")]
     async fn extract_rumor_timestamp_for_advancement(
         &self,
         event: &Event,
         session: &Arc<AccountSession>,
-        account: &Account,
     ) -> Result<Option<Timestamp>> {
-        // Prefer session signer; fall back to Whitenoise lookup for external
-        // signers that may not yet be registered on the session.
-        let signer = match session.get_signer() {
-            Some(s) => s,
-            None => self.get_signer_for_account(account)?,
+        let Some(signer) = session.get_signer() else {
+            return Ok(None);
         };
 
         match extract_rumor(&signer, event).await {
@@ -485,7 +484,7 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .route_account_event_for_processing(&event, &session, &account)
+            .route_account_event_for_processing(&session, &account, &event)
             .await;
 
         // Unhandled events return Ok(())

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use nostr_sdk::prelude::*;
 
 use crate::{
@@ -9,6 +11,7 @@ use crate::{
         Whitenoise,
         accounts::Account,
         error::{Result, WhitenoiseError},
+        session::AccountSession,
     },
 };
 
@@ -31,6 +34,21 @@ impl Whitenoise {
                     e
                 );
                 return; // Skip - no retry
+            }
+        };
+
+        // Resolve active session — if the account logged out between receipt
+        // and processing, discard the event.
+        let session = match self.session(&account.pubkey) {
+            Some(s) => s,
+            None => {
+                tracing::debug!(
+                    target: "whitenoise::event_processor::process_account_event",
+                    "Skipping event {}: no active session for account {}",
+                    event.id.to_hex(),
+                    account.pubkey.to_hex()
+                );
+                return;
             }
         };
 
@@ -73,7 +91,7 @@ impl Whitenoise {
         );
 
         let result = self
-            .route_account_event_for_processing(&event, &account)
+            .route_account_event_for_processing(&event, &session, &account)
             .await;
 
         // Handle the result - success, retry, or give up
@@ -127,7 +145,7 @@ impl Whitenoise {
                     Kind::GiftWrap => {
                         // Use rumor timestamp for advancement per NIP-59
                         match self
-                            .extract_rumor_timestamp_for_advancement(&event, &account)
+                            .extract_rumor_timestamp_for_advancement(&event, &session, &account)
                             .await
                         {
                             Ok(Some(rumor_timestamp)) => {
@@ -308,19 +326,26 @@ impl Whitenoise {
     async fn route_account_event_for_processing(
         &self,
         event: &Event,
+        session: &Arc<AccountSession>,
         account: &Account,
     ) -> Result<()> {
         match event.kind {
             Kind::GiftWrap => match validate_giftwrap_target(account, event) {
-                Ok(()) => self.handle_giftwrap(account, event.clone()).await,
+                Ok(()) => self.handle_giftwrap(session, account, event.clone()).await,
                 Err(e) => Err(e),
             },
-            Kind::MlsGroupMessage => self.handle_mls_message(account, event.clone()).await,
+            Kind::MlsGroupMessage => {
+                self.handle_mls_message(session, account, event.clone())
+                    .await
+            }
             Kind::Metadata => self.handle_metadata(event.clone()).await,
             Kind::RelayList | Kind::InboxRelays | Kind::MlsKeyPackageRelays => {
                 self.handle_relay_list(event.clone()).await
             }
-            Kind::ContactList => self.handle_contact_list(account, event.clone()).await,
+            Kind::ContactList => {
+                self.handle_contact_list(session, account, event.clone())
+                    .await
+            }
             _ => {
                 tracing::debug!(
                     target: "whitenoise::event_processor::route_event_for_processing",
@@ -337,9 +362,15 @@ impl Whitenoise {
     async fn extract_rumor_timestamp_for_advancement(
         &self,
         event: &Event,
+        session: &Arc<AccountSession>,
         account: &Account,
     ) -> Result<Option<Timestamp>> {
-        let signer = self.get_signer_for_account(account)?;
+        // Prefer session signer; fall back to Whitenoise lookup for external
+        // signers that may not yet be registered on the session.
+        let signer = match session.get_signer() {
+            Some(s) => s,
+            None => self.get_signer_for_account(account)?,
+        };
 
         match extract_rumor(&signer, event).await {
             Ok(unwrapped) => Ok(Some(unwrapped.rumor.created_at)),
@@ -441,6 +472,7 @@ mod tests {
     async fn test_route_account_event_unhandled_kind() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
@@ -453,7 +485,7 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .route_account_event_for_processing(&event, &account)
+            .route_account_event_for_processing(&event, &session, &account)
             .await;
 
         // Unhandled events return Ok(())

--- a/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
@@ -1,13 +1,15 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use nostr_sdk::prelude::*;
-use tokio::sync::{OwnedSemaphorePermit, watch};
+use tokio::sync::watch;
 
 use crate::whitenoise::{
     Whitenoise,
     accounts::Account,
     database::processed_events::ProcessedEvent,
     error::{Result, WhitenoiseError},
+    session::AccountSession,
     utils::timestamp_to_datetime,
 };
 use crate::{
@@ -24,8 +26,13 @@ const CONTACT_LIST_CATCH_UP_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Whitenoise {
     #[perf_instrument("event_handlers")]
-    pub(crate) async fn handle_contact_list(&self, account: &Account, event: Event) -> Result<()> {
-        let _permit = self.acquire_contact_list_guard(account).await?;
+    pub(crate) async fn handle_contact_list(
+        &self,
+        session: &Arc<AccountSession>,
+        account: &Account,
+        event: Event,
+    ) -> Result<()> {
+        let _permit = session.acquire_contact_list_permit().await?;
         let account_id = account.id.ok_or(WhitenoiseError::AccountNotFound)?;
 
         if self.should_skip_contact_list(&event, account_id).await? {
@@ -37,7 +44,7 @@ impl Whitenoise {
             .update_follows_from_event(contacts.clone(), &self.database)
             .await?;
 
-        self.schedule_background_user_fetch(&contacts, &account.pubkey);
+        self.schedule_background_user_fetch(session, &contacts);
 
         self.event_tracker
             .track_processed_account_event(&event, &account.pubkey)
@@ -52,20 +59,6 @@ impl Whitenoise {
         );
 
         Ok(())
-    }
-
-    #[perf_instrument("event_handlers")]
-    async fn acquire_contact_list_guard(&self, account: &Account) -> Result<OwnedSemaphorePermit> {
-        self.account_manager
-            .get_session(&account.pubkey)
-            .ok_or_else(|| {
-                WhitenoiseError::ContactList(format!(
-                    "No active session for account {}",
-                    account.pubkey.to_hex()
-                ))
-            })?
-            .acquire_contact_list_permit()
-            .await
     }
 
     #[perf_instrument("event_handlers")]
@@ -111,7 +104,7 @@ impl Whitenoise {
     ///
     /// This avoids the login bootstrap flood where each followed user triggers
     /// its own relay-list and metadata fetch workflow.
-    fn schedule_background_user_fetch(&self, pubkeys: &[PublicKey], account_pubkey: &PublicKey) {
+    fn schedule_background_user_fetch(&self, session: &Arc<AccountSession>, pubkeys: &[PublicKey]) {
         if pubkeys.is_empty() {
             return;
         }
@@ -119,10 +112,7 @@ impl Whitenoise {
         let pubkeys = pubkeys.to_vec();
         let total = pubkeys.len();
 
-        let cancel_rx = self
-            .account_manager
-            .get_session(account_pubkey)
-            .map(|s| s.subscribe_cancellation());
+        let cancel_rx = Some(session.subscribe_cancellation());
 
         let tid = crate::perf::current_trace_id();
         tokio::spawn(crate::perf::with_trace_id(tid, async move {
@@ -324,6 +314,7 @@ mod tests {
     async fn test_handle_contact_list_success() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
@@ -338,7 +329,7 @@ mod tests {
         let event = build_contact_list_event(&keys, &contacts, Some(timestamp)).await;
 
         whitenoise
-            .handle_contact_list(&account, event.clone())
+            .handle_contact_list(&session, &account, event.clone())
             .await
             .unwrap();
 
@@ -375,6 +366,7 @@ mod tests {
     async fn test_handle_contact_list_idempotency() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
@@ -385,11 +377,11 @@ mod tests {
 
         // Process the same event twice
         whitenoise
-            .handle_contact_list(&account, event.clone())
+            .handle_contact_list(&session, &account, event.clone())
             .await
             .unwrap();
         whitenoise
-            .handle_contact_list(&account, event)
+            .handle_contact_list(&session, &account, event)
             .await
             .unwrap();
 
@@ -402,6 +394,7 @@ mod tests {
     async fn test_handle_contact_list_stale_events_ignored() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
@@ -418,7 +411,7 @@ mod tests {
         let current_event =
             build_contact_list_event(&keys, &[current_contact], Some(current_timestamp)).await;
         whitenoise
-            .handle_contact_list(&account, current_event)
+            .handle_contact_list(&session, &account, current_event)
             .await
             .unwrap();
 
@@ -426,7 +419,7 @@ mod tests {
         let older_event =
             build_contact_list_event(&keys, &[older_contact], Some(older_timestamp)).await;
         whitenoise
-            .handle_contact_list(&account, older_event)
+            .handle_contact_list(&session, &account, older_event)
             .await
             .unwrap();
 
@@ -438,7 +431,7 @@ mod tests {
         let same_ts_event =
             build_contact_list_event(&keys, &[same_ts_contact], Some(current_timestamp)).await;
         whitenoise
-            .handle_contact_list(&account, same_ts_event)
+            .handle_contact_list(&session, &account, same_ts_event)
             .await
             .unwrap();
 
@@ -454,6 +447,7 @@ mod tests {
     async fn test_handle_contact_list_newer_event_replaces() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
@@ -469,7 +463,7 @@ mod tests {
         // Process first event
         let first_event = build_contact_list_event(&keys, &[first_contact], Some(t1)).await;
         whitenoise
-            .handle_contact_list(&account, first_event)
+            .handle_contact_list(&session, &account, first_event)
             .await
             .unwrap();
         assert_eq!(
@@ -480,7 +474,7 @@ mod tests {
         // Process newer event - should replace
         let second_event = build_contact_list_event(&keys, &[second_contact], Some(t2)).await;
         whitenoise
-            .handle_contact_list(&account, second_event)
+            .handle_contact_list(&session, &account, second_event)
             .await
             .unwrap();
 
@@ -491,7 +485,7 @@ mod tests {
         // Process empty list - should clear all follows
         let empty_event = build_contact_list_event(&keys, &[], Some(t3)).await;
         whitenoise
-            .handle_contact_list(&account, empty_event)
+            .handle_contact_list(&session, &account, empty_event)
             .await
             .unwrap();
 
@@ -510,12 +504,14 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let account1 = whitenoise.create_identity().await.unwrap();
+        let session1 = whitenoise.require_session(&account1.pubkey).unwrap();
         let keys1 = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account1.pubkey)
             .unwrap();
 
         let account2 = whitenoise.create_identity().await.unwrap();
+        let session2 = whitenoise.require_session(&account2.pubkey).unwrap();
         let keys2 = whitenoise
             .secrets_store
             .get_nostr_keys_for_pubkey(&account2.pubkey)
@@ -526,6 +522,7 @@ mod tests {
 
         whitenoise
             .handle_contact_list(
+                &session1,
                 &account1,
                 build_contact_list_event(&keys1, &[contact1], None).await,
             )
@@ -533,6 +530,7 @@ mod tests {
             .unwrap();
         whitenoise
             .handle_contact_list(
+                &session2,
                 &account2,
                 build_contact_list_event(&keys2, &[contact2], None).await,
             )
@@ -548,14 +546,21 @@ mod tests {
         assert_eq!(follows2[0].pubkey, contact2);
     }
 
+    /// Verifies that an Account with `id: None` still triggers an error even
+    /// when a valid session exists. The handler checks `account.id` early and
+    /// returns `AccountNotFound` before doing any work.
     #[tokio::test]
     async fn test_handle_contact_list_requires_saved_account() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let keys = Keys::generate();
+        // Create a real identity (which has a session) then fabricate an
+        // Account struct with id: None to simulate the unsaved-account path.
+        let real_account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&real_account.pubkey).unwrap();
+
         let unsaved_account = Account {
             id: None,
-            pubkey: keys.public_key(),
+            pubkey: real_account.pubkey,
             user_id: 0,
             account_type: AccountType::Local,
             last_synced_at: None,
@@ -563,11 +568,15 @@ mod tests {
             updated_at: chrono::Utc::now(),
         };
 
+        let keys = whitenoise
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&real_account.pubkey)
+            .unwrap();
         let event = build_contact_list_event(&keys, &[Keys::generate().public_key()], None).await;
 
         assert!(
             whitenoise
-                .handle_contact_list(&unsaved_account, event)
+                .handle_contact_list(&session, &unsaved_account, event)
                 .await
                 .is_err()
         );

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::Utc;
 use mdk_core::GroupId;
 use nostr_sdk::prelude::*;
@@ -12,53 +14,38 @@ use crate::{
         database::published_key_packages::PublishedKeyPackage,
         error::{Result, WhitenoiseError},
         group_information::{GroupInformation, GroupType},
+        session::AccountSession,
     },
 };
 
 impl Whitenoise {
     #[perf_instrument("event_handlers")]
-    pub async fn handle_giftwrap(&self, account: &Account, event: Event) -> Result<()> {
+    pub async fn handle_giftwrap(
+        &self,
+        session: &Arc<AccountSession>,
+        account: &Account,
+        event: Event,
+    ) -> Result<()> {
         tracing::debug!(
             target: "whitenoise::event_handlers::handle_giftwrap",
             "Giftwrap received for account: {}",
             account.pubkey.to_hex()
         );
 
-        // For external signer accounts, use the registered signer.
-        // For local accounts, use the keys from the secrets store.
         let _decrypt_span = perf_span!("event_handlers::giftwrap_decrypt");
-        let unwrapped = if account.uses_external_signer() {
-            let signer = self.get_external_signer(&account.pubkey).ok_or_else(|| {
-                WhitenoiseError::Configuration(format!(
-                    "No external signer registered for account: {}",
-                    account.pubkey.to_hex()
-                ))
-            })?;
-            tracing::debug!(
-                target: "whitenoise::event_handlers::handle_giftwrap",
-                "Using external signer for giftwrap decryption"
-            );
-            // Arc<dyn NostrSigner> implements NostrSigner, so we can pass it directly
-            extract_rumor(&signer, &event).await.map_err(|e| {
-                WhitenoiseError::Configuration(format!(
-                    "Failed to decrypt giftwrap with external signer: {}",
-                    e
-                ))
-            })?
-        } else {
-            let keys = self
-                .secrets_store
-                .get_nostr_keys_for_pubkey(&account.pubkey)?;
-            extract_rumor(&keys, &event).await.map_err(|e| {
-                WhitenoiseError::Configuration(format!("Failed to decrypt giftwrap: {}", e))
-            })?
-        };
+        let signer = session
+            .get_signer()
+            .ok_or(WhitenoiseError::SignerUnavailable(account.pubkey))?;
+
+        let unwrapped = extract_rumor(&signer, &event).await.map_err(|e| {
+            WhitenoiseError::Configuration(format!("Failed to decrypt giftwrap: {}", e))
+        })?;
 
         drop(_decrypt_span);
 
         match unwrapped.rumor.kind {
             Kind::MlsWelcome => {
-                self.process_welcome(account, event, unwrapped.rumor)
+                self.process_welcome(session, account, event, unwrapped.rumor)
                     .await?;
             }
             _ => {
@@ -76,6 +63,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn process_welcome(
         &self,
+        session: &Arc<AccountSession>,
         account: &Account,
         event: Event,
         rumor: UnsignedEvent,
@@ -144,7 +132,7 @@ impl Whitenoise {
             }
         }
 
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let mdk = &*session.mdk;
 
         // Process the welcome to get group info (but don't accept yet)
         let welcome = mdk
@@ -589,6 +577,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         let mut welcome_rumor =
             build_welcome_rumor(&whitenoise, &creator_account, member_account.pubkey).await;
@@ -615,7 +604,7 @@ mod tests {
         .unwrap();
 
         let result = whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await;
         assert!(
             result.is_ok(),
@@ -639,6 +628,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         let mut welcome_rumor =
             build_welcome_rumor(&whitenoise, &creator_account, member_account.pubkey).await;
@@ -666,7 +656,7 @@ mod tests {
         .unwrap();
 
         let result = whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await;
         assert!(
             result.is_ok(),
@@ -691,6 +681,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         // Build a real MLS Welcome giftwrap addressed to the member
         let giftwrap_event =
@@ -698,7 +689,7 @@ mod tests {
 
         // Member should successfully process welcome
         let result = whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await;
         assert!(result.is_ok());
     }
@@ -711,6 +702,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         // Build a real MLS Welcome giftwrap addressed to the member
         let giftwrap_event =
@@ -718,7 +710,7 @@ mod tests {
 
         // Member processes the welcome
         let result = whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await;
         assert!(result.is_ok());
 
@@ -759,6 +751,7 @@ mod tests {
     async fn test_handle_giftwrap_non_welcome_ok() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
+        let account_session = whitenoise.require_session(&account.pubkey).unwrap();
 
         // Build a non-welcome rumor and giftwrap it to the account
         let sender_keys = create_test_keys();
@@ -775,7 +768,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = whitenoise.handle_giftwrap(&account, giftwrap_event).await;
+        let result = whitenoise
+            .handle_giftwrap(&account_session, &account, giftwrap_event)
+            .await;
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
     }
 
@@ -905,12 +900,13 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         // Build and process a real MLS Welcome
         let giftwrap_event =
             build_welcome_giftwrap(&whitenoise, &creator_account, member_account.pubkey).await;
         whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await
             .unwrap();
 
@@ -960,6 +956,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
         // Member starts with subscriptions but no groups
@@ -983,7 +980,7 @@ mod tests {
         let giftwrap_event =
             build_welcome_giftwrap(&whitenoise, &creator_account, member_account.pubkey).await;
         whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await
             .unwrap();
 
@@ -1076,6 +1073,7 @@ mod tests {
         let creator_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         // Build a real MLS Welcome giftwrap addressed to the member
         let giftwrap_event =
@@ -1089,7 +1087,7 @@ mod tests {
 
         // Processing should fail because the DB lookup errors out
         let result = whitenoise
-            .handle_giftwrap(&member_account, giftwrap_event)
+            .handle_giftwrap(&member_session, &member_account, giftwrap_event)
             .await;
         assert!(
             result.is_err(),

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -32,6 +32,10 @@ impl Whitenoise {
             account.pubkey.to_hex()
         );
 
+        // Fail fast if the signer is unavailable (external-signer account
+        // that hasn't re-registered after restart). The event stays
+        // unprocessed and relay replay will deliver it again once the
+        // signer slot is filled via register_external_signer().
         let _decrypt_span = perf_span!("event_handlers::giftwrap_decrypt");
         let signer = session
             .get_signer()

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -148,8 +148,9 @@ impl Whitenoise {
         message: Message,
     ) -> Result<()> {
         if is_push_group_message_kind(message.kind) {
-            if let Err(error) = self
-                .handle_push_application_message(session, outcome, &message)
+            if let Err(error) = session
+                .push()
+                .handle_received_push_group_message(&message, outcome.context.sender_leaf_index)
                 .await
             {
                 tracing::warn!(
@@ -167,19 +168,6 @@ impl Whitenoise {
 
         self.handle_standard_application_message(account, mdk, group_id, inner_event, message)
             .await
-    }
-
-    async fn handle_push_application_message(
-        &self,
-        session: &Arc<AccountSession>,
-        outcome: &MessageProcessingOutcome,
-        message: &Message,
-    ) -> Result<()> {
-        session
-            .push()
-            .handle_received_push_group_message(message, outcome.context.sender_leaf_index)
-            .await?;
-        Ok(())
     }
 
     #[perf_instrument("event_handlers")]

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use mdk_core::prelude::group_types::GroupState;
 use mdk_core::prelude::message_types::Message;
 use mdk_core::prelude::{GroupId, MessageProcessingOutcome, MessageProcessingResult};
@@ -20,6 +22,7 @@ use crate::{
         message_aggregator::{ChatMessage, emoji_utils, reaction_handler},
         message_streaming::{MessageUpdate, UpdateTrigger},
         push_notifications::is_push_group_message_kind,
+        session::AccountSession,
     },
 };
 #[cfg(test)]
@@ -46,7 +49,12 @@ fn extract_group_id(result: &MessageProcessingResult) -> Option<&GroupId> {
 
 impl Whitenoise {
     #[perf_instrument("event_handlers")]
-    pub async fn handle_mls_message(&self, account: &Account, event: Event) -> Result<()> {
+    pub async fn handle_mls_message(
+        &self,
+        session: &Arc<AccountSession>,
+        account: &Account,
+        event: Event,
+    ) -> Result<()> {
         tracing::debug!(
           target: "whitenoise::event_handlers::handle_mls_message",
           "Handling MLS message {} (kind {}) for account: {}",
@@ -55,7 +63,7 @@ impl Whitenoise {
           account.pubkey.to_hex()
         );
 
-        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let mdk = &*session.mdk;
         let _mls_proc = perf_span!("event_handlers::mls_process_message");
         let outcome = match mdk.process_message_with_context(&event) {
             Ok(outcome) => {
@@ -111,8 +119,9 @@ impl Whitenoise {
 
         if let Some((group_id, inner_event, message)) = Self::extract_message_details(&outcome) {
             self.handle_application_message_outcome(
+                session,
                 account,
-                &mdk,
+                mdk,
                 &outcome,
                 group_id,
                 inner_event,
@@ -121,7 +130,7 @@ impl Whitenoise {
             .await?;
         }
 
-        self.handle_non_application_outcome(account, &mdk, outcome.result)
+        self.handle_non_application_outcome(session, account, mdk, outcome.result)
             .await?;
 
         Ok(())
@@ -130,6 +139,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn handle_application_message_outcome(
         &self,
+        session: &Arc<AccountSession>,
         account: &Account,
         mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         outcome: &MessageProcessingOutcome,
@@ -139,7 +149,7 @@ impl Whitenoise {
     ) -> Result<()> {
         if is_push_group_message_kind(message.kind) {
             if let Err(error) = self
-                .handle_push_application_message(mdk, account, outcome, &message)
+                .handle_push_application_message(session, outcome, &message)
                 .await
             {
                 tracing::warn!(
@@ -161,19 +171,14 @@ impl Whitenoise {
 
     async fn handle_push_application_message(
         &self,
-        mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
-        account: &Account,
+        session: &Arc<AccountSession>,
         outcome: &MessageProcessingOutcome,
         message: &Message,
     ) -> Result<()> {
-        #[allow(deprecated)]
-        self.handle_received_push_group_message(
-            mdk,
-            account,
-            message,
-            outcome.context.sender_leaf_index,
-        )
-        .await?;
+        session
+            .push()
+            .handle_received_push_group_message(message, outcome.context.sender_leaf_index)
+            .await?;
         Ok(())
     }
 
@@ -270,6 +275,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn handle_non_application_outcome(
         &self,
+        session: &Arc<AccountSession>,
         account: &Account,
         mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         result: MessageProcessingResult,
@@ -280,7 +286,7 @@ impl Whitenoise {
         match result {
             MessageProcessingResult::ApplicationMessage(_) => Ok(()),
             MessageProcessingResult::Proposal(update_result) => {
-                self.handle_auto_committed_proposal(account, mdk, update_result)
+                self.handle_auto_committed_proposal(session, account, mdk, update_result)
                     .await
             }
             MessageProcessingResult::PendingProposal { mls_group_id } => {
@@ -312,7 +318,7 @@ impl Whitenoise {
                 Ok(())
             }
             MessageProcessingResult::Commit { mls_group_id } => {
-                self.handle_commit_outcome(account, mdk, &mls_group_id)
+                self.handle_commit_outcome(session, account, mdk, &mls_group_id)
                     .await
             }
             MessageProcessingResult::Unprocessable { mls_group_id } => {
@@ -339,10 +345,10 @@ impl Whitenoise {
         }
     }
 
-    #[allow(deprecated)]
     #[perf_instrument("event_handlers")]
     async fn handle_auto_committed_proposal(
         &self,
+        session: &Arc<AccountSession>,
         account: &Account,
         mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         update_result: mdk_core::prelude::UpdateGroupResult,
@@ -350,13 +356,10 @@ impl Whitenoise {
         let group_id = &update_result.mls_group_id;
         let relay_urls = Self::ensure_group_relays(mdk, group_id)?;
 
-        self.publish_and_merge_commit(
-            update_result.evolution_event.clone(),
-            &account.pubkey,
-            group_id,
-            &relay_urls,
-        )
-        .await?;
+        session
+            .groups()
+            .publish_and_merge_commit(update_result.evolution_event.clone(), group_id, &relay_urls)
+            .await?;
 
         self.background_refresh_account_group_subscriptions(account);
 
@@ -386,6 +389,7 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     async fn handle_commit_outcome(
         &self,
+        session: &Arc<AccountSession>,
         account: &Account,
         mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         mls_group_id: &GroupId,
@@ -408,14 +412,19 @@ impl Whitenoise {
                 account.pubkey.to_hex(),
                 hex::encode(mls_group_id.as_slice())
             );
-            #[allow(deprecated)]
-            self.mark_as_removed(account, mls_group_id).await?;
+            drop(
+                session
+                    .membership()
+                    .for_group(mls_group_id)
+                    .mark_as_removed()
+                    .await?,
+            );
         }
 
-        #[allow(deprecated)]
         if still_active
-            && let Err(error) = self
-                .reconcile_group_push_tokens_for_active_leaves(account, mls_group_id)
+            && let Err(error) = session
+                .push()
+                .reconcile_group_tokens_for_active_leaves(mls_group_id)
                 .await
         {
             tracing::warn!(
@@ -911,6 +920,7 @@ mod tests {
         // Arrange: Setup whitenoise and create a group
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
 
@@ -944,7 +954,7 @@ mod tests {
         let message_event = mdk.create_message(group_id, inner, None).unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, message_event)
+            .handle_mls_message(&creator_session, &creator_account, message_event)
             .await;
         assert!(result.is_ok(), "Failed to handle regular message");
 
@@ -971,7 +981,7 @@ mod tests {
         let reaction_event = mdk.create_message(group_id, reaction_inner, None).unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, reaction_event)
+            .handle_mls_message(&creator_session, &creator_account, reaction_event)
             .await;
         assert!(result.is_ok(), "Failed to handle reaction");
 
@@ -1002,7 +1012,7 @@ mod tests {
         let deletion_event = mdk.create_message(group_id, deletion_inner, None).unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, deletion_event)
+            .handle_mls_message(&creator_session, &creator_account, deletion_event)
             .await;
         assert!(result.is_ok(), "Failed to handle deletion");
 
@@ -1101,6 +1111,7 @@ mod tests {
     async fn test_handle_mls_message_error_handling() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
 
@@ -1136,7 +1147,7 @@ mod tests {
         bad_event.kind = Kind::TextNote;
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, bad_event)
+            .handle_mls_message(&creator_session, &creator_account, bad_event)
             .await;
 
         assert!(result.is_err(), "Expected error for corrupted event");
@@ -1151,6 +1162,7 @@ mod tests {
     async fn test_handle_mls_message_orphaned_reactions_and_deletions() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
 
@@ -1188,7 +1200,7 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, reaction_event)
+            .handle_mls_message(&creator_session, &creator_account, reaction_event)
             .await;
         assert!(result.is_ok(), "Orphaned reaction should be stored");
 
@@ -1218,7 +1230,7 @@ mod tests {
         let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, message_event)
+            .handle_mls_message(&creator_session, &creator_account, message_event)
             .await;
         assert!(
             result.is_ok(),
@@ -1255,6 +1267,7 @@ mod tests {
     async fn test_invalid_orphaned_reactions_are_skipped() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
 
@@ -1289,7 +1302,7 @@ mod tests {
         let valid_event = mdk.create_message(group_id, valid_reaction, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&creator_account, valid_event)
+            .handle_mls_message(&creator_session, &creator_account, valid_event)
             .await
             .unwrap();
 
@@ -1307,7 +1320,7 @@ mod tests {
             .unwrap();
 
         whitenoise
-            .handle_mls_message(&creator_account, invalid_event)
+            .handle_mls_message(&creator_session, &creator_account, invalid_event)
             .await
             .unwrap();
 
@@ -1323,7 +1336,7 @@ mod tests {
         let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
-            .handle_mls_message(&creator_account, message_event)
+            .handle_mls_message(&creator_session, &creator_account, message_event)
             .await;
 
         // The critical assertion: message processing should succeed
@@ -1436,6 +1449,7 @@ mod tests {
     async fn test_handle_mls_message_cache_integration() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
 
         let member_accounts = members
@@ -1473,7 +1487,7 @@ mod tests {
                 .unwrap();
 
             whitenoise
-                .handle_mls_message(&creator_account, event)
+                .handle_mls_message(&creator_session, &creator_account, event)
                 .await
                 .unwrap();
         }
@@ -1512,6 +1526,7 @@ mod tests {
         let admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
@@ -1531,7 +1546,7 @@ mod tests {
         let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, event)
+            .handle_mls_message(&member_session, &member_account, event)
             .await
             .unwrap();
 
@@ -1569,6 +1584,7 @@ mod tests {
         let admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
@@ -1603,7 +1619,7 @@ mod tests {
         let event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, event)
+            .handle_mls_message(&member_session, &member_account, event)
             .await
             .unwrap();
 
@@ -1644,6 +1660,7 @@ mod tests {
         let admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
@@ -1671,7 +1688,7 @@ mod tests {
         let event = admin_mdk.create_message(&group_id, removal, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, event)
+            .handle_mls_message(&member_session, &member_account, event)
             .await
             .unwrap();
 
@@ -1701,6 +1718,7 @@ mod tests {
         let admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
@@ -1718,7 +1736,7 @@ mod tests {
         let event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, event)
+            .handle_mls_message(&member_session, &member_account, event)
             .await
             .unwrap();
 
@@ -1745,6 +1763,7 @@ mod tests {
         let admin_account = whitenoise.create_identity().await.unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
@@ -1763,7 +1782,7 @@ mod tests {
         let request_event = admin_mdk.create_message(&group_id, request, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, request_event)
+            .handle_mls_message(&member_session, &member_account, request_event)
             .await
             .unwrap();
 
@@ -1786,7 +1805,7 @@ mod tests {
         let response_event = admin_mdk.create_message(&group_id, response, None).unwrap();
 
         whitenoise
-            .handle_mls_message(&member_account, response_event)
+            .handle_mls_message(&member_session, &member_account, response_event)
             .await
             .unwrap();
 
@@ -1810,6 +1829,7 @@ mod tests {
         let members = setup_multiple_test_accounts(&whitenoise, 2).await;
         let member_one = members[0].0.clone();
         let member_two = members[1].0.clone();
+        let member_two_session = whitenoise.require_session(&member_two.pubkey).unwrap();
 
         wait_for_key_package_publication(&whitenoise, &[&member_one, &member_two]).await;
 
@@ -1851,7 +1871,7 @@ mod tests {
         };
 
         whitenoise
-            .handle_mls_message(&member_two, removal_event)
+            .handle_mls_message(&member_two_session, &member_two, removal_event)
             .await
             .unwrap();
 
@@ -1878,6 +1898,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let admin_account = whitenoise.create_identity().await.unwrap();
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
 
@@ -1895,7 +1916,7 @@ mod tests {
         // Admin processes the leave proposal -- should auto-commit because
         // admin_account is the group admin
         let result = whitenoise
-            .handle_mls_message(&admin_account, leave_result.evolution_event)
+            .handle_mls_message(&admin_session, &admin_account, leave_result.evolution_event)
             .await;
         assert!(
             result.is_ok(),
@@ -1927,6 +1948,7 @@ mod tests {
     async fn test_unprocessable_message_returns_err() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
 
         let member_accounts = members
@@ -1963,14 +1985,16 @@ mod tests {
 
         // First processing: should succeed
         let first = whitenoise
-            .handle_mls_message(&creator_account, event.clone())
+            .handle_mls_message(&creator_session, &creator_account, event.clone())
             .await;
         assert!(first.is_ok(), "First processing should succeed: {first:?}");
 
         // Second processing of the same event: MDK returns Unprocessable because
         // the event was already processed and its state recorded as Processed.
         // Our handler must propagate this as an error.
-        let second = whitenoise.handle_mls_message(&creator_account, event).await;
+        let second = whitenoise
+            .handle_mls_message(&creator_session, &creator_account, event)
+            .await;
         assert!(
             second.is_err(),
             "Second processing of same event should return Err"
@@ -2002,6 +2026,7 @@ mod tests {
     async fn test_unprocessable_not_tracked_via_process_account_event() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
 
         let member_accounts = members
@@ -2082,7 +2107,9 @@ mod tests {
 
         // Confirm that handle_mls_message itself returns Err on duplicate so
         // any caller that bypasses the skip check also cannot silently succeed.
-        let direct_result = whitenoise.handle_mls_message(&creator_account, event).await;
+        let direct_result = whitenoise
+            .handle_mls_message(&creator_session, &creator_account, event)
+            .await;
         assert!(
             direct_result.is_err(),
             "Direct second call to handle_mls_message must return Err"
@@ -2097,6 +2124,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let admin_account = whitenoise.create_identity().await.unwrap();
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_account = members[0].0.clone();
 
@@ -2112,7 +2140,7 @@ mod tests {
 
         // Admin auto-commits the leave proposal
         whitenoise
-            .handle_mls_message(&admin_account, leave_result.evolution_event)
+            .handle_mls_message(&admin_session, &admin_account, leave_result.evolution_event)
             .await
             .expect("auto-commit should succeed");
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -286,7 +286,7 @@ impl Whitenoise {
         match result {
             MessageProcessingResult::ApplicationMessage(_) => Ok(()),
             MessageProcessingResult::Proposal(update_result) => {
-                self.handle_auto_committed_proposal(session, account, mdk, update_result)
+                self.handle_auto_committed_proposal(session, account, update_result)
                     .await
             }
             MessageProcessingResult::PendingProposal { mls_group_id } => {
@@ -350,14 +350,13 @@ impl Whitenoise {
         &self,
         session: &Arc<AccountSession>,
         account: &Account,
-        mdk: &mdk_core::prelude::MDK<MdkSqliteStorage>,
         update_result: mdk_core::prelude::UpdateGroupResult,
     ) -> Result<()> {
         let group_id = &update_result.mls_group_id;
-        let relay_urls = Self::ensure_group_relays(mdk, group_id)?;
+        let groups = session.groups();
+        let relay_urls = groups.ensure_relays(group_id)?;
 
-        session
-            .groups()
+        groups
             .publish_and_merge_commit(update_result.evolution_event.clone(), group_id, &relay_urls)
             .await?;
 
@@ -412,13 +411,11 @@ impl Whitenoise {
                 account.pubkey.to_hex(),
                 hex::encode(mls_group_id.as_slice())
             );
-            drop(
-                session
-                    .membership()
-                    .for_group(mls_group_id)
-                    .mark_as_removed()
-                    .await?,
-            );
+            let _ = session
+                .membership()
+                .for_group(mls_group_id)
+                .mark_as_removed()
+                .await?;
         }
 
         if still_active

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1238,8 +1238,11 @@ pub mod test_utils {
             .await
             .unwrap();
 
+            let session = whitenoise
+                .require_session(&member_account.pubkey)
+                .expect("member must have an active session");
             whitenoise
-                .handle_giftwrap(member_account, giftwrap)
+                .handle_giftwrap(&session, member_account, giftwrap)
                 .await
                 .expect("member should process welcome successfully");
         }

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -598,24 +598,6 @@ impl Whitenoise {
         session.push().clear_registration().await
     }
 
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::push().handle_received_push_group_message() instead."
-    )]
-    pub(crate) async fn handle_received_push_group_message(
-        &self,
-        _mdk: &MDK<MdkSqliteStorage>,
-        account: &Account,
-        message: &mdk_core::prelude::message_types::Message,
-        sender_leaf_index: Option<u32>,
-    ) -> Result<bool> {
-        let session = self.require_session(&account.pubkey)?;
-        session
-            .push()
-            .handle_received_push_group_message(message, sender_leaf_index)
-            .await
-    }
-
     #[cfg(test)]
     #[deprecated(
         since = "0.0.0",
@@ -703,6 +685,7 @@ impl Whitenoise {
         session.push().remove_local_token_from_group(group_id).await
     }
 
+    #[cfg(test)]
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::push().reconcile_group_tokens_for_active_leaves() instead."

--- a/src/whitenoise/session/groups.rs
+++ b/src/whitenoise/session/groups.rs
@@ -210,7 +210,7 @@ impl<'a> GroupOps<'a> {
     /// `clear_pending_commit`, rolling back the MLS group to its pre-commit
     /// state.
     // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
-    async fn publish_and_merge_commit(
+    pub(crate) async fn publish_and_merge_commit(
         &self,
         evolution_event: Event,
         group_id: &GroupId,

--- a/src/whitenoise/session/groups.rs
+++ b/src/whitenoise/session/groups.rs
@@ -187,7 +187,7 @@ impl<'a> GroupOps<'a> {
     }
 
     /// Return the relay URLs configured for the group, or error if none.
-    fn ensure_relays(&self, group_id: &GroupId) -> Result<Vec<RelayUrl>> {
+    pub(crate) fn ensure_relays(&self, group_id: &GroupId) -> Result<Vec<RelayUrl>> {
         let relays = self
             .session
             .mdk


### PR DESCRIPTION
![marmot](https://blossom.primal.net/0c4c0a9469f949ba2fde9d1619098c113809db918cf9bdb1d4ed3db464224666.jpg)

## What

Threads `Arc<AccountSession>` into the three account-scoped event handlers so they use session-owned resources directly, eliminating per-event MDK recreation and deprecated Whitenoise bridge calls.

This is Phase 15 of the session-projection rearchitecture.

## Why

Every incoming MLS message, giftwrap, and contact-list event called `create_mdk_for_account()` to build a fresh MDK from scratch. The session already holds a cached MDK instance, a signer slot, and typed ops views (PushOps, MembershipOps, GroupOps) that wrap the same work. Wiring the session into the dispatch path lets handlers use what already exists.

## How

**Dispatch** (`account_event_processor.rs`): After resolving the `Account`, resolve the `Arc<AccountSession>`. If the account logged out between event receipt and processing, the session is gone; log and discard the event. Thread the session into `route_account_event_for_processing` and all account-scoped handler calls.

**handle_mls_message**: `session.mdk` replaces `create_mdk_for_account()`. Four deprecated Whitenoise wrappers replaced with session ops:
- `session.push().handle_received_push_group_message()`
- `session.push().reconcile_group_tokens_for_active_leaves()`
- `session.membership().for_group().mark_as_removed()`
- `session.groups().publish_and_merge_commit()`

**handle_giftwrap**: `session.get_signer()` replaces the external-vs-local signer branching. `session.mdk` replaces `create_mdk_for_account()`.

**handle_contact_list**: The session is passed directly for `acquire_contact_list_permit()` and `subscribe_cancellation()`, removing redundant lookups through `account_manager.get_session()`.

**Cleanup**:
- `GroupOps::publish_and_merge_commit` promoted to `pub(crate)`
- Removed dead `Whitenoise::handle_received_push_group_message` (zero callers after migration)
- Gated `Whitenoise::reconcile_group_push_tokens_for_active_leaves` with `#[cfg(test)]`

## What stays transitional

Global handlers (`handle_metadata`, `handle_relay_list`) are not account-scoped and unchanged. Background tasks in `schedule_background_user_fetch` and `background_finalize_welcome` still use `Whitenoise::get_instance()` for shared services (discovery relay, key rotation, event_sender) that have not moved to session yet. Phase 16a (SharedServices extraction) will clean these up.

## Validation

- `just check` passes (fmt, docs, clippy, dead_code)
- Test failures are pre-existing relay-timeout flakiness (all fail at `create_identity()` without Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event processing was reworked to make session-aware handling consistent across contact list, group messages, and giftwrap flows.
* **Bug Fixes**
  * Events received without an active session are now quietly discarded to avoid spurious processing.
* **Tests**
  * New and updated tests cover session-missing behavior and updated session-scoped flows.
* **Documentation**
  * Implementation plan marked as completed for the session-scoped dispatch phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->