### PR TITLE
refactor(phase-16a): extract SharedServices holder

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -430,7 +430,7 @@ split phase.
 
 ### Phase 16a: Extract SharedServices while keeping singleton compatibility (~800 LOC)
 
-- [ ] Not started
+- [x] In review in PR #773
 
 <details>
 <summary>Details</summary>

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -556,7 +556,7 @@ impl EphemeralPlane {
         event_id: &str,
         group_id: &GroupId,
         database: &Database,
-        stream_manager: &Arc<MessageStreamManager>,
+        stream_manager: &MessageStreamManager,
     ) -> MessagePublishResult {
         match self.publish_event_to(event, account_pubkey, relays).await {
             Ok(output) => {

--- a/src/whitenoise/account_settings.rs
+++ b/src/whitenoise/account_settings.rs
@@ -21,21 +21,6 @@ pub struct AccountSettings {
 
 #[allow(deprecated)]
 impl Whitenoise {
-    /// Returns the settings for `account`, creating a default row if none exists.
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::settings().get() instead."
-    )]
-    pub async fn account_settings(
-        &self,
-        account: &Account,
-    ) -> Result<AccountSettings, WhitenoiseError> {
-        let session = self
-            .session(&account.pubkey)
-            .ok_or(WhitenoiseError::AccountNotFound)?;
-        session.settings().get().await
-    }
-
     /// Sets the notification preference for `account` and returns the updated settings.
     ///
     /// Disabling notifications here does not clear any locally stored push
@@ -91,7 +76,13 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
 
-        let settings = whitenoise.account_settings(&account).await.unwrap();
+        let settings = whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .settings()
+            .get()
+            .await
+            .unwrap();
         assert!(settings.notifications_enabled);
         assert_eq!(settings.account_pubkey, account.pubkey);
 

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -32,10 +32,10 @@ impl Whitenoise {
         // `compute_global_since_timestamp()` for ALL accounts, forcing
         // global subscriptions to use `since=None` (unbounded re-fetch).
         let now_ms = Utc::now().timestamp_millis();
-        Account::update_last_synced_max(&account.pubkey, now_ms, &self.database).await?;
+        Account::update_last_synced_max(&account.pubkey, now_ms, &self.shared.database).await?;
         account.last_synced_at = DateTime::from_timestamp_millis(now_ms);
 
-        let user = account.user(&self.database).await?;
+        let user = account.user(&self.shared.database).await?;
 
         let relays = self
             .setup_relays_for_new_account(&mut account, &user)
@@ -74,7 +74,7 @@ impl Whitenoise {
         // tasks) was set up during the original login and is still active —
         // re-running activate_account would create duplicate subscriptions and
         // needlessly kill in-progress background tasks.
-        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await {
+        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.shared.database).await {
             tracing::debug!(
                 target: "whitenoise::accounts",
                 "Account {} is already logged in, returning existing account",
@@ -129,7 +129,7 @@ impl Whitenoise {
 
         // If this account is already logged in, return it as-is (see comment
         // in login() for rationale on not re-activating).
-        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await {
+        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.shared.database).await {
             tracing::debug!(
                 target: "whitenoise::accounts",
                 "Account {} is already logged in, returning existing account",
@@ -182,7 +182,7 @@ impl Whitenoise {
     ///
     /// * `account` - The account to log out.
     pub async fn logout(&self, pubkey: &PublicKey) -> Result<()> {
-        let account = Account::find_by_pubkey(pubkey, &self.database).await?;
+        let account = Account::find_by_pubkey(pubkey, &self.shared.database).await?;
         let ephemeral_warm_relays = self
             .account_ephemeral_warm_relay_urls(&account)
             .await
@@ -208,6 +208,7 @@ impl Whitenoise {
 
         if !ephemeral_warm_relays.is_empty()
             && let Err(error) = self
+                .shared
                 .relay_control
                 .unwarm_ephemeral_relays(&ephemeral_warm_relays)
                 .await
@@ -220,7 +221,7 @@ impl Whitenoise {
         }
 
         // Delete the account from the database
-        account.delete(&self.database).await?;
+        account.delete(&self.shared.database).await?;
 
         // Sync discovery subscriptions with remaining accounts (tears down on last logout)
         if let Err(e) = self.sync_discovery_subscriptions().await {
@@ -233,7 +234,10 @@ impl Whitenoise {
 
         // Remove the private key from the secret store
         // For local accounts this is required; for external accounts this is best-effort cleanup
-        let result = self.secrets_store.remove_private_key_for_pubkey(pubkey);
+        let result = self
+            .shared
+            .secrets_store
+            .remove_private_key_for_pubkey(pubkey);
         match (account.has_local_key(), result) {
             (true, Err(e)) => return Err(e.into()), // Local account MUST have key
             (false, Err(e)) => tracing::debug!("Expected - no key for external account: {}", e),
@@ -252,7 +256,7 @@ impl Whitenoise {
     ///
     /// Returns the count of accounts as a `usize`. Returns 0 if no accounts exist.
     pub async fn get_accounts_count(&self) -> Result<usize> {
-        let accounts = Account::all(&self.database).await?;
+        let accounts = Account::all(&self.shared.database).await?;
         Ok(accounts.len())
     }
 
@@ -262,7 +266,7 @@ impl Whitenoise {
     /// the Whitenoise instance. Each account represents a distinct identity with
     /// its own keypair, relay configurations, and associated data.
     pub async fn all_accounts(&self) -> Result<Vec<Account>> {
-        Account::all(&self.database).await
+        Account::all(&self.shared.database).await
     }
 
     /// Finds and returns an account by its public key.
@@ -274,7 +278,7 @@ impl Whitenoise {
     ///
     /// * `pubkey` - The public key of the account to find
     pub async fn find_account_by_pubkey(&self, pubkey: &PublicKey) -> Result<Account> {
-        Account::find_by_pubkey(pubkey, &self.database).await
+        Account::find_by_pubkey(pubkey, &self.shared.database).await
     }
 }
 
@@ -347,6 +351,7 @@ mod tests {
         account: &Account,
     ) {
         let key_package_event = whitenoise
+            .shared
             .relay_control
             .fetch_user_key_package(
                 account.pubkey,
@@ -404,18 +409,21 @@ mod tests {
         let nip65_relay_urls = Relay::urls(&nip65_relays);
         // Check that all three event types were published
         let inbox_events = whitenoise
+            .shared
             .relay_control
             .fetch_user_relays(account.pubkey, RelayType::Inbox, &nip65_relay_urls)
             .await
             .unwrap();
 
         let key_package_relays_events = whitenoise
+            .shared
             .relay_control
             .fetch_user_relays(account.pubkey, RelayType::KeyPackage, &nip65_relay_urls)
             .await
             .unwrap();
 
         let key_package_events = whitenoise
+            .shared
             .relay_control
             .fetch_user_key_package(
                 account.pubkey,
@@ -452,7 +460,7 @@ mod tests {
             account.last_synced_at.is_some(),
             "New identity should have last_synced_at set to prevent global subscription poisoning"
         );
-        let db_account = Account::find_by_pubkey(&account.pubkey, &whitenoise.database)
+        let db_account = Account::find_by_pubkey(&account.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(
@@ -653,9 +661,13 @@ mod tests {
     async fn test_update_metadata() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         let default_relays = whitenoise.load_default_relays().await.unwrap();
         whitenoise
@@ -676,7 +688,7 @@ mod tests {
         let result = account.update_metadata(&new_metadata, &whitenoise).await;
         result.expect("Failed to update metadata. Are test relays running on localhost:8080 and localhost:7777?");
 
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         assert_eq!(user.metadata.name, new_metadata.name);
         assert_eq!(user.metadata.display_name, new_metadata.display_name);
         assert_eq!(user.metadata.about, new_metadata.about);
@@ -686,6 +698,7 @@ mod tests {
         let nip65_relays = account.nip65_relays(&whitenoise).await.unwrap();
         let nip65_relay_urls = Relay::urls(&nip65_relays);
         let fetched_metadata = whitenoise
+            .shared
             .relay_control
             .fetch_metadata_from(&nip65_relay_urls, account.pubkey)
             .await
@@ -706,11 +719,19 @@ mod tests {
 
         // Local account logout removes key
         let (local_account, keys) = create_test_account(&whitenoise).await;
-        local_account.save(&whitenoise.database).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        local_account
+            .save(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&local_account.pubkey)
                 .is_ok()
@@ -718,6 +739,7 @@ mod tests {
         whitenoise.logout(&local_account.pubkey).await.unwrap();
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&local_account.pubkey)
                 .is_err()
@@ -728,8 +750,9 @@ mod tests {
         let ext_account = Account::new_external(&whitenoise, ext_keys.public_key())
             .await
             .unwrap();
-        ext_account.save(&whitenoise.database).await.unwrap();
+        ext_account.save(&whitenoise.shared.database).await.unwrap();
         whitenoise
+            .shared
             .secrets_store
             .store_private_key(&ext_keys)
             .unwrap(); // Stale key
@@ -737,6 +760,7 @@ mod tests {
         whitenoise.logout(&ext_account.pubkey).await.unwrap();
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&ext_account.pubkey)
                 .is_err()
@@ -746,7 +770,7 @@ mod tests {
         let ext2 = Account::new_external(&whitenoise, Keys::generate().public_key())
             .await
             .unwrap();
-        ext2.save(&whitenoise.database).await.unwrap();
+        ext2.save(&whitenoise.shared.database).await.unwrap();
         assert!(whitenoise.logout(&ext2.pubkey).await.is_ok());
     }
 
@@ -756,7 +780,7 @@ mod tests {
 
         // Create a local account directly in the database (bypassing relay setup)
         let (account, keys) = create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(
             account.account_type,
@@ -765,10 +789,15 @@ mod tests {
         );
 
         // Store the key in secrets store
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         // Verify the key is stored
         let stored_keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey);
         assert!(stored_keys.is_ok(), "Key should be stored after login");
@@ -778,6 +807,7 @@ mod tests {
 
         // Verify the key was removed
         let stored_keys_after = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey);
         assert!(
@@ -796,7 +826,7 @@ mod tests {
 
         // Create external account manually (bypassing relay setup)
         let account = Account::new_external(&whitenoise, pubkey).await.unwrap();
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(
             account.account_type,
@@ -805,17 +835,27 @@ mod tests {
         );
 
         // Manually store a stale key (simulating orphaned key from failed migration)
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         // Verify the stale key is stored
-        let stored_keys = whitenoise.secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+        let stored_keys = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&pubkey);
         assert!(stored_keys.is_ok(), "Stale key should be stored");
 
         // Logout should clean up the stale key via best-effort removal
         whitenoise.logout(&pubkey).await.unwrap();
 
         // Verify the stale key was removed
-        let stored_keys_after = whitenoise.secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+        let stored_keys_after = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&pubkey);
         assert!(
             stored_keys_after.is_err(),
             "Stale key should be removed after logout"
@@ -832,7 +872,7 @@ mod tests {
 
         // Create external account manually (bypassing relay setup)
         let account = Account::new_external(&whitenoise, pubkey).await.unwrap();
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(
             account.account_type,
@@ -841,7 +881,10 @@ mod tests {
         );
 
         // Don't store any key - verify there's no key
-        let stored_keys = whitenoise.secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+        let stored_keys = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&pubkey);
         assert!(stored_keys.is_err(), "No key should be stored");
 
         // Logout should succeed even with no key to remove
@@ -892,7 +935,11 @@ mod tests {
         // Create and persist account with stored keys
         let (account, keys) = create_test_account(&whitenoise).await;
         let account = whitenoise.persist_account(&account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         // Use the test image file
         let test_image_path = ".test/fake_image.png";
@@ -931,7 +978,11 @@ mod tests {
 
         let (account, keys) = create_test_account(&whitenoise).await;
         let account = whitenoise.persist_account(&account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         let blossom_url = nostr_sdk::Url::parse("http://localhost:3000").unwrap();
 

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -118,12 +118,12 @@ impl Whitenoise {
             !discovered.found(RelayType::KeyPackage),
         );
 
-        let account = Account::find_by_pubkey(pubkey, &self.database)
+        let account = Account::find_by_pubkey(pubkey, &self.shared.database)
             .await
             .map_err(LoginError::from)?;
         let default_relays = self.load_default_relays().await.map_err(LoginError::from)?;
         let user = account
-            .user(&self.database)
+            .user(&self.shared.database)
             .await
             .map_err(LoginError::from)?;
 
@@ -138,10 +138,11 @@ impl Whitenoise {
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             if !discovered.found(relay_type) {
                 // Missing — assign defaults in the DB and publish via the signer.
-                user.add_relays(&default_relays, relay_type, &self.database)
+                user.add_relays(&default_relays, relay_type, &self.shared.database)
                     .await
                     .map_err(LoginError::from)?;
                 if let Err(error) = self
+                    .shared
                     .relay_control
                     .publish_relay_list_with_signer(
                         &default_urls,
@@ -207,7 +208,7 @@ impl Whitenoise {
                 "External signer not found for pending login".to_string(),
             ))?;
 
-        let mut account = Account::find_by_pubkey(pubkey, &self.database)
+        let mut account = Account::find_by_pubkey(pubkey, &self.shared.database)
             .await
             .map_err(LoginError::from)?;
 
@@ -292,7 +293,7 @@ impl Whitenoise {
         &self,
         pubkey: PublicKey,
     ) -> core::result::Result<(Account, User), LoginError> {
-        let account = match Account::find_by_pubkey(&pubkey, &self.database).await {
+        let account = match Account::find_by_pubkey(&pubkey, &self.shared.database).await {
             Ok(existing) => {
                 let mut account_mut = existing.clone();
                 if account_mut.account_type != AccountType::External {
@@ -308,6 +309,7 @@ impl Whitenoise {
                         .map_err(LoginError::from)?;
                 }
                 let _ = self
+                    .shared
                     .secrets_store
                     .remove_private_key_for_pubkey(&account_mut.pubkey);
                 account_mut
@@ -323,7 +325,7 @@ impl Whitenoise {
         };
 
         let user = account
-            .user(&self.database)
+            .user(&self.shared.database)
             .await
             .map_err(LoginError::from)?;
         Ok((account, user))
@@ -340,7 +342,7 @@ impl Whitenoise {
     ) -> crate::whitenoise::error::Result<(Account, super::ExternalSignerRelaySetup)> {
         // Check if account already exists
         let mut account =
-            if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await {
+            if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.shared.database).await {
                 tracing::debug!(
                     target: "whitenoise::accounts",
                     "Found existing account"
@@ -361,6 +363,7 @@ impl Whitenoise {
 
                 // Best-effort removal of any local keys
                 let _ = self
+                    .shared
                     .secrets_store
                     .remove_private_key_for_pubkey(&account_mut.pubkey);
 
@@ -424,7 +427,8 @@ impl Whitenoise {
                     target: "whitenoise::accounts",
                     "Publishing NIP-65 relay list (defaults)"
                 );
-                self.relay_control
+                self.shared
+                    .relay_control
                     .publish_relay_list_with_signer(
                         &nip65_urls,
                         RelayType::Nip65,
@@ -442,7 +446,8 @@ impl Whitenoise {
                     target: "whitenoise::accounts",
                     "Publishing inbox relay list (defaults)"
                 );
-                self.relay_control
+                self.shared
+                    .relay_control
                     .publish_relay_list_with_signer(
                         &Relay::urls(&relay_setup.inbox_relays),
                         RelayType::Inbox,
@@ -460,7 +465,8 @@ impl Whitenoise {
                     target: "whitenoise::accounts",
                     "Publishing key package relay list (defaults)"
                 );
-                self.relay_control
+                self.shared
+                    .relay_control
                     .publish_relay_list_with_signer(
                         &Relay::urls(&relay_setup.key_package_relays),
                         RelayType::KeyPackage,
@@ -574,7 +580,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = whitenoise.secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+        let result = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&pubkey);
         assert!(
             result.is_err(),
             "External signer account should not have local keys"
@@ -693,6 +702,7 @@ mod tests {
 
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&pubkey)
                 .is_err(),
@@ -742,7 +752,11 @@ mod tests {
         let (local_account, _) = Account::new(&whitenoise, Some(keys.clone())).await.unwrap();
         assert_eq!(local_account.account_type, AccountType::Local);
         whitenoise.persist_account(&local_account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         let migrated = whitenoise
             .login_with_external_signer_for_test(keys.clone())
@@ -758,6 +772,7 @@ mod tests {
 
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&pubkey)
                 .is_err(),
@@ -776,9 +791,14 @@ mod tests {
         let account = Account::new_external(&whitenoise, pubkey).await.unwrap();
         whitenoise.persist_account(&account).await.unwrap();
 
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&pubkey)
                 .is_ok()
@@ -791,6 +811,7 @@ mod tests {
 
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&pubkey)
                 .is_err(),
@@ -939,7 +960,11 @@ mod tests {
 
         let (local_account, keys) = Account::new(&whitenoise, None).await.unwrap();
         let local_account = whitenoise.persist_account(&local_account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
         assert_eq!(local_account.account_type, AccountType::Local);
 
         let (account, _user) = whitenoise
@@ -950,6 +975,7 @@ mod tests {
         assert_eq!(account.account_type, AccountType::External);
         assert!(
             whitenoise
+                .shared
                 .secrets_store
                 .get_nostr_keys_for_pubkey(&account.pubkey)
                 .is_err(),

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -59,7 +59,7 @@ impl Whitenoise {
         //    this check, a concurrent second call could see the DB row created
         //    by a first call that hasn't finished activation yet and return
         //    Complete prematurely.
-        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.database).await
+        if let Ok(existing) = Account::find_by_pubkey(&pubkey, &self.shared.database).await
             && !self.account_manager.has_pending_login(&pubkey)
             && self.account_manager.get_session(&pubkey).is_some()
         {
@@ -154,16 +154,17 @@ impl Whitenoise {
             !discovered.found(RelayType::KeyPackage),
         );
 
-        let account = Account::find_by_pubkey(pubkey, &self.database)
+        let account = Account::find_by_pubkey(pubkey, &self.shared.database)
             .await
             .map_err(LoginError::from)?;
         let default_relays = self.load_default_relays().await.map_err(LoginError::from)?;
         let keys = self
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(pubkey)
             .map_err(|e| LoginError::Internal(e.to_string()))?;
         let user = account
-            .user(&self.database)
+            .user(&self.shared.database)
             .await
             .map_err(LoginError::from)?;
 
@@ -182,7 +183,7 @@ impl Whitenoise {
         let _publish_span = perf_span!("accounts::login_publish_defaults::publish_missing");
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             if !discovered.found(relay_type) {
-                user.add_relays(&default_relays, relay_type, &self.database)
+                user.add_relays(&default_relays, relay_type, &self.shared.database)
                     .await
                     .map_err(LoginError::from)?;
             } else {
@@ -306,7 +307,7 @@ impl Whitenoise {
             pubkey.to_hex()
         );
 
-        let mut account = Account::find_by_pubkey(pubkey, &self.database)
+        let mut account = Account::find_by_pubkey(pubkey, &self.shared.database)
             .await
             .map_err(LoginError::from)?;
 
@@ -387,13 +388,13 @@ impl Whitenoise {
         self.remove_external_signer(pubkey);
 
         // Clean up the partial account if it exists.
-        if let Ok(account) = Account::find_by_pubkey(pubkey, &self.database).await {
+        if let Ok(account) = Account::find_by_pubkey(pubkey, &self.shared.database).await {
             // Remove relay associations that try_discover_relay_lists may have
             // written to the DB before the user cancelled.  The user_relays table
             // has no CASCADE from accounts, so these rows would otherwise persist
             // as stale data for a subsequent login with the same pubkey.
-            if let Ok(user) = account.user(&self.database).await
-                && let Err(e) = user.remove_all_relays(&self.database).await
+            if let Ok(user) = account.user(&self.shared.database).await
+                && let Err(e) = user.remove_all_relays(&self.shared.database).await
             {
                 tracing::warn!(
                     target: "whitenoise::accounts",
@@ -403,11 +404,14 @@ impl Whitenoise {
                 );
             }
             account
-                .delete(&self.database)
+                .delete(&self.shared.database)
                 .await
                 .map_err(LoginError::from)?;
             // Best-effort removal of the keychain entry.
-            let _ = self.secrets_store.remove_private_key_for_pubkey(pubkey);
+            let _ = self
+                .shared
+                .secrets_store
+                .remove_private_key_for_pubkey(pubkey);
             tracing::info!(
                 target: "whitenoise::accounts",
                 "Cleaned up partial login for {}",
@@ -673,14 +677,14 @@ mod tests {
             .create_base_account_with_private_key(keys)
             .await
             .unwrap();
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = discovered.relays(relay_type);
             if !relays.is_empty() {
-                user.add_relays(relays, relay_type, &whitenoise.database)
+                user.add_relays(relays, relay_type, &whitenoise.shared.database)
                     .await
                     .unwrap();
             }
@@ -706,11 +710,11 @@ mod tests {
             .insert_external_signer(pubkey, keys.clone())
             .await
             .unwrap();
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = discovered.relays(relay_type);
             if !relays.is_empty() {
-                user.add_relays(relays, relay_type, &whitenoise.database)
+                user.add_relays(relays, relay_type, &whitenoise.shared.database)
                     .await
                     .unwrap();
             }
@@ -1205,10 +1209,11 @@ mod tests {
             .create_test_identity_with_keys(&keys)
             .await
             .unwrap();
-        let original_synced_at = Account::find_by_pubkey(&original.pubkey, &whitenoise.database)
-            .await
-            .unwrap()
-            .last_synced_at;
+        let original_synced_at =
+            Account::find_by_pubkey(&original.pubkey, &whitenoise.shared.database)
+                .await
+                .unwrap()
+                .last_synced_at;
         assert!(
             original_synced_at.is_some(),
             "create_identity must set last_synced_at"
@@ -1233,7 +1238,7 @@ mod tests {
             "Should return the same account row"
         );
 
-        let after = Account::find_by_pubkey(&original.pubkey, &whitenoise.database)
+        let after = Account::find_by_pubkey(&original.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(
@@ -1262,7 +1267,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            Account::find_by_pubkey(&pubkey, &whitenoise.database)
+            Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
                 .await
                 .is_ok()
         );
@@ -1625,12 +1630,12 @@ mod tests {
         )
         .await;
 
-        let account = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let account = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         let nip65_before = user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(
@@ -1645,7 +1650,7 @@ mod tests {
         assert!(!whitenoise.account_manager.has_pending_login(&pubkey));
 
         let nip65_after = user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(
@@ -2434,16 +2439,24 @@ mod tests {
             .unwrap();
         assert!(merged.is_complete(), "Stash must be complete after merge");
 
-        let account = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let account = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let user = account.user(&whitenoise.database).await.unwrap();
-        user.add_relays(&[inbox_relay], RelayType::Inbox, &whitenoise.database)
-            .await
-            .unwrap();
-        user.add_relays(&[kp_relay], RelayType::KeyPackage, &whitenoise.database)
-            .await
-            .unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
+        user.add_relays(
+            &[inbox_relay],
+            RelayType::Inbox,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        user.add_relays(
+            &[kp_relay],
+            RelayType::KeyPackage,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let result = whitenoise
             .login_publish_default_relays(&pubkey)

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -278,7 +278,7 @@ impl Account {
         let keys = keys.unwrap_or_else(Keys::generate);
 
         let (user, _created) =
-            User::find_or_create_by_pubkey(&keys.public_key(), &whitenoise.database).await?;
+            User::find_or_create_by_pubkey(&keys.public_key(), &whitenoise.shared.database).await?;
 
         let account = Account {
             id: None,
@@ -300,7 +300,7 @@ impl Account {
         pubkey: PublicKey,
     ) -> Result<Account> {
         let (user, _created) =
-            User::find_or_create_by_pubkey(&pubkey, &whitenoise.database).await?;
+            User::find_or_create_by_pubkey(&pubkey, &whitenoise.shared.database).await?;
 
         let account = Account {
             id: None,
@@ -346,24 +346,28 @@ impl Account {
         relay_type: RelayType,
         whitenoise: &Whitenoise,
     ) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.database).await?;
-        let relays = user.relays(relay_type, &whitenoise.database).await?;
+        let user = self.user(&whitenoise.shared.database).await?;
+        let relays = user.relays(relay_type, &whitenoise.shared.database).await?;
         Ok(relays)
     }
 
     /// Helper method to retrieve the NIP-65 relays for this account.
     #[perf_instrument("accounts")]
     pub(crate) async fn nip65_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.database).await?;
-        let relays = user.relays(RelayType::Nip65, &whitenoise.database).await?;
+        let user = self.user(&whitenoise.shared.database).await?;
+        let relays = user
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
+            .await?;
         Ok(relays)
     }
 
     /// Helper method to retrieve the inbox relays for this account.
     #[perf_instrument("accounts")]
     pub(crate) async fn inbox_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.database).await?;
-        let relays = user.relays(RelayType::Inbox, &whitenoise.database).await?;
+        let user = self.user(&whitenoise.shared.database).await?;
+        let relays = user
+            .relays(RelayType::Inbox, &whitenoise.shared.database)
+            .await?;
         Ok(relays)
     }
 
@@ -393,9 +397,9 @@ impl Account {
     /// Helper method to retrieve the key package relays for this account.
     #[perf_instrument("accounts")]
     pub(crate) async fn key_package_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.database).await?;
+        let user = self.user(&whitenoise.shared.database).await?;
         let relays = user
-            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
             .await?;
         Ok(relays)
     }
@@ -422,8 +426,8 @@ impl Account {
         relay_type: RelayType,
         whitenoise: &Whitenoise,
     ) -> Result<()> {
-        let user = self.user(&whitenoise.database).await?;
-        user.add_relay(relay, relay_type, &whitenoise.database)
+        let user = self.user(&whitenoise.shared.database).await?;
+        user.add_relay(relay, relay_type, &whitenoise.shared.database)
             .await?;
 
         whitenoise
@@ -455,8 +459,8 @@ impl Account {
         relay_type: RelayType,
         whitenoise: &Whitenoise,
     ) -> Result<()> {
-        let user = self.user(&whitenoise.database).await?;
-        user.remove_relay(relay, relay_type, &whitenoise.database)
+        let user = self.user(&whitenoise.shared.database).await?;
+        user.remove_relay(relay, relay_type, &whitenoise.shared.database)
             .await?;
         whitenoise
             .background_publish_account_relay_list(self, relay_type, None)
@@ -476,7 +480,7 @@ impl Account {
     /// * `whitenoise` - The Whitenoise instance used to access the database
     #[perf_instrument("accounts")]
     pub async fn metadata(&self, whitenoise: &Whitenoise) -> Result<Metadata> {
-        let user = self.user(&whitenoise.database).await?;
+        let user = self.user(&whitenoise.shared.database).await?;
         Ok(user.metadata.clone())
     }
 
@@ -497,12 +501,12 @@ impl Account {
         whitenoise: &Whitenoise,
     ) -> Result<()> {
         tracing::debug!(target: "whitenoise::accounts", "Updating metadata for account: {:?}", self.pubkey);
-        let mut user = self.user(&whitenoise.database).await?;
+        let mut user = self.user(&whitenoise.shared.database).await?;
         user.metadata = metadata.clone();
         user.mark_metadata_known_now();
-        let saved_user = user.save(&whitenoise.database).await?;
+        let saved_user = user.save(&whitenoise.shared.database).await?;
         let user_pubkey = saved_user.pubkey;
-        whitenoise.user_stream_manager.emit(
+        whitenoise.shared.user_stream_manager.emit(
             &user_pubkey,
             UserUpdate {
                 trigger: UserUpdateTrigger::LocalMetadataChanged,
@@ -592,22 +596,22 @@ mod tests {
     async fn test_effective_inbox_relays_returns_inbox_when_present() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
 
         let inbox_url = RelayUrl::parse("wss://inbox.example.com").unwrap();
         let nip65_url = RelayUrl::parse("wss://nip65.example.com").unwrap();
 
-        let inbox_relay = Relay::find_or_create_by_url(&inbox_url, &whitenoise.database)
+        let inbox_relay = Relay::find_or_create_by_url(&inbox_url, &whitenoise.shared.database)
             .await
             .unwrap();
-        let nip65_relay = Relay::find_or_create_by_url(&nip65_url, &whitenoise.database)
+        let nip65_relay = Relay::find_or_create_by_url(&nip65_url, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        user.add_relay(&inbox_relay, RelayType::Inbox, &whitenoise.database)
+        user.add_relay(&inbox_relay, RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
-        user.add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+        user.add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -621,14 +625,14 @@ mod tests {
     async fn test_effective_inbox_relays_falls_back_to_nip65() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
 
         // Only add NIP-65 relays — no inbox relays
         let nip65_url = RelayUrl::parse("wss://nip65.example.com").unwrap();
-        let nip65_relay = Relay::find_or_create_by_url(&nip65_url, &whitenoise.database)
+        let nip65_relay = Relay::find_or_create_by_url(&nip65_url, &whitenoise.shared.database)
             .await
             .unwrap();
-        user.add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+        user.add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -653,9 +657,13 @@ mod tests {
     async fn test_update_metadata_emits_local_metadata_changed_update() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = create_test_account(&whitenoise).await;
-        let account = account.save(&whitenoise.database).await.unwrap();
+        let account = account.save(&whitenoise.shared.database).await.unwrap();
 
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         let default_relays = whitenoise.load_default_relays().await.unwrap();
         whitenoise
@@ -982,7 +990,7 @@ mod tests {
         assert!(persisted.id.is_some());
         assert_eq!(persisted.account_type, AccountType::External);
 
-        let found = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let found = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(found.pubkey, pubkey);
@@ -995,7 +1003,10 @@ mod tests {
         let keys = nostr_sdk::Keys::generate();
         let pubkey = keys.public_key();
         let _account = Account::new_external(&whitenoise, pubkey).await.unwrap();
-        let result = whitenoise.secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+        let result = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&pubkey);
         assert!(
             result.is_err(),
             "External account creation should not store any keys"
@@ -1055,7 +1066,7 @@ mod tests {
         let random_pk = nostr_sdk::Keys::generate().public_key();
         assert!(whitenoise.find_account_by_pubkey(&random_pk).await.is_err());
 
-        let user = account1.user(&whitenoise.database).await.unwrap();
+        let user = account1.user(&whitenoise.shared.database).await.unwrap();
         assert_eq!(user.pubkey, account1.pubkey);
 
         let metadata = account1.metadata(&whitenoise).await.unwrap();
@@ -1069,7 +1080,11 @@ mod tests {
 
         let (account, keys) = create_test_account(&whitenoise).await;
         let account = whitenoise.persist_account(&account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         assert!(account.nip65_relays(&whitenoise).await.unwrap().is_empty());
         assert!(account.inbox_relays(&whitenoise).await.unwrap().is_empty());
@@ -1110,7 +1125,7 @@ mod tests {
 
         let test_relay = Relay::find_or_create_by_url(
             &RelayUrl::parse("wss://test.relay.example").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1135,7 +1150,11 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = create_test_account(&whitenoise).await;
         let account = whitenoise.persist_account(&account).await.unwrap();
-        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys)
+            .unwrap();
 
         assert!(account.nip65_relays(&whitenoise).await.unwrap().is_empty());
         assert!(account.inbox_relays(&whitenoise).await.unwrap().is_empty());
@@ -1147,7 +1166,7 @@ mod tests {
                 .is_empty()
         );
 
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         let url1 = RelayUrl::parse("ws://127.0.0.1:19010").unwrap();
         let url2 = RelayUrl::parse("ws://127.0.0.1:19011").unwrap();
         let url3 = RelayUrl::parse("ws://127.0.0.1:19012").unwrap();
@@ -1155,15 +1174,19 @@ mod tests {
         let relay2 = whitenoise.find_or_create_relay_by_url(&url2).await.unwrap();
         let relay3 = whitenoise.find_or_create_relay_by_url(&url3).await.unwrap();
 
-        user.add_relays(&[relay1], RelayType::Nip65, &whitenoise.database)
+        user.add_relays(&[relay1], RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
-        user.add_relays(&[relay2], RelayType::Inbox, &whitenoise.database)
+        user.add_relays(&[relay2], RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
-        user.add_relays(&[relay3], RelayType::KeyPackage, &whitenoise.database)
-            .await
-            .unwrap();
+        user.add_relays(
+            &[relay3],
+            RelayType::KeyPackage,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let nip65 = account.nip65_relays(&whitenoise).await.unwrap();
         assert_eq!(nip65.len(), 1);
@@ -1204,19 +1227,27 @@ mod tests {
         use nostr_sdk::prelude::*;
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let accounts = Account::all(&whitenoise.database).await.unwrap();
+        let accounts = Account::all(&whitenoise.shared.database).await.unwrap();
         assert!(accounts.is_empty());
 
         let (account1, keys1) = create_test_account(&whitenoise).await;
         let (account2, keys2) = create_test_account(&whitenoise).await;
 
-        account1.save(&whitenoise.database).await.unwrap();
-        account2.save(&whitenoise.database).await.unwrap();
+        account1.save(&whitenoise.shared.database).await.unwrap();
+        account2.save(&whitenoise.shared.database).await.unwrap();
 
-        whitenoise.secrets_store.store_private_key(&keys1).unwrap();
-        whitenoise.secrets_store.store_private_key(&keys2).unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys1)
+            .unwrap();
+        whitenoise
+            .shared
+            .secrets_store
+            .store_private_key(&keys2)
+            .unwrap();
 
-        let loaded_accounts = Account::all(&whitenoise.database).await.unwrap();
+        let loaded_accounts = Account::all(&whitenoise.shared.database).await.unwrap();
         assert_eq!(loaded_accounts.len(), 2);
         let pubkeys: Vec<PublicKey> = loaded_accounts.iter().map(|a| a.pubkey).collect();
         assert!(pubkeys.contains(&account1.pubkey));

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -31,7 +31,7 @@ impl Whitenoise {
     ) -> Result<Account> {
         let (account, _keys) = Account::new(self, Some(keys.clone())).await?;
 
-        self.secrets_store.store_private_key(keys).map_err(|e| {
+        self.shared.secrets_store.store_private_key(keys).map_err(|e| {
             tracing::error!(target: "whitenoise::accounts", "Failed to store private key: {}", e);
             e
         })?;
@@ -49,7 +49,7 @@ impl Whitenoise {
         inbox_relays: &[Relay],
         key_package_relays: &[Relay],
     ) -> Result<()> {
-        self.discovery_sync_worker.request_rebuild();
+        self.shared.discovery_sync_worker.request_rebuild();
 
         // Session must exist before subscriptions so that event handlers
         // (e.g. contact-list guard) can look it up immediately.
@@ -84,7 +84,7 @@ impl Whitenoise {
         account: &Account,
         inbox_relays: &[Relay],
     ) -> Result<()> {
-        self.discovery_sync_worker.request_rebuild();
+        self.shared.discovery_sync_worker.request_rebuild();
 
         // Session must exist before subscriptions so that event handlers
         // (e.g. contact-list guard) can look it up immediately.
@@ -102,10 +102,10 @@ impl Whitenoise {
 
     #[perf_instrument("accounts")]
     pub(super) async fn persist_account(&self, account: &Account) -> Result<Account> {
-        let saved_account = account.save(&self.database).await.map_err(|e| {
+        let saved_account = account.save(&self.shared.database).await.map_err(|e| {
             tracing::error!(target: "whitenoise::accounts", "Failed to save account: {}", e);
             // Try to clean up stored private key
-            if let Err(cleanup_err) = self.secrets_store.remove_private_key_for_pubkey(&account.pubkey) {
+            if let Err(cleanup_err) = self.shared.secrets_store.remove_private_key_for_pubkey(&account.pubkey) {
                 tracing::error!(target: "whitenoise::accounts", "Failed to cleanup private key after account save failure: {}", cleanup_err);
             }
             e
@@ -128,6 +128,7 @@ impl Whitenoise {
             let relays_urls = Relay::urls(key_package_relays);
 
             if let Some(event) = self
+                .shared
                 .relay_control
                 .fetch_user_key_package(account.pubkey, &relays_urls)
                 .await?
@@ -172,8 +173,12 @@ impl Whitenoise {
     /// and still has live local key material.
     #[perf_instrument("accounts")]
     async fn is_own_key_package(&self, pubkey: &PublicKey, event_id: &EventId) -> bool {
-        match PublishedKeyPackage::find_by_event_id(pubkey, &event_id.to_hex(), &self.database)
-            .await
+        match PublishedKeyPackage::find_by_event_id(
+            pubkey,
+            &event_id.to_hex(),
+            &self.shared.database,
+        )
+        .await
         {
             Ok(Some(pkg)) => !pkg.key_material_deleted,
             Ok(None) => false,
@@ -216,12 +221,16 @@ impl Whitenoise {
     ) -> Result<Vec<Relay>> {
         let default_relays = self.load_default_relays().await?;
 
-        user.add_relays(&default_relays, RelayType::Nip65, &self.database)
+        user.add_relays(&default_relays, RelayType::Nip65, &self.shared.database)
             .await?;
-        user.add_relays(&default_relays, RelayType::Inbox, &self.database)
+        user.add_relays(&default_relays, RelayType::Inbox, &self.shared.database)
             .await?;
-        user.add_relays(&default_relays, RelayType::KeyPackage, &self.database)
-            .await?;
+        user.add_relays(
+            &default_relays,
+            RelayType::KeyPackage,
+            &self.shared.database,
+        )
+        .await?;
 
         self.background_publish_account_relay_list(
             account,
@@ -462,6 +471,7 @@ impl Whitenoise {
         // Relay-control ephemeral sessions add/connect target relays internally,
         // so callers no longer need a separate pre-connection step here.
         let relay_event = self
+            .shared
             .relay_control
             .fetch_user_relays(pubkey, relay_type, &source_relay_urls)
             .await?;
@@ -514,7 +524,7 @@ impl Whitenoise {
         relays: &[Relay],
         relay_type: RelayType,
     ) -> Result<()> {
-        let user = account.user(&self.database).await?;
+        let user = account.user(&self.shared.database).await?;
         let relay_urls = Relay::urls(relays).into_iter().collect::<HashSet<_>>();
         user.sync_relay_urls(self, relay_type, &relay_urls, None)
             .await?;
@@ -534,7 +544,8 @@ impl Whitenoise {
     {
         let relays_urls = Relay::urls(relays);
         let target_relays_urls = Relay::urls(target_relays);
-        self.relay_control
+        self.shared
+            .relay_control
             .publish_relay_list_with_signer(
                 &relays_urls,
                 relay_type,
@@ -551,9 +562,9 @@ impl Whitenoise {
         account: &Account,
     ) -> Result<()> {
         let account_clone = account.clone();
-        let ephemeral = self.relay_control.ephemeral();
+        let ephemeral = self.shared.relay_control.ephemeral();
         let signer = self.get_signer_for_account(account)?;
-        let user = account.user(&self.database).await?;
+        let user = account.user(&self.shared.database).await?;
         let relays = account.nip65_relays(self).await?;
 
         tokio::spawn(async move {
@@ -586,7 +597,7 @@ impl Whitenoise {
         relays: Option<&[Relay]>,
     ) -> Result<()> {
         let account_clone = account.clone();
-        let ephemeral = self.relay_control.ephemeral();
+        let ephemeral = self.shared.relay_control.ephemeral();
         let relays = if let Some(relays) = relays {
             relays.to_vec()
         } else {
@@ -626,10 +637,10 @@ impl Whitenoise {
         account: &Account,
     ) -> Result<()> {
         let account_clone = account.clone();
-        let ephemeral = self.relay_control.ephemeral();
+        let ephemeral = self.shared.relay_control.ephemeral();
         let relays = account.nip65_relays(self).await?;
         let signer = self.get_signer_for_account(account)?;
-        let follows = account.follows(&self.database).await?;
+        let follows = account.follows(&self.shared.database).await?;
         let follows_pubkeys = follows.iter().map(|f| f.pubkey).collect::<Vec<_>>();
         let created_at = Timestamp::now();
 
@@ -699,7 +710,7 @@ impl Whitenoise {
         let group_specs = self.extract_group_subscription_specs(account).await?;
 
         for relay_url in group_specs.iter().flat_map(|spec| spec.relays.iter()) {
-            if let Err(e) = Relay::find_or_create_by_url(relay_url, &self.database).await {
+            if let Err(e) = Relay::find_or_create_by_url(relay_url, &self.shared.database).await {
                 tracing::warn!(
                     target: "whitenoise::accounts",
                     relay = %relay_url,
@@ -709,7 +720,8 @@ impl Whitenoise {
             }
         }
 
-        self.relay_control
+        self.shared
+            .relay_control
             .sync_account_group_subscriptions(
                 account.pubkey,
                 &group_specs,
@@ -744,7 +756,7 @@ impl Whitenoise {
         let group_specs = self.extract_group_subscription_specs(account).await?;
 
         for relay_url in group_specs.iter().flat_map(|group| group.relays.iter()) {
-            Relay::find_or_create_by_url(relay_url, &self.database).await?;
+            Relay::find_or_create_by_url(relay_url, &self.shared.database).await?;
         }
 
         if Self::is_background_task_cancelled(cancel_rx) {
@@ -756,7 +768,8 @@ impl Whitenoise {
             return Ok(());
         }
 
-        self.relay_control
+        self.shared
+            .relay_control
             .sync_account_group_subscriptions(
                 account.pubkey,
                 &group_specs,
@@ -840,7 +853,7 @@ impl Whitenoise {
 
         // Ensure group relays are in the database
         for relay_url in group_specs.iter().flat_map(|group| group.relays.iter()) {
-            Relay::find_or_create_by_url(relay_url, &self.database).await?;
+            Relay::find_or_create_by_url(relay_url, &self.shared.database).await?;
         }
 
         // Standard buffer for initial activation (no prior teardown gap to cover).
@@ -872,7 +885,7 @@ impl Whitenoise {
         // — avoids cancelling a partially-warmed session if activation fails.
         let (activation_result, _) = tokio::join!(
             session.activate_subscriptions(
-                &self.relay_control,
+                &self.shared.relay_control,
                 &inbox_relays,
                 &group_specs,
                 since,
@@ -937,7 +950,7 @@ impl Whitenoise {
 
         let (activation_result, _) = tokio::join!(
             session.activate_subscriptions(
-                &self.relay_control,
+                &self.shared.relay_control,
                 &inbox_relays,
                 &group_specs,
                 since,
@@ -971,11 +984,14 @@ impl Whitenoise {
         // so there's no contention, and this halves the worst-case timeout.
         let session = self.session(&account.pubkey);
         let (anon_result, account_result) = tokio::join!(
-            self.relay_control.warm_ephemeral_relays(&warm_relays),
+            self.shared
+                .relay_control
+                .warm_ephemeral_relays(&warm_relays),
             async {
                 match &session {
                     Some(s) => s.ephemeral.warm_relays(&warm_relays).await,
                     None => Ok(self
+                        .shared
                         .relay_control
                         .warm_ephemeral_relays_for_account(account.pubkey, &warm_relays)
                         .await?),
@@ -1025,7 +1041,7 @@ mod tests {
 
     #[cfg(feature = "integration-tests")]
     async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
-        whitenoise.external_signers.clear();
+        whitenoise.shared.external_signers.clear();
         whitenoise.account_manager.clear_sessions();
         whitenoise.account_manager.clear_pending_logins();
         whitenoise.reset_nostr_client().await.unwrap();
@@ -1160,6 +1176,7 @@ mod tests {
 
         assert_eq!(
             whitenoise
+                .shared
                 .relay_control
                 .group_plane_account_group_count(&creator_account.pubkey)
                 .await,
@@ -1182,6 +1199,7 @@ mod tests {
         );
         assert_eq!(
             whitenoise
+                .shared
                 .relay_control
                 .group_plane_account_group_count(&creator_account.pubkey)
                 .await,
@@ -1201,24 +1219,24 @@ mod tests {
     async fn test_sync_account_relays_replaces_stale_relays() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
 
         let stale_relay = Relay::find_or_create_by_url(
             &RelayUrl::parse("wss://stale-relay.example.com").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         let replacement_a = Relay::find_or_create_by_url(
             &RelayUrl::parse("wss://replacement-a.example.com").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         let replacement_b = Relay::find_or_create_by_url(
             &RelayUrl::parse("wss://replacement-b.example.com").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1226,7 +1244,7 @@ mod tests {
         user.add_relays(
             std::slice::from_ref(&stale_relay),
             RelayType::Nip65,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1283,13 +1301,18 @@ mod tests {
     async fn test_is_own_key_package_returns_true_for_tracked_kp() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Use a valid 64-char hex string as event_id
         let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        PublishedKeyPackage::create(&account.pubkey, &[1, 2, 3], event_hex, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &[1, 2, 3],
+            event_hex,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let event_id = EventId::parse(event_hex).unwrap();
         assert!(
@@ -1303,20 +1326,28 @@ mod tests {
     async fn test_is_own_key_package_returns_false_when_key_material_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         let event_hex = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        PublishedKeyPackage::create(&account.pubkey, &[1, 2, 3], event_hex, &whitenoise.database)
-            .await
-            .unwrap();
+        PublishedKeyPackage::create(
+            &account.pubkey,
+            &[1, 2, 3],
+            event_hex,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Mark key material as deleted
-        let pkg =
-            PublishedKeyPackage::find_by_event_id(&account.pubkey, event_hex, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
-        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &whitenoise.database)
+        let pkg = PublishedKeyPackage::find_by_event_id(
+            &account.pubkey,
+            event_hex,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1334,7 +1365,7 @@ mod tests {
         let pubkey = Keys::generate().public_key();
 
         // Close the pool to simulate a database error
-        whitenoise.database.pool.close().await;
+        whitenoise.shared.database.pool.close().await;
 
         let event_id = EventId::all_zeros();
         assert!(!whitenoise.is_own_key_package(&pubkey, &event_id).await);
@@ -1417,7 +1448,7 @@ mod tests {
             .refresh_account_group_subscriptions_with_cancel(&creator_account, Some(&rx))
             .await;
 
-        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.database)
+        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(stored_relay.url, relay_url);
@@ -1448,7 +1479,7 @@ mod tests {
 
         let _ = whitenoise.setup_subscriptions(&creator_account, &[]).await;
 
-        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.database)
+        let stored_relay = Relay::find_by_url(&relay_url, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(stored_relay.url, relay_url);

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -406,32 +406,6 @@ impl Whitenoise {
             .await
     }
 
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::membership().visible_groups() instead."
-    )]
-    #[perf_instrument("account_groups")]
-    pub async fn get_visible_account_groups(
-        &self,
-        account: &Account,
-    ) -> Result<Vec<AccountGroup>, WhitenoiseError> {
-        let session = self.require_session(&account.pubkey)?;
-        session.membership().visible_groups().await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::membership().pending_groups() instead."
-    )]
-    #[perf_instrument("account_groups")]
-    pub async fn get_pending_account_groups(
-        &self,
-        account: &Account,
-    ) -> Result<Vec<AccountGroup>, WhitenoiseError> {
-        let session = self.require_session(&account.pubkey)?;
-        session.membership().pending_groups().await
-    }
-
     /// Accepts a group invite and best-effort shares the local push token.
     #[deprecated(
         since = "0.0.0",
@@ -516,24 +490,6 @@ impl Whitenoise {
     ) -> Result<AccountGroup, WhitenoiseError> {
         let session = self.require_session(&account.pubkey)?;
         session.membership().mark_message_read(message_id).await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::membership().for_group().last_read_message_id() instead."
-    )]
-    #[perf_instrument("account_groups")]
-    pub async fn get_last_read_message_id(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-    ) -> Result<Option<EventId>, WhitenoiseError> {
-        let session = self.require_session(&account.pubkey)?;
-        session
-            .membership()
-            .for_group(group_id)
-            .last_read_message_id()
-            .await
     }
 
     #[deprecated(
@@ -655,34 +611,6 @@ impl Whitenoise {
             .for_group(mls_group_id)
             .mark_as_removed()
             .await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::membership().dm_group_with_peer() instead."
-    )]
-    #[perf_instrument("account_groups")]
-    pub async fn get_dm_group_with_peer(
-        &self,
-        account: &Account,
-        peer_pubkey: &PublicKey,
-    ) -> Result<Option<GroupId>, WhitenoiseError> {
-        let session = self.require_session(&account.pubkey)?;
-        session.membership().dm_group_with_peer(peer_pubkey).await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::membership().for_group().clear_chat() instead."
-    )]
-    #[perf_instrument("account_groups")]
-    pub async fn clear_chat(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-    ) -> Result<(), WhitenoiseError> {
-        let session = self.require_session(&account.pubkey)?;
-        session.membership().for_group(group_id).clear_chat().await
     }
 
     /// Deletes all local data for a group from this account's perspective.
@@ -955,7 +883,10 @@ mod tests {
         ag3.decline(&whitenoise).await.unwrap();
 
         let visible = whitenoise
-            .get_visible_account_groups(&account)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .visible_groups()
             .await
             .unwrap();
 
@@ -986,7 +917,10 @@ mod tests {
         ag2.accept(&whitenoise).await.unwrap();
 
         let pending = whitenoise
-            .get_pending_account_groups(&account)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .pending_groups()
             .await
             .unwrap();
 
@@ -1132,7 +1066,10 @@ mod tests {
 
         // No pending groups should remain
         let pending = whitenoise
-            .get_pending_account_groups(&account)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .pending_groups()
             .await
             .unwrap();
         assert!(pending.is_empty());
@@ -1229,7 +1166,11 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .get_last_read_message_id(&account, &group_id)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .last_read_message_id()
             .await
             .unwrap();
 
@@ -1244,7 +1185,11 @@ mod tests {
 
         // Don't create account group - it shouldn't exist
         let result = whitenoise
-            .get_last_read_message_id(&account, &group_id)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .last_read_message_id()
             .await
             .unwrap();
 
@@ -1528,7 +1473,10 @@ mod tests {
         let other = whitenoise.create_identity().await.unwrap();
 
         let result = whitenoise
-            .get_dm_group_with_peer(&account, &other.pubkey)
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&other.pubkey)
             .await
             .unwrap();
 
@@ -1554,7 +1502,10 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .get_dm_group_with_peer(&creator, &member.pubkey)
+            .session(&creator.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&member.pubkey)
             .await
             .unwrap();
 
@@ -1580,7 +1531,10 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .get_dm_group_with_peer(&creator, &member.pubkey)
+            .session(&creator.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&member.pubkey)
             .await
             .unwrap();
 
@@ -1623,7 +1577,10 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .get_dm_group_with_peer(&creator, &member.pubkey)
+            .session(&creator.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&member.pubkey)
             .await
             .unwrap();
 
@@ -1655,7 +1612,10 @@ mod tests {
             .unwrap();
 
         let result = whitenoise
-            .get_dm_group_with_peer(&creator, &member.pubkey)
+            .session(&creator.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&member.pubkey)
             .await
             .unwrap();
 
@@ -1683,7 +1643,10 @@ mod tests {
 
         // Search for a DM with a different user
         let result = whitenoise
-            .get_dm_group_with_peer(&creator, &stranger.pubkey)
+            .session(&creator.pubkey)
+            .unwrap()
+            .membership()
+            .dm_group_with_peer(&stranger.pubkey)
             .await
             .unwrap();
 
@@ -2374,7 +2337,13 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[140; 32]);
 
-        let result = whitenoise.clear_chat(&account, &group_id).await;
+        let result = whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await;
 
         assert!(matches!(result, Err(WhitenoiseError::GroupNotFound)));
     }
@@ -2408,7 +2377,14 @@ mod tests {
             .unwrap();
 
         let before = Utc::now();
-        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await
+            .unwrap();
         let after = Utc::now();
 
         let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
@@ -2463,7 +2439,14 @@ mod tests {
         assert_eq!(ag.last_read_message_id, Some(msg_id));
 
         // Clear the chat
-        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await
+            .unwrap();
 
         // Verify last_read_message_id is reset
         let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
@@ -2488,7 +2471,14 @@ mod tests {
             .unwrap();
 
         // First clear
-        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await
+            .unwrap();
         let ag1 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
             .await
             .unwrap()
@@ -2496,7 +2486,14 @@ mod tests {
         let first_cleared_at = ag1.chat_cleared_at.unwrap();
 
         // Second clear should also succeed
-        whitenoise.clear_chat(&account, &group_id).await.unwrap();
+        whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await
+            .unwrap();
         let ag2 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
             .await
             .unwrap()

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -236,7 +236,7 @@ impl AccountGroup {
             account_pubkey,
             mls_group_id,
             dm_peer_pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await?;
         Ok((account_group, was_created))
@@ -249,9 +249,12 @@ impl AccountGroup {
         account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
     ) -> Result<Option<Self>, WhitenoiseError> {
-        let account_group =
-            Self::find_by_account_and_group(account_pubkey, mls_group_id, &whitenoise.database)
-                .await?;
+        let account_group = Self::find_by_account_and_group(
+            account_pubkey,
+            mls_group_id,
+            &whitenoise.shared.database,
+        )
+        .await?;
         Ok(account_group)
     }
 
@@ -262,7 +265,8 @@ impl AccountGroup {
         whitenoise: &Whitenoise,
         account_pubkey: &PublicKey,
     ) -> Result<Vec<Self>, WhitenoiseError> {
-        let groups = Self::find_visible_for_account(account_pubkey, &whitenoise.database).await?;
+        let groups =
+            Self::find_visible_for_account(account_pubkey, &whitenoise.shared.database).await?;
         Ok(groups)
     }
 
@@ -272,7 +276,8 @@ impl AccountGroup {
         whitenoise: &Whitenoise,
         account_pubkey: &PublicKey,
     ) -> Result<Vec<Self>, WhitenoiseError> {
-        let groups = Self::find_pending_for_account(account_pubkey, &whitenoise.database).await?;
+        let groups =
+            Self::find_pending_for_account(account_pubkey, &whitenoise.shared.database).await?;
         Ok(groups)
     }
 
@@ -280,7 +285,7 @@ impl AccountGroup {
     #[perf_instrument("account_groups")]
     pub async fn accept(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
         let updated = self
-            .update_user_confirmation(true, &whitenoise.database)
+            .update_user_confirmation(true, &whitenoise.shared.database)
             .await?;
         Ok(updated)
     }
@@ -296,9 +301,12 @@ impl AccountGroup {
         account_pubkey: &PublicKey,
         peer_pubkey: &PublicKey,
     ) -> Result<Option<GroupId>, WhitenoiseError> {
-        let group_id =
-            Self::find_dm_group_id_by_peer(account_pubkey, peer_pubkey, &whitenoise.database)
-                .await?;
+        let group_id = Self::find_dm_group_id_by_peer(
+            account_pubkey,
+            peer_pubkey,
+            &whitenoise.shared.database,
+        )
+        .await?;
         Ok(group_id)
     }
 
@@ -307,7 +315,7 @@ impl AccountGroup {
     #[perf_instrument("account_groups")]
     pub async fn decline(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
         let updated = self
-            .update_user_confirmation(false, &whitenoise.database)
+            .update_user_confirmation(false, &whitenoise.shared.database)
             .await?;
         Ok(updated)
     }
@@ -316,7 +324,7 @@ impl AccountGroup {
     #[perf_instrument("account_groups")]
     pub async fn archive(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
         let updated = self
-            .update_archived_at(Some(Utc::now()), &whitenoise.database)
+            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
             .await?;
         Ok(updated)
     }
@@ -324,7 +332,9 @@ impl AccountGroup {
     /// Unarchives this chat by clearing archived_at.
     #[perf_instrument("account_groups")]
     pub async fn unarchive(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
-        let updated = self.update_archived_at(None, &whitenoise.database).await?;
+        let updated = self
+            .update_archived_at(None, &whitenoise.shared.database)
+            .await?;
         Ok(updated)
     }
 
@@ -336,7 +346,7 @@ impl AccountGroup {
         whitenoise: &Whitenoise,
     ) -> Result<Self, WhitenoiseError> {
         let updated = self
-            .update_muted_until(Some(until), &whitenoise.database)
+            .update_muted_until(Some(until), &whitenoise.shared.database)
             .await?;
         Ok(updated)
     }
@@ -344,7 +354,9 @@ impl AccountGroup {
     /// Unmutes this chat by clearing muted_until.
     #[perf_instrument("account_groups")]
     pub async fn unmute(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
-        let updated = self.update_muted_until(None, &whitenoise.database).await?;
+        let updated = self
+            .update_muted_until(None, &whitenoise.shared.database)
+            .await?;
         Ok(updated)
     }
 
@@ -355,7 +367,7 @@ impl AccountGroup {
         &self,
         whitenoise: &Whitenoise,
     ) -> Result<Option<Self>, WhitenoiseError> {
-        self.mark_removed_atomic(&whitenoise.database)
+        self.mark_removed_atomic(&whitenoise.shared.database)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -367,7 +379,7 @@ impl AccountGroup {
         &self,
         whitenoise: &Whitenoise,
     ) -> Result<Option<Self>, WhitenoiseError> {
-        self.mark_left_atomic(&whitenoise.database)
+        self.mark_left_atomic(&whitenoise.shared.database)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -703,7 +715,8 @@ impl Whitenoise {
 
         // 3. Delete all DB data in a transaction (fallible — must run before
         //    non-rollbackable MDK cleanup so a DB failure leaves state intact)
-        self.database
+        self.shared
+            .database
             .delete_chat_data(&account.pubkey, group_id)
             .await?;
 
@@ -728,8 +741,10 @@ impl Whitenoise {
         }
 
         // 5. Clean up orphaned media files from disk
-        let media_files =
-            crate::whitenoise::media_files::MediaFiles::new(&self.storage, &self.database);
+        let media_files = crate::whitenoise::media_files::MediaFiles::new(
+            &self.shared.storage,
+            &self.shared.database,
+        );
         if let Err(e) = media_files.cleanup_orphaned_files().await {
             tracing::warn!(
                 target: "whitenoise::accounts_groups",
@@ -744,9 +759,11 @@ impl Whitenoise {
                 trigger: ChatListUpdateTrigger::ChatDeleted,
                 item,
             };
-            self.chat_list_stream_manager
+            self.shared
+                .chat_list_stream_manager
                 .emit(&account.pubkey, update.clone());
-            self.archived_chat_list_stream_manager
+            self.shared
+                .archived_chat_list_stream_manager
                 .emit(&account.pubkey, update);
         }
 
@@ -763,11 +780,12 @@ impl Whitenoise {
     /// `dm_peer_pubkey`, then resolves the peer from MLS membership. Intended
     /// to be called once at startup.
     pub(crate) async fn backfill_dm_peer_pubkeys(&self) -> Result<(), WhitenoiseError> {
-        let accounts = crate::whitenoise::accounts::Account::all(&self.database).await?;
+        let accounts = crate::whitenoise::accounts::Account::all(&self.shared.database).await?;
 
         for account in &accounts {
             let group_ids =
-                AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &self.database).await?;
+                AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &self.shared.database)
+                    .await?;
 
             if group_ids.is_empty() {
                 continue;
@@ -797,7 +815,7 @@ impl Whitenoise {
                         &account.pubkey,
                         &group_id,
                         peer_pubkey,
-                        &self.database,
+                        &self.shared.database,
                     )
                     .await
                 {
@@ -1243,7 +1261,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1265,7 +1283,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1275,7 +1293,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1305,7 +1323,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1327,7 +1345,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1337,7 +1355,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1368,7 +1386,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1388,7 +1406,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             same_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1398,7 +1416,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             same_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2097,7 +2115,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        re_save.save(&whitenoise.database).await.unwrap();
+        re_save.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and confirm muted_until survived
         let found = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
@@ -2131,15 +2149,15 @@ mod tests {
             .unwrap();
 
         let past = Utc::now() - chrono::Duration::seconds(10);
-        ag1.update_muted_until(Some(past), &whitenoise.database)
+        ag1.update_muted_until(Some(past), &whitenoise.shared.database)
             .await
             .unwrap();
-        ag2.update_muted_until(Some(past), &whitenoise.database)
+        ag2.update_muted_until(Some(past), &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Run cleanup
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.database)
+        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2187,7 +2205,7 @@ mod tests {
             .unwrap()
             .unwrap();
         expired_ag
-            .update_muted_until(Some(past), &whitenoise.database)
+            .update_muted_until(Some(past), &whitenoise.shared.database)
             .await
             .unwrap();
         whitenoise
@@ -2200,7 +2218,7 @@ mod tests {
             .unwrap();
 
         // Run cleanup — should only clear the expired one
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.database)
+        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2254,7 +2272,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        re_save.save(&whitenoise.database).await.unwrap();
+        re_save.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and confirm removed_at survived
         let found = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
@@ -2368,9 +2386,12 @@ mod tests {
         let group_id = GroupId::from_slice(&[141; 32]);
 
         // No AccountGroup row exists for this pubkey/group_id
-        let result =
-            AccountGroup::chat_cleared_at_ms(&account.pubkey, &group_id, &whitenoise.database)
-                .await;
+        let result = AccountGroup::chat_cleared_at_ms(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await;
 
         assert!(matches!(result, Err(WhitenoiseError::GroupNotFound)));
     }
@@ -2414,7 +2435,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2430,7 +2451,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             Utc::now(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2515,7 +2536,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2558,7 +2579,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2571,7 +2592,7 @@ mod tests {
 
         // group_information must be deleted by delete_chat_data
         let gi_result =
-            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database).await;
         assert!(
             gi_result.is_err(),
             "group_information must be deleted when sole account deletes"
@@ -2581,7 +2602,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2602,7 +2623,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2622,7 +2643,7 @@ mod tests {
         let ag_a = AccountGroup::find_by_account_and_group(
             &account_a.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2632,14 +2653,15 @@ mod tests {
         let ag_b = AccountGroup::find_by_account_and_group(
             &account_b.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         assert!(ag_b.is_some(), "B's row must still exist");
 
         // Shared data must still exist
-        let gi = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+        let gi =
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database).await;
         assert!(
             gi.is_ok(),
             "group_information must persist while B still has the group"
@@ -2650,7 +2672,7 @@ mod tests {
 
         // Now everything should be cleaned up
         let gi_after =
-            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database).await;
         assert!(
             gi_after.is_err(),
             "group_information must be deleted after all accounts delete"
@@ -2659,7 +2681,7 @@ mod tests {
         let ag_a_after = AccountGroup::find_by_account_and_group(
             &account_a.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2671,7 +2693,7 @@ mod tests {
         let ag_b_after = AccountGroup::find_by_account_and_group(
             &account_b.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/app_settings.rs
+++ b/src/whitenoise/app_settings.rs
@@ -125,7 +125,7 @@ impl Whitenoise {
     /// theme preferences and other UI configuration. If no settings exist
     /// in the database, default settings will be created and saved.
     pub async fn app_settings(&self) -> Result<AppSettings> {
-        AppSettings::find_or_create_default(&self.database).await
+        AppSettings::find_or_create_default(&self.shared.database).await
     }
 
     /// Updates only the theme mode in the application settings.
@@ -139,7 +139,7 @@ impl Whitenoise {
     ///
     /// * `theme_mode` - The new [`ThemeMode`] to set (Light, Dark, or System)
     pub async fn update_theme_mode(&self, theme_mode: ThemeMode) -> Result<()> {
-        AppSettings::update_theme_mode(theme_mode, &self.database).await
+        AppSettings::update_theme_mode(theme_mode, &self.shared.database).await
     }
 
     /// Updates only the language in the application settings.
@@ -148,7 +148,7 @@ impl Whitenoise {
     ///
     /// * `language` - The new [`Language`] to set
     pub async fn update_language(&self, language: Language) -> Result<()> {
-        AppSettings::update_language(language, &self.database).await
+        AppSettings::update_language(language, &self.shared.database).await
     }
 }
 

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -291,14 +291,17 @@ impl Whitenoise {
         };
 
         let group_info =
-            match GroupInformation::find_by_mls_group_id(group_id, &self.database).await {
+            match GroupInformation::find_by_mls_group_id(group_id, &self.shared.database).await {
                 Ok(info) => info,
                 Err(_) => return Ok(None),
             };
 
-        let account_group =
-            AccountGroup::find_by_account_and_group(&account.pubkey, group_id, &self.database)
-                .await?;
+        let account_group = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            group_id,
+            &self.shared.database,
+        )
+        .await?;
         let Some(account_group) = account_group else {
             return Ok(None);
         };
@@ -311,7 +314,7 @@ impl Whitenoise {
             let other_pk = members.iter().find(|pk| *pk != &account.pubkey).copied();
             match other_pk {
                 Some(pk) => {
-                    let user = User::find_by_pubkey(&pk, &self.database).await.ok();
+                    let user = User::find_by_pubkey(&pk, &self.shared.database).await.ok();
                     (Some(pk), user)
                 }
                 None => (None, None),
@@ -322,7 +325,7 @@ impl Whitenoise {
 
         let last_message_summary = AggregatedMessage::find_last_by_group_ids(
             std::slice::from_ref(group_id),
-            &self.database,
+            &self.shared.database,
         )
         .await?
         .into_iter()
@@ -330,7 +333,7 @@ impl Whitenoise {
         .filter(|s| account_group.is_message_visible(s.created_at));
 
         let last_message = if let Some(mut summary) = last_message_summary {
-            let author_user = User::find_by_pubkey(&summary.author, &self.database)
+            let author_user = User::find_by_pubkey(&summary.author, &self.shared.database)
                 .await
                 .ok();
             summary.author_display_name = resolve_display_name(author_user.as_ref());
@@ -363,7 +366,7 @@ impl Whitenoise {
         let unread_count = AggregatedMessage::count_unread_for_group(
             group_id,
             account_group.last_read_message_id.as_ref(),
-            &self.database,
+            &self.shared.database,
             cleared_ms,
         )
         .await?;
@@ -400,9 +403,11 @@ impl Whitenoise {
         trigger: ChatListUpdateTrigger,
     ) {
         let has_active = self
+            .shared
             .chat_list_stream_manager
             .has_subscribers(&account.pubkey);
         let has_archived = self
+            .shared
             .archived_chat_list_stream_manager
             .has_subscribers(&account.pubkey);
 
@@ -430,24 +435,27 @@ impl Whitenoise {
         group_id: &GroupId,
         trigger: ChatListUpdateTrigger,
     ) {
-        let account_groups = match AccountGroup::find_by_group(group_id, &self.database).await {
-            Ok(groups) => groups,
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::chat_list_streaming",
-                    "Failed to find accounts in group {}: {}",
-                    hex::encode(group_id.as_slice()),
-                    e
-                );
-                return;
-            }
-        };
+        let account_groups =
+            match AccountGroup::find_by_group(group_id, &self.shared.database).await {
+                Ok(groups) => groups,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::chat_list_streaming",
+                        "Failed to find accounts in group {}: {}",
+                        hex::encode(group_id.as_slice()),
+                        e
+                    );
+                    return;
+                }
+            };
 
         for ag in account_groups {
             let has_active = self
+                .shared
                 .chat_list_stream_manager
                 .has_subscribers(&ag.account_pubkey);
             let has_archived = self
+                .shared
                 .archived_chat_list_stream_manager
                 .has_subscribers(&ag.account_pubkey);
 
@@ -470,7 +478,7 @@ impl Whitenoise {
         group_id: &GroupId,
         trigger: ChatListUpdateTrigger,
     ) {
-        let account = match Account::find_by_pubkey(pubkey, &self.database).await {
+        let account = match Account::find_by_pubkey(pubkey, &self.shared.database).await {
             Ok(acc) => acc,
             Err(e) => {
                 tracing::warn!(
@@ -483,8 +491,9 @@ impl Whitenoise {
             }
         };
 
-        let has_active = self.chat_list_stream_manager.has_subscribers(pubkey);
+        let has_active = self.shared.chat_list_stream_manager.has_subscribers(pubkey);
         let has_archived = self
+            .shared
             .archived_chat_list_stream_manager
             .has_subscribers(pubkey);
 
@@ -496,10 +505,14 @@ impl Whitenoise {
                     | ChatListUpdateTrigger::ChatDeleted => {
                         // Item is moving between lists or being removed — notify both channels
                         if has_active {
-                            self.chat_list_stream_manager.emit(pubkey, update.clone());
+                            self.shared
+                                .chat_list_stream_manager
+                                .emit(pubkey, update.clone());
                         }
                         if has_archived {
-                            self.archived_chat_list_stream_manager.emit(pubkey, update);
+                            self.shared
+                                .archived_chat_list_stream_manager
+                                .emit(pubkey, update);
                         }
                     }
                     ChatListUpdateTrigger::RemovedFromGroup | ChatListUpdateTrigger::LeftGroup => {
@@ -507,20 +520,24 @@ impl Whitenoise {
                         // archived, in which case the update must reach the archived stream.
                         if update.item.archived_at.is_some() {
                             if has_archived {
-                                self.archived_chat_list_stream_manager.emit(pubkey, update);
+                                self.shared
+                                    .archived_chat_list_stream_manager
+                                    .emit(pubkey, update);
                             }
                         } else if has_active {
-                            self.chat_list_stream_manager.emit(pubkey, update);
+                            self.shared.chat_list_stream_manager.emit(pubkey, update);
                         }
                     }
                     _ => {
                         // Route to the channel matching the item's archive status
                         if update.item.archived_at.is_some() {
                             if has_archived {
-                                self.archived_chat_list_stream_manager.emit(pubkey, update);
+                                self.shared
+                                    .archived_chat_list_stream_manager
+                                    .emit(pubkey, update);
                             }
                         } else if has_active {
-                            self.chat_list_stream_manager.emit(pubkey, update);
+                            self.shared.chat_list_stream_manager.emit(pubkey, update);
                         }
                     }
                 }
@@ -641,11 +658,11 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut member_user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut member_user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         member_user.metadata = Metadata::new();
-        member_user.save(&whitenoise.database).await.unwrap();
+        member_user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -679,11 +696,11 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = Metadata::new().display_name("Bob Display").name("Bob Name");
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -713,11 +730,11 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = Metadata::new().name("Bob Name");
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -746,13 +763,13 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         let mut metadata = Metadata::new().name("Fallback Name");
         metadata.display_name = Some(String::new());
         user.metadata = metadata;
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -898,7 +915,7 @@ mod tests {
             &msg1,
             &group1.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -922,7 +939,7 @@ mod tests {
             &msg2,
             &group2.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -987,13 +1004,13 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = user
             .metadata
             .picture(nostr_sdk::Url::parse("https://example.com/pic.jpg").unwrap());
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -1054,11 +1071,11 @@ mod tests {
         let creator = whitenoise.create_identity().await.unwrap();
         let member = whitenoise.create_identity().await.unwrap();
 
-        let mut user = User::find_by_pubkey(&creator.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&creator.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = user.metadata.display_name("Alice");
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let config = create_nostr_group_config_data(vec![creator.pubkey]);
         let group = whitenoise
@@ -1091,7 +1108,7 @@ mod tests {
             &msg,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1158,7 +1175,7 @@ mod tests {
             &msg,
             &group1.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1221,11 +1238,11 @@ mod tests {
         let member = whitenoise.create_identity().await.unwrap();
 
         // Set author display name
-        let mut user = User::find_by_pubkey(&creator.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&creator.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = user.metadata.display_name("Alice");
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let config = create_nostr_group_config_data(vec![creator.pubkey]);
         let group = whitenoise
@@ -1252,7 +1269,7 @@ mod tests {
             &msg,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1277,11 +1294,11 @@ mod tests {
         let member = whitenoise.create_identity().await.unwrap();
 
         // Set other user's display name
-        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.database)
+        let mut user = User::find_by_pubkey(&member.pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         user.metadata = Metadata::new().display_name("Bob");
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let mut config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
         config.name = String::new();
@@ -1549,7 +1566,7 @@ mod tests {
                 &msg,
                 &group.mls_group_id,
                 &creator.pubkey,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -2052,9 +2069,11 @@ mod tests {
 
         // Subscribe to both channels
         let mut active_rx = whitenoise
+            .shared
             .chat_list_stream_manager
             .subscribe(&creator.pubkey);
         let mut archived_rx = whitenoise
+            .shared
             .archived_chat_list_stream_manager
             .subscribe(&creator.pubkey);
 

--- a/src/whitenoise/database/account/drafts.rs
+++ b/src/whitenoise/database/account/drafts.rs
@@ -77,11 +77,11 @@ mod tests {
     async fn save_creates_draft_scoped_to_account() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo = DraftsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = DraftsRepo::new(keys.public_key(), wn.shared.database.clone());
         let draft = repo.save(&group_id, "hello", None, &[]).await.unwrap();
 
         assert!(draft.id.is_some());
@@ -93,11 +93,11 @@ mod tests {
     async fn find_returns_saved_draft() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo = DraftsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = DraftsRepo::new(keys.public_key(), wn.shared.database.clone());
         repo.save(&group_id, "persisted", None, &[]).await.unwrap();
 
         let found = repo.find(&group_id).await.unwrap();
@@ -109,11 +109,11 @@ mod tests {
     async fn find_returns_none_when_no_draft_exists() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo = DraftsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = DraftsRepo::new(keys.public_key(), wn.shared.database.clone());
         let found = repo.find(&group_id).await.unwrap();
         assert!(found.is_none());
     }
@@ -122,11 +122,11 @@ mod tests {
     async fn delete_removes_draft() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo = DraftsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = DraftsRepo::new(keys.public_key(), wn.shared.database.clone());
         repo.save(&group_id, "to delete", None, &[]).await.unwrap();
         repo.delete(&group_id).await.unwrap();
 
@@ -137,11 +137,11 @@ mod tests {
     async fn delete_nonexistent_is_noop() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo = DraftsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = DraftsRepo::new(keys.public_key(), wn.shared.database.clone());
         assert!(repo.delete(&group_id).await.is_ok());
     }
 
@@ -150,13 +150,13 @@ mod tests {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys_a = Keys::generate();
         let keys_b = Keys::generate();
-        insert_test_account(&wn.database, &keys_a.public_key()).await;
-        insert_test_account(&wn.database, &keys_b.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys_a.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys_b.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&wn.database, &group_id).await;
+        insert_test_group(&wn.shared.database, &group_id).await;
 
-        let repo_a = DraftsRepo::new(keys_a.public_key(), wn.database.clone());
-        let repo_b = DraftsRepo::new(keys_b.public_key(), wn.database.clone());
+        let repo_a = DraftsRepo::new(keys_a.public_key(), wn.shared.database.clone());
+        let repo_b = DraftsRepo::new(keys_b.public_key(), wn.shared.database.clone());
 
         repo_a
             .save(&group_id, "account A draft", None, &[])

--- a/src/whitenoise/database/account/follows.rs
+++ b/src/whitenoise/database/account/follows.rs
@@ -144,9 +144,9 @@ mod tests {
     async fn all_returns_empty_for_new_account() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         assert!(repo.all().await.unwrap().is_empty());
@@ -156,11 +156,11 @@ mod tests {
     async fn add_and_all_returns_followed_user() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        let target_user = insert_test_user(&wn.database, &target_pk).await;
+        let target_user = insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         repo.add(&target_user).await.unwrap();
@@ -174,11 +174,11 @@ mod tests {
     async fn is_following_returns_false_when_not_following() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        insert_test_user(&wn.database, &target_pk).await;
+        insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         assert!(!repo.is_following(&target_pk).await.unwrap());
@@ -188,10 +188,10 @@ mod tests {
     async fn is_following_returns_false_for_unknown_user() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let unknown_pk = Keys::generate().public_key();
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         assert!(!repo.is_following(&unknown_pk).await.unwrap());
@@ -201,11 +201,11 @@ mod tests {
     async fn add_then_is_following_returns_true() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        let target_user = insert_test_user(&wn.database, &target_pk).await;
+        let target_user = insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         repo.add(&target_user).await.unwrap();
@@ -217,11 +217,11 @@ mod tests {
     async fn remove_clears_follow() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        let target_user = insert_test_user(&wn.database, &target_pk).await;
+        let target_user = insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         repo.add(&target_user).await.unwrap();
@@ -235,11 +235,11 @@ mod tests {
     async fn remove_nonexistent_is_noop() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        let target_user = insert_test_user(&wn.database, &target_pk).await;
+        let target_user = insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo = AccountFollowsRepo::new(keys.public_key(), wn.database.clone())
+        let repo = AccountFollowsRepo::new(keys.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
         assert!(repo.remove(&target_user).await.is_ok());
@@ -250,15 +250,15 @@ mod tests {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys_a = Keys::generate();
         let keys_b = Keys::generate();
-        insert_test_account(&wn.database, &keys_a.public_key()).await;
-        insert_test_account(&wn.database, &keys_b.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys_a.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys_b.public_key()).await;
         let target_pk = Keys::generate().public_key();
-        let target_user = insert_test_user(&wn.database, &target_pk).await;
+        let target_user = insert_test_user(&wn.shared.database, &target_pk).await;
 
-        let repo_a = AccountFollowsRepo::new(keys_a.public_key(), wn.database.clone())
+        let repo_a = AccountFollowsRepo::new(keys_a.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
-        let repo_b = AccountFollowsRepo::new(keys_b.public_key(), wn.database.clone())
+        let repo_b = AccountFollowsRepo::new(keys_b.public_key(), wn.shared.database.clone())
             .await
             .unwrap();
 
@@ -273,7 +273,7 @@ mod tests {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let unknown_pk = Keys::generate().public_key();
 
-        let result = AccountFollowsRepo::new(unknown_pk, wn.database.clone()).await;
+        let result = AccountFollowsRepo::new(unknown_pk, wn.shared.database.clone()).await;
         assert!(result.is_err());
     }
 }

--- a/src/whitenoise/database/account/settings.rs
+++ b/src/whitenoise/database/account/settings.rs
@@ -74,9 +74,9 @@ mod tests {
     async fn find_or_create_returns_defaults_for_new_account() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
 
-        let repo = AccountSettingsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = AccountSettingsRepo::new(keys.public_key(), wn.shared.database.clone());
         let settings = repo.find_or_create().await.unwrap();
 
         assert!(settings.id.is_some());
@@ -88,9 +88,9 @@ mod tests {
     async fn find_or_create_is_idempotent() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
 
-        let repo = AccountSettingsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = AccountSettingsRepo::new(keys.public_key(), wn.shared.database.clone());
         let first = repo.find_or_create().await.unwrap();
         let second = repo.find_or_create().await.unwrap();
 
@@ -102,7 +102,7 @@ mod tests {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
 
-        let repo = AccountSettingsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = AccountSettingsRepo::new(keys.public_key(), wn.shared.database.clone());
         assert!(repo.notifications_enabled().await.unwrap());
     }
 
@@ -110,9 +110,9 @@ mod tests {
     async fn update_notifications_enabled_persists_value() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
 
-        let repo = AccountSettingsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = AccountSettingsRepo::new(keys.public_key(), wn.shared.database.clone());
 
         let updated = repo.update_notifications_enabled(false).await.unwrap();
         assert!(!updated.notifications_enabled);
@@ -124,9 +124,9 @@ mod tests {
     async fn update_notifications_enabled_round_trips() {
         let (wn, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&wn.database, &keys.public_key()).await;
+        insert_test_account(&wn.shared.database, &keys.public_key()).await;
 
-        let repo = AccountSettingsRepo::new(keys.public_key(), wn.database.clone());
+        let repo = AccountSettingsRepo::new(keys.public_key(), wn.shared.database.clone());
 
         let disabled = repo.update_notifications_enabled(false).await.unwrap();
         assert!(!disabled.notifications_enabled);

--- a/src/whitenoise/database/account_settings.rs
+++ b/src/whitenoise/database/account_settings.rs
@@ -132,12 +132,14 @@ mod tests {
     async fn test_find_or_create_creates_default_row() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
 
-        let settings =
-            AccountSettings::find_or_create_for_pubkey(&keys.public_key(), &whitenoise.database)
-                .await
-                .unwrap();
+        let settings = AccountSettings::find_or_create_for_pubkey(
+            &keys.public_key(),
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(settings.id.is_some());
         assert_eq!(settings.account_pubkey, keys.public_key());
@@ -148,16 +150,20 @@ mod tests {
     async fn test_find_or_create_returns_existing_row() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
 
-        let first =
-            AccountSettings::find_or_create_for_pubkey(&keys.public_key(), &whitenoise.database)
-                .await
-                .unwrap();
-        let second =
-            AccountSettings::find_or_create_for_pubkey(&keys.public_key(), &whitenoise.database)
-                .await
-                .unwrap();
+        let first = AccountSettings::find_or_create_for_pubkey(
+            &keys.public_key(),
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let second = AccountSettings::find_or_create_for_pubkey(
+            &keys.public_key(),
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(first.id, second.id);
     }
@@ -169,7 +175,7 @@ mod tests {
 
         let enabled = AccountSettings::notifications_enabled_for_pubkey(
             &keys.public_key(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -181,19 +187,19 @@ mod tests {
     async fn test_notifications_enabled_returns_stored_value() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
 
         AccountSettings::update_notifications_enabled(
             &keys.public_key(),
             false,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         let enabled = AccountSettings::notifications_enabled_for_pubkey(
             &keys.public_key(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -205,12 +211,12 @@ mod tests {
     async fn test_update_notifications_enabled_toggles_and_returns_updated() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
 
         let disabled = AccountSettings::update_notifications_enabled(
             &keys.public_key(),
             false,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -220,7 +226,7 @@ mod tests {
         let enabled = AccountSettings::update_notifications_enabled(
             &keys.public_key(),
             true,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -716,11 +716,12 @@ mod tests {
         };
 
         // Test save_account
-        let result = account.save(&whitenoise.database).await;
+        let result = account.save(&whitenoise.shared.database).await;
         assert!(result.is_ok());
 
         // Test that we can load it back (this verifies it was saved correctly)
-        let loaded_account = Account::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_account =
+            Account::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_account.is_ok());
 
         let loaded = loaded_account.unwrap();
@@ -756,11 +757,12 @@ mod tests {
             updated_at: test_updated_at,
         };
 
-        let result = account.save(&whitenoise.database).await;
+        let result = account.save(&whitenoise.shared.database).await;
         assert!(result.is_ok());
 
         // Verify it was saved correctly by loading it back
-        let loaded_account = Account::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_account =
+            Account::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_account.is_ok());
 
         let loaded = loaded_account.unwrap();
@@ -781,7 +783,8 @@ mod tests {
 
         // Try to load a non-existent account
         let non_existent_pubkey = nostr_sdk::Keys::generate().public_key();
-        let result = Account::find_by_pubkey(&non_existent_pubkey, &whitenoise.database).await;
+        let result =
+            Account::find_by_pubkey(&non_existent_pubkey, &whitenoise.shared.database).await;
 
         assert!(result.is_err());
         if let Err(WhitenoiseError::AccountNotFound) = result {
@@ -813,11 +816,12 @@ mod tests {
         };
 
         // Save the account
-        let save_result = original_account.save(&whitenoise.database).await;
+        let save_result = original_account.save(&whitenoise.shared.database).await;
         assert!(save_result.is_ok());
 
         // Load the account back
-        let loaded_account = Account::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_account =
+            Account::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_account.is_ok());
 
         let account = loaded_account.unwrap();
@@ -864,7 +868,7 @@ mod tests {
         };
 
         // Save the account first
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Create test users that will be followers
         let mut test_users = Vec::new();
@@ -895,31 +899,34 @@ mod tests {
             };
 
             // Save user first
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             test_users.push((user_pubkey, metadata.clone()));
         }
 
         // Now manually insert the account_follows relationships
         // First we need to get the actual account ID and user IDs from the database
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         for (user_pubkey, _) in &test_users {
-            let saved_user = User::find_by_pubkey(user_pubkey, &whitenoise.database)
+            let saved_user = User::find_by_pubkey(user_pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
             // Create follower relationship using the proper API
             saved_account
-                .follow_user(&saved_user, &whitenoise.database)
+                .follow_user(&saved_user, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
 
         // Test follows
-        let followers = saved_account.follows(&whitenoise.database).await.unwrap();
+        let followers = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Verify we got all followers
         assert_eq!(followers.len(), 3);
@@ -963,13 +970,16 @@ mod tests {
         };
 
         // Save the account
-        account.save(&whitenoise.database).await.unwrap();
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        account.save(&whitenoise.shared.database).await.unwrap();
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Test follows with no followers
-        let followers = saved_account.follows(&whitenoise.database).await.unwrap();
+        let followers = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Verify empty result
         assert_eq!(followers.len(), 0);
@@ -997,7 +1007,7 @@ mod tests {
         };
 
         // Save the account
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Create a single test user
         let user_pubkey = nostr_sdk::Keys::generate().public_key();
@@ -1016,24 +1026,27 @@ mod tests {
         };
 
         // Save user
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the saved account and user with their database IDs
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.database)
+        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Create the follower relationship using the proper API
         saved_account
-            .follow_user(&saved_user, &whitenoise.database)
+            .follow_user(&saved_user, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Test follows
-        let followers = saved_account.follows(&whitenoise.database).await.unwrap();
+        let followers = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Verify single follower
         assert_eq!(followers.len(), 1);
@@ -1066,7 +1079,7 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Create a user with complex metadata
         let user_pubkey = nostr_sdk::Keys::generate().public_key();
@@ -1088,24 +1101,27 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Create the follower relationship
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.database)
+        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Create the follower relationship using the proper API
         saved_account
-            .follow_user(&saved_user, &whitenoise.database)
+            .follow_user(&saved_user, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Test follows
-        let followers = saved_account.follows(&whitenoise.database).await.unwrap();
+        let followers = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Verify complex metadata is preserved
         assert_eq!(followers.len(), 1);
@@ -1136,7 +1152,7 @@ mod tests {
         };
 
         // Test follows with non-existent account
-        let result = fake_account.follows(&whitenoise.database).await;
+        let result = fake_account.follows(&whitenoise.shared.database).await;
 
         // Should return empty list rather than error since no followers exist
         assert!(result.is_ok());
@@ -1164,7 +1180,7 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Create multiple users with predictable names
         let user_names = vec!["Alpha", "Beta", "Charlie", "Delta", "Echo"];
@@ -1183,16 +1199,16 @@ mod tests {
                 updated_at: test_timestamp,
             };
 
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
             test_users.push(user_pubkey);
         }
 
         // Create follower relationships
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         for user_pubkey in &test_users {
-            let saved_user = User::find_by_pubkey(user_pubkey, &whitenoise.database)
+            let saved_user = User::find_by_pubkey(user_pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1203,14 +1219,20 @@ mod tests {
             .bind(saved_user.id)
             .bind(test_timestamp.timestamp_millis())
             .bind(test_timestamp.timestamp_millis())
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
         }
 
         // Test follows multiple times to ensure consistent ordering
-        let followers1 = saved_account.follows(&whitenoise.database).await.unwrap();
-        let followers2 = saved_account.follows(&whitenoise.database).await.unwrap();
+        let followers1 = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        let followers2 = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         assert_eq!(followers1.len(), 5);
         assert_eq!(followers2.len(), 5);
@@ -1240,18 +1262,18 @@ mod tests {
             created_at,
             updated_at,
         };
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
-        let before = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let before = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let event_ms = chrono::Utc::now().timestamp_millis();
-        Account::update_last_synced_max(&pubkey, event_ms, &whitenoise.database)
+        Account::update_last_synced_max(&pubkey, event_ms, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let after = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let after = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1278,17 +1300,17 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
-        let before = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let before = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        Account::update_last_synced_max(&pubkey, older_ms, &whitenoise.database)
+        Account::update_last_synced_max(&pubkey, older_ms, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let after = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let after = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1315,17 +1337,17 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
-        let before = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let before = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        Account::update_last_synced_max(&pubkey, newer_ms, &whitenoise.database)
+        Account::update_last_synced_max(&pubkey, newer_ms, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let after = Account::find_by_pubkey(&pubkey, &whitenoise.database)
+        let after = Account::find_by_pubkey(&pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1338,40 +1360,52 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Should return None when no accounts exist
-        let account = Account::first(&whitenoise.database).await.unwrap();
+        let account = Account::first(&whitenoise.shared.database).await.unwrap();
         assert!(account.is_none());
 
         // If there's a single account, it should return that account
         let test_keys = nostr_sdk::Keys::generate();
-        User::find_or_create_by_pubkey(&test_keys.public_key(), &whitenoise.database)
+        User::find_or_create_by_pubkey(&test_keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
         let (test_account, _) = Account::new(&whitenoise, Some(test_keys)).await.unwrap();
-        test_account.save(&whitenoise.database).await.unwrap();
-        let account = Account::first(&whitenoise.database).await.unwrap();
+        test_account
+            .save(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        let account = Account::first(&whitenoise.shared.database).await.unwrap();
         assert!(account.is_some());
         assert_eq!(account.unwrap().pubkey, test_account.pubkey);
 
         // If there's more than one account, it should still return the first one
         let test_keys2 = nostr_sdk::Keys::generate();
-        User::find_or_create_by_pubkey(&test_keys2.public_key(), &whitenoise.database)
+        User::find_or_create_by_pubkey(&test_keys2.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
         let (test_account2, _) = Account::new(&whitenoise, Some(test_keys2)).await.unwrap();
-        test_account2.save(&whitenoise.database).await.unwrap();
-        let account2 = Account::first(&whitenoise.database).await.unwrap();
+        test_account2
+            .save(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        let account2 = Account::first(&whitenoise.shared.database).await.unwrap();
         assert!(account2.is_some());
         assert_eq!(account2.unwrap().pubkey, test_account.pubkey);
 
         // If that first account is deleted, it should return the second one
-        test_account.delete(&whitenoise.database).await.unwrap();
-        let account3 = Account::first(&whitenoise.database).await.unwrap();
+        test_account
+            .delete(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        let account3 = Account::first(&whitenoise.shared.database).await.unwrap();
         assert!(account3.is_some());
         assert_eq!(account3.unwrap().pubkey, test_account2.pubkey);
 
         // If all accounts are deleted, it should return None
-        test_account2.delete(&whitenoise.database).await.unwrap();
-        let account4 = Account::first(&whitenoise.database).await.unwrap();
+        test_account2
+            .delete(&whitenoise.shared.database)
+            .await
+            .unwrap();
+        let account4 = Account::first(&whitenoise.shared.database).await.unwrap();
         assert!(account4.is_none());
     }
 
@@ -1379,10 +1413,10 @@ mod tests {
     async fn test_update_follows_from_event_empty_list() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = crate::whitenoise::test_utils::create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the account with database ID populated
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1390,7 +1424,7 @@ mod tests {
         let contacts = vec![];
 
         let result = account
-            .update_follows_from_event(contacts, &whitenoise.database)
+            .update_follows_from_event(contacts, &whitenoise.shared.database)
             .await;
 
         assert!(result.is_ok());
@@ -1398,7 +1432,7 @@ mod tests {
         assert!(newly_created.is_empty());
 
         // Verify no follows exist
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert!(follows.is_empty());
     }
 
@@ -1406,10 +1440,10 @@ mod tests {
     async fn test_update_follows_from_event_new_follows() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = crate::whitenoise::test_utils::create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the account with database ID populated
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1419,7 +1453,7 @@ mod tests {
         let contacts = vec![contact1, contact2];
 
         let result = account
-            .update_follows_from_event(contacts.clone(), &whitenoise.database)
+            .update_follows_from_event(contacts.clone(), &whitenoise.shared.database)
             .await;
 
         assert!(result.is_ok());
@@ -1429,7 +1463,7 @@ mod tests {
         assert!(newly_created.contains(&contact2));
 
         // Verify follows were created
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 2);
 
         // Verify the correct users are being followed
@@ -1439,7 +1473,7 @@ mod tests {
 
         // Verify users were created (2 contacts + 1 account user = 3 total)
         let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
-            .fetch_one(&whitenoise.database.pool)
+            .fetch_one(&whitenoise.shared.database.pool)
             .await
             .unwrap();
         assert_eq!(user_count, 3);
@@ -1449,10 +1483,10 @@ mod tests {
     async fn test_update_follows_from_event_replace_existing() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = crate::whitenoise::test_utils::create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the account with database ID populated
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1464,12 +1498,12 @@ mod tests {
         for pubkey in [&old_contact1, &old_contact2] {
             let (user, _) = crate::whitenoise::users::User::find_or_create_by_pubkey(
                 pubkey,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
             account
-                .follow_user(&user, &whitenoise.database)
+                .follow_user(&user, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -1480,7 +1514,7 @@ mod tests {
         let contacts = vec![new_contact1, new_contact2];
 
         let result = account
-            .update_follows_from_event(contacts.clone(), &whitenoise.database)
+            .update_follows_from_event(contacts.clone(), &whitenoise.shared.database)
             .await;
 
         assert!(result.is_ok());
@@ -1490,7 +1524,7 @@ mod tests {
         assert!(!newly_created.contains(&new_contact1)); // This user already existed
 
         // Verify follows were replaced using proper API
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 2);
 
         // Verify the correct users are being followed
@@ -1503,10 +1537,10 @@ mod tests {
     async fn test_update_follows_from_event_duplicate_contacts() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = crate::whitenoise::test_utils::create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the account with database ID populated
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1516,7 +1550,7 @@ mod tests {
         let contacts = vec![contact1, contact2, contact1]; // contact1 appears twice
 
         let result = account
-            .update_follows_from_event(contacts.clone(), &whitenoise.database)
+            .update_follows_from_event(contacts.clone(), &whitenoise.shared.database)
             .await;
 
         // This should now succeed due to deduplication
@@ -1527,7 +1561,7 @@ mod tests {
         assert_eq!(result_unwrapped.len(), 2); // Both contacts should be newly created
 
         // Verify follows using proper API
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 2); // Only 2 follows due to deduplication
 
         // Verify the correct users are being followed
@@ -1540,10 +1574,10 @@ mod tests {
     async fn test_update_follows_from_event_large_contact_list() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = crate::whitenoise::test_utils::create_test_account(&whitenoise).await;
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Get the account with database ID populated
-        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.database)
+        let account = Account::find_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1554,7 +1588,7 @@ mod tests {
         }
 
         let result = account
-            .update_follows_from_event(contacts.clone(), &whitenoise.database)
+            .update_follows_from_event(contacts.clone(), &whitenoise.shared.database)
             .await;
 
         assert!(result.is_ok());
@@ -1562,12 +1596,12 @@ mod tests {
         assert_eq!(newly_created.len(), 100);
 
         // Verify all follows were created using proper API
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 100);
 
         // Verify all users were created (100 contacts + 1 account user = 101 total)
         let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
-            .fetch_one(&whitenoise.database.pool)
+            .fetch_one(&whitenoise.shared.database.pool)
             .await
             .unwrap();
         assert_eq!(user_count, 101);
@@ -1626,11 +1660,12 @@ mod tests {
         };
 
         // Save the account
-        let result = account.save(&whitenoise.database).await;
+        let result = account.save(&whitenoise.shared.database).await;
         assert!(result.is_ok());
 
         // Load the account back and verify account_type is preserved
-        let loaded_account = Account::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_account =
+            Account::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_account.is_ok());
 
         let loaded = loaded_account.unwrap();
@@ -1661,7 +1696,7 @@ mod tests {
         };
 
         // Save the account
-        account.save(&whitenoise.database).await.unwrap();
+        account.save(&whitenoise.shared.database).await.unwrap();
 
         // Create a user to follow
         let user_pubkey = nostr_sdk::Keys::generate().public_key();
@@ -1675,23 +1710,26 @@ mod tests {
             metadata_known_at: None,
             updated_at: test_timestamp,
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Load the account and add a follow relationship
-        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.database)
+        let saved_account = Account::find_by_pubkey(&account_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.database)
+        let saved_user = User::find_by_pubkey(&user_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         saved_account
-            .follow_user(&saved_user, &whitenoise.database)
+            .follow_user(&saved_user, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Verify the external account can have follows
-        let follows = saved_account.follows(&whitenoise.database).await.unwrap();
+        let follows = saved_account
+            .follows(&whitenoise.shared.database)
+            .await
+            .unwrap();
         assert_eq!(follows.len(), 1);
         assert_eq!(follows[0].pubkey, user_pubkey);
 
@@ -1703,21 +1741,21 @@ mod tests {
     async fn test_delete_account_success() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, _keys) = create_test_account(&whitenoise).await;
-        let saved = account.save(&whitenoise.database).await.unwrap();
+        let saved = account.save(&whitenoise.shared.database).await.unwrap();
 
         // Verify it exists.
         assert!(
-            Account::find_by_pubkey(&saved.pubkey, &whitenoise.database)
+            Account::find_by_pubkey(&saved.pubkey, &whitenoise.shared.database)
                 .await
                 .is_ok()
         );
 
         // Delete it.
-        saved.delete(&whitenoise.database).await.unwrap();
+        saved.delete(&whitenoise.shared.database).await.unwrap();
 
         // Verify it's gone.
         assert!(
-            Account::find_by_pubkey(&saved.pubkey, &whitenoise.database)
+            Account::find_by_pubkey(&saved.pubkey, &whitenoise.shared.database)
                 .await
                 .is_err()
         );
@@ -1739,7 +1777,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let result = account.delete(&whitenoise.database).await;
+        let result = account.delete(&whitenoise.shared.database).await;
         assert!(result.is_err());
         assert!(
             matches!(result.unwrap_err(), WhitenoiseError::AccountNotFound),

--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -740,7 +740,7 @@ mod tests {
         let result = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -754,10 +754,14 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[2; 32]);
 
-        let (account_group, was_created) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, was_created) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(was_created);
         assert_eq!(account_group.account_pubkey, account.pubkey);
@@ -773,17 +777,25 @@ mod tests {
         let group_id = GroupId::from_slice(&[3; 32]);
 
         // First create
-        let (original, was_created) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (original, was_created) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(was_created);
 
         // Second call should find existing
-        let (found, was_created) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (found, was_created) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(!was_created);
         assert_eq!(found.id, original.id);
@@ -795,15 +807,19 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[4; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(account_group.user_confirmation.is_none());
 
         let updated = account_group
-            .update_user_confirmation(true, &whitenoise.database)
+            .update_user_confirmation(true, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -817,13 +833,17 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[5; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let updated = account_group
-            .update_user_confirmation(false, &whitenoise.database)
+            .update_user_confirmation(false, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -838,30 +858,43 @@ mod tests {
         let group_id2 = GroupId::from_slice(&[9; 32]); // Will be accepted
         let group_id3 = GroupId::from_slice(&[10; 32]); // Will be declined
 
-        let (_ag1, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id1, None, &whitenoise.database)
-                .await
-                .unwrap();
-        let (ag2, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id2, None, &whitenoise.database)
-                .await
-                .unwrap();
-        let (ag3, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id3, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (_ag1, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id1,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let (ag2, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id2,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let (ag3, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id3,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // ag1 stays pending (NULL)
-        ag2.update_user_confirmation(true, &whitenoise.database)
+        ag2.update_user_confirmation(true, &whitenoise.shared.database)
             .await
             .unwrap();
-        ag3.update_user_confirmation(false, &whitenoise.database)
+        ag3.update_user_confirmation(false, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let visible = AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.database)
-            .await
-            .unwrap();
+        let visible =
+            AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         // Should only include pending and accepted, not declined
         assert_eq!(visible.len(), 2);
@@ -878,22 +911,31 @@ mod tests {
         let group_id1 = GroupId::from_slice(&[11; 32]); // Will be pending
         let group_id2 = GroupId::from_slice(&[12; 32]); // Will be accepted
 
-        let (_, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id1, None, &whitenoise.database)
-                .await
-                .unwrap();
-        let (ag2, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id2, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (_, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id1,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let (ag2, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id2,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
-        ag2.update_user_confirmation(true, &whitenoise.database)
+        ag2.update_user_confirmation(true, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let pending = AccountGroup::find_pending_for_account(&account.pubkey, &whitenoise.database)
-            .await
-            .unwrap();
+        let pending =
+            AccountGroup::find_pending_for_account(&account.pubkey, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].mls_group_id, group_id1);
@@ -906,14 +948,22 @@ mod tests {
         let account2 = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[14; 32]);
 
-        let (ag1, created1) =
-            AccountGroup::find_or_create(&account1.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
-        let (ag2, created2) =
-            AccountGroup::find_or_create(&account2.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag1, created1) = AccountGroup::find_or_create(
+            &account1.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let (ag2, created2) = AccountGroup::find_or_create(
+            &account2.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(created1);
         assert!(created2);
@@ -927,7 +977,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[15; 32]);
 
-        let result = AccountGroup::find_by_group(&group_id, &whitenoise.database)
+        let result = AccountGroup::find_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -940,12 +990,16 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[16; 32]);
 
-        let (created_ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (created_ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
-        let result = AccountGroup::find_by_group(&group_id, &whitenoise.database)
+        let result = AccountGroup::find_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -965,19 +1019,34 @@ mod tests {
         let other_group = GroupId::from_slice(&[18; 32]);
 
         // Add accounts 1 and 2 to the target group
-        AccountGroup::find_or_create(&account1.pubkey, &target_group, None, &whitenoise.database)
-            .await
-            .unwrap();
-        AccountGroup::find_or_create(&account2.pubkey, &target_group, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account1.pubkey,
+            &target_group,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        AccountGroup::find_or_create(
+            &account2.pubkey,
+            &target_group,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Add account 3 to a different group (should not be returned)
-        AccountGroup::find_or_create(&account3.pubkey, &other_group, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account3.pubkey,
+            &other_group,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
-        let result = AccountGroup::find_by_group(&target_group, &whitenoise.database)
+        let result = AccountGroup::find_by_group(&target_group, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1020,7 +1089,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let saved = ag.save(&whitenoise.database).await.unwrap();
+        let saved = ag.save(&whitenoise.shared.database).await.unwrap();
 
         assert!(saved.id.is_some());
         assert_eq!(saved.account_pubkey, account.pubkey);
@@ -1056,7 +1125,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        let original = ag.save(&whitenoise.database).await.unwrap();
+        let original = ag.save(&whitenoise.shared.database).await.unwrap();
         assert_eq!(original.welcomer_pubkey, Some(welcomer.pubkey));
         assert_eq!(original.user_confirmation, Some(true));
         assert_eq!(original.pin_order, Some(100));
@@ -1080,7 +1149,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        let saved = update.save(&whitenoise.database).await.unwrap();
+        let saved = update.save(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(saved.id, original.id);
         assert!(saved.user_confirmation.is_none());
@@ -1094,14 +1163,18 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[32; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Archive the group
         let archived = ag
-            .update_archived_at(Some(Utc::now()), &whitenoise.database)
+            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(archived.is_archived());
@@ -1125,13 +1198,13 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        resaved.save(&whitenoise.database).await.unwrap();
+        resaved.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and verify archived_at survived the save()
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1156,7 +1229,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1170,15 +1243,19 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             message_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(account_group.last_read_message_id.is_none());
 
@@ -1187,7 +1264,7 @@ mod tests {
             .update_last_read_if_newer(
                 &message_id,
                 message_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1208,7 +1285,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1225,7 +1302,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1235,22 +1312,26 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Set to older message first
         let updated = account_group
             .update_last_read_if_newer(
                 &older_msg_id,
                 older_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap()
@@ -1262,7 +1343,7 @@ mod tests {
             .update_last_read_if_newer(
                 &newer_msg_id,
                 newer_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1283,7 +1364,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1300,7 +1381,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1310,22 +1391,26 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Set to newer message first
         let updated = account_group
             .update_last_read_if_newer(
                 &newer_msg_id,
                 newer_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap()
@@ -1337,7 +1422,7 @@ mod tests {
             .update_last_read_if_newer(
                 &older_msg_id,
                 older_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1348,7 +1433,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1368,7 +1453,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1381,21 +1466,25 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             message_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         account_group
             .update_last_read_if_newer(
                 &message_id,
                 message_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1404,7 +1493,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1419,15 +1508,19 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[60; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(account_group.pin_order.is_none());
 
         let updated = account_group
-            .update_pin_order(Some(42), &whitenoise.database)
+            .update_pin_order(Some(42), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1440,21 +1533,25 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[61; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Set pin order first
         let pinned = account_group
-            .update_pin_order(Some(100), &whitenoise.database)
+            .update_pin_order(Some(100), &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(pinned.pin_order, Some(100));
 
         // Clear pin order
         let unpinned = pinned
-            .update_pin_order(None, &whitenoise.database)
+            .update_pin_order(None, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1467,13 +1564,17 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[62; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         account_group
-            .update_pin_order(Some(77), &whitenoise.database)
+            .update_pin_order(Some(77), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1481,7 +1582,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1496,16 +1597,20 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[63; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(account_group.archived_at.is_none());
 
         let now = Utc::now();
         let updated = account_group
-            .update_archived_at(Some(now), &whitenoise.database)
+            .update_archived_at(Some(now), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1519,21 +1624,25 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[64; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Set archived
         let archived = account_group
-            .update_archived_at(Some(Utc::now()), &whitenoise.database)
+            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(archived.is_archived());
 
         // Clear archived
         let unarchived = archived
-            .update_archived_at(None, &whitenoise.database)
+            .update_archived_at(None, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(unarchived.archived_at.is_none());
@@ -1546,13 +1655,17 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[65; 32]);
 
-        let (account_group, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (account_group, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         account_group
-            .update_archived_at(Some(Utc::now()), &whitenoise.database)
+            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1560,7 +1673,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1586,12 +1699,17 @@ mod tests {
         .unwrap();
 
         // Create account_group WITHOUT dm_peer_pubkey (simulates pre-migration state)
-        AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.database)
+            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1621,13 +1739,13 @@ mod tests {
             &account.pubkey,
             &group_id,
             Some(&peer.pubkey),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.database)
+            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1651,12 +1769,17 @@ mod tests {
         .unwrap();
 
         // Create account_group without dm_peer_pubkey
-        AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.database)
+            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1672,16 +1795,21 @@ mod tests {
         let group_id = GroupId::from_slice(&[73; 32]);
 
         // Create account_group without dm_peer_pubkey
-        AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Update the dm_peer_pubkey
         AccountGroup::update_dm_peer_pubkey(
             &account.pubkey,
             &group_id,
             &peer.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1690,7 +1818,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1712,7 +1840,7 @@ mod tests {
             &account.pubkey,
             &group_id,
             Some(&original_peer.pubkey),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1722,7 +1850,7 @@ mod tests {
             &account.pubkey,
             &group_id,
             &new_peer.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1731,7 +1859,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1746,14 +1874,18 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[83; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Mark as removed
         let removed = ag
-            .mark_removed_atomic(&whitenoise.database)
+            .mark_removed_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("first mark_removed_atomic must update the row");
@@ -1778,13 +1910,13 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        resaved.save(&whitenoise.database).await.unwrap();
+        resaved.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and verify removed_at survived
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1802,15 +1934,19 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[90; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(ag.removed_at.is_none());
         assert!(!ag.self_removed);
 
         let left = ag
-            .mark_left_atomic(&whitenoise.database)
+            .mark_left_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("first mark_left_atomic must update the row");
@@ -1826,19 +1962,26 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[91; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let first = ag
-            .mark_left_atomic(&whitenoise.database)
+            .mark_left_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("first call must succeed");
 
         // Second call must be a no-op
-        let second = first.mark_left_atomic(&whitenoise.database).await.unwrap();
+        let second = first
+            .mark_left_atomic(&whitenoise.shared.database)
+            .await
+            .unwrap();
         assert!(second.is_none(), "second mark_left_atomic must return None");
     }
 
@@ -1848,14 +1991,18 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[92; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // User leaves voluntarily
         let left = ag
-            .mark_left_atomic(&whitenoise.database)
+            .mark_left_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("mark_left_atomic must succeed");
@@ -1863,7 +2010,7 @@ mod tests {
 
         // Later commit arrives — mark_removed_atomic must be a no-op
         let removed = left
-            .mark_removed_atomic(&whitenoise.database)
+            .mark_removed_atomic(&whitenoise.shared.database)
             .await
             .unwrap();
         assert!(
@@ -1875,7 +2022,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1892,14 +2039,18 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[93; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Admin kicks user first
         let removed = ag
-            .mark_removed_atomic(&whitenoise.database)
+            .mark_removed_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("mark_removed_atomic must succeed");
@@ -1907,7 +2058,7 @@ mod tests {
 
         // User tries to leave — must be a no-op
         let left = removed
-            .mark_left_atomic(&whitenoise.database)
+            .mark_left_atomic(&whitenoise.shared.database)
             .await
             .unwrap();
         assert!(
@@ -1919,7 +2070,7 @@ mod tests {
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1936,14 +2087,18 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[94; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // User leaves voluntarily
         let left = ag
-            .mark_left_atomic(&whitenoise.database)
+            .mark_left_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("mark_left_atomic must succeed");
@@ -1968,13 +2123,13 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        resaved.save(&whitenoise.database).await.unwrap();
+        resaved.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and verify self_removed survived
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1992,21 +2147,25 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[84; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Decline the invite first
         let declined = ag
-            .update_user_confirmation(false, &whitenoise.database)
+            .update_user_confirmation(false, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(declined.user_confirmation, Some(false));
 
         // Admin removes the user — user_confirmation must stay Some(false)
         let removed = declined
-            .mark_removed_atomic(&whitenoise.database)
+            .mark_removed_atomic(&whitenoise.shared.database)
             .await
             .unwrap()
             .expect("mark_removed_atomic must update the row");
@@ -2027,16 +2186,20 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[90; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(ag.chat_cleared_at.is_none());
 
         let now = Utc::now();
         let updated = ag
-            .update_chat_cleared_at(Some(now), &whitenoise.database)
+            .update_chat_cleared_at(Some(now), &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2049,19 +2212,23 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[91; 32]);
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let cleared = ag
-            .update_chat_cleared_at(Some(Utc::now()), &whitenoise.database)
+            .update_chat_cleared_at(Some(Utc::now()), &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(cleared.chat_cleared_at.is_some());
 
         let uncleared = cleared
-            .update_chat_cleared_at(None, &whitenoise.database)
+            .update_chat_cleared_at(None, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(uncleared.chat_cleared_at.is_none());
@@ -2079,7 +2246,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2092,22 +2259,26 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             message_time,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Set the read marker first
         let with_marker = ag
             .update_last_read_if_newer(
                 &message_id,
                 message_time.timestamp_millis(),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap()
@@ -2116,7 +2287,7 @@ mod tests {
 
         // Reset
         let reset = with_marker
-            .reset_last_read_message_id(&whitenoise.database)
+            .reset_last_read_message_id(&whitenoise.shared.database)
             .await
             .unwrap();
         assert!(reset.last_read_message_id.is_none());

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -1671,7 +1671,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count, 0);
@@ -1682,9 +1682,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let ids = AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let ids =
+            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert!(ids.is_empty());
     }
 
@@ -1698,7 +1699,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1709,19 +1710,23 @@ mod tests {
     async fn test_insert_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(1, author);
 
         // Insert message
-        let result =
-            AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-                .await;
+        let result = AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await;
         assert!(result.is_ok());
 
         // Verify it was inserted
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count, 1);
@@ -1731,7 +1736,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1744,7 +1749,7 @@ mod tests {
     async fn test_insert_multiple_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[2; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -1753,13 +1758,18 @@ mod tests {
         for i in 1..=3 {
             let message = create_test_chat_message(i, author);
             message_ids.push(message.id.clone());
-            AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &message,
+                &group_id,
+                &author,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
         }
 
         // Verify count
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count, 3);
@@ -1769,7 +1779,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1777,7 +1787,7 @@ mod tests {
 
         // Verify event IDs
         let event_ids =
-            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(event_ids.len(), 3);
@@ -1790,19 +1800,25 @@ mod tests {
     async fn test_mark_deleted_does_not_decrease_count() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[3; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message
         let message = create_test_chat_message(10, author);
-        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
-        let count_before = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let count_before =
+            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(count_before, 1);
 
         // Mark as deleted - need a valid 64-char hex ID
@@ -1811,13 +1827,13 @@ mod tests {
             &message.id,
             &group_id,
             &deletion_event_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         // Count should remain the same - mark_deleted doesn't remove the row
-        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count_after, 1);
@@ -1827,7 +1843,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1839,39 +1855,55 @@ mod tests {
     async fn test_delete_by_group_removes_all_events() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[4; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert multiple messages
         let message1 = create_test_chat_message(20, author);
-        AggregatedMessage::insert_message(&message1, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message1,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let message2 = create_test_chat_message(21, author);
-        AggregatedMessage::insert_message(&message2, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message2,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let message3 = create_test_chat_message(22, author);
-        AggregatedMessage::insert_message(&message3, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message3,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Verify count before deletion
-        let count_before = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let count_before =
+            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(count_before, 3);
 
         // Delete all events for the group
-        AggregatedMessage::delete_by_group(&group_id, &whitenoise.database)
+        AggregatedMessage::delete_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Count should now be zero
-        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
+        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count_after, 0);
@@ -1881,7 +1913,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1889,7 +1921,7 @@ mod tests {
 
         // No event IDs should be found
         let event_ids =
-            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.database)
+            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert!(event_ids.is_empty());
@@ -1900,36 +1932,46 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id_1 = GroupId::from_slice(&[5; 32]);
         let group_id_2 = GroupId::from_slice(&[6; 32]);
-        setup_group(&group_id_1, &whitenoise.database).await;
-        setup_group(&group_id_2, &whitenoise.database).await;
+        setup_group(&group_id_1, &whitenoise.shared.database).await;
+        setup_group(&group_id_2, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert message in group 1
         let message1 = create_test_chat_message(30, author);
-        AggregatedMessage::insert_message(&message1, &group_id_1, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message1,
+            &group_id_1,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Insert message in group 2
         let message2 = create_test_chat_message(31, author);
-        AggregatedMessage::insert_message(&message2, &group_id_2, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message2,
+            &group_id_2,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Delete group 1
-        AggregatedMessage::delete_by_group(&group_id_1, &whitenoise.database)
+        AggregatedMessage::delete_by_group(&group_id_1, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Group 1 should be empty
-        let count_1 = AggregatedMessage::count_by_group(&group_id_1, &whitenoise.database)
+        let count_1 = AggregatedMessage::count_by_group(&group_id_1, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count_1, 0);
 
         // Group 2 should still have its message
-        let count_2 = AggregatedMessage::count_by_group(&group_id_2, &whitenoise.database)
+        let count_2 = AggregatedMessage::count_by_group(&group_id_2, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(count_2, 1);
@@ -1939,15 +1981,20 @@ mod tests {
     async fn test_update_reactions() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[7; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message with empty reactions
         let message = create_test_chat_message(40, author);
-        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Update with reactions
         let mut reactions = ReactionSummary::default();
@@ -1964,7 +2011,7 @@ mod tests {
             &message.id,
             &group_id,
             &reactions,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1974,7 +2021,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1987,7 +2034,7 @@ mod tests {
     async fn test_find_last_by_group_ids_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let result = AggregatedMessage::find_last_by_group_ids(&[], &whitenoise.database)
+        let result = AggregatedMessage::find_last_by_group_ids(&[], &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(result.is_empty());
@@ -2011,7 +2058,7 @@ mod tests {
             &group_empty,
             &group_multiple_messages,
         ] {
-            setup_group(group_id, &whitenoise.database).await;
+            setup_group(group_id, &whitenoise.shared.database).await;
         }
 
         let author = Keys::generate().public_key();
@@ -2057,7 +2104,7 @@ mod tests {
             &msg_with_media,
             &group_with_media,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2069,7 +2116,7 @@ mod tests {
             &msg_no_media,
             &group_no_media,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2082,7 +2129,7 @@ mod tests {
             &msg_older,
             &group_with_deletion,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2094,7 +2141,7 @@ mod tests {
             &msg_deleted,
             &group_with_deletion,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2102,7 +2149,7 @@ mod tests {
             &msg_deleted.id,
             &group_with_deletion,
             &format!("{:0>64}", "del"),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2117,7 +2164,7 @@ mod tests {
             &msg_first,
             &group_multiple_messages,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2129,7 +2176,7 @@ mod tests {
             &msg_last,
             &group_multiple_messages,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2143,7 +2190,7 @@ mod tests {
                 group_empty.clone(),
                 group_multiple_messages.clone(),
             ],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2182,16 +2229,21 @@ mod tests {
     async fn test_find_by_message_id_returns_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[70; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(70, author);
-        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let event_id = EventId::from_hex(&message.id).unwrap();
-        let found = AggregatedMessage::find_by_message_id(&event_id, &whitenoise.database)
+        let found = AggregatedMessage::find_by_message_id(&event_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2206,7 +2258,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let fake_id = EventId::all_zeros();
 
-        let found = AggregatedMessage::find_by_message_id(&fake_id, &whitenoise.database)
+        let found = AggregatedMessage::find_by_message_id(&fake_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2217,20 +2269,29 @@ mod tests {
     async fn test_count_unread_for_group_no_read_marker_returns_all() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[80; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         for i in 1..=3 {
             let msg = create_test_chat_message(80 + i, author);
-            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_id,
+                &author,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
         }
 
-        let count =
-            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database, None)
-                .await
-                .unwrap();
+        let count = AggregatedMessage::count_unread_for_group(
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(count, 3);
     }
@@ -2239,16 +2300,21 @@ mod tests {
     async fn test_count_unread_for_group_with_read_marker() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[90; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let mut messages = Vec::new();
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(90 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_id,
+                &author,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
             messages.push(msg);
         }
 
@@ -2257,7 +2323,7 @@ mod tests {
         let count = AggregatedMessage::count_unread_for_group(
             &group_id,
             Some(&read_marker_id),
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -2270,15 +2336,15 @@ mod tests {
     async fn test_count_unread_for_group_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[100; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(100, author);
         let msg2 = create_test_chat_message(101, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2287,15 +2353,19 @@ mod tests {
             &msg2.id,
             &group_id,
             &format!("{:0>64}", "del"),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let count =
-            AggregatedMessage::count_unread_for_group(&group_id, None, &whitenoise.database, None)
-                .await
-                .unwrap();
+        let count = AggregatedMessage::count_unread_for_group(
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(count, 1); // Only msg1 counted
     }
@@ -2304,7 +2374,7 @@ mod tests {
     async fn test_count_unread_for_groups_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let result = AggregatedMessage::count_unread_for_groups(&[], &whitenoise.database)
+        let result = AggregatedMessage::count_unread_for_groups(&[], &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2320,7 +2390,7 @@ mod tests {
         let group3 = GroupId::from_slice(&[112; 32]); // Empty group
 
         for group_id in [&group1, &group2, &group3] {
-            setup_group(group_id, &whitenoise.database).await;
+            setup_group(group_id, &whitenoise.shared.database).await;
         }
 
         let author = Keys::generate().public_key();
@@ -2328,7 +2398,7 @@ mod tests {
         // Group 1: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(110 + i, author);
-            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -2336,7 +2406,7 @@ mod tests {
         // Group 2: 5 messages
         for i in 1..=5 {
             let msg = create_test_chat_message(120 + i, author);
-            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -2349,9 +2419,10 @@ mod tests {
             (group3.clone(), None, None),
         ];
 
-        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[&group1], 3);
@@ -2367,7 +2438,7 @@ mod tests {
         let group2 = GroupId::from_slice(&[131; 32]);
 
         for group_id in [&group1, &group2] {
-            setup_group(group_id, &whitenoise.database).await;
+            setup_group(group_id, &whitenoise.shared.database).await;
         }
 
         let author = Keys::generate().public_key();
@@ -2377,7 +2448,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(130 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
             group1_messages.push(msg);
@@ -2389,7 +2460,7 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(140 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
             group2_messages.push(msg);
@@ -2401,9 +2472,10 @@ mod tests {
             (group2.clone(), Some(marker2), None),
         ];
 
-        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[&group1], 3); // Messages 3, 4, 5 unread
@@ -2419,7 +2491,7 @@ mod tests {
         let group_empty = GroupId::from_slice(&[152; 32]);
 
         for group_id in [&group_with_marker, &group_without_marker, &group_empty] {
-            setup_group(group_id, &whitenoise.database).await;
+            setup_group(group_id, &whitenoise.shared.database).await;
         }
 
         let author = Keys::generate().public_key();
@@ -2433,7 +2505,7 @@ mod tests {
                 &msg,
                 &group_with_marker,
                 &author,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -2448,7 +2520,7 @@ mod tests {
                 &msg,
                 &group_without_marker,
                 &author,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -2460,9 +2532,10 @@ mod tests {
             (group_empty.clone(), None, None),
         ];
 
-        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[&group_with_marker], 2); // Messages 3, 4 unread
@@ -2474,23 +2547,32 @@ mod tests {
     async fn test_update_delivery_status_and_find_by_id() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[200; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message with Sending status
         let mut message = create_test_chat_message(200, author);
         message.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Verify initial Sending status via find_by_id
-        let found =
-            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(
+            &message.id,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
 
         // Update to Sent(3) — returned message should have the updated status
@@ -2499,18 +2581,22 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Sent(3),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         assert_eq!(updated.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Verify via find_by_id as well
-        let found =
-            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(
+            &message.id,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Update to Failed
@@ -2519,7 +2605,7 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Failed("timeout".to_string()),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2535,10 +2621,14 @@ mod tests {
         let group_id = GroupId::from_slice(&[201; 32]);
         let author = Keys::generate().public_key();
 
-        let found =
-            AggregatedMessage::find_by_id("nonexistent", &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(
+            "nonexistent",
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(found.is_none());
     }
 
@@ -2546,22 +2636,31 @@ mod tests {
     async fn test_insert_message_with_no_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[202; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(202, author);
         // delivery_status is None (incoming message)
         assert!(message.delivery_status.is_none());
 
-        AggregatedMessage::insert_message(&message, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &message,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
-        let found =
-            AggregatedMessage::find_by_id(&message.id, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(
+            &message.id,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(found.delivery_status, None);
     }
 
@@ -2569,28 +2668,38 @@ mod tests {
     async fn test_find_messages_by_group_preserves_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[203; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert incoming message (no delivery status)
         let msg_incoming = create_test_chat_message(203, author);
-        AggregatedMessage::insert_message(&msg_incoming, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_incoming,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Insert outgoing message with Sent status
         let mut msg_outgoing = create_test_chat_message(204, author);
         msg_outgoing.delivery_status = Some(DeliveryStatus::Sent(2));
-        AggregatedMessage::insert_message(&msg_outgoing, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_outgoing,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group(
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2606,7 +2715,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[205; 32]);
         let author = Keys::generate().public_key();
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         // Try to update delivery status for a message that doesn't exist
         let result = AggregatedMessage::update_delivery_status(
@@ -2614,7 +2723,7 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Sent(1),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await;
 
@@ -2634,35 +2743,50 @@ mod tests {
     async fn test_find_messages_by_group_excludes_retried() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[206; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a normal message
         let msg_normal = create_test_chat_message(206, author);
-        AggregatedMessage::insert_message(&msg_normal, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_normal,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Insert a message with Retried status (simulating a retried failed message)
         let mut msg_retried = create_test_chat_message(207, author);
         msg_retried.delivery_status = Some(DeliveryStatus::Retried);
-        AggregatedMessage::insert_message(&msg_retried, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_retried,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Insert a message with Failed status (should still be visible)
         let mut msg_failed = create_test_chat_message(208, author);
         msg_failed.delivery_status = Some(DeliveryStatus::Failed("error".to_string()));
-        AggregatedMessage::insert_message(&msg_failed, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &msg_failed,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group(
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2680,7 +2804,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let group_id = GroupId::from_slice(&[170; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(170, author);
@@ -2688,7 +2812,7 @@ mod tests {
         let msg3 = create_test_chat_message(172, author);
 
         for msg in [&msg1, &msg2, &msg3] {
-            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -2698,15 +2822,16 @@ mod tests {
             &msg2.id,
             &group_id,
             &format!("{:0>64}", "del"),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         let input = vec![(group_id.clone(), None, None)];
-        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(result[&group_id], 2); // msg1 and msg3, excluding deleted msg2
     }
@@ -2715,11 +2840,11 @@ mod tests {
     async fn test_insert_delivery_status_and_has_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[180; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(180, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2728,7 +2853,7 @@ mod tests {
             &msg.id,
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2740,7 +2865,7 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Sending,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2750,7 +2875,7 @@ mod tests {
             &msg.id,
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2758,7 +2883,7 @@ mod tests {
 
         // Verify it shows up in find_by_id
         let found =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.database)
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .unwrap();
@@ -2769,11 +2894,11 @@ mod tests {
     async fn test_insert_delivery_status_upsert() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[181; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(181, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2783,7 +2908,7 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Sending,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2794,13 +2919,13 @@ mod tests {
             &group_id,
             &author,
             &DeliveryStatus::Sent(2),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         let found =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.database)
+            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .unwrap();
@@ -2811,25 +2936,25 @@ mod tests {
     async fn test_unmark_deleted_reverses_deletion() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[182; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(182, author);
         let msg2 = create_test_chat_message(183, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let del_id = format!("{:0>64x}", 0xde1182u64);
 
         // Mark both as deleted by the same deletion event
-        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_id, &whitenoise.database)
+        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_id, &whitenoise.shared.database)
             .await
             .unwrap();
-        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_id, &whitenoise.database)
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2838,7 +2963,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2848,7 +2973,7 @@ mod tests {
         );
 
         // Unmark — both should revert to not deleted
-        AggregatedMessage::unmark_deleted(&del_id, &group_id, &whitenoise.database)
+        AggregatedMessage::unmark_deleted(&del_id, &group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2856,7 +2981,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2871,30 +2996,30 @@ mod tests {
     async fn test_unmark_deleted_only_affects_matching_deletion() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[184; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(184, author);
         let msg2 = create_test_chat_message(185, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let del_a = format!("{:0>64x}", 0xde1au64);
         let del_b = format!("{:0>64x}", 0xde1bu64);
 
-        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_a, &whitenoise.database)
+        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_a, &whitenoise.shared.database)
             .await
             .unwrap();
-        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_b, &whitenoise.database)
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_b, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Unmark only del_a — msg1 should revert to not-deleted, msg2 stays deleted
-        AggregatedMessage::unmark_deleted(&del_a, &group_id, &whitenoise.database)
+        AggregatedMessage::unmark_deleted(&del_a, &group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -2902,7 +3027,7 @@ mod tests {
             &group_id,
             &author,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2915,7 +3040,7 @@ mod tests {
     async fn test_find_orphaned_reactions_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[186; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         // Use valid hex IDs (find_orphaned_reactions parses message_id as EventId)
@@ -2943,28 +3068,39 @@ mod tests {
         .bind(&empty_tokens)
         .bind(&empty_reactions)
         .bind(&empty_media)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // The reaction should appear as orphaned
-        let orphans =
-            AggregatedMessage::find_orphaned_reactions(&parent_id, &group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let orphans = AggregatedMessage::find_orphaned_reactions(
+            &parent_id,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(orphans.len(), 1, "Non-deleted reaction should be found");
 
         // Now mark the reaction as deleted
         let del_id = format!("{:0>64x}", 0xde1186u64);
-        AggregatedMessage::mark_deleted(&reaction_id, &group_id, &del_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::mark_deleted(
+            &reaction_id,
+            &group_id,
+            &del_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Deleted reaction should NOT appear as orphaned
-        let orphans =
-            AggregatedMessage::find_orphaned_reactions(&parent_id, &group_id, &whitenoise.database)
-                .await
-                .unwrap();
+        let orphans = AggregatedMessage::find_orphaned_reactions(
+            &parent_id,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(orphans.len(), 0, "Deleted reaction should be excluded");
     }
 
@@ -2978,7 +3114,7 @@ mod tests {
             "nonexistent",
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -3026,7 +3162,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -3040,7 +3176,7 @@ mod tests {
     async fn test_paginated_default_returns_up_to_50_newest() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[201; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
@@ -3052,7 +3188,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3061,7 +3197,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -3096,7 +3232,7 @@ mod tests {
     async fn test_paginated_before_cursor_excludes_on_or_after() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[202; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_100_000;
@@ -3108,7 +3244,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3120,7 +3256,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(cursor_ts),
                 before_message_id: Some(cursor_id.clone()),
@@ -3145,7 +3281,7 @@ mod tests {
     async fn test_paginated_limit_is_respected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[203; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_200_000;
@@ -3156,7 +3292,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3164,7 +3300,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             Some(3),
             None,
@@ -3187,7 +3323,7 @@ mod tests {
     async fn test_paginated_limit_capped_at_200() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[204; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_300_000;
@@ -3201,7 +3337,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3210,7 +3346,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             Some(u32::MAX),
             None,
@@ -3225,7 +3361,7 @@ mod tests {
     async fn test_paginated_pages_are_contiguous_without_overlap_or_gap() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[205; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_400_000;
@@ -3237,7 +3373,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3246,7 +3382,7 @@ mod tests {
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             Some(5),
             None,
@@ -3261,7 +3397,7 @@ mod tests {
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(cursor_ts),
                 before_message_id: Some(cursor_id.to_string()),
@@ -3290,7 +3426,7 @@ mod tests {
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(cursor_ts2),
                 before_message_id: Some(cursor_id2.to_string()),
@@ -3312,7 +3448,7 @@ mod tests {
     async fn test_paginated_tied_timestamps_no_skip_or_duplicate_across_pages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[206; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -3322,18 +3458,32 @@ mod tests {
 
         // Seeds 1–6: all at `tie_ts` (identical created_at seconds)
         // Seeds 7–8: flanking timestamps to confirm ordering is correct
-        insert_message_at(7, author, tie_ts - 1, &group_id, &whitenoise.database).await; // earlier
+        insert_message_at(
+            7,
+            author,
+            tie_ts - 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await; // earlier
         for i in 1u8..=6 {
-            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.database).await;
+            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.shared.database).await;
         }
-        insert_message_at(8, author, tie_ts + 1, &group_id, &whitenoise.database).await; // later
+        insert_message_at(
+            8,
+            author,
+            tie_ts + 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await; // later
 
         // Total 8 messages. Page size 3 — three pages needed.
         // Page 1: newest 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             Some(3),
             None,
@@ -3348,7 +3498,7 @@ mod tests {
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(c1_ts),
                 before_message_id: Some(c1_id.clone()),
@@ -3367,7 +3517,7 @@ mod tests {
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(c2_ts),
                 before_message_id: Some(c2_id.clone()),
@@ -3390,7 +3540,7 @@ mod tests {
         let page4 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(c3_ts),
                 before_message_id: Some(c3_id.clone()),
@@ -3442,7 +3592,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(ts),
                 ..Default::default()
@@ -3461,7 +3611,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before_message_id: Some(
                     "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
@@ -3490,7 +3640,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some("not-valid-hex-at-all".to_string()),
@@ -3510,7 +3660,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some("00000000000000000000000000000001".to_string()),
@@ -3533,7 +3683,7 @@ mod tests {
     async fn test_paginated_after_cursor_returns_only_newer_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[220; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_000_000;
@@ -3545,7 +3695,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3556,7 +3706,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3582,7 +3732,7 @@ mod tests {
     async fn test_paginated_after_cursor_returns_oldest_first() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[221; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_100_000;
@@ -3593,7 +3743,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3604,7 +3754,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3631,17 +3781,31 @@ mod tests {
     async fn test_paginated_after_cursor_tied_timestamps() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[222; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let tie_ts: u64 = 1_710_200_000;
 
         // Insert one message before the tie, six at tie_ts, one after
-        insert_message_at(7, author, tie_ts - 1, &group_id, &whitenoise.database).await;
+        insert_message_at(
+            7,
+            author,
+            tie_ts - 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await;
         for i in 1u8..=6 {
-            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.database).await;
+            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.shared.database).await;
         }
-        insert_message_at(8, author, tie_ts + 1, &group_id, &whitenoise.database).await;
+        insert_message_at(
+            8,
+            author,
+            tie_ts + 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await;
 
         // Use the earliest message (seed 7, ts-1) as the after cursor
         let cursor_ts = Timestamp::from(tie_ts - 1);
@@ -3651,7 +3815,7 @@ mod tests {
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3669,7 +3833,7 @@ mod tests {
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(c1_ts),
                 after_message_id: Some(c1_id.clone()),
@@ -3687,7 +3851,7 @@ mod tests {
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(c2_ts),
                 after_message_id: Some(c2_id.clone()),
@@ -3737,7 +3901,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some(id.to_string()),
@@ -3766,7 +3930,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(ts),
                 ..Default::default()
@@ -3785,7 +3949,7 @@ mod tests {
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after_message_id: Some(
                     "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
@@ -3807,7 +3971,7 @@ mod tests {
     async fn test_paginated_after_cursor_past_newest_returns_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[225; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_500_000;
@@ -3818,7 +3982,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3829,7 +3993,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3855,8 +4019,8 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_a = GroupId::from_slice(&[210; 32]);
         let group_b = GroupId::from_slice(&[211; 32]);
-        setup_group(&group_a, &whitenoise.database).await;
-        setup_group(&group_b, &whitenoise.database).await;
+        setup_group(&group_a, &whitenoise.shared.database).await;
+        setup_group(&group_b, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_701_000_000;
@@ -3868,7 +4032,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_a,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3878,7 +4042,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_b,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3886,7 +4050,7 @@ mod tests {
         let results_a = AggregatedMessage::find_messages_by_group_paginated(
             &group_a,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -3896,7 +4060,7 @@ mod tests {
         let results_b = AggregatedMessage::find_messages_by_group_paginated(
             &group_b,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -3922,7 +4086,7 @@ mod tests {
     async fn test_paginated_deleted_messages_are_included_as_tombstones() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[212; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_702_000_000;
@@ -3934,7 +4098,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -3942,14 +4106,19 @@ mod tests {
         // Delete seed-2 message
         let msg2_id = format!("{:0>64}", format!("{:x}", 2u8));
         let deletion_id = format!("{:0>64x}", 0xde1212u64);
-        AggregatedMessage::mark_deleted(&msg2_id, &group_id, &deletion_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::mark_deleted(
+            &msg2_id,
+            &group_id,
+            &deletion_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -3981,7 +4150,7 @@ mod tests {
     async fn test_unread_minimum_deleted_messages_are_included_as_tombstones() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[214; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_702_000_000;
@@ -3993,7 +4162,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4001,9 +4170,14 @@ mod tests {
         // Delete seed-2 message
         let msg2_id = format!("{:0>64}", format!("{:x}", 2u8));
         let deletion_id = format!("{:0>64x}", 0xde1212u64);
-        AggregatedMessage::mark_deleted(&msg2_id, &group_id, &deletion_id, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::mark_deleted(
+            &msg2_id,
+            &group_id,
+            &deletion_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // No read marker → all non-deleted messages are unread (cnt=2), minimum=3
         // LIMIT = MAX(2, 3) = 3, so all 3 rows (including the tombstone) are returned.
@@ -4012,7 +4186,7 @@ mod tests {
             &author,
             None,
             3,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4040,13 +4214,20 @@ mod tests {
     async fn test_paginated_non_kind9_messages_are_excluded() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[213; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_703_000_000;
 
         // Insert one kind-9 message via the normal helper
-        insert_message_at(1, author, base_ts + 1, &group_id, &whitenoise.database).await;
+        insert_message_at(
+            1,
+            author,
+            base_ts + 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await;
 
         // Insert a kind-7 reaction row directly with raw SQL (insert_message always writes kind=9)
         let reaction_id = format!("{:0>64}", format!("{:x}", 200u8));
@@ -4068,14 +4249,14 @@ mod tests {
         .bind(&empty_tokens)
         .bind(&empty_reactions)
         .bind(&empty_media)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -4103,7 +4284,7 @@ mod tests {
     async fn test_paginated_uppercase_cursor_id_is_canonicalized() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[214; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_704_000_000;
@@ -4115,7 +4296,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4128,7 +4309,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(Timestamp::from(base_ts + 3)),
                 before_message_id: Some(uppercase_id.clone()),
@@ -4156,17 +4337,17 @@ mod tests {
     async fn test_paginated_single_message_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[215; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let ts: u64 = 1_705_000_000;
 
-        let msg = insert_message_at(1, author, ts, &group_id, &whitenoise.database).await;
+        let msg = insert_message_at(1, author, ts, &group_id, &whitenoise.shared.database).await;
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -4184,7 +4365,7 @@ mod tests {
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
                 before_message_id: Some(page1[0].id.clone()),
@@ -4207,7 +4388,7 @@ mod tests {
     async fn test_paginated_exactly_default_limit_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[216; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_706_000_000;
@@ -4218,7 +4399,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4226,7 +4407,7 @@ mod tests {
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -4243,7 +4424,7 @@ mod tests {
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
                 before_message_id: Some(page1[0].id.clone()),
@@ -4266,7 +4447,7 @@ mod tests {
     async fn test_paginated_limit_one_traverses_all_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[217; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_707_000_000;
@@ -4278,7 +4459,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4299,7 +4480,7 @@ mod tests {
             let page = AggregatedMessage::find_messages_by_group_paginated(
                 &group_id,
                 &author,
-                &whitenoise.database,
+                &whitenoise.shared.database,
                 &opts,
                 Some(1),
                 None,
@@ -4339,7 +4520,7 @@ mod tests {
     async fn test_paginated_cursor_at_oldest_message_yields_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[218; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_708_000_000;
@@ -4351,7 +4532,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4360,7 +4541,7 @@ mod tests {
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -4374,7 +4555,7 @@ mod tests {
         let next_page = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions {
                 before: Some(oldest.created_at),
                 before_message_id: Some(oldest.id.clone()),
@@ -4399,13 +4580,20 @@ mod tests {
     async fn test_paginated_retried_messages_are_excluded() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[219; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_709_000_000;
 
         // Insert a normal message (seed 1) and a retried message (seed 2)
-        insert_message_at(1, author, base_ts + 1, &group_id, &whitenoise.database).await;
+        insert_message_at(
+            1,
+            author,
+            base_ts + 1,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await;
 
         let retried_msg = ChatMessage {
             id: format!("{:0>64}", format!("{:x}", 2u8)),
@@ -4422,14 +4610,19 @@ mod tests {
             media_attachments: vec![],
             delivery_status: Some(DeliveryStatus::Retried),
         };
-        AggregatedMessage::insert_message(&retried_msg, &group_id, &author, &whitenoise.database)
-            .await
-            .unwrap();
+        AggregatedMessage::insert_message(
+            &retried_msg,
+            &group_id,
+            &author,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             None,
@@ -4476,7 +4669,7 @@ mod tests {
     async fn test_search_messages_in_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[42; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -4494,7 +4687,7 @@ mod tests {
         ];
 
         for msg in &messages {
-            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.database)
+            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -4505,7 +4698,7 @@ mod tests {
             &author,
             "hello",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4521,7 +4714,7 @@ mod tests {
             &author,
             "big plans",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4540,7 +4733,7 @@ mod tests {
             &author,
             "big",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4553,7 +4746,7 @@ mod tests {
             &author,
             "MARMOT",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4567,7 +4760,7 @@ mod tests {
             &author,
             "日本語",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4581,7 +4774,7 @@ mod tests {
             &author,
             "привет",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4594,7 +4787,7 @@ mod tests {
             &author,
             "नमस्ते",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4608,7 +4801,7 @@ mod tests {
             &author,
             "nonexistent",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4621,7 +4814,7 @@ mod tests {
             &author,
             "",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4636,7 +4829,7 @@ mod tests {
             &author,
             "",
             2,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4650,7 +4843,7 @@ mod tests {
     async fn test_search_same_timestamp_deterministic_ordering() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[99; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let same_ts = Timestamp::from(1_700_000_000u64);
@@ -4680,9 +4873,14 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_id,
+                &author,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
         }
 
         // Search for all three: "same-ts" matches every message
@@ -4691,7 +4889,7 @@ mod tests {
             &author,
             "same-ts",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             None,
         )
         .await
@@ -4727,7 +4925,7 @@ mod tests {
         let group_declined = GroupId::from_slice(&[12; 32]);
 
         for gid in [&group_a, &group_b, &group_declined] {
-            setup_group(gid, &whitenoise.database).await;
+            setup_group(gid, &whitenoise.shared.database).await;
         }
 
         // Link account to groups: A = accepted, B = pending (null), C = declined
@@ -4754,19 +4952,19 @@ mod tests {
                 created_at: now,
                 updated_at: now,
             };
-            ag.save(&whitenoise.database).await.unwrap();
+            ag.save(&whitenoise.shared.database).await.unwrap();
         }
 
         let author = Keys::generate().public_key();
 
         // Insert messages: "marmot" in all three groups
         let msg_a = create_test_chat_message_with_content(1, author, "marmot in group A");
-        AggregatedMessage::insert_message(&msg_a, &group_a, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_a, &group_a, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let msg_b = create_test_chat_message_with_content(2, author, "marmot in group B");
-        AggregatedMessage::insert_message(&msg_b, &group_b, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_b, &group_b, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -4776,20 +4974,20 @@ mod tests {
             &msg_declined,
             &group_declined,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
         // Also add a second message in group A to verify per-group positions
         let msg_a2 = create_test_chat_message_with_content(4, author, "another marmot in group A");
-        AggregatedMessage::insert_message(&msg_a2, &group_a, &author, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg_a2, &group_a, &author, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Cross-group search for "marmot"
         let results =
-            AggregatedMessage::search_messages(&pubkey, "marmot", 50, &whitenoise.database)
+            AggregatedMessage::search_messages(&pubkey, "marmot", 50, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -4840,9 +5038,10 @@ mod tests {
         assert_eq!(group_b_result.position, 0);
 
         // Empty query returns all non-declined messages
-        let all_results = AggregatedMessage::search_messages(&pubkey, "", 50, &whitenoise.database)
-            .await
-            .unwrap();
+        let all_results =
+            AggregatedMessage::search_messages(&pubkey, "", 50, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(
             all_results.len(),
             3,
@@ -4851,16 +5050,20 @@ mod tests {
 
         // Limit is respected
         let limited =
-            AggregatedMessage::search_messages(&pubkey, "marmot", 1, &whitenoise.database)
+            AggregatedMessage::search_messages(&pubkey, "marmot", 1, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(limited.len(), 1, "limit should cap results");
 
         // No match returns empty
-        let no_match =
-            AggregatedMessage::search_messages(&pubkey, "nonexistent", 50, &whitenoise.database)
-                .await
-                .unwrap();
+        let no_match = AggregatedMessage::search_messages(
+            &pubkey,
+            "nonexistent",
+            50,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(no_match.is_empty(), "no match should return empty");
     }
 
@@ -4870,7 +5073,7 @@ mod tests {
     async fn test_find_messages_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[240; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
@@ -4882,7 +5085,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         }
@@ -4895,7 +5098,7 @@ mod tests {
             &group_id,
             &author,
             Some(cleared_at_ms),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -4907,7 +5110,7 @@ mod tests {
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
             &author,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &PaginationOptions::default(),
             None,
             Some(cleared_at_ms),
@@ -4922,7 +5125,7 @@ mod tests {
             &author,
             None,
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             Some(cleared_at_ms),
         )
         .await
@@ -4934,7 +5137,7 @@ mod tests {
     async fn test_count_unread_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[241; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
@@ -4946,7 +5149,7 @@ mod tests {
                 author,
                 base_ts + u64::from(i),
                 &group_id,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
             messages.push(msg);
@@ -4959,7 +5162,7 @@ mod tests {
         let count = AggregatedMessage::count_unread_for_group(
             &group_id,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             Some(cleared_at_ms),
         )
         .await
@@ -4971,7 +5174,7 @@ mod tests {
         let count = AggregatedMessage::count_unread_for_group(
             &group_id,
             Some(&marker),
-            &whitenoise.database,
+            &whitenoise.shared.database,
             Some(cleared_at_ms),
         )
         .await
@@ -4980,9 +5183,10 @@ mod tests {
 
         // count_unread_for_groups batch API
         let input = vec![(group_id.clone(), None, Some(cleared_at_ms))];
-        let result = AggregatedMessage::count_unread_for_groups(&input, &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(result[&group_id], 3);
     }
 
@@ -4990,7 +5194,7 @@ mod tests {
     async fn test_search_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[242; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
@@ -5013,9 +5217,14 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.database)
-                .await
-                .unwrap();
+            AggregatedMessage::insert_message(
+                &msg,
+                &group_id,
+                &author,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
         }
 
         // cleared_at = message 2's timestamp → messages 3, 4 visible
@@ -5026,7 +5235,7 @@ mod tests {
             &author,
             "hello",
             50,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             Some(cleared_at_ms),
         )
         .await
@@ -5048,7 +5257,7 @@ mod tests {
     async fn test_delivery_status_isolated_between_accounts() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[42; 32]);
-        setup_group(&group_id, &whitenoise.database).await;
+        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let account_a = Keys::generate().public_key();
         let account_b = Keys::generate().public_key();
@@ -5056,16 +5265,20 @@ mod tests {
         // Account A sends a message with delivery status
         let mut msg = create_test_chat_message(1, account_a);
         msg.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(&msg, &group_id, &account_a, &whitenoise.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &account_a, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Account A sees delivery status on their own message
-        let fetched_by_a =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &account_a, &whitenoise.database)
-                .await
-                .unwrap()
-                .expect("message should exist");
+        let fetched_by_a = AggregatedMessage::find_by_id(
+            &msg.id,
+            &group_id,
+            &account_a,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .expect("message should exist");
         assert_eq!(
             fetched_by_a.delivery_status,
             Some(DeliveryStatus::Sending),
@@ -5073,11 +5286,15 @@ mod tests {
         );
 
         // Account B queries the same message — must NOT see A's delivery status
-        let fetched_by_b =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &account_b, &whitenoise.database)
-                .await
-                .unwrap()
-                .expect("message should exist for any account");
+        let fetched_by_b = AggregatedMessage::find_by_id(
+            &msg.id,
+            &group_id,
+            &account_b,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .expect("message should exist for any account");
         assert_eq!(
             fetched_by_b.delivery_status, None,
             "other account must not see sender's delivery status (issue #739)"

--- a/src/whitenoise/database/app_settings.rs
+++ b/src/whitenoise/database/app_settings.rs
@@ -309,9 +309,9 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let settings = AppSettings::new(ThemeMode::System, None);
-        settings.save(&whitenoise.database).await.unwrap();
+        settings.save(&whitenoise.shared.database).await.unwrap();
 
-        let loaded = AppSettings::find_or_create_default(&whitenoise.database)
+        let loaded = AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(loaded.id, settings.id);
@@ -326,15 +326,15 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Ensure default settings exist
-        AppSettings::find_or_create_default(&whitenoise.database)
+        AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
 
-        AppSettings::update_theme_mode(ThemeMode::Dark, &whitenoise.database)
+        AppSettings::update_theme_mode(ThemeMode::Dark, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let loaded = AppSettings::find_or_create_default(&whitenoise.database)
+        let loaded = AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(loaded.theme_mode, ThemeMode::Dark);
@@ -347,15 +347,15 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Ensure default settings exist
-        AppSettings::find_or_create_default(&whitenoise.database)
+        AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
 
-        AppSettings::update_language(Language::Spanish, &whitenoise.database)
+        AppSettings::update_language(Language::Spanish, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let loaded = AppSettings::find_or_create_default(&whitenoise.database)
+        let loaded = AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(loaded.language, Language::Spanish);
@@ -367,7 +367,7 @@ mod tests {
 
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let settings = AppSettings::find_or_create_default(&whitenoise.database)
+        let settings = AppSettings::find_or_create_default(&whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(settings.id, 1);
@@ -384,7 +384,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         sqlx::query("DELETE FROM app_settings WHERE id = 1")
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
 
@@ -395,11 +395,11 @@ mod tests {
         .bind("light")
         .bind(i64::MAX)
         .bind(chrono::Utc::now().timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
-        let result = AppSettings::find_or_create_default(&whitenoise.database).await;
+        let result = AppSettings::find_or_create_default(&whitenoise.shared.database).await;
         assert!(matches!(result, Err(WhitenoiseError::SqlxError(_))));
     }
 }

--- a/src/whitenoise/database/cached_graph_users.rs
+++ b/src/whitenoise/database/cached_graph_users.rs
@@ -402,7 +402,7 @@ mod tests {
             Some(vec![follow1, follow2]),
         );
 
-        let saved = user.upsert(&whitenoise.database).await.unwrap();
+        let saved = user.upsert(&whitenoise.shared.database).await.unwrap();
 
         assert!(saved.id.is_some());
         assert_eq!(saved.pubkey, keys.public_key());
@@ -426,7 +426,7 @@ mod tests {
             Some(Metadata::new().name("Original Name")),
             Some(vec![]),
         );
-        let saved1 = user1.upsert(&whitenoise.database).await.unwrap();
+        let saved1 = user1.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Update with new data
         let user2 = CachedGraphUser::new(
@@ -434,7 +434,7 @@ mod tests {
             Some(Metadata::new().name("Updated Name")),
             Some(vec![Keys::generate().public_key()]),
         );
-        let saved2 = user2.upsert(&whitenoise.database).await.unwrap();
+        let saved2 = user2.upsert(&whitenoise.shared.database).await.unwrap();
 
         // ID should remain the same
         assert_eq!(saved1.id, saved2.id);
@@ -462,7 +462,7 @@ mod tests {
         .bind(keys.public_key().to_hex())
         .bind(old_time)
         .bind(old_time)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -470,14 +470,14 @@ mod tests {
         let before = CachedGraphUser::find_fresh_batch_with_ttl(
             &[keys.public_key()],
             10000,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         assert_eq!(before.len(), 1);
 
         // Run cleanup
-        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.database)
+        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -487,7 +487,7 @@ mod tests {
         let after = CachedGraphUser::find_fresh_batch_with_ttl(
             &[keys.public_key()],
             10000,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -501,19 +501,20 @@ mod tests {
 
         // Create a fresh entry
         let user = CachedGraphUser::new(keys.public_key(), Some(Metadata::new()), Some(vec![]));
-        user.upsert(&whitenoise.database).await.unwrap();
+        user.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Run cleanup
-        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.database)
+        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.shared.database)
             .await
             .unwrap();
 
         assert_eq!(deleted, 0);
 
         // Verify it still exists
-        let after = CachedGraphUser::find_fresh_batch(&[keys.public_key()], &whitenoise.database)
-            .await
-            .unwrap();
+        let after =
+            CachedGraphUser::find_fresh_batch(&[keys.public_key()], &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(after.len(), 1);
     }
 
@@ -531,7 +532,7 @@ mod tests {
         .bind(keys.public_key().to_hex())
         .bind(two_hours_ago)
         .bind(two_hours_ago)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -539,7 +540,7 @@ mod tests {
         let result_1h = CachedGraphUser::find_fresh_batch_with_ttl(
             &[keys.public_key()],
             1,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -549,7 +550,7 @@ mod tests {
         let result_3h = CachedGraphUser::find_fresh_batch_with_ttl(
             &[keys.public_key()],
             3,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -570,18 +571,18 @@ mod tests {
         .bind(keys.public_key().to_hex())
         .bind(two_hours_ago)
         .bind(two_hours_ago)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // With 3-hour TTL, should not be deleted
-        let deleted_3h = CachedGraphUser::cleanup_stale_with_ttl(3, &whitenoise.database)
+        let deleted_3h = CachedGraphUser::cleanup_stale_with_ttl(3, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(deleted_3h, 0);
 
         // With 1-hour TTL, should be deleted
-        let deleted_1h = CachedGraphUser::cleanup_stale_with_ttl(1, &whitenoise.database)
+        let deleted_1h = CachedGraphUser::cleanup_stale_with_ttl(1, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(deleted_1h, 1);
@@ -591,7 +592,7 @@ mod tests {
     async fn find_fresh_batch_returns_empty_for_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let result = CachedGraphUser::find_fresh_batch(&[], &whitenoise.database)
+        let result = CachedGraphUser::find_fresh_batch(&[], &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -611,19 +612,19 @@ mod tests {
             Some(Metadata::new().name("User1")),
             Some(vec![]),
         );
-        user1.upsert(&whitenoise.database).await.unwrap();
+        user1.upsert(&whitenoise.shared.database).await.unwrap();
 
         let user2 = CachedGraphUser::new(
             keys2.public_key(),
             Some(Metadata::new().name("User2")),
             Some(vec![]),
         );
-        user2.upsert(&whitenoise.database).await.unwrap();
+        user2.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Batch fetch both
         let result = CachedGraphUser::find_fresh_batch(
             &[keys1.public_key(), keys2.public_key()],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -650,7 +651,7 @@ mod tests {
             Some(Metadata::new().name("Fresh")),
             Some(vec![]),
         );
-        fresh.upsert(&whitenoise.database).await.unwrap();
+        fresh.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Insert stale entry directly
         let old_time = (Utc::now() - Duration::hours(25)).timestamp_millis();
@@ -661,14 +662,14 @@ mod tests {
         .bind(stale_keys.public_key().to_hex())
         .bind(old_time)
         .bind(old_time)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // Batch fetch both
         let result = CachedGraphUser::find_fresh_batch(
             &[fresh_keys.public_key(), stale_keys.public_key()],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -691,12 +692,12 @@ mod tests {
             Some(Metadata::new().name("Exists")),
             Some(vec![]),
         );
-        user.upsert(&whitenoise.database).await.unwrap();
+        user.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Batch fetch both
         let result = CachedGraphUser::find_fresh_batch(
             &[existing_keys.public_key(), missing_keys.public_key()],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -718,14 +719,14 @@ mod tests {
             Some(Metadata::new().name("Original")),
             Some(vec![follow1]),
         );
-        user.upsert(&whitenoise.database).await.unwrap();
+        user.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Now upsert metadata only
         let updated = CachedGraphUser::upsert_metadata_only(
             &keys.public_key(),
             &Metadata::new().name("Updated"),
             CONFIDENT_CACHE_TTL_MS,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -751,13 +752,13 @@ mod tests {
             Some(Metadata::new().name("Alice")),
             Some(vec![follow1]),
         );
-        user.upsert(&whitenoise.database).await.unwrap();
+        user.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Now upsert follows only
         let updated = CachedGraphUser::upsert_follows_only(
             &keys.public_key(),
             &[follow1, follow2],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -781,7 +782,7 @@ mod tests {
             &keys.public_key(),
             &Metadata::new().name("New"),
             CONFIDENT_CACHE_TTL_MS,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -803,7 +804,7 @@ mod tests {
         let saved = CachedGraphUser::upsert_follows_only(
             &keys.public_key(),
             &[follow1],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -837,7 +838,7 @@ mod tests {
         .bind(written_31m_ago)
         .bind(written_31m_ago)
         .bind(confident_expires)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -852,13 +853,13 @@ mod tests {
         .bind(written_31m_ago)
         .bind(written_31m_ago)
         .bind(uncertain_expires)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         let fresh = CachedGraphUser::find_fresh_metadata_batch(
             &[confident_pk, uncertain_pk],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -877,7 +878,7 @@ mod tests {
             &keys.public_key(),
             &Metadata::new().name("Test"),
             UNCERTAIN_CACHE_TTL_MS,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -910,14 +911,16 @@ mod tests {
         .bind(now)
         .bind(now)
         .bind(now)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
-        let fresh =
-            CachedGraphUser::find_fresh_metadata_batch(&[keys.public_key()], &whitenoise.database)
-                .await
-                .unwrap();
+        let fresh = CachedGraphUser::find_fresh_metadata_batch(
+            &[keys.public_key()],
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(
             fresh.is_empty(),

--- a/src/whitenoise/database/drafts.rs
+++ b/src/whitenoise/database/drafts.rs
@@ -163,9 +163,9 @@ mod tests {
     async fn test_save_creates_new_draft() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&whitenoise.database, &group_id).await;
+        insert_test_group(&whitenoise.shared.database, &group_id).await;
 
         let draft = Draft::save(
             &keys.public_key(),
@@ -173,7 +173,7 @@ mod tests {
             "hello",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -190,9 +190,9 @@ mod tests {
     async fn test_save_updates_existing_draft() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&whitenoise.database, &group_id).await;
+        insert_test_group(&whitenoise.shared.database, &group_id).await;
 
         let first = Draft::save(
             &keys.public_key(),
@@ -200,7 +200,7 @@ mod tests {
             "v1",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -210,7 +210,7 @@ mod tests {
             "v2",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -223,9 +223,9 @@ mod tests {
     async fn test_save_preserves_created_at_on_update() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&whitenoise.database, &group_id).await;
+        insert_test_group(&whitenoise.shared.database, &group_id).await;
 
         let first = Draft::save(
             &keys.public_key(),
@@ -233,7 +233,7 @@ mod tests {
             "v1",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -247,7 +247,7 @@ mod tests {
             "v2",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -260,9 +260,9 @@ mod tests {
     async fn test_find_returns_draft() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&whitenoise.database, &group_id).await;
+        insert_test_group(&whitenoise.shared.database, &group_id).await;
 
         Draft::save(
             &keys.public_key(),
@@ -270,12 +270,12 @@ mod tests {
             "persisted",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.database)
+        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.shared.database)
             .await
             .unwrap()
             .expect("draft should exist");
@@ -288,7 +288,7 @@ mod tests {
         let keys = Keys::generate();
         let group_id = GroupId::from_slice(b"test-group-id-00");
 
-        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.database)
+        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(found.is_none());
@@ -298,9 +298,9 @@ mod tests {
     async fn test_delete_removes_draft() {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let keys = Keys::generate();
-        insert_test_account(&whitenoise.database, &keys.public_key()).await;
+        insert_test_account(&whitenoise.shared.database, &keys.public_key()).await;
         let group_id = GroupId::from_slice(b"test-group-id-00");
-        insert_test_group(&whitenoise.database, &group_id).await;
+        insert_test_group(&whitenoise.shared.database, &group_id).await;
 
         Draft::save(
             &keys.public_key(),
@@ -308,16 +308,16 @@ mod tests {
             "to delete",
             None,
             &[],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        Draft::delete(&keys.public_key(), &group_id, &whitenoise.database)
+        Draft::delete(&keys.public_key(), &group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
-        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.database)
+        let found = Draft::find(&keys.public_key(), &group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(found.is_none());
@@ -329,7 +329,8 @@ mod tests {
         let keys = Keys::generate();
         let group_id = GroupId::from_slice(b"test-group-id-00");
 
-        let result = Draft::delete(&keys.public_key(), &group_id, &whitenoise.database).await;
+        let result =
+            Draft::delete(&keys.public_key(), &group_id, &whitenoise.shared.database).await;
         assert!(result.is_ok());
     }
 }

--- a/src/whitenoise/database/group_information.rs
+++ b/src/whitenoise/database/group_information.rs
@@ -186,7 +186,8 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let result = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database).await;
+        let result =
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -202,7 +203,7 @@ mod tests {
         let (group_info, was_created) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -222,7 +223,7 @@ mod tests {
         let (original_group_info, was_created) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::DirectMessage),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -232,7 +233,7 @@ mod tests {
         let (found_group_info, was_created) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group), // Different type, but should find existing
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -251,7 +252,7 @@ mod tests {
         let (group_info, was_created) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             None, // Should use default (Group)
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -264,7 +265,7 @@ mod tests {
     async fn test_find_by_mls_group_ids_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let result = GroupInformation::find_by_mls_group_ids(&[], &whitenoise.database)
+        let result = GroupInformation::find_by_mls_group_ids(&[], &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(result.is_empty());
@@ -279,7 +280,7 @@ mod tests {
         let (created_group_info, _) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::DirectMessage),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -287,7 +288,7 @@ mod tests {
         // Find it in batch query
         let results = GroupInformation::find_by_mls_group_ids(
             std::slice::from_ref(&group_id),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -309,7 +310,7 @@ mod tests {
         let (group_info1, _) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id1,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -317,7 +318,7 @@ mod tests {
         let (group_info2, _) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id2,
             Some(GroupType::DirectMessage),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -325,7 +326,7 @@ mod tests {
         // Query for all three (one missing)
         let results = GroupInformation::find_by_mls_group_ids(
             &[group_id1.clone(), group_id2.clone(), group_id3],
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -354,10 +355,12 @@ mod tests {
         let group_id1 = GroupId::from_slice(&[9; 32]);
         let group_id2 = GroupId::from_slice(&[10; 32]);
 
-        let results =
-            GroupInformation::find_by_mls_group_ids(&[group_id1, group_id2], &whitenoise.database)
-                .await
-                .unwrap();
+        let results = GroupInformation::find_by_mls_group_ids(
+            &[group_id1, group_id2],
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(results.is_empty());
     }
@@ -371,14 +374,15 @@ mod tests {
         let (dm_group_info, _) = GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::DirectMessage),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let found_dm = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let found_dm =
+            GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(found_dm.group_type, GroupType::DirectMessage);
         assert_eq!(found_dm.id, dm_group_info.id);
@@ -400,11 +404,11 @@ mod tests {
         .bind("not_a_real_group_type")
         .bind(now_ms)
         .bind(now_ms)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
-        let err = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.database)
+        let err = GroupInformation::find_by_mls_group_id(&group_id, &whitenoise.shared.database)
             .await
             .unwrap_err();
 

--- a/src/whitenoise/database/group_push_tokens.rs
+++ b/src/whitenoise/database/group_push_tokens.rs
@@ -297,7 +297,7 @@ mod tests {
             &first_server,
             Some(&relay_hint),
             "ciphertext-one",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -313,7 +313,7 @@ mod tests {
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -326,22 +326,26 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &account.pubkey,
             &mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         assert_eq!(stored, vec![replaced.clone()]);
 
-        let deleted =
-            GroupPushToken::delete(&account.pubkey, &mls_group_id, 7, &whitenoise.database)
-                .await
-                .unwrap();
+        let deleted = GroupPushToken::delete(
+            &account.pubkey,
+            &mls_group_id,
+            7,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(deleted);
 
         let stored_after_delete = GroupPushToken::find_by_account_and_group(
             &account.pubkey,
             &mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -365,7 +369,7 @@ mod tests {
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -377,7 +381,7 @@ mod tests {
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -385,7 +389,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &account.pubkey,
             &mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -413,7 +417,7 @@ mod tests {
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -425,7 +429,7 @@ mod tests {
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -434,7 +438,7 @@ mod tests {
             &account.pubkey,
             &mls_group_id,
             &member_pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -443,7 +447,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &account.pubkey,
             &mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -470,7 +474,7 @@ mod tests {
             &server_pubkey,
             None,
             "a1g1l1",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -482,7 +486,7 @@ mod tests {
             &server_pubkey,
             None,
             "a1g2l2",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -494,7 +498,7 @@ mod tests {
             &server_pubkey,
             None,
             "a2g1l3",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -502,26 +506,26 @@ mod tests {
         let account_one_group_one = GroupPushToken::find_by_account_and_group(
             &account_one.pubkey,
             &group_one,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         let account_one_group_two = GroupPushToken::find_by_account_and_group(
             &account_one.pubkey,
             &group_two,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         let account_two_group_one = GroupPushToken::find_by_account_and_group(
             &account_two.pubkey,
             &group_one,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
         let account_one_groups =
-            GroupPushToken::group_ids_for_account(&account_one.pubkey, &whitenoise.database)
+            GroupPushToken::group_ids_for_account(&account_one.pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -551,7 +555,7 @@ mod tests {
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -566,7 +570,7 @@ mod tests {
         .bind(account.pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(4_i64)
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -580,7 +584,7 @@ mod tests {
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -607,7 +611,7 @@ mod tests {
             &server_pubkey,
             None,
             " \n\t\r ",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap_err();

--- a/src/whitenoise/database/push_registrations.rs
+++ b/src/whitenoise/database/push_registrations.rs
@@ -188,7 +188,7 @@ mod tests {
             "token-a",
             &first_server,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -206,7 +206,7 @@ mod tests {
             "token-b",
             &second_server,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -218,7 +218,7 @@ mod tests {
         assert!(replaced.updated_at >= created.updated_at);
 
         let stored =
-            PushRegistration::find_by_account_pubkey(&account.pubkey, &whitenoise.database)
+            PushRegistration::find_by_account_pubkey(&account.pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .unwrap();
@@ -238,7 +238,7 @@ mod tests {
             "token-one",
             &server_pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -248,25 +248,31 @@ mod tests {
             "token-two",
             &server_pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
 
-        let deleted =
-            PushRegistration::delete_by_account_pubkey(&account_one.pubkey, &whitenoise.database)
-                .await
-                .unwrap();
+        let deleted = PushRegistration::delete_by_account_pubkey(
+            &account_one.pubkey,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(deleted);
 
-        let account_one_registration =
-            PushRegistration::find_by_account_pubkey(&account_one.pubkey, &whitenoise.database)
-                .await
-                .unwrap();
-        let account_two_registration =
-            PushRegistration::find_by_account_pubkey(&account_two.pubkey, &whitenoise.database)
-                .await
-                .unwrap();
+        let account_one_registration = PushRegistration::find_by_account_pubkey(
+            &account_one.pubkey,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let account_two_registration = PushRegistration::find_by_account_pubkey(
+            &account_two.pubkey,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(account_one_registration.is_none());
         assert_eq!(account_two_registration.unwrap().raw_token, "token-two");
@@ -285,7 +291,7 @@ mod tests {
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -298,7 +304,7 @@ mod tests {
         )
         .bind(shared_at_ms)
         .bind(account.pubkey.to_hex())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -310,7 +316,7 @@ mod tests {
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -322,7 +328,7 @@ mod tests {
             "token-b",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -342,7 +348,7 @@ mod tests {
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -355,7 +361,7 @@ mod tests {
         )
         .bind(updated_at_ms)
         .bind(account.pubkey.to_hex())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -367,7 +373,7 @@ mod tests {
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -379,7 +385,7 @@ mod tests {
             "token-b",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -398,7 +404,7 @@ mod tests {
             "   ",
             &server_pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap_err();

--- a/src/whitenoise/database/users.rs
+++ b/src/whitenoise/database/users.rs
@@ -824,7 +824,7 @@ mod tests {
         use crate::whitenoise::test_utils::create_mock_whitenoise;
 
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let users = User::all(&whitenoise.database).await.unwrap();
+        let users = User::all(&whitenoise.shared.database).await.unwrap();
         assert!(users.is_empty());
 
         let test_pubkey1 = nostr_sdk::Keys::generate().public_key();
@@ -847,10 +847,10 @@ mod tests {
             updated_at: chrono::Utc::now(),
         };
 
-        let saved1 = user1.save(&whitenoise.database).await.unwrap();
-        let saved2 = user2.save(&whitenoise.database).await.unwrap();
+        let saved1 = user1.save(&whitenoise.shared.database).await.unwrap();
+        let saved2 = user2.save(&whitenoise.shared.database).await.unwrap();
 
-        let all_users = User::all(&whitenoise.database).await.unwrap();
+        let all_users = User::all(&whitenoise.shared.database).await.unwrap();
         assert_eq!(all_users.len(), 2);
 
         let pubkeys: Vec<_> = all_users.iter().map(|u| u.pubkey).collect();
@@ -882,11 +882,11 @@ mod tests {
             metadata_known_at: None,
             updated_at: test_updated_at,
         };
-        let result = user.save(&whitenoise.database).await;
+        let result = user.save(&whitenoise.shared.database).await;
         assert!(result.is_ok());
 
         // Test that we can load it back (this verifies it was saved correctly)
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_user.is_ok());
 
         let loaded = loaded_user.unwrap();
@@ -924,11 +924,11 @@ mod tests {
             updated_at: test_updated_at,
         };
 
-        let result = user.save(&whitenoise.database).await;
+        let result = user.save(&whitenoise.shared.database).await;
         assert!(result.is_ok());
 
         // Verify it was saved correctly by loading it back
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_user.is_ok());
 
         let loaded = loaded_user.unwrap();
@@ -959,9 +959,9 @@ mod tests {
         };
         user.mark_metadata_known_now();
 
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
-        let loaded = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        let loaded = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(loaded.metadata_known_at.is_some());
@@ -983,9 +983,9 @@ mod tests {
         };
         user.mark_metadata_known_now();
 
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
-        let loaded = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        let loaded = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(loaded.metadata, Metadata::new());
@@ -1000,7 +1000,7 @@ mod tests {
 
         // Try to load a non-existent user
         let non_existent_pubkey = nostr_sdk::Keys::generate().public_key();
-        let result = User::find_by_pubkey(&non_existent_pubkey, &whitenoise.database).await;
+        let result = User::find_by_pubkey(&non_existent_pubkey, &whitenoise.shared.database).await;
 
         assert!(result.is_err());
         if let Err(WhitenoiseError::UserNotFound) = result {
@@ -1016,7 +1016,7 @@ mod tests {
 
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let result = User::find_by_pubkeys(&[], &whitenoise.database)
+        let result = User::find_by_pubkeys(&[], &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(result.is_empty());
@@ -1029,9 +1029,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let test_pubkey = nostr_sdk::Keys::generate().public_key();
 
-        let (user, created) = User::find_or_create_by_pubkey(&test_pubkey, &whitenoise.database)
-            .await
-            .unwrap();
+        let (user, created) =
+            User::find_or_create_by_pubkey(&test_pubkey, &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert!(created);
         assert_eq!(user.metadata, Metadata::new());
@@ -1053,9 +1054,9 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
-        let result = User::find_by_pubkeys(&[test_pubkey], &whitenoise.database)
+        let result = User::find_by_pubkeys(&[test_pubkey], &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1083,12 +1084,13 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: chrono::Utc::now(),
             };
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
         }
 
-        let result = User::find_by_pubkeys(&[pubkey1, pubkey2, pubkey3], &whitenoise.database)
-            .await
-            .unwrap();
+        let result =
+            User::find_by_pubkeys(&[pubkey1, pubkey2, pubkey3], &whitenoise.shared.database)
+                .await
+                .unwrap();
 
         assert_eq!(result.len(), 3);
 
@@ -1115,12 +1117,14 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
-        let result =
-            User::find_by_pubkeys(&[existing_pubkey, missing_pubkey], &whitenoise.database)
-                .await
-                .unwrap();
+        let result = User::find_by_pubkeys(
+            &[existing_pubkey, missing_pubkey],
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Should only contain the existing user
         assert_eq!(result.len(), 1);
@@ -1136,7 +1140,7 @@ mod tests {
         let pubkey1 = nostr_sdk::Keys::generate().public_key();
         let pubkey2 = nostr_sdk::Keys::generate().public_key();
 
-        let result = User::find_by_pubkeys(&[pubkey1, pubkey2], &whitenoise.database)
+        let result = User::find_by_pubkeys(&[pubkey1, pubkey2], &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1164,9 +1168,9 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
-        let result = User::find_by_pubkeys(&[test_pubkey], &whitenoise.database)
+        let result = User::find_by_pubkeys(&[test_pubkey], &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1208,11 +1212,11 @@ mod tests {
         };
 
         // Save the user
-        let save_result = original_user.save(&whitenoise.database).await;
+        let save_result = original_user.save(&whitenoise.shared.database).await;
         assert!(save_result.is_ok());
 
         // Load the user back
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
         assert!(loaded_user.is_ok());
 
         let user = loaded_user.unwrap();
@@ -1287,11 +1291,11 @@ mod tests {
             };
 
             // Save the user
-            let save_result = user.save(&whitenoise.database).await;
+            let save_result = user.save(&whitenoise.shared.database).await;
             assert!(save_result.is_ok(), "Failed to save {}", description);
 
             // Load the user back
-            let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database).await;
+            let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database).await;
             assert!(loaded_user.is_ok(), "Failed to load {}", description);
 
             let loaded = loaded_user.unwrap();
@@ -1354,11 +1358,11 @@ mod tests {
         };
 
         // Save the user first
-        let save_result = user.save(&whitenoise.database).await;
+        let save_result = user.save(&whitenoise.shared.database).await;
         assert!(save_result.is_ok());
 
         // Load the user to get the actual database ID
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1387,9 +1391,9 @@ mod tests {
         };
 
         // Save relays to database
-        relay1.save(&whitenoise.database).await.unwrap();
-        relay2.save(&whitenoise.database).await.unwrap();
-        relay3.save(&whitenoise.database).await.unwrap();
+        relay1.save(&whitenoise.shared.database).await.unwrap();
+        relay2.save(&whitenoise.shared.database).await.unwrap();
+        relay3.save(&whitenoise.shared.database).await.unwrap();
 
         // Insert into user_relays table
         sqlx::query(
@@ -1400,7 +1404,7 @@ mod tests {
         .bind("nip65")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -1412,7 +1416,7 @@ mod tests {
         .bind("nip65")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -1424,13 +1428,13 @@ mod tests {
         .bind("inbox")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // Test loading nostr relays
         let nostr_relays = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1442,7 +1446,7 @@ mod tests {
 
         // Test loading inbox relays
         let inbox_relays = loaded_user
-            .relays(RelayType::Inbox, &whitenoise.database)
+            .relays(RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1451,7 +1455,7 @@ mod tests {
 
         // Test loading key package relays (should be empty)
         let key_package_relays = loaded_user
-            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1479,14 +1483,14 @@ mod tests {
         };
 
         // Save the user first
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Test loading relays when none exist
         let result = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1513,8 +1517,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1526,7 +1530,7 @@ mod tests {
             created_at: test_timestamp,
             updated_at: test_timestamp,
         };
-        relay.save(&whitenoise.database).await.unwrap();
+        relay.save(&whitenoise.shared.database).await.unwrap();
 
         // Add the same relay for different types
         for relay_type in ["nip65", "inbox", "key_package"] {
@@ -1538,7 +1542,7 @@ mod tests {
             .bind(relay_type)
             .bind(test_timestamp.timestamp_millis())
             .bind(test_timestamp.timestamp_millis())
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
         }
@@ -1546,7 +1550,7 @@ mod tests {
         // Test each relay type returns the same relay
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = loaded_user
-                .relays(relay_type, &whitenoise.database)
+                .relays(relay_type, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1584,13 +1588,13 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user1.save(&whitenoise.database).await.unwrap();
-        user2.save(&whitenoise.database).await.unwrap();
+        user1.save(&whitenoise.shared.database).await.unwrap();
+        user2.save(&whitenoise.shared.database).await.unwrap();
 
-        let loaded_user1 = User::find_by_pubkey(&user1_pubkey, &whitenoise.database)
+        let loaded_user1 = User::find_by_pubkey(&user1_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
-        let loaded_user2 = User::find_by_pubkey(&user2_pubkey, &whitenoise.database)
+        let loaded_user2 = User::find_by_pubkey(&user2_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1611,8 +1615,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        relay1.save(&whitenoise.database).await.unwrap();
-        relay2.save(&whitenoise.database).await.unwrap();
+        relay1.save(&whitenoise.shared.database).await.unwrap();
+        relay2.save(&whitenoise.shared.database).await.unwrap();
 
         // Associate relay1 with user1 and relay2 with user2
         sqlx::query(
@@ -1623,7 +1627,7 @@ mod tests {
         .bind("nip65")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
@@ -1635,17 +1639,17 @@ mod tests {
         .bind("nip65")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // Test that each user gets only their own relays
         let user1_relays = loaded_user1
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         let user2_relays = loaded_user2
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1676,8 +1680,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1686,17 +1690,20 @@ mod tests {
 
         // Pre-create the relay in the database
         let existing_relay = Relay::new(&relay_url);
-        let saved_relay = existing_relay.save(&whitenoise.database).await.unwrap();
+        let saved_relay = existing_relay
+            .save(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Add relay association - should work with existing relay
         let result = loaded_user
-            .add_relay(&saved_relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&saved_relay, RelayType::Nip65, &whitenoise.shared.database)
             .await;
         assert!(result.is_ok());
 
         // Verify the relay was associated
         let user_relays = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(user_relays.len(), 1);
@@ -1723,8 +1730,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1732,7 +1739,7 @@ mod tests {
         let new_relay_url = nostr_sdk::RelayUrl::parse("wss://new-relay.example.com").unwrap();
 
         // Verify relay doesn't exist yet
-        let find_result = Relay::find_by_url(&new_relay_url, &whitenoise.database).await;
+        let find_result = Relay::find_by_url(&new_relay_url, &whitenoise.shared.database).await;
         assert!(find_result.is_err());
 
         // Create the relay (this is what find_or_create_relay would do)
@@ -1743,20 +1750,20 @@ mod tests {
 
         // Add relay association
         let result = loaded_user
-            .add_relay(&new_relay, RelayType::Inbox, &whitenoise.database)
+            .add_relay(&new_relay, RelayType::Inbox, &whitenoise.shared.database)
             .await;
         assert!(result.is_ok());
 
         // Verify the relay was associated
         let user_relays = loaded_user
-            .relays(RelayType::Inbox, &whitenoise.database)
+            .relays(RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(user_relays.len(), 1);
         assert_eq!(user_relays[0].url, new_relay_url);
 
         // Verify relay exists in database (since we created it)
-        let find_result = Relay::find_by_url(&new_relay_url, &whitenoise.database).await;
+        let find_result = Relay::find_by_url(&new_relay_url, &whitenoise.shared.database).await;
         assert!(find_result.is_ok());
     }
 
@@ -1780,8 +1787,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1792,26 +1799,26 @@ mod tests {
             .await
             .unwrap();
         loaded_user
-            .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Verify relay was added
         let user_relays = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(user_relays.len(), 1);
 
         // Remove the relay
         let result = loaded_user
-            .remove_relay(&relay, RelayType::Nip65, &whitenoise.database)
+            .remove_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
             .await;
         assert!(result.is_ok());
 
         // Verify relay was removed
         let user_relays = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(user_relays.len(), 0);
@@ -1837,8 +1844,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1847,7 +1854,11 @@ mod tests {
             nostr_sdk::RelayUrl::parse("wss://non-existent.example.com").unwrap();
         let non_existent_relay = Relay::new(&non_existent_url);
         let result = loaded_user
-            .remove_relay(&non_existent_relay, RelayType::Nip65, &whitenoise.database)
+            .remove_relay(
+                &non_existent_relay,
+                RelayType::Nip65,
+                &whitenoise.shared.database,
+            )
             .await;
 
         assert!(result.is_err());
@@ -1878,19 +1889,19 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
         // Create a relay in the database but don't associate it with the user
         let relay_url = nostr_sdk::RelayUrl::parse("wss://unassociated.example.com").unwrap();
         let relay = Relay::new(&relay_url);
-        let saved_relay = relay.save(&whitenoise.database).await.unwrap();
+        let saved_relay = relay.save(&whitenoise.shared.database).await.unwrap();
 
         // Try to remove the relay - it exists in database but not associated with user
         let result = loaded_user
-            .remove_relay(&saved_relay, RelayType::Nip65, &whitenoise.database)
+            .remove_relay(&saved_relay, RelayType::Nip65, &whitenoise.shared.database)
             .await;
 
         assert!(result.is_err());
@@ -1921,8 +1932,8 @@ mod tests {
             updated_at: test_timestamp,
         };
 
-        user.save(&whitenoise.database).await.unwrap();
-        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+        user.save(&whitenoise.shared.database).await.unwrap();
+        let loaded_user = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1938,7 +1949,7 @@ mod tests {
             updated_at: relay_updated_at,
         };
 
-        relay.save(&whitenoise.database).await.unwrap();
+        relay.save(&whitenoise.shared.database).await.unwrap();
 
         // Associate with user
         sqlx::query(
@@ -1949,13 +1960,13 @@ mod tests {
         .bind("nip65")
         .bind(test_timestamp.timestamp_millis())
         .bind(test_timestamp.timestamp_millis())
-        .execute(&whitenoise.database.pool)
+        .execute(&whitenoise.shared.database.pool)
         .await
         .unwrap();
 
         // Load relays and verify all properties
         let relays = loaded_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 

--- a/src/whitenoise/drafts.rs
+++ b/src/whitenoise/drafts.rs
@@ -96,7 +96,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -122,7 +122,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -148,7 +148,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -184,7 +184,7 @@ mod tests {
         GroupInformation::find_or_create_by_mls_group_id(
             &group_id,
             Some(GroupType::Group),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -99,6 +99,7 @@ impl Whitenoise {
             Ok(()) => {
                 // Record that we processed this event successfully
                 if let Err(e) = self
+                    .shared
                     .event_tracker
                     .track_processed_account_event(&event, &account.pubkey)
                     .await
@@ -121,7 +122,7 @@ impl Whitenoise {
                         if let Err(e) = Account::update_last_synced_max(
                             &account.pubkey,
                             created_ms,
-                            &self.database,
+                            &self.shared.database,
                         )
                         .await
                         {
@@ -155,7 +156,7 @@ impl Whitenoise {
                                 if let Err(e) = Account::update_last_synced_max(
                                     &account.pubkey,
                                     created_ms,
-                                    &self.database,
+                                    &self.shared.database,
                                 )
                                 .await
                                 {
@@ -228,10 +229,12 @@ impl Whitenoise {
 
         let hash_str = &subscription_id[..underscore_pos.unwrap()];
         // Get all accounts and find the one whose hash matches
-        let accounts = Account::all(&self.database).await?;
+        let accounts = Account::all(&self.shared.database).await?;
         for account in accounts.iter() {
-            let pubkey_hash =
-                hash_pubkey_for_subscription_id(self.relay_control.session_salt(), &account.pubkey);
+            let pubkey_hash = hash_pubkey_for_subscription_id(
+                self.shared.relay_control.session_salt(),
+                &account.pubkey,
+            );
             if pubkey_hash == hash_str {
                 return Ok(account.pubkey);
             }
@@ -259,7 +262,7 @@ impl Whitenoise {
             target_pubkey.to_hex()
         );
 
-        Account::find_by_pubkey(&target_pubkey, &self.database).await
+        Account::find_by_pubkey(&target_pubkey, &self.shared.database).await
     }
 
     /// Check if an account event should be skipped (not processed)
@@ -271,6 +274,7 @@ impl Whitenoise {
         account: &Account,
     ) -> Result<Option<&'static str>> {
         let already_processed = match self
+            .shared
             .event_tracker
             .already_processed_account_event(&event.id, &account.pubkey)
             .await
@@ -297,6 +301,7 @@ impl Whitenoise {
             Kind::MlsGroupMessage => false,
             Kind::GiftWrap => false,
             _ => match self
+                .shared
                 .event_tracker
                 .account_published_event(&event.id, &account.pubkey)
                 .await
@@ -455,7 +460,7 @@ mod tests {
 
         // Build the expected subscription hash for this account
         let mut hasher = Sha256::new();
-        hasher.update(whitenoise.relay_control.session_salt());
+        hasher.update(whitenoise.shared.relay_control.session_salt());
         hasher.update(account.pubkey.to_bytes());
         let hash = hasher.finalize();
         let pubkey_hash = format!("{:x}", hash)[..12].to_string();
@@ -474,6 +479,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -547,6 +553,7 @@ mod tests {
 
         assert!(
             whitenoise
+                .shared
                 .event_tracker
                 .already_processed_account_event(&event.id, &admin_account.pubkey)
                 .await
@@ -555,6 +562,7 @@ mod tests {
         );
         assert!(
             whitenoise
+                .shared
                 .event_tracker
                 .already_processed_account_event(&event.id, &member_account.pubkey)
                 .await
@@ -597,6 +605,7 @@ mod tests {
         let (whitenoise, _d, _l) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -630,6 +639,7 @@ mod tests {
         // Event must NOT be tracked as processed
         assert!(
             !whitenoise
+                .shared
                 .event_tracker
                 .already_processed_account_event(&event.id, &account.pubkey)
                 .await

--- a/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
@@ -41,12 +41,13 @@ impl Whitenoise {
 
         let contacts = crate::nostr_manager::utils::pubkeys_from_event(&event);
         let newly_created = account
-            .update_follows_from_event(contacts.clone(), &self.database)
+            .update_follows_from_event(contacts.clone(), &self.shared.database)
             .await?;
 
         self.schedule_background_user_fetch(session, &contacts);
 
-        self.event_tracker
+        self.shared
+            .event_tracker
             .track_processed_account_event(&event, &account.pubkey)
             .await?;
 
@@ -63,7 +64,7 @@ impl Whitenoise {
 
     #[perf_instrument("event_handlers")]
     async fn should_skip_contact_list(&self, event: &Event, account_id: i64) -> Result<bool> {
-        if ProcessedEvent::exists(&event.id, Some(account_id), &self.database).await? {
+        if ProcessedEvent::exists(&event.id, Some(account_id), &self.shared.database).await? {
             tracing::debug!(
                 target: "whitenoise::handle_contact_list",
                 "Skipping already processed event {}",
@@ -83,7 +84,8 @@ impl Whitenoise {
     async fn is_stale_contact_list(&self, event: &Event, account_id: i64) -> Result<bool> {
         let event_time = timestamp_to_datetime(event.created_at)?;
         let newest_time =
-            ProcessedEvent::newest_contact_list_timestamp(account_id, &self.database).await?;
+            ProcessedEvent::newest_contact_list_timestamp(account_id, &self.shared.database)
+                .await?;
 
         match newest_time {
             Some(newest) if event_time.timestamp_millis() <= newest.timestamp_millis() => {
@@ -134,7 +136,7 @@ impl Whitenoise {
                 total,
             );
 
-            whitenoise.discovery_sync_worker.request_rebuild();
+            whitenoise.shared.discovery_sync_worker.request_rebuild();
 
             let fetched = Self::fetch_users_batch(whitenoise, &pubkeys, cancel_rx).await;
 
@@ -160,6 +162,7 @@ impl Whitenoise {
         unique_pubkeys.dedup();
 
         let Some(context_relay) = whitenoise
+            .shared
             .relay_control
             .discovery()
             .relays()
@@ -193,7 +196,7 @@ impl Whitenoise {
                 } else {
                     tokio::select! {
                         result = whitenoise
-                            .relay_control
+                            .shared.relay_control
                             .discovery()
                             .fetch_events(filter, CONTACT_LIST_CATCH_UP_TIMEOUT) => Some(result),
                         _ = cancel_rx.changed() => {
@@ -208,6 +211,7 @@ impl Whitenoise {
             } else {
                 Some(
                     whitenoise
+                        .shared
                         .relay_control
                         .discovery()
                         .fetch_events(filter, CONTACT_LIST_CATCH_UP_TIMEOUT)
@@ -316,6 +320,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -334,7 +339,7 @@ mod tests {
             .unwrap();
 
         // Verify follows were created and deduplicated
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 2, "Duplicates should be deduplicated");
 
         let follow_pubkeys: Vec<PublicKey> = follows.iter().map(|u| u.pubkey).collect();
@@ -344,14 +349,14 @@ mod tests {
         // Verify event was tracked as processed
         let account_id = account.id.unwrap();
         assert!(
-            ProcessedEvent::exists(&event.id, Some(account_id), &whitenoise.database)
+            ProcessedEvent::exists(&event.id, Some(account_id), &whitenoise.shared.database)
                 .await
                 .unwrap()
         );
 
         // Verify timestamp was recorded for future ordering checks
         let newest_timestamp =
-            ProcessedEvent::newest_contact_list_timestamp(account_id, &whitenoise.database)
+            ProcessedEvent::newest_contact_list_timestamp(account_id, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .unwrap();
@@ -368,6 +373,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -386,7 +392,7 @@ mod tests {
             .unwrap();
 
         // Should still have exactly 1 follow
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 1);
     }
 
@@ -396,6 +402,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -423,7 +430,7 @@ mod tests {
             .await
             .unwrap();
 
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 1);
         assert_eq!(follows[0].pubkey, current_contact, "Older event ignored");
 
@@ -435,7 +442,7 @@ mod tests {
             .await
             .unwrap();
 
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 1);
         assert_eq!(
             follows[0].pubkey, current_contact,
@@ -449,6 +456,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let session = whitenoise.require_session(&account.pubkey).unwrap();
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)
             .unwrap();
@@ -467,7 +475,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            account.follows(&whitenoise.database).await.unwrap().len(),
+            account
+                .follows(&whitenoise.shared.database)
+                .await
+                .unwrap()
+                .len(),
             1
         );
 
@@ -478,7 +490,7 @@ mod tests {
             .await
             .unwrap();
 
-        let follows = account.follows(&whitenoise.database).await.unwrap();
+        let follows = account.follows(&whitenoise.shared.database).await.unwrap();
         assert_eq!(follows.len(), 1);
         assert_eq!(follows[0].pubkey, second_contact);
 
@@ -491,7 +503,7 @@ mod tests {
 
         assert!(
             account
-                .follows(&whitenoise.database)
+                .follows(&whitenoise.shared.database)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -506,6 +518,7 @@ mod tests {
         let account1 = whitenoise.create_identity().await.unwrap();
         let session1 = whitenoise.require_session(&account1.pubkey).unwrap();
         let keys1 = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account1.pubkey)
             .unwrap();
@@ -513,6 +526,7 @@ mod tests {
         let account2 = whitenoise.create_identity().await.unwrap();
         let session2 = whitenoise.require_session(&account2.pubkey).unwrap();
         let keys2 = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account2.pubkey)
             .unwrap();
@@ -537,8 +551,8 @@ mod tests {
             .await
             .unwrap();
 
-        let follows1 = account1.follows(&whitenoise.database).await.unwrap();
-        let follows2 = account2.follows(&whitenoise.database).await.unwrap();
+        let follows1 = account1.follows(&whitenoise.shared.database).await.unwrap();
+        let follows2 = account2.follows(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(follows1.len(), 1);
         assert_eq!(follows2.len(), 1);
@@ -569,6 +583,7 @@ mod tests {
         };
 
         let keys = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&real_account.pubkey)
             .unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -107,7 +107,7 @@ impl Whitenoise {
         match PublishedKeyPackage::find_by_event_id(
             &account.pubkey,
             &key_package_event_id.to_hex(),
-            &self.database,
+            &self.shared.database,
         )
         .await
         {
@@ -176,7 +176,7 @@ impl Whitenoise {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        account_group.save(&self.database).await?;
+        account_group.save(&self.shared.database).await?;
         tracing::debug!(target: "whitenoise::event_processor::process_welcome", "New AccountGroup created and saved");
 
         // Now accept the welcome to finalize MLS membership
@@ -396,7 +396,7 @@ impl Whitenoise {
         if let Err(e) = PublishedKeyPackage::mark_consumed(
             &account.pubkey,
             &key_package_event_id.to_hex(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         {
@@ -533,6 +533,7 @@ mod tests {
                 .unwrap(),
         );
         let key_pkg_event = whitenoise
+            .shared
             .relay_control
             .fetch_user_key_package(member_pubkey, &relays_urls)
             .await
@@ -568,6 +569,7 @@ mod tests {
 
         // Use the creator's real keys as signer to build the giftwrap
         let creator_signer = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&creator_account.pubkey)
             .unwrap();
@@ -598,6 +600,7 @@ mod tests {
         welcome_rumor.ensure_id();
 
         let creator_signer = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&creator_account.pubkey)
             .unwrap();
@@ -650,6 +653,7 @@ mod tests {
         welcome_rumor.ensure_id();
 
         let creator_signer = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&creator_account.pubkey)
             .unwrap();
@@ -812,6 +816,7 @@ mod tests {
 
         // Group plane should contain the group
         let plane_count = whitenoise
+            .shared
             .relay_control
             .group_plane_account_group_count(&creator_account.pubkey)
             .await;
@@ -976,6 +981,7 @@ mod tests {
         );
         assert_eq!(
             whitenoise
+                .shared
                 .relay_control
                 .group_plane_account_group_count(&member_account.pubkey)
                 .await,
@@ -1012,6 +1018,7 @@ mod tests {
 
         // The new group must be in the group plane
         let plane_count = whitenoise
+            .shared
             .relay_control
             .group_plane_account_group_count(&member_account.pubkey)
             .await;
@@ -1048,6 +1055,7 @@ mod tests {
 
         // Remove the private key so signer-dependent operations fail
         whitenoise
+            .shared
             .secrets_store
             .remove_private_key_for_pubkey(&account.pubkey)
             .unwrap();
@@ -1088,7 +1096,7 @@ mod tests {
 
         // Corrupt the database by dropping the published_key_packages table
         sqlx::query("DROP TABLE published_key_packages")
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
 

--- a/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
@@ -14,20 +14,20 @@ impl Whitenoise {
     #[perf_instrument("event_handlers")]
     pub async fn handle_metadata(&self, event: Event) -> Result<()> {
         let (mut user, newly_created) =
-            User::find_or_create_by_pubkey(&event.pubkey, &self.database).await?;
+            User::find_or_create_by_pubkey(&event.pubkey, &self.shared.database).await?;
         match Metadata::from_json(&event.content) {
             Ok(metadata) => {
                 let should_update = user
-                    .should_update_metadata(&event, newly_created, &self.database)
+                    .should_update_metadata(&event, newly_created, &self.shared.database)
                     .await?;
 
                 if should_update {
                     user.metadata = metadata;
                     user.mark_metadata_known_now();
-                    let saved_user = user.save(&self.database).await?;
+                    let saved_user = user.save(&self.shared.database).await?;
                     let user_pubkey = saved_user.pubkey;
 
-                    self.user_stream_manager.emit(
+                    self.shared.user_stream_manager.emit(
                         &user_pubkey,
                         UserUpdate {
                             trigger: UserUpdateTrigger::MetadataChanged,
@@ -35,7 +35,8 @@ impl Whitenoise {
                         },
                     );
 
-                    self.event_tracker
+                    self.shared
+                        .event_tracker
                         .track_processed_global_event(&event)
                         .await?;
 
@@ -47,10 +48,10 @@ impl Whitenoise {
                     );
                 } else if user.metadata_is_unknown() {
                     user.mark_metadata_known_now();
-                    let saved_user = user.save(&self.database).await?;
+                    let saved_user = user.save(&self.shared.database).await?;
                     let user_pubkey = saved_user.pubkey;
 
-                    self.user_stream_manager.emit(
+                    self.shared.user_stream_manager.emit(
                         &user_pubkey,
                         UserUpdate {
                             trigger: UserUpdateTrigger::MetadataChanged,
@@ -186,7 +187,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         ProcessedEvent::create(
             &event.id,
@@ -194,7 +195,7 @@ mod tests {
             Some(Utc::now()),
             Some(Kind::Metadata),
             Some(&keys.public_key()),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -9,6 +9,7 @@ use nostr_sdk::prelude::*;
 #[cfg(test)]
 use crate::whitenoise::database::aggregated_messages::PaginationOptions;
 use crate::{
+    nostr_manager::parser::ContentParser,
     perf_instrument, perf_span,
     whitenoise::{
         Whitenoise,
@@ -493,7 +494,7 @@ impl Whitenoise {
         let mut chat_message = self
             .shared
             .message_aggregator
-            .process_single_message(message, &self.content_parser, media_files)
+            .process_single_message(message, &ContentParser::new(), media_files)
             .await?;
 
         // Preserve existing delivery status for relay echoes of locally-sent messages.

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -100,10 +100,13 @@ impl Whitenoise {
         // MDK has already processed the message (updating MLS state), but we
         // must not write application-level data for a group the user deleted.
         if let Some(group_id) = extract_group_id(&outcome.result) {
-            let has_account_group =
-                AccountGroup::find_by_account_and_group(&account.pubkey, group_id, &self.database)
-                    .await?
-                    .is_some();
+            let has_account_group = AccountGroup::find_by_account_and_group(
+                &account.pubkey,
+                group_id,
+                &self.shared.database,
+            )
+            .await?
+            .is_some();
 
             if !has_account_group {
                 tracing::info!(
@@ -457,17 +460,21 @@ impl Whitenoise {
         trigger: UpdateTrigger,
         message: ChatMessage,
     ) {
-        self.message_stream_manager
+        self.shared
+            .message_stream_manager
             .emit(group_id, MessageUpdate { trigger, message });
     }
 
     /// Gets the ID of the last message in a group (if any).
     async fn get_last_message_id(&self, group_id: &GroupId) -> Option<String> {
-        AggregatedMessage::find_last_by_group_ids(std::slice::from_ref(group_id), &self.database)
-            .await
-            .ok()
-            .and_then(|v| v.into_iter().next())
-            .map(|s| s.message_id.to_hex())
+        AggregatedMessage::find_last_by_group_ids(
+            std::slice::from_ref(group_id),
+            &self.shared.database,
+        )
+        .await
+        .ok()
+        .and_then(|v| v.into_iter().next())
+        .map(|s| s.message_id.to_hex())
     }
 
     /// Cache a new chat message and return it for emission.
@@ -481,9 +488,10 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<ChatMessage> {
-        let media_files = MediaFile::find_by_group(&self.database, group_id).await?;
+        let media_files = MediaFile::find_by_group(&self.shared.database, group_id).await?;
 
         let mut chat_message = self
+            .shared
             .message_aggregator
             .process_single_message(message, &self.content_parser, media_files)
             .await?;
@@ -495,7 +503,7 @@ impl Whitenoise {
             &chat_message.id,
             group_id,
             account_pubkey,
-            &self.database,
+            &self.shared.database,
         )
         .await?
             && existing_message.delivery_status.is_some()
@@ -503,8 +511,13 @@ impl Whitenoise {
             chat_message.delivery_status = existing_message.delivery_status;
         }
 
-        AggregatedMessage::insert_message(&chat_message, group_id, account_pubkey, &self.database)
-            .await?;
+        AggregatedMessage::insert_message(
+            &chat_message,
+            group_id,
+            account_pubkey,
+            &self.shared.database,
+        )
+        .await?;
 
         // Apply orphaned reactions/deletions - modifies in-place and returns final state
         let final_message = self
@@ -540,7 +553,7 @@ impl Whitenoise {
             &message.id.to_string(),
             group_id,
             account_pubkey,
-            &self.database,
+            &self.shared.database,
         )
         .await?
         {
@@ -553,7 +566,7 @@ impl Whitenoise {
             return Ok(None);
         }
 
-        AggregatedMessage::insert_reaction(message, group_id, &self.database).await?;
+        AggregatedMessage::insert_reaction(message, group_id, &self.shared.database).await?;
 
         let result = self
             .apply_reaction_to_target(account_pubkey, message, group_id)
@@ -589,16 +602,20 @@ impl Whitenoise {
     ) -> Result<Option<ChatMessage>> {
         let target_id = extract_reaction_target_id(&reaction.tags)?;
 
-        let Some(mut target) =
-            AggregatedMessage::find_by_id(&target_id, group_id, account_pubkey, &self.database)
-                .await?
+        let Some(mut target) = AggregatedMessage::find_by_id(
+            &target_id,
+            group_id,
+            account_pubkey,
+            &self.shared.database,
+        )
+        .await?
         else {
             return Ok(None); // True orphan: target not yet cached
         };
 
         let emoji = emoji_utils::validate_and_normalize_reaction(
             &reaction.content,
-            self.message_aggregator.config().normalize_emoji,
+            self.shared.message_aggregator.config().normalize_emoji,
         )?;
 
         reaction_handler::add_reaction_to_message(
@@ -613,7 +630,7 @@ impl Whitenoise {
             &target.id,
             group_id,
             &target.reactions,
-            &self.database,
+            &self.shared.database,
         )
         .await?;
 
@@ -638,7 +655,7 @@ impl Whitenoise {
             &message.id.to_string(),
             group_id,
             account_pubkey,
-            &self.database,
+            &self.shared.database,
         )
         .await?
         {
@@ -651,7 +668,7 @@ impl Whitenoise {
             return Ok(Vec::new());
         }
 
-        AggregatedMessage::insert_deletion(message, group_id, &self.database).await?;
+        AggregatedMessage::insert_deletion(message, group_id, &self.shared.database).await?;
 
         let updates = self
             .apply_deletions_to_targets(account_pubkey, message, group_id)
@@ -700,7 +717,8 @@ impl Whitenoise {
     ) -> Result<Option<(UpdateTrigger, ChatMessage)>> {
         // Check if target is a reaction
         if let Some(reaction) =
-            AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.database).await?
+            AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.shared.database)
+                .await?
         {
             let parent_update = self
                 .remove_reaction_from_parent(account_pubkey, &reaction, group_id)
@@ -709,23 +727,27 @@ impl Whitenoise {
                 target_id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.database,
+                &self.shared.database,
             )
             .await?;
             return Ok(parent_update.map(|msg| (UpdateTrigger::ReactionRemoved, msg)));
         }
 
         // Check if target is a message
-        if let Some(mut msg) =
-            AggregatedMessage::find_by_id(target_id, group_id, account_pubkey, &self.database)
-                .await?
+        if let Some(mut msg) = AggregatedMessage::find_by_id(
+            target_id,
+            group_id,
+            account_pubkey,
+            &self.shared.database,
+        )
+        .await?
         {
             msg.is_deleted = true;
             AggregatedMessage::mark_deleted(
                 target_id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.database,
+                &self.shared.database,
             )
             .await?;
             return Ok(Some((UpdateTrigger::MessageDeleted, msg)));
@@ -736,7 +758,7 @@ impl Whitenoise {
             target_id,
             group_id,
             &deletion_event_id.to_string(),
-            &self.database,
+            &self.shared.database,
         )
         .await?;
         Ok(None)
@@ -753,9 +775,13 @@ impl Whitenoise {
             return Ok(None);
         };
 
-        let Some(mut parent) =
-            AggregatedMessage::find_by_id(&parent_id, group_id, account_pubkey, &self.database)
-                .await?
+        let Some(mut parent) = AggregatedMessage::find_by_id(
+            &parent_id,
+            group_id,
+            account_pubkey,
+            &self.shared.database,
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -765,7 +791,7 @@ impl Whitenoise {
                 &parent_id,
                 group_id,
                 &parent.reactions,
-                &self.database,
+                &self.shared.database,
             )
             .await?;
 
@@ -791,13 +817,19 @@ impl Whitenoise {
         mut message: ChatMessage,
         group_id: &GroupId,
     ) -> Result<ChatMessage> {
-        let orphaned_reactions =
-            AggregatedMessage::find_orphaned_reactions(&message.id, group_id, &self.database)
-                .await?;
+        let orphaned_reactions = AggregatedMessage::find_orphaned_reactions(
+            &message.id,
+            group_id,
+            &self.shared.database,
+        )
+        .await?;
 
-        let orphaned_deletions =
-            AggregatedMessage::find_orphaned_deletions(&message.id, group_id, &self.database)
-                .await?;
+        let orphaned_deletions = AggregatedMessage::find_orphaned_deletions(
+            &message.id,
+            group_id,
+            &self.shared.database,
+        )
+        .await?;
 
         if !orphaned_reactions.is_empty() || !orphaned_deletions.is_empty() {
             tracing::info!(
@@ -813,7 +845,7 @@ impl Whitenoise {
         for reaction in orphaned_reactions {
             let reaction_emoji = match emoji_utils::validate_and_normalize_reaction(
                 &reaction.content,
-                self.message_aggregator.config().normalize_emoji,
+                self.shared.message_aggregator.config().normalize_emoji,
             ) {
                 Ok(emoji) => emoji,
                 Err(e) => {
@@ -842,7 +874,7 @@ impl Whitenoise {
                 &message.id,
                 group_id,
                 &message.reactions,
-                &self.database,
+                &self.shared.database,
             )
             .await?;
         }
@@ -854,7 +886,7 @@ impl Whitenoise {
                 &message.id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.database,
+                &self.shared.database,
             )
             .await?;
         }
@@ -948,7 +980,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -975,7 +1007,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1006,7 +1038,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1067,7 +1099,7 @@ mod tests {
             &group.mls_group_id,
             &creator_account.pubkey,
             &DeliveryStatus::Sent(1),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1083,7 +1115,7 @@ mod tests {
             &message_id.to_string(),
             &group.mls_group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1193,7 +1225,7 @@ mod tests {
         let orphaned_reactions = AggregatedMessage::find_orphaned_reactions(
             &future_message_id.to_string(),
             group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1227,7 +1259,7 @@ mod tests {
             &future_message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1335,7 +1367,7 @@ mod tests {
             &future_message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1482,7 +1514,7 @@ mod tests {
             &group.mls_group_id,
             &creator_account.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1538,7 +1570,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1556,7 +1588,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1611,7 +1643,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1632,7 +1664,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1664,7 +1696,7 @@ mod tests {
             &token_tag.server_pubkey,
             Some(&token_tag.relay_hint),
             &token_tag.encrypted_token.to_base64(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1680,7 +1712,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1690,7 +1722,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1840,7 +1872,7 @@ mod tests {
             &stale_token.server_pubkey,
             Some(&stale_token.relay_hint),
             &stale_token.encrypted_token.to_base64(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1863,7 +1895,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_two.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2065,6 +2097,7 @@ mod tests {
             .await;
 
         let tracked_after_first = whitenoise
+            .shared
             .event_tracker
             .already_processed_account_event(&event_id, &creator_account.pubkey)
             .await
@@ -2084,6 +2117,7 @@ mod tests {
 
         // Still tracked — no double-entry, no crash.
         let tracked_after_second = whitenoise
+            .shared
             .event_tracker
             .already_processed_account_event(&event_id, &creator_account.pubkey)
             .await

--- a/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
@@ -19,7 +19,7 @@ impl Whitenoise {
         let already_processed = ProcessedEvent::exists(
             &event.id,
             None, // Global events (relay lists)
-            &self.database,
+            &self.shared.database,
         )
         .await?;
 
@@ -34,7 +34,7 @@ impl Whitenoise {
         }
 
         let (user, _newly_created) =
-            User::find_or_create_by_pubkey(&event.pubkey, &self.database).await?;
+            User::find_or_create_by_pubkey(&event.pubkey, &self.shared.database).await?;
 
         let relay_type = event.kind.into();
         let relay_urls = crate::nostr_manager::utils::relay_urls_from_event(&event);
@@ -54,7 +54,7 @@ impl Whitenoise {
             event_created_at,
             Some(event.kind),
             Some(&event.pubkey),
-            &self.database,
+            &self.shared.database,
         )
         .await?;
 
@@ -81,21 +81,22 @@ impl Whitenoise {
                 }
             };
 
-            let account = match Account::find_by_pubkey(&user_pubkey, &whitenoise.database).await {
-                Ok(account) => Some(account),
-                Err(WhitenoiseError::AccountNotFound) => None,
-                Err(error) => {
-                    tracing::warn!(
-                        target: "whitenoise::handle_relay_list",
-                        "Failed to look up account for relay list refresh {}: {}",
-                        event_pubkey,
-                        error
-                    );
-                    None
-                }
-            };
+            let account =
+                match Account::find_by_pubkey(&user_pubkey, &whitenoise.shared.database).await {
+                    Ok(account) => Some(account),
+                    Err(WhitenoiseError::AccountNotFound) => None,
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "whitenoise::handle_relay_list",
+                            "Failed to look up account for relay list refresh {}: {}",
+                            event_pubkey,
+                            error
+                        );
+                        None
+                    }
+                };
 
-            whitenoise.discovery_sync_worker.request_rebuild();
+            whitenoise.shared.discovery_sync_worker.request_rebuild();
 
             if let Some(account) = account
                 && let Err(error) = whitenoise.refresh_account_subscriptions(&account).await
@@ -146,7 +147,7 @@ mod tests {
             .await
             .unwrap();
         let relays = user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(relays.len(), 2);
@@ -162,7 +163,7 @@ mod tests {
         whitenoise.handle_relay_list(event.clone()).await.unwrap();
 
         // Event should be recorded exactly once
-        let processed = ProcessedEvent::exists(&event.id, None, &whitenoise.database)
+        let processed = ProcessedEvent::exists(&event.id, None, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(processed);
@@ -173,7 +174,7 @@ mod tests {
             .await
             .unwrap();
         let relays = user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(relays.len(), 1);

--- a/src/whitenoise/event_processor/global_event_processor.rs
+++ b/src/whitenoise/event_processor/global_event_processor.rs
@@ -37,6 +37,7 @@ impl Whitenoise {
         match result {
             Ok(()) => {
                 if let Err(e) = self
+                    .shared
                     .event_tracker
                     .track_processed_global_event(&event)
                     .await
@@ -65,6 +66,7 @@ impl Whitenoise {
     #[perf_instrument("event_processor")]
     async fn should_skip_global_event_processing(&self, event: &Event) -> Option<&'static str> {
         let already_processed = match self
+            .shared
             .event_tracker
             .already_processed_global_event(&event.id)
             .await
@@ -85,7 +87,12 @@ impl Whitenoise {
         }
 
         // For global events, check if WE published this event
-        let should_skip = match self.event_tracker.global_published_event(&event.id).await {
+        let should_skip = match self
+            .shared
+            .event_tracker
+            .global_published_event(&event.id)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 tracing::error!(

--- a/src/whitenoise/follows.rs
+++ b/src/whitenoise/follows.rs
@@ -26,11 +26,12 @@ impl Whitenoise {
     )]
     #[perf_instrument("follows")]
     pub async fn follow_user(&self, account: &Account, pubkey: &PublicKey) -> Result<()> {
-        let (user, newly_created) = User::find_or_create_by_pubkey(pubkey, &self.database).await?;
+        let (user, newly_created) =
+            User::find_or_create_by_pubkey(pubkey, &self.shared.database).await?;
 
         if newly_created {
             self.start_background_user_resolution_if_unknown(user.pubkey);
-            self.discovery_sync_worker.request_rebuild();
+            self.shared.discovery_sync_worker.request_rebuild();
         }
 
         let session = self

--- a/src/whitenoise/group_information.rs
+++ b/src/whitenoise/group_information.rs
@@ -74,7 +74,7 @@ impl GroupInformation {
         let (group_info, _was_created) = Self::find_or_create_by_mls_group_id(
             mls_group_id,
             Some(group_type),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await?;
         Ok(group_info)
@@ -94,7 +94,7 @@ impl GroupInformation {
         let (group_info, _was_created) = GroupInformation::find_or_create_by_mls_group_id(
             mls_group_id,
             Some(Self::infer_group_type_from_group_name(&group.name)),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await?;
         Ok(group_info)
@@ -109,7 +109,7 @@ impl GroupInformation {
         whitenoise: &Whitenoise,
     ) -> Result<Vec<GroupInformation>, WhitenoiseError> {
         let mdk = whitenoise.create_mdk_for_account(account_pubkey)?;
-        Self::get_by_mls_group_ids_with_mdk(mls_group_ids, &mdk, &whitenoise.database).await
+        Self::get_by_mls_group_ids_with_mdk(mls_group_ids, &mdk, &whitenoise.shared.database).await
     }
 
     /// Get group information for multiple MLS group IDs using an existing MDK instance.

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -330,20 +330,6 @@ impl Whitenoise {
         session.groups().visible().await
     }
 
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::groups().visible_with_info() instead."
-    )]
-    pub async fn visible_groups_with_info(
-        &self,
-        account: &Account,
-    ) -> Result<Vec<GroupWithInfoAndMembership>> {
-        let session = self
-            .session(&account.pubkey)
-            .ok_or(WhitenoiseError::AccountNotFound)?;
-        session.groups().visible_with_info().await
-    }
-
     #[deprecated(since = "0.0.0", note = "Use AccountSession::groups().get() instead.")]
     pub async fn group(&self, account: &Account, group_id: &GroupId) -> Result<group_types::Group> {
         let session = self
@@ -1607,7 +1593,13 @@ mod tests {
             .await
             .unwrap();
 
-        let mut with_info = whitenoise.visible_groups_with_info(&account).await.unwrap();
+        let mut with_info = whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .groups()
+            .visible_with_info()
+            .await
+            .unwrap();
 
         // Both groups are visible; GroupInformation is included for each.
         assert_eq!(with_info.len(), 2, "Both groups should be returned");
@@ -1651,7 +1643,13 @@ mod tests {
             .unwrap();
         ag_declined.decline(&whitenoise).await.unwrap();
 
-        let with_info = whitenoise.visible_groups_with_info(&account).await.unwrap();
+        let with_info = whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .groups()
+            .visible_with_info()
+            .await
+            .unwrap();
 
         assert_eq!(with_info.len(), 1, "Declined group should be excluded");
         assert_eq!(with_info[0].group.mls_group_id, group_accepted.mls_group_id);
@@ -1685,7 +1683,10 @@ mod tests {
             .unwrap();
 
         let non_dms: Vec<_> = whitenoise
-            .visible_groups_with_info(&account)
+            .session(&account.pubkey)
+            .unwrap()
+            .groups()
+            .visible_with_info()
             .await
             .unwrap()
             .into_iter()

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -35,12 +35,16 @@ impl Whitenoise {
         fallback_account: &Account,
         context: &'static str,
     ) -> Result<Vec<Relay>> {
-        let inbox_relays = member.relays(RelayType::Inbox, &self.database).await?;
+        let inbox_relays = member
+            .relays(RelayType::Inbox, &self.shared.database)
+            .await?;
         if !inbox_relays.is_empty() {
             return Ok(inbox_relays);
         }
 
-        let nip65_relays = member.relays(RelayType::Nip65, &self.database).await?;
+        let nip65_relays = member
+            .relays(RelayType::Nip65, &self.shared.database)
+            .await?;
         if !nip65_relays.is_empty() {
             return Ok(nip65_relays);
         }
@@ -74,7 +78,7 @@ impl Whitenoise {
     /// Resolves a single member for group creation: finds or creates the user record,
     /// syncs relay lists for new users, fetches and validates the key package.
     async fn resolve_member_key_package(&self, pk: &PublicKey) -> Result<(User, Event)> {
-        let (user, created) = User::find_or_create_by_pubkey(pk, &self.database).await?;
+        let (user, created) = User::find_or_create_by_pubkey(pk, &self.shared.database).await?;
         if created && let Err(e) = user.update_relay_lists(self).await {
             tracing::warn!(
                 target: "whitenoise::groups",
@@ -269,6 +273,7 @@ impl Whitenoise {
                             Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
                         whitenoise
+                            .shared
                             .relay_control
                             .publish_welcome(
                                 &member_pubkey,
@@ -428,7 +433,8 @@ impl Whitenoise {
         let mut users = Vec::new();
 
         for pk in members.iter() {
-            let (user, newly_created) = User::find_or_create_by_pubkey(pk, &self.database).await?;
+            let (user, newly_created) =
+                User::find_or_create_by_pubkey(pk, &self.shared.database).await?;
 
             if newly_created && let Err(e) = user.update_relay_lists(self).await {
                 tracing::warn!(
@@ -438,7 +444,9 @@ impl Whitenoise {
                     e
                 );
             }
-            let mut relays_to_use = user.relays(RelayType::KeyPackage, &self.database).await?;
+            let mut relays_to_use = user
+                .relays(RelayType::KeyPackage, &self.shared.database)
+                .await?;
             if relays_to_use.is_empty() {
                 tracing::warn!(
                     target: "whitenoise::accounts::groups::add_members_to_group",
@@ -449,6 +457,7 @@ impl Whitenoise {
             }
             let relays_to_use_urls = Relay::urls(&relays_to_use);
             let some_event = self
+                .shared
                 .relay_control
                 .fetch_user_key_package(*pk, &relays_to_use_urls)
                 .await?;
@@ -517,7 +526,8 @@ impl Whitenoise {
 
             let relay_urls = Relay::urls(&relays_to_use);
 
-            self.relay_control
+            self.shared
+                .relay_control
                 .publish_welcome(
                     &member_pubkey,
                     welcome_rumor.clone(),
@@ -694,11 +704,12 @@ mod tests {
         let mut member_pubkeys = Vec::new();
         for _ in 0..2 {
             let member_account = whitenoise.create_identity().await.unwrap();
-            let member_user = User::find_by_pubkey(&member_account.pubkey, &whitenoise.database)
-                .await
-                .unwrap();
+            let member_user =
+                User::find_by_pubkey(&member_account.pubkey, &whitenoise.shared.database)
+                    .await
+                    .unwrap();
             creator_account
-                .follow_user(&member_user, &whitenoise.database)
+                .follow_user(&member_user, &whitenoise.shared.database)
                 .await
                 .unwrap();
             member_pubkeys.push(member_account.pubkey);
@@ -1248,9 +1259,12 @@ mod tests {
         relay_type: RelayType,
         relay_urls: &[&str],
     ) -> Vec<RelayUrl> {
-        let existing_relays = user.relays(relay_type, &whitenoise.database).await.unwrap();
+        let existing_relays = user
+            .relays(relay_type, &whitenoise.shared.database)
+            .await
+            .unwrap();
         for relay in existing_relays {
-            user.remove_relay(&relay, relay_type, &whitenoise.database)
+            user.remove_relay(&relay, relay_type, &whitenoise.shared.database)
                 .await
                 .unwrap();
         }
@@ -1262,7 +1276,7 @@ mod tests {
                 .find_or_create_relay_by_url(&relay_url)
                 .await
                 .unwrap();
-            user.add_relay(&relay, relay_type, &whitenoise.database)
+            user.add_relay(&relay, relay_type, &whitenoise.shared.database)
                 .await
                 .unwrap();
             configured_urls.push(relay_url);
@@ -1277,7 +1291,10 @@ mod tests {
         let fallback_account = whitenoise.create_identity().await.unwrap();
         let member_account = whitenoise.create_identity().await.unwrap();
 
-        let fallback_user = fallback_account.user(&whitenoise.database).await.unwrap();
+        let fallback_user = fallback_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(
             &whitenoise,
             &fallback_user,
@@ -1286,7 +1303,10 @@ mod tests {
         )
         .await;
 
-        let member_user = member_account.user(&whitenoise.database).await.unwrap();
+        let member_user = member_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(
             &whitenoise,
             &member_user,
@@ -1323,7 +1343,10 @@ mod tests {
         let fallback_account = whitenoise.create_identity().await.unwrap();
         let member_account = whitenoise.create_identity().await.unwrap();
 
-        let fallback_user = fallback_account.user(&whitenoise.database).await.unwrap();
+        let fallback_user = fallback_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(
             &whitenoise,
             &fallback_user,
@@ -1332,7 +1355,10 @@ mod tests {
         )
         .await;
 
-        let member_user = member_account.user(&whitenoise.database).await.unwrap();
+        let member_user = member_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         let nip65_urls = set_user_relays(
             &whitenoise,
             &member_user,
@@ -1360,11 +1386,17 @@ mod tests {
         let fallback_account = whitenoise.create_identity().await.unwrap();
         let member_account = whitenoise.create_identity().await.unwrap();
 
-        let member_user = member_account.user(&whitenoise.database).await.unwrap();
+        let member_user = member_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(&whitenoise, &member_user, RelayType::Inbox, &[]).await;
         set_user_relays(&whitenoise, &member_user, RelayType::Nip65, &[]).await;
 
-        let fallback_user = fallback_account.user(&whitenoise.database).await.unwrap();
+        let fallback_user = fallback_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         let fallback_urls = set_user_relays(
             &whitenoise,
             &fallback_user,
@@ -1391,11 +1423,17 @@ mod tests {
         let fallback_account = whitenoise.create_identity().await.unwrap();
         let member_account = whitenoise.create_identity().await.unwrap();
 
-        let member_user = member_account.user(&whitenoise.database).await.unwrap();
+        let member_user = member_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(&whitenoise, &member_user, RelayType::Inbox, &[]).await;
         set_user_relays(&whitenoise, &member_user, RelayType::Nip65, &[]).await;
 
-        let fallback_user = fallback_account.user(&whitenoise.database).await.unwrap();
+        let fallback_user = fallback_account
+            .user(&whitenoise.shared.database)
+            .await
+            .unwrap();
         set_user_relays(&whitenoise, &fallback_user, RelayType::Nip65, &[]).await;
 
         let error = whitenoise
@@ -1478,7 +1516,7 @@ mod tests {
         sqlx::query("DELETE FROM accounts_groups WHERE account_pubkey = ? AND mls_group_id = ?")
             .bind(account.pubkey.to_hex())
             .bind(group.mls_group_id.as_slice())
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
 
@@ -1918,7 +1956,7 @@ mod tests {
 
         // Verify the nostr_key (upload keypair) was stored in the database
         let media_file = crate::whitenoise::database::media_files::MediaFile::find_by_hash(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &hash,
         )
         .await

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -156,7 +156,7 @@ impl Whitenoise {
         // NOTE: Cannot delegate through session.groups().media() — this wrapper has no `account`
         // parameter and therefore no session to look up. Both paths query the same DB table;
         // this divergence is harmless until the method signature is updated in phase 15+.
-        MediaFile::find_by_group(&self.database, group_id).await
+        MediaFile::find_by_group(&self.shared.database, group_id).await
     }
 
     #[deprecated(note = "Use AccountSession::groups().media().get_group_image_path() instead.")]

--- a/src/whitenoise/groups/publish.rs
+++ b/src/whitenoise/groups/publish.rs
@@ -52,7 +52,8 @@ impl Whitenoise {
         relay_urls: &[RelayUrl],
     ) -> Result<()> {
         let _span = perf_span!("groups::publish_event_with_retry");
-        self.relay_control
+        self.shared
+            .relay_control
             .publish_event_to(event, account_pubkey, relay_urls)
             .await?;
         Ok(())

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -371,6 +371,7 @@ impl Whitenoise {
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<EventId> {
         let result = self
+            .shared
             .relay_control
             .publish_key_package_with_signer(encoded_key_package, relay_urls, tags, signer)
             .await?;
@@ -402,7 +403,7 @@ impl Whitenoise {
             &account.pubkey,
             hash_ref,
             &event_id.to_hex(),
-            &self.database,
+            &self.shared.database,
         )
         .await
         {
@@ -476,15 +477,18 @@ impl Whitenoise {
             match PublishedKeyPackage::find_by_event_id(
                 &account.pubkey,
                 &event_id.to_hex(),
-                &self.database,
+                &self.shared.database,
             )
             .await
             {
                 Ok(Some(pkg)) if !pkg.key_material_deleted => {
                     let mdk = self.create_mdk_for_account(account.pubkey)?;
                     mdk.delete_key_package_from_storage_by_hash_ref(&pkg.key_package_hash_ref)?;
-                    if let Err(e) =
-                        PublishedKeyPackage::mark_key_material_deleted(pkg.id, &self.database).await
+                    if let Err(e) = PublishedKeyPackage::mark_key_material_deleted(
+                        pkg.id,
+                        &self.shared.database,
+                    )
+                    .await
                     {
                         tracing::warn!(
                             target: "whitenoise::key_packages",
@@ -527,6 +531,7 @@ impl Whitenoise {
         let key_package_relays_urls = Relay::urls(&key_package_relays);
 
         let result = self
+            .shared
             .relay_control
             .publish_event_deletion_with_signer(event_id, &key_package_relays_urls, signer)
             .await?;
@@ -901,6 +906,7 @@ impl Whitenoise {
         context: &str,
     ) -> Result<()> {
         match self
+            .shared
             .relay_control
             .publish_batch_event_deletion_with_signer(event_ids, relay_urls, signer)
             .await
@@ -949,7 +955,7 @@ impl Whitenoise {
         account_pubkey: &nostr_sdk::PublicKey,
         event_id: &str,
     ) -> Result<Option<PublishedKeyPackage>> {
-        PublishedKeyPackage::find_by_event_id(account_pubkey, event_id, &self.database)
+        PublishedKeyPackage::find_by_event_id(account_pubkey, event_id, &self.shared.database)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -970,7 +976,7 @@ impl Whitenoise {
         hash_ref: &[u8],
         event_id: &str,
     ) -> Result<()> {
-        PublishedKeyPackage::create(account_pubkey, hash_ref, event_id, &self.database)
+        PublishedKeyPackage::create(account_pubkey, hash_ref, event_id, &self.shared.database)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -998,7 +1004,7 @@ impl Whitenoise {
         .bind(age_secs)
         .bind(account_pubkey.to_hex())
         .bind(event_id)
-        .execute(&self.database.pool)
+        .execute(&self.shared.database.pool)
         .await
         .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
 
@@ -1051,20 +1057,25 @@ mod tests {
     async fn create_account_with_relay(whitenoise: &Whitenoise) -> Account {
         let (account, keys) = create_test_account(whitenoise).await;
         whitenoise
+            .shared
             .secrets_store
             .store_private_key(&keys)
             .expect("Should store keys");
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         // Use a loopback IP so connection refusal is instant (no DNS lookup).
         let relay = crate::whitenoise::relays::Relay::find_or_create_by_url(
             &RelayUrl::parse("ws://127.0.0.1:1").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
-        user.add_relay(&relay, crate::RelayType::KeyPackage, &whitenoise.database)
-            .await
-            .unwrap();
+        user.add_relay(
+            &relay,
+            crate::RelayType::KeyPackage,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         account
     }
 
@@ -1076,6 +1087,7 @@ mod tests {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         whitenoise
+            .shared
             .secrets_store
             .store_private_key(&keys)
             .expect("Should store keys");
@@ -1181,6 +1193,7 @@ mod tests {
 
         // Store keys in the secrets store (simulates a local account)
         whitenoise
+            .shared
             .secrets_store
             .store_private_key(&keys)
             .expect("Should store keys");
@@ -1219,16 +1232,20 @@ mod tests {
         let (account, _keys) = create_test_account(&whitenoise).await;
 
         // Setup relays
-        let user = account.user(&whitenoise.database).await.unwrap();
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
         let relay = crate::whitenoise::relays::Relay::find_or_create_by_url(
             &RelayUrl::parse("wss://test.relay.com").unwrap(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
-        user.add_relay(&relay, crate::RelayType::KeyPackage, &whitenoise.database)
-            .await
-            .unwrap();
+        user.add_relay(
+            &relay,
+            crate::RelayType::KeyPackage,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Should return relay URLs
         let urls = whitenoise.prepare_key_package_relay_urls(&account).await;
@@ -1763,6 +1780,7 @@ mod tests {
         // before fetching key packages from relays.
         let (account, keys) = create_test_account(&whitenoise).await;
         whitenoise
+            .shared
             .secrets_store
             .store_private_key(&keys)
             .expect("Should store keys");

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -1,6 +1,7 @@
 pub use crate::whitenoise::database::aggregated_messages::PaginationOptions;
 
 use crate::{
+    nostr_manager::parser::ContentParser,
     perf_instrument,
     types::MessageWithTokens,
     whitenoise::{
@@ -281,7 +282,7 @@ impl Whitenoise {
                 pubkey,
                 group_id,
                 new_events.clone(),
-                &self.content_parser,
+                &ContentParser::new(),
                 media_files,
             )
             .await?;

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -164,7 +164,7 @@ impl Whitenoise {
         let mut total_synced = 0;
         let mut total_groups_checked = 0;
 
-        let accounts = Account::all(&self.database).await?;
+        let accounts = Account::all(&self.shared.database).await?;
 
         for account in accounts {
             let mdk = self.create_mdk_for_account(account.pubkey)?;
@@ -215,7 +215,8 @@ impl Whitenoise {
             return Ok(false);
         }
 
-        let cached_count = AggregatedMessage::count_by_group(group_id, &self.database).await?;
+        let cached_count =
+            AggregatedMessage::count_by_group(group_id, &self.shared.database).await?;
 
         if mdk_messages.len() != cached_count {
             tracing::debug!(
@@ -246,7 +247,7 @@ impl Whitenoise {
         }
 
         let cached_ids =
-            AggregatedMessage::get_all_event_ids_by_group(group_id, &self.database).await?;
+            AggregatedMessage::get_all_event_ids_by_group(group_id, &self.shared.database).await?;
 
         let new_events: Vec<Message> = mdk_messages
             .into_iter()
@@ -271,9 +272,10 @@ impl Whitenoise {
             hex::encode(group_id.as_slice())
         );
 
-        let media_files = MediaFile::find_by_group(&self.database, group_id).await?;
+        let media_files = MediaFile::find_by_group(&self.shared.database, group_id).await?;
 
         let processed_messages = self
+            .shared
             .message_aggregator
             .aggregate_messages_for_group(
                 pubkey,
@@ -284,8 +286,13 @@ impl Whitenoise {
             )
             .await?;
 
-        AggregatedMessage::save_events(new_events, processed_messages, group_id, &self.database)
-            .await?;
+        AggregatedMessage::save_events(
+            new_events,
+            processed_messages,
+            group_id,
+            &self.shared.database,
+        )
+        .await?;
 
         tracing::debug!(
             target: "whitenoise::cache",
@@ -649,7 +656,7 @@ mod tests {
         // compares total event count (MDK) vs cache count.
         // Cache only has kind 9 from proactive caching, sync fills in the rest.
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(
@@ -675,7 +682,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -716,7 +723,7 @@ mod tests {
 
         // Verify 2 messages already in cache (proactive caching)
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 2);
@@ -737,7 +744,7 @@ mod tests {
 
         // Verify 3 messages in cache
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 3);
@@ -747,7 +754,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -793,7 +800,7 @@ mod tests {
 
         // Cache already has 5 messages from proactive caching
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -803,7 +810,7 @@ mod tests {
 
         // Cache should still have 5 messages
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -813,7 +820,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -832,7 +839,7 @@ mod tests {
         whitenoise.sync_message_cache_on_startup().await.unwrap();
 
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -1002,7 +1009,7 @@ mod tests {
 
         // Verify kind 9 was cached
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 1, "kind 9 message should be cached");
@@ -1032,7 +1039,7 @@ mod tests {
 
         // Cache count should be 2 (kind 9 + kind 7)
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(
@@ -1045,7 +1052,7 @@ mod tests {
             &chat_result.message.id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1092,7 +1099,7 @@ mod tests {
             &event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1194,7 +1201,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             &DeliveryStatus::Failed("simulated failure".to_string()),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1204,7 +1211,7 @@ mod tests {
             &original_event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1236,7 +1243,7 @@ mod tests {
             &original_event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1254,7 +1261,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1329,7 +1336,7 @@ mod tests {
             &event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1356,9 +1363,9 @@ mod tests {
                 max_publish_attempts: 1,
                 ad_hoc_relay_ttl: std::time::Duration::from_secs(30),
             },
-            whitenoise.database.clone(),
+            whitenoise.shared.database.clone(),
             whitenoise.event_sender.clone(),
-            whitenoise.relay_control.observability().clone(),
+            whitenoise.shared.relay_control.observability().clone(),
         );
 
         ephemeral
@@ -1368,8 +1375,8 @@ mod tests {
                 &unreachable_relays,
                 &event_id,
                 &group.mls_group_id,
-                &whitenoise.database,
-                &whitenoise.message_stream_manager,
+                &whitenoise.shared.database,
+                &whitenoise.shared.message_stream_manager,
             )
             .await;
 
@@ -1378,7 +1385,7 @@ mod tests {
             &event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1450,7 +1457,7 @@ mod tests {
         );
 
         // Delete the cache to simulate stale state
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.database)
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1502,11 +1509,11 @@ mod tests {
         assert!(!mdk_messages.is_empty());
 
         // Clear the cache entirely
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.database)
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 0, "Cache should be empty after deletion");
@@ -1522,7 +1529,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1555,9 +1562,10 @@ mod tests {
             .await
             .unwrap();
 
-        let cached_count = AggregatedMessage::count_by_group(&group_id, &whitenoise.database)
-            .await
-            .unwrap();
+        let cached_count =
+            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+                .await
+                .unwrap();
         assert_eq!(cached_count, 0);
     }
 
@@ -1597,17 +1605,17 @@ mod tests {
 
         // Verify proactive cache has 4 messages
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 4);
 
         // Clear the cache to simulate a stale/corrupt state
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.database)
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
             .await
             .unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 0, "Cache should be empty");
@@ -1620,7 +1628,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1693,7 +1701,7 @@ mod tests {
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1705,7 +1713,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1721,7 +1729,7 @@ mod tests {
             &del_event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1777,7 +1785,7 @@ mod tests {
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1799,7 +1807,7 @@ mod tests {
             &creator.pubkey,
             "+",
             &group.mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -1809,7 +1817,7 @@ mod tests {
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1870,7 +1878,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1889,7 +1897,7 @@ mod tests {
             &creator.pubkey,
             "",
             &group.mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -1899,7 +1907,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2005,7 +2013,7 @@ mod tests {
             &creator.pubkey,
             "",
             &group.mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -2038,7 +2046,7 @@ mod tests {
             &author,
             "",
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -2099,7 +2107,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -2122,7 +2130,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -2192,7 +2200,7 @@ mod tests {
             &last_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -2211,7 +2219,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         // Close the pool to force DB errors on find_by_id
-        whitenoise.database.pool.close().await;
+        whitenoise.shared.database.pool.close().await;
 
         cascade_delivery_failure(
             7,
@@ -2220,7 +2228,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;
@@ -2238,7 +2246,7 @@ mod tests {
         let stream_manager = MessageStreamManager::new();
 
         // Close the pool to force DB errors on unmark_deleted
-        whitenoise.database.pool.close().await;
+        whitenoise.shared.database.pool.close().await;
 
         cascade_delivery_failure(
             5,
@@ -2247,7 +2255,7 @@ mod tests {
             &Keys::generate().public_key(),
             "",
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &stream_manager,
         )
         .await;

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -147,7 +147,6 @@ impl WhitenoiseConfig {
 pub struct Whitenoise {
     pub config: WhitenoiseConfig,
     pub(crate) shared: Arc<shared::SharedServices>,
-    content_parser: crate::nostr_manager::parser::ContentParser,
     event_sender: Sender<ProcessableEvent>,
     shutdown_sender: Sender<()>,
     /// Shutdown signal for scheduled tasks
@@ -175,7 +174,6 @@ impl std::fmt::Debug for Whitenoise {
         f.debug_struct("Whitenoise")
             .field("config", &self.config)
             .field("shared", &"<REDACTED>")
-            .field("content_parser", &"<REDACTED>")
             .field("event_sender", &"<REDACTED>")
             .field("shutdown_sender", &"<REDACTED>")
             .field("scheduler_shutdown", &"<REDACTED>")
@@ -222,7 +220,6 @@ impl Whitenoise {
         Self {
             config,
             shared,
-            content_parser: crate::nostr_manager::parser::ContentParser::new(),
             event_sender: components.event_sender,
             shutdown_sender: components.shutdown_sender,
             scheduler_shutdown: components.scheduler_shutdown,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, OnceLock};
 use ::rand::RngCore;
 
 use dashmap::DashMap;
-use nostr_sdk::prelude::NostrSigner;
 use nostr_sdk::{PublicKey, RelayUrl};
 use tokio::sync::{
     Mutex, OnceCell,
@@ -44,6 +43,7 @@ pub mod relays;
 pub mod scheduled_tasks;
 pub mod secrets_store;
 pub mod session;
+pub(crate) mod shared;
 mod signer;
 pub mod storage;
 mod streaming;
@@ -146,33 +146,16 @@ impl WhitenoiseConfig {
 
 pub struct Whitenoise {
     pub config: WhitenoiseConfig,
-    pub(crate) database: Arc<Database>,
-    event_tracker: std::sync::Arc<dyn event_tracker::EventTracker>,
+    pub(crate) shared: Arc<shared::SharedServices>,
     content_parser: crate::nostr_manager::parser::ContentParser,
-    relay_control: Arc<RelayControlPlane>,
-    secrets_store: SecretsStore,
-    storage: storage::Storage,
-    message_aggregator: message_aggregator::MessageAggregator,
-    message_stream_manager: Arc<message_streaming::MessageStreamManager>,
-    user_stream_manager: user_streaming::UserStreamManager,
-    chat_list_stream_manager: chat_list_streaming::ChatListStreamManager,
-    archived_chat_list_stream_manager: chat_list_streaming::ChatListStreamManager,
-    notification_stream_manager: notification_streaming::NotificationStreamManager,
     event_sender: Sender<ProcessableEvent>,
     shutdown_sender: Sender<()>,
-    /// Per-user guards that dedupe targeted discovery resolution for the same pubkey.
-    user_resolution_guards: DashMap<PublicKey, Arc<Mutex<()>>>,
     /// Shutdown signal for scheduled tasks
     scheduler_shutdown: watch::Sender<bool>,
     /// Handles for spawned scheduler tasks
     scheduler_handles: Mutex<Vec<JoinHandle<()>>>,
-    /// External signers for accounts using NIP-55 (Amber) or similar.
-    /// Maps account pubkey to their signer implementation.
-    external_signers: DashMap<PublicKey, Arc<dyn NostrSigner>>,
     /// Per-account session manager. Holds active sessions and pending logins.
     pub(crate) account_manager: session::AccountManager,
-    /// Debounced worker that coalesces discovery subscription rebuilds.
-    discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker,
 }
 
 static GLOBAL_WHITENOISE: OnceCell<Whitenoise> = OnceCell::const_new();
@@ -191,21 +174,10 @@ impl std::fmt::Debug for Whitenoise {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Whitenoise")
             .field("config", &self.config)
-            .field("database", &"<REDACTED>")
-            .field("event_tracker", &"<REDACTED>")
+            .field("shared", &"<REDACTED>")
             .field("content_parser", &"<REDACTED>")
-            .field("relay_control", &"<REDACTED>")
-            .field("secrets_store", &"<REDACTED>")
-            .field("storage", &"<REDACTED>")
-            .field("message_aggregator", &"<REDACTED>")
-            .field("message_stream_manager", &"<REDACTED>")
-            .field("user_stream_manager", &"<REDACTED>")
-            .field("chat_list_stream_manager", &"<REDACTED>")
-            .field("archived_chat_list_stream_manager", &"<REDACTED>")
-            .field("notification_stream_manager", &"<REDACTED>")
             .field("event_sender", &"<REDACTED>")
             .field("shutdown_sender", &"<REDACTED>")
-            .field("user_resolution_guards", &"<REDACTED>")
             .field("scheduler_shutdown", &"<REDACTED>")
             .field("scheduler_handles", &"<REDACTED>")
             .field("account_manager", &"<REDACTED>")
@@ -228,12 +200,10 @@ impl Whitenoise {
             session_salt,
         ));
 
-        Self {
-            config,
+        let shared = Arc::new(shared::SharedServices {
             database,
-            event_tracker: components.event_tracker,
-            content_parser: crate::nostr_manager::parser::ContentParser::new(),
             relay_control,
+            event_tracker: components.event_tracker,
             secrets_store: components.secrets_store,
             storage: components.storage,
             message_aggregator: components.message_aggregator,
@@ -244,14 +214,20 @@ impl Whitenoise {
             ),
             notification_stream_manager: notification_streaming::NotificationStreamManager::default(
             ),
+            user_resolution_guards: DashMap::new(),
+            external_signers: DashMap::new(),
+            discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
+        });
+
+        Self {
+            config,
+            shared,
+            content_parser: crate::nostr_manager::parser::ContentParser::new(),
             event_sender: components.event_sender,
             shutdown_sender: components.shutdown_sender,
-            user_resolution_guards: DashMap::new(),
             scheduler_shutdown: components.scheduler_shutdown,
             scheduler_handles: Mutex::new(Vec::new()),
-            external_signers: DashMap::new(),
             account_manager: session::AccountManager::default(),
-            discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
         }
     }
 
@@ -491,7 +467,7 @@ impl Whitenoise {
                 scheduler_shutdown,
             },
         );
-        whitenoise.relay_control.start_telemetry_persistors().await;
+        whitenoise.shared.relay_control.start_telemetry_persistors().await;
 
         init_timing::record("core_services");
 
@@ -502,11 +478,11 @@ impl Whitenoise {
         }
 
         // Create default app settings in the database if they don't exist
-        AppSettings::find_or_create_default(&whitenoise.database).await?;
+        AppSettings::find_or_create_default(&whitenoise.shared.database).await?;
 
         init_timing::record("database_seeding");
 
-        whitenoise.relay_control.start_discovery_plane().await?;
+        whitenoise.shared.relay_control.start_discovery_plane().await?;
 
         init_timing::record("discovery_plane");
 
@@ -567,6 +543,7 @@ impl Whitenoise {
             let worker_shutdown_rx = whitenoise_ref.scheduler_shutdown.subscribe();
             let handle = tokio::spawn(async move {
                 whitenoise_ref
+                    .shared
                     .discovery_sync_worker
                     .run(whitenoise_ref, worker_shutdown_rx)
                     .await;
@@ -664,13 +641,13 @@ impl Whitenoise {
         self.account_manager.deactivate_all_inboxes().await;
 
         // Tear down shared relay-control subscriptions (group, ephemeral, telemetry)
-        self.relay_control.shutdown_all().await;
+        self.shared.relay_control.shutdown_all().await;
 
         // Remove database (accounts and media) data
-        self.database.delete_all_data().await?;
+        self.shared.database.delete_all_data().await?;
 
         // Remove storage artifacts (media cache, etc.)
-        self.storage.wipe_all().await?;
+        self.shared.storage.wipe_all().await?;
 
         // Remove MLS related data
         let mls_dir = self.config.data_dir.join("mls");
@@ -753,14 +730,14 @@ impl Whitenoise {
     #[cfg(feature = "integration-tests")]
     #[perf_instrument("whitenoise")]
     pub async fn wipe_database(&self) -> Result<()> {
-        self.database.delete_all_data().await?;
+        self.shared.database.delete_all_data().await?;
         Ok(())
     }
 
     #[cfg(feature = "integration-tests")]
     #[perf_instrument("whitenoise")]
     pub async fn reset_nostr_client(&self) -> Result<()> {
-        self.relay_control.reset_for_tests().await?;
+        self.shared.relay_control.reset_for_tests().await?;
         Ok(())
     }
 }
@@ -914,7 +891,11 @@ pub mod test_utils {
                 scheduler_shutdown,
             },
         );
-        whitenoise.relay_control.start_telemetry_persistors().await;
+        whitenoise
+            .shared
+            .relay_control
+            .start_telemetry_persistors()
+            .await;
 
         (whitenoise, event_receiver, data_temp, logs_temp)
     }
@@ -968,7 +949,7 @@ pub mod test_utils {
         let count: (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM published_events WHERE account_id = ?")
                 .bind(account_id)
-                .fetch_one(&whitenoise.database.pool)
+                .fetch_one(&whitenoise.shared.database.pool)
                 .await
                 .unwrap();
 
@@ -1149,6 +1130,7 @@ pub mod test_utils {
                     );
 
                     match whitenoise
+                        .shared
                         .relay_control
                         .fetch_user_key_package(publisher_account.pubkey, &relay_urls)
                         .await
@@ -1187,6 +1169,7 @@ pub mod test_utils {
             let relay_urls =
                 Relay::urls(&member_account.key_package_relays(whitenoise).await.unwrap());
             let key_package_event = whitenoise
+                .shared
                 .relay_control
                 .fetch_user_key_package(member_account.pubkey, &relay_urls)
                 .await
@@ -1225,6 +1208,7 @@ pub mod test_utils {
         );
 
         let admin_signer = whitenoise
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&admin_account.pubkey)
             .unwrap();
@@ -1423,7 +1407,12 @@ mod tests {
         #[tokio::test]
         async fn test_whitenoise_initialization() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-            assert!(Account::all(&whitenoise.database).await.unwrap().is_empty());
+            assert!(
+                Account::all(&whitenoise.shared.database)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
 
             // Verify directories were created
             assert!(whitenoise.config.data_dir.exists());
@@ -1450,13 +1439,13 @@ mod tests {
             assert!(whitenoise1.config.data_dir.exists());
             assert!(whitenoise2.config.data_dir.exists());
             assert!(
-                Account::all(&whitenoise1.database)
+                Account::all(&whitenoise1.shared.database)
                     .await
                     .unwrap()
                     .is_empty()
             );
             assert!(
-                Account::all(&whitenoise2.database)
+                Account::all(&whitenoise2.shared.database)
                     .await
                     .unwrap()
                     .is_empty()
@@ -1484,12 +1473,13 @@ mod tests {
 
             // Create some test media files in cache
             whitenoise
+                .shared
                 .storage
                 .media_files
                 .store_file("test_image.jpg", b"fake image data")
                 .await
                 .unwrap();
-            let media_cache_dir = whitenoise.storage.media_files.cache_dir();
+            let media_cache_dir = whitenoise.shared.storage.media_files.cache_dir();
             assert!(media_cache_dir.exists());
             let cache_entries: Vec<_> = std::fs::read_dir(media_cache_dir)
                 .unwrap()
@@ -1502,11 +1492,16 @@ mod tests {
             assert!(result.is_ok());
 
             // Verify cleanup
-            assert!(Account::all(&whitenoise.database).await.unwrap().is_empty());
+            assert!(
+                Account::all(&whitenoise.shared.database)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
             assert!(!test_log_file.exists());
 
             // Media cache directory should be removed
-            let media_cache_dir_after = whitenoise.storage.media_files.cache_dir();
+            let media_cache_dir_after = whitenoise.shared.storage.media_files.cache_dir();
             assert!(!media_cache_dir_after.exists());
 
             // MLS directory should be recreated as empty
@@ -1571,7 +1566,7 @@ mod tests {
             group_information::GroupInformation::find_or_create_by_mls_group_id(
                 &group_id,
                 Some(group_information::GroupType::Group),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1614,7 +1609,7 @@ mod tests {
                 &msg1,
                 &group_id,
                 &test_pubkey,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1622,7 +1617,7 @@ mod tests {
                 &msg2,
                 &group_id,
                 &test_pubkey,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1676,7 +1671,7 @@ mod tests {
             };
 
             // Emit an update (will be caught by subscriber during drain phase)
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -1730,7 +1725,7 @@ mod tests {
                 &msg,
                 group_id,
                 &author,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1742,7 +1737,7 @@ mod tests {
             group_information::GroupInformation::find_or_create_by_mls_group_id(
                 group_id,
                 Some(group_information::GroupType::Group),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1766,12 +1761,12 @@ mod tests {
             .bind(&hex)
             .bind(now_ms)
             .bind(now_ms)
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
             let user_id: i64 = sqlx::query_scalar("SELECT id FROM users WHERE pubkey = ?")
                 .bind(&hex)
-                .fetch_one(&whitenoise.database.pool)
+                .fetch_one(&whitenoise.shared.database.pool)
                 .await
                 .unwrap();
             // account row (FK target for accounts_groups)
@@ -1784,7 +1779,7 @@ mod tests {
             .bind(user_id)
             .bind(now_ms)
             .bind(now_ms)
-            .execute(&whitenoise.database.pool)
+            .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
             // accounts_groups row
@@ -1792,7 +1787,7 @@ mod tests {
                 pubkey,
                 group_id,
                 None,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -2073,7 +2068,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2164,7 +2159,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2223,7 +2218,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2278,7 +2273,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_a,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2324,7 +2319,7 @@ mod tests {
         /// security check, but does not need a full session to be active.
         async fn create_db_account(whitenoise: &Whitenoise) -> accounts::Account {
             let (account, _keys) = accounts::Account::new(whitenoise, None).await.unwrap();
-            account.save(&whitenoise.database).await.unwrap()
+            account.save(&whitenoise.shared.database).await.unwrap()
         }
 
         /// Core happy-path scenario: user opens the chat (snapshot), scrolls up to load
@@ -2476,14 +2471,14 @@ mod tests {
                 delivery_status: None,
             };
 
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
                     message: new_msg_a.clone(),
                 },
             );
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2672,7 +2667,7 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            whitenoise.message_stream_manager.emit(
+            whitenoise.shared.message_stream_manager.emit(
                 &group_id,
                 message_streaming::MessageUpdate {
                     trigger: message_streaming::UpdateTrigger::NewMessage,
@@ -2797,7 +2792,7 @@ mod tests {
                 updated_at: Utc::now(),
             };
             user.mark_metadata_known_now();
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let subscription = whitenoise.subscribe_to_user(&pubkey).await.unwrap();
 
@@ -2815,7 +2810,7 @@ mod tests {
             assert!(subscription.initial_user.id.is_some());
             assert!(subscription.initial_user.metadata_is_unknown());
 
-            let saved_user = User::find_by_pubkey(&pubkey, &whitenoise.database)
+            let saved_user = User::find_by_pubkey(&pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(saved_user, subscription.initial_user);
@@ -2891,7 +2886,7 @@ mod tests {
             );
             session
                 .activate_subscriptions(
-                    &whitenoise.relay_control,
+                    &whitenoise.shared.relay_control,
                     &inbox_relays,
                     &[], // empty group specs — simulates the missing group
                     creator_account.since_timestamp(10),
@@ -3287,7 +3282,7 @@ mod tests {
                     &msg,
                     &group.mls_group_id,
                     &creator.pubkey,
-                    &whitenoise.database,
+                    &whitenoise.shared.database,
                 )
                 .await
                 .unwrap();
@@ -3580,7 +3575,7 @@ mod tests {
             // subscription recovery. Registration should still succeed.
             sqlx::query("DELETE FROM users WHERE id = ?")
                 .bind(account.user_id)
-                .execute(&whitenoise.database.pool)
+                .execute(&whitenoise.shared.database.pool)
                 .await
                 .unwrap();
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, OnceLock};
 
 use ::rand::RngCore;
 
-use dashmap::DashMap;
 use nostr_sdk::{PublicKey, RelayUrl};
 use tokio::sync::{
     Mutex, OnceCell,
@@ -198,24 +197,14 @@ impl Whitenoise {
             session_salt,
         ));
 
-        let shared = Arc::new(shared::SharedServices {
+        let shared = Arc::new(shared::SharedServices::new(
             database,
             relay_control,
-            event_tracker: components.event_tracker,
-            secrets_store: components.secrets_store,
-            storage: components.storage,
-            message_aggregator: components.message_aggregator,
-            message_stream_manager: Arc::new(message_streaming::MessageStreamManager::default()),
-            user_stream_manager: user_streaming::UserStreamManager::default(),
-            chat_list_stream_manager: chat_list_streaming::ChatListStreamManager::default(),
-            archived_chat_list_stream_manager: chat_list_streaming::ChatListStreamManager::default(
-            ),
-            notification_stream_manager: notification_streaming::NotificationStreamManager::default(
-            ),
-            user_resolution_guards: DashMap::new(),
-            external_signers: DashMap::new(),
-            discovery_sync_worker: discovery_sync_worker::DiscoverySyncWorker::new(),
-        });
+            components.event_tracker,
+            components.secrets_store,
+            components.storage,
+            components.message_aggregator,
+        ));
 
         Self {
             config,

--- a/src/whitenoise/notification_streaming/mod.rs
+++ b/src/whitenoise/notification_streaming/mod.rs
@@ -34,7 +34,7 @@ impl Whitenoise {
         message: &ChatMessage,
         group_name: Option<String>,
     ) {
-        if !self.notification_stream_manager.has_subscribers() {
+        if !self.shared.notification_stream_manager.has_subscribers() {
             return;
         }
 
@@ -55,7 +55,7 @@ impl Whitenoise {
             return;
         }
 
-        let is_dm = GroupInformation::find_by_mls_group_id(group_id, &self.database)
+        let is_dm = GroupInformation::find_by_mls_group_id(group_id, &self.shared.database)
             .await
             .ok()
             .map(|gi| gi.group_type == GroupType::DirectMessage)
@@ -76,7 +76,7 @@ impl Whitenoise {
             timestamp,
         };
 
-        self.notification_stream_manager.emit(update);
+        self.shared.notification_stream_manager.emit(update);
     }
 
     #[perf_instrument("notification_streaming")]
@@ -87,11 +87,11 @@ impl Whitenoise {
         group_name: &str,
         welcomer_pubkey: PublicKey,
     ) {
-        if !self.notification_stream_manager.has_subscribers() {
+        if !self.shared.notification_stream_manager.has_subscribers() {
             return;
         }
 
-        let is_dm = GroupInformation::find_by_mls_group_id(group_id, &self.database)
+        let is_dm = GroupInformation::find_by_mls_group_id(group_id, &self.shared.database)
             .await
             .ok()
             .map(|group_info| group_info.group_type == GroupType::DirectMessage)
@@ -111,7 +111,7 @@ impl Whitenoise {
             timestamp: Utc::now(),
         };
 
-        self.notification_stream_manager.emit(update);
+        self.shared.notification_stream_manager.emit(update);
     }
 
     /// Emits a new-message notification only if notifications are enabled for the account.
@@ -183,7 +183,7 @@ impl Whitenoise {
     /// Returns whether notifications are enabled for `account`. Fail-open on error.
     #[perf_instrument("notification_streaming")]
     async fn are_notifications_enabled(&self, account: &Account) -> bool {
-        AccountSettings::notifications_enabled_for_pubkey(&account.pubkey, &self.database)
+        AccountSettings::notifications_enabled_for_pubkey(&account.pubkey, &self.shared.database)
             .await
             .unwrap_or_else(|e| {
                 tracing::warn!(
@@ -198,7 +198,9 @@ impl Whitenoise {
 
     #[perf_instrument("notification_streaming")]
     async fn build_notification_user(&self, pubkey: &PublicKey) -> NotificationUser {
-        let user = User::find_by_pubkey(pubkey, &self.database).await.ok();
+        let user = User::find_by_pubkey(pubkey, &self.shared.database)
+            .await
+            .ok();
 
         let (display_name, picture_url) = user
             .map(|u| {
@@ -228,8 +230,12 @@ impl Whitenoise {
         account_pubkey: &PublicKey,
         group_id: &GroupId,
     ) -> Option<&'static str> {
-        match AccountGroup::find_by_account_and_group(account_pubkey, group_id, &self.database)
-            .await
+        match AccountGroup::find_by_account_and_group(
+            account_pubkey,
+            group_id,
+            &self.shared.database,
+        )
+        .await
         {
             Ok(Some(ag)) => {
                 if ag.is_removed() {
@@ -257,7 +263,7 @@ impl Whitenoise {
 
     #[perf_instrument("notification_streaming")]
     async fn is_own_account(&self, pubkey: &PublicKey) -> bool {
-        Account::find_by_pubkey(pubkey, &self.database)
+        Account::find_by_pubkey(pubkey, &self.shared.database)
             .await
             .is_ok()
     }
@@ -297,7 +303,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
 
         // Subscribe to get notifications
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         // Create a message from the account itself (should be filtered)
         let message = create_test_message(account.pubkey, "Hello");
@@ -321,7 +327,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
 
         // Subscribe to get notifications
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         // Create a message from an external user (not in database as account)
         let external_sender = Keys::generate().public_key();
@@ -381,7 +387,7 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
 
         // Subscribe to get notifications
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let welcomer = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[4u8; 32]);
@@ -464,7 +470,7 @@ mod tests {
     async fn test_emit_new_message_notification_if_enabled_emits_when_enabled() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Hello enabled");
@@ -494,12 +500,16 @@ mod tests {
     async fn test_emit_new_message_notification_if_enabled_suppressed_when_disabled() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         // Disable notifications
-        AccountSettings::update_notifications_enabled(&account.pubkey, false, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountSettings::update_notifications_enabled(
+            &account.pubkey,
+            false,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Should not arrive");
@@ -524,7 +534,7 @@ mod tests {
     async fn test_emit_group_invite_notification_if_enabled_emits_when_enabled() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let welcomer = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[12u8; 32]);
@@ -552,12 +562,16 @@ mod tests {
     async fn test_emit_group_invite_notification_if_enabled_suppressed_when_disabled() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         // Disable notifications
-        AccountSettings::update_notifications_enabled(&account.pubkey, false, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountSettings::update_notifications_enabled(
+            &account.pubkey,
+            false,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let welcomer = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[13u8; 32]);
@@ -602,14 +616,14 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.database).await.unwrap()
+        ag.save(&whitenoise.shared.database).await.unwrap()
     }
 
     #[tokio::test]
     async fn test_emit_new_message_notification_suppressed_for_pending_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Pending group msg");
@@ -634,7 +648,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.database).await.unwrap();
+        ag.save(&whitenoise.shared.database).await.unwrap();
 
         whitenoise
             .emit_new_message_notification(
@@ -656,7 +670,7 @@ mod tests {
     async fn test_emit_new_message_notification_suppressed_for_declined_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Declined group msg");
@@ -681,7 +695,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.database).await.unwrap();
+        ag.save(&whitenoise.shared.database).await.unwrap();
 
         whitenoise
             .emit_new_message_notification(
@@ -703,7 +717,7 @@ mod tests {
     async fn test_emit_new_message_notification_suppressed_for_unknown_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Unknown group msg");
@@ -730,7 +744,7 @@ mod tests {
     async fn test_group_invite_notification_still_emits_for_pending_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let welcomer = Keys::generate().public_key();
         let group_id = GroupId::from_slice(&[23u8; 32]);
@@ -754,7 +768,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.database).await.unwrap();
+        ag.save(&whitenoise.shared.database).await.unwrap();
 
         whitenoise
             .emit_group_invite_notification(&account, &group_id, "Invite Group", welcomer)
@@ -795,7 +809,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.database).await.unwrap();
+        ag.save(&whitenoise.shared.database).await.unwrap();
 
         assert_eq!(
             whitenoise
@@ -848,9 +862,9 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        let saved = ag.save(&whitenoise.database).await.unwrap();
+        let saved = ag.save(&whitenoise.shared.database).await.unwrap();
         saved
-            .update_muted_until(Some(muted_until), &whitenoise.database)
+            .update_muted_until(Some(muted_until), &whitenoise.shared.database)
             .await
             .unwrap();
     }
@@ -859,7 +873,7 @@ mod tests {
     async fn test_emit_new_message_notification_suppressed_for_muted_chat() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Muted chat msg");
@@ -893,7 +907,7 @@ mod tests {
     async fn test_emit_new_message_notification_resumes_after_mute_expires() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Post-expiry msg");
@@ -932,7 +946,7 @@ mod tests {
     async fn test_emit_new_message_notification_suppressed_for_forever_muted_chat() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
-        let mut rx = whitenoise.notification_stream_manager.subscribe();
+        let mut rx = whitenoise.shared.notification_stream_manager.subscribe();
 
         let external_sender = Keys::generate().public_key();
         let message = create_test_message(external_sender, "Forever muted msg");

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -822,11 +822,11 @@ mod tests {
         group_id: &GroupId,
     ) -> Result<()> {
         let user_relay_sync = whitenoise.user_relay_sync_context();
-        let ephemeral = whitenoise.relay_control.ephemeral();
+        let ephemeral = whitenoise.shared.relay_control.ephemeral();
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &user_relay_sync,
             &ephemeral,
             account.pubkey,
@@ -843,6 +843,7 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 if whitenoise
+                    .shared
                     .relay_control
                     .fetch_user_relays(user_pubkey, RelayType::Inbox, query_relays)
                     .await
@@ -868,6 +869,7 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 let events = whitenoise
+                    .shared
                     .relay_control
                     .ephemeral()
                     .fetch_events_from(
@@ -908,7 +910,7 @@ mod tests {
                     &message_id.to_string(),
                     group_id,
                     account_pubkey,
-                    &whitenoise.database,
+                    &whitenoise.shared.database,
                 )
                 .await
                 .unwrap()
@@ -934,9 +936,9 @@ mod tests {
                 max_publish_attempts: 1,
                 ad_hoc_relay_ttl: Duration::from_secs(30),
             },
-            whitenoise.database.clone(),
+            whitenoise.shared.database.clone(),
             whitenoise.event_sender.clone(),
-            whitenoise.relay_control.observability().clone(),
+            whitenoise.shared.relay_control.observability().clone(),
         )
     }
 
@@ -1117,21 +1119,21 @@ mod tests {
         let relay_url = RelayUrl::parse("wss://cached-push.example.com").unwrap();
         let (server_user, _created) = crate::whitenoise::users::User::find_or_create_by_pubkey(
             &server_pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
-        let relay = Relay::find_or_create_by_url(&relay_url, &whitenoise.database)
+        let relay = Relay::find_or_create_by_url(&relay_url, &whitenoise.shared.database)
             .await
             .unwrap();
 
         server_user
-            .add_relay(&relay, RelayType::Inbox, &whitenoise.database)
+            .add_relay(&relay, RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &whitenoise.user_relay_sync_context(),
             server_pubkey,
             &[],
@@ -1152,21 +1154,21 @@ mod tests {
         let duplicate_cached_hint = RelayUrl::parse("wss://cached-push.example.com").unwrap();
         let (server_user, _created) = crate::whitenoise::users::User::find_or_create_by_pubkey(
             &server_pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
-        let relay = Relay::find_or_create_by_url(&cached_relay, &whitenoise.database)
+        let relay = Relay::find_or_create_by_url(&cached_relay, &whitenoise.shared.database)
             .await
             .unwrap();
 
         server_user
-            .add_relay(&relay, RelayType::Inbox, &whitenoise.database)
+            .add_relay(&relay, RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
 
         let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &whitenoise.user_relay_sync_context(),
             server_pubkey,
             &[duplicate_cached_hint, fresh_hint.clone()],
@@ -1179,7 +1181,7 @@ mod tests {
         assert_eq!(
             Relay::urls(
                 &server_user
-                    .relays(RelayType::Inbox, &whitenoise.database)
+                    .relays(RelayType::Inbox, &whitenoise.shared.database)
                     .await
                     .unwrap()
             ),
@@ -1193,7 +1195,7 @@ mod tests {
         let server_pubkey = Keys::generate().public_key();
 
         let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &whitenoise.user_relay_sync_context(),
             server_pubkey,
             &[],
@@ -1204,13 +1206,15 @@ mod tests {
         assert!(resolved_relays.is_empty());
         assert_eq!(relay_source, NotificationRelaySource::HintFallback);
 
-        let server_user =
-            crate::whitenoise::users::User::find_by_pubkey(&server_pubkey, &whitenoise.database)
-                .await
-                .unwrap();
+        let server_user = crate::whitenoise::users::User::find_by_pubkey(
+            &server_pubkey,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(
             server_user
-                .relays(RelayType::Inbox, &whitenoise.database)
+                .relays(RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1237,7 +1241,7 @@ mod tests {
         batches[0].relay_hints.clear();
 
         publish_notification_batches_best_effort(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &whitenoise.user_relay_sync_context(),
             &test_ephemeral_plane(&whitenoise),
             sender_pubkey,
@@ -1246,13 +1250,15 @@ mod tests {
         )
         .await;
 
-        let server_user =
-            crate::whitenoise::users::User::find_by_pubkey(&server_pubkey, &whitenoise.database)
-                .await
-                .unwrap();
+        let server_user = crate::whitenoise::users::User::find_by_pubkey(
+            &server_pubkey,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(
             server_user
-                .relays(RelayType::Inbox, &whitenoise.database)
+                .relays(RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1285,7 +1291,7 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1325,7 +1331,7 @@ mod tests {
             .await
             .unwrap();
         server_user
-            .remove_all_relays(&whitenoise.database)
+            .remove_all_relays(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1356,7 +1362,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &sender_token,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1368,7 +1374,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &recipient_token.to_base64(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1432,7 +1438,7 @@ mod tests {
             .await
             .unwrap();
         server_user
-            .remove_all_relays(&whitenoise.database)
+            .remove_all_relays(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1481,7 +1487,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &sender_token,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1493,7 +1499,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &recipient_token.to_base64(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1544,7 +1550,7 @@ mod tests {
             .await
             .unwrap();
         server_user
-            .remove_all_relays(&whitenoise.database)
+            .remove_all_relays(&whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1570,9 +1576,9 @@ mod tests {
         assert!(batches[0].events.len() > 1);
 
         publish_notification_batches_best_effort(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &whitenoise.user_relay_sync_context(),
-            &whitenoise.relay_control.ephemeral(),
+            &whitenoise.shared.relay_control.ephemeral(),
             sender_account.pubkey,
             &notification_token_counts_by_server(&token_tags),
             batches,
@@ -1638,7 +1644,7 @@ mod tests {
             &unreachable_server_pubkey,
             Some(&unreachable_relay),
             &encrypted_fcm_token_base64(&unreachable_server_pubkey, "bad-recipient-device"),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1647,7 +1653,7 @@ mod tests {
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.database,
+            &whitenoise.shared.database,
             &user_relay_sync,
             &ephemeral,
             creator.pubkey,
@@ -1660,7 +1666,7 @@ mod tests {
             &send_result.message.id.to_string(),
             &group_id,
             &creator.pubkey,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -1818,7 +1824,7 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1914,7 +1920,7 @@ mod tests {
             &server_pubkey,
             Some(&relay_hint),
             "ciphertext-one",
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1927,7 +1933,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -1969,7 +1975,7 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2013,7 +2019,7 @@ mod tests {
         let cached_before_disable = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2054,7 +2060,7 @@ mod tests {
         let cached_after_disable = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2165,7 +2171,7 @@ mod tests {
         let cached_after_share = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2194,7 +2200,7 @@ mod tests {
         let cached_after_removal = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2353,7 +2359,7 @@ mod tests {
         let cached_before = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2379,7 +2385,7 @@ mod tests {
         let cached_after = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2436,7 +2442,7 @@ mod tests {
         let accepted_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &accepted_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2451,7 +2457,7 @@ mod tests {
         let pending_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &pending_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2501,7 +2507,7 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &creator.pubkey,
             &group.mls_group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2553,7 +2559,7 @@ mod tests {
         let cached_before = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -2574,7 +2580,7 @@ mod tests {
         let cached_after = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -561,43 +561,6 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
 /// directly.
 #[allow(deprecated)]
 impl Whitenoise {
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::push().registration() instead."
-    )]
-    pub async fn push_registration(&self, account: &Account) -> Result<Option<PushRegistration>> {
-        let session = self.require_session(&account.pubkey)?;
-        session.push().registration().await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::push().upsert_registration() instead."
-    )]
-    pub async fn upsert_push_registration(
-        &self,
-        account: &Account,
-        platform: PushPlatform,
-        raw_token: &str,
-        server_pubkey: &PublicKey,
-        relay_hint: Option<&RelayUrl>,
-    ) -> Result<PushRegistration> {
-        let session = self.require_session(&account.pubkey)?;
-        session
-            .push()
-            .upsert_registration(platform, raw_token, server_pubkey, relay_hint)
-            .await
-    }
-
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::push().clear_registration() instead."
-    )]
-    pub async fn clear_push_registration(&self, account: &Account) -> Result<()> {
-        let session = self.require_session(&account.pubkey)?;
-        session.push().clear_registration().await
-    }
-
     #[cfg(test)]
     #[deprecated(
         since = "0.0.0",
@@ -683,23 +646,6 @@ impl Whitenoise {
     ) -> Result<()> {
         let session = self.require_session(&account.pubkey)?;
         session.push().remove_local_token_from_group(group_id).await
-    }
-
-    #[cfg(test)]
-    #[deprecated(
-        since = "0.0.0",
-        note = "Use AccountSession::push().reconcile_group_tokens_for_active_leaves() instead."
-    )]
-    pub(crate) async fn reconcile_group_push_tokens_for_active_leaves(
-        &self,
-        account: &Account,
-        group_id: &GroupId,
-    ) -> Result<()> {
-        let session = self.require_session(&account.pubkey)?;
-        session
-            .push()
-            .reconcile_group_tokens_for_active_leaves(group_id)
-            .await
     }
 }
 
@@ -1687,15 +1633,20 @@ mod tests {
 
         assert!(
             whitenoise
-                .push_registration(&account)
+                .session(&account.pubkey)
+                .unwrap()
+                .push()
+                .registration()
                 .await
                 .unwrap()
                 .is_none()
         );
 
         let created = whitenoise
-            .upsert_push_registration(
-                &account,
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &"aa".repeat(32),
                 &server_pubkey,
@@ -1709,13 +1660,10 @@ mod tests {
         assert_eq!(created.relay_hint, Some(relay_hint.clone()));
 
         let replaced = whitenoise
-            .upsert_push_registration(
-                &account,
-                PushPlatform::Fcm,
-                "token-two",
-                &server_pubkey,
-                None,
-            )
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(PushPlatform::Fcm, "token-two", &server_pubkey, None)
             .await
             .unwrap();
         assert_eq!(replaced.platform, PushPlatform::Fcm);
@@ -1723,16 +1671,28 @@ mod tests {
         assert_eq!(replaced.relay_hint, None);
 
         let stored = whitenoise
-            .push_registration(&account)
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .registration()
             .await
             .unwrap()
             .unwrap();
         assert_eq!(stored, replaced);
 
-        whitenoise.clear_push_registration(&account).await.unwrap();
+        whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .clear_registration()
+            .await
+            .unwrap();
         assert!(
             whitenoise
-                .push_registration(&account)
+                .session(&account.pubkey)
+                .unwrap()
+                .push()
+                .registration()
                 .await
                 .unwrap()
                 .is_none()
@@ -1746,13 +1706,10 @@ mod tests {
         let server_pubkey = Keys::generate().public_key();
 
         whitenoise
-            .upsert_push_registration(
-                &account,
-                PushPlatform::Fcm,
-                "device-token",
-                &server_pubkey,
-                None,
-            )
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(PushPlatform::Fcm, "device-token", &server_pubkey, None)
             .await
             .unwrap();
 
@@ -1762,7 +1719,13 @@ mod tests {
             .unwrap();
         assert!(!settings.notifications_enabled);
 
-        let stored = whitenoise.push_registration(&account).await.unwrap();
+        let stored = whitenoise
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .registration()
+            .await
+            .unwrap();
         assert!(stored.is_some());
         assert_eq!(stored.unwrap().raw_token, "device-token");
     }
@@ -1774,7 +1737,10 @@ mod tests {
         let server_pubkey = Keys::generate().public_key();
 
         let err = whitenoise
-            .upsert_push_registration(&account, PushPlatform::Apns, "   ", &server_pubkey, None)
+            .session(&account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(PushPlatform::Apns, "   ", &server_pubkey, None)
             .await
             .unwrap_err();
 
@@ -1802,8 +1768,10 @@ mod tests {
         let apns_hex_token = "11".repeat(32);
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -1859,8 +1827,10 @@ mod tests {
             count_published_events_for_account(&whitenoise, &admin_account).await;
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -1926,7 +1896,10 @@ mod tests {
         .unwrap();
 
         whitenoise
-            .reconcile_group_push_tokens_for_active_leaves(&member_account, &group_id)
+            .session(&member_account.pubkey)
+            .unwrap()
+            .push()
+            .reconcile_group_tokens_for_active_leaves(&group_id)
             .await
             .unwrap();
 
@@ -1954,8 +1927,10 @@ mod tests {
         let apns_hex_token = "33".repeat(32);
 
         whitenoise
-            .upsert_push_registration(
-                &member_account,
+            .session(&member_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -2006,8 +1981,10 @@ mod tests {
         let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &"66".repeat(32),
                 &server_pubkey,
@@ -2103,8 +2080,10 @@ mod tests {
             count_published_events_for_account(&whitenoise, &admin_account).await;
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -2149,8 +2128,10 @@ mod tests {
             count_published_events_for_account(&whitenoise, &admin_account).await;
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &"55".repeat(32),
                 &server_pubkey,
@@ -2183,8 +2164,10 @@ mod tests {
         );
 
         whitenoise
-            .upsert_push_registration(
-                &admin_account,
+            .session(&admin_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Fcm,
                 "token-without-relay-hint",
                 &server_pubkey,
@@ -2338,8 +2321,10 @@ mod tests {
         let apns_hex_token = "33".repeat(32);
 
         whitenoise
-            .upsert_push_registration(
-                &member_account,
+            .session(&member_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -2428,8 +2413,10 @@ mod tests {
 
         // Register push and trigger fanout via upsert.
         whitenoise
-            .upsert_push_registration(
-                &member_account,
+            .session(&member_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &apns_hex_token,
                 &server_pubkey,
@@ -2482,8 +2469,10 @@ mod tests {
         let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
 
         whitenoise
-            .upsert_push_registration(
-                &creator,
+            .session(&creator.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &"44".repeat(32),
                 &server_pubkey,
@@ -2532,8 +2521,10 @@ mod tests {
         let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
 
         whitenoise
-            .upsert_push_registration(
-                &member_account,
+            .session(&member_account.pubkey)
+            .unwrap()
+            .push()
+            .upsert_registration(
                 PushPlatform::Apns,
                 &"55".repeat(32),
                 &server_pubkey,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -22,7 +22,8 @@ use crate::whitenoise::{
     database::Database,
     error::{Result, WhitenoiseError},
     relays::{Relay, RelayType},
-    users::UserRelaySyncContext,
+    shared::SharedServices,
+    users::relay_sync,
 };
 use crate::{
     perf_instrument,
@@ -372,16 +373,18 @@ fn notification_token_counts_by_server(tokens: &[TokenTag]) -> BTreeMap<PublicKe
 }
 
 async fn resolve_notification_server_relays(
-    database: &Database,
-    user_relay_sync: &UserRelaySyncContext,
+    shared: &SharedServices,
     server_pubkey: PublicKey,
     relay_hints: &[RelayUrl],
 ) -> Result<(Vec<RelayUrl>, NotificationRelaySource)> {
     let (server_user, _created) =
-        crate::whitenoise::users::User::find_or_create_by_pubkey(&server_pubkey, database).await?;
+        crate::whitenoise::users::User::find_or_create_by_pubkey(&server_pubkey, &shared.database)
+            .await?;
     let deduped_hints = dedupe_relay_urls(relay_hints);
 
-    let cached_relays = server_user.relays(RelayType::Inbox, database).await?;
+    let cached_relays = server_user
+        .relays(RelayType::Inbox, &shared.database)
+        .await?;
     if !cached_relays.is_empty() {
         return Ok((
             dedupe_relay_urls(&Relay::urls(&cached_relays)),
@@ -393,9 +396,13 @@ async fn resolve_notification_server_relays(
         return Ok((Vec::new(), NotificationRelaySource::HintFallback));
     }
 
-    let synced_relays = match user_relay_sync
-        .sync_relay_type_for_pubkey(server_pubkey, RelayType::Inbox, &deduped_hints)
-        .await
+    let synced_relays = match relay_sync::sync_relay_type_for_pubkey(
+        shared,
+        server_pubkey,
+        RelayType::Inbox,
+        &deduped_hints,
+    )
+    .await
     {
         Ok(relays) => relays,
         Err(error) => {
@@ -407,7 +414,9 @@ async fn resolve_notification_server_relays(
                 error = %error,
                 "Failed to sync notification server inbox relays from relay hints"
             );
-            server_user.relays(RelayType::Inbox, database).await?
+            server_user
+                .relays(RelayType::Inbox, &shared.database)
+                .await?
         }
     };
     if !synced_relays.is_empty() {
@@ -421,8 +430,7 @@ async fn resolve_notification_server_relays(
 }
 
 async fn publish_notification_batches_best_effort(
-    database: &Database,
-    user_relay_sync: &UserRelaySyncContext,
+    shared: &SharedServices,
     ephemeral: &EphemeralPlane,
     account_pubkey: PublicKey,
     token_counts_by_server: &BTreeMap<PublicKey, usize>,
@@ -434,13 +442,9 @@ async fn publish_notification_batches_best_effort(
             .copied()
             .unwrap_or_default();
         let event_count = batch.events.len();
-        let relay_resolution = resolve_notification_server_relays(
-            database,
-            user_relay_sync,
-            batch.server_pubkey,
-            &batch.relay_hints,
-        )
-        .await;
+        let relay_resolution =
+            resolve_notification_server_relays(shared, batch.server_pubkey, &batch.relay_hints)
+                .await;
 
         let (relay_urls, relay_source) = match relay_resolution {
             Ok(result) => result,
@@ -508,8 +512,7 @@ async fn publish_notification_batches_best_effort(
 
 pub(crate) async fn publish_notification_requests_after_delivery_with(
     config: &WhitenoiseConfig,
-    database: &Database,
-    user_relay_sync: &UserRelaySyncContext,
+    shared: &SharedServices,
     ephemeral: &EphemeralPlane,
     account_pubkey: PublicKey,
     group_id: &GroupId,
@@ -526,7 +529,8 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
             )
         })?;
     let cached_tokens =
-        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, database).await?;
+        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, &shared.database)
+            .await?;
     let recipient_tokens = prepare_notification_recipient_tokens(
         &account_pubkey,
         &cached_tokens,
@@ -542,8 +546,7 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
     let batches = build_notification_batches(recipient_tokens)?;
 
     publish_notification_batches_best_effort(
-        database,
-        user_relay_sync,
+        shared,
         ephemeral,
         account_pubkey,
         &token_counts_by_server,
@@ -767,13 +770,11 @@ mod tests {
         account: &Account,
         group_id: &GroupId,
     ) -> Result<()> {
-        let user_relay_sync = whitenoise.user_relay_sync_context();
         let ephemeral = whitenoise.shared.relay_control.ephemeral();
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.shared.database,
-            &user_relay_sync,
+            &whitenoise.shared,
             &ephemeral,
             account.pubkey,
             group_id,
@@ -1078,14 +1079,10 @@ mod tests {
             .await
             .unwrap();
 
-        let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.shared.database,
-            &whitenoise.user_relay_sync_context(),
-            server_pubkey,
-            &[],
-        )
-        .await
-        .unwrap();
+        let (resolved_relays, relay_source) =
+            resolve_notification_server_relays(&whitenoise.shared, server_pubkey, &[])
+                .await
+                .unwrap();
 
         assert_eq!(resolved_relays, vec![relay_url]);
         assert_eq!(relay_source, NotificationRelaySource::Cached);
@@ -1114,8 +1111,7 @@ mod tests {
             .unwrap();
 
         let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.shared.database,
-            &whitenoise.user_relay_sync_context(),
+            &whitenoise.shared,
             server_pubkey,
             &[duplicate_cached_hint, fresh_hint.clone()],
         )
@@ -1140,14 +1136,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let server_pubkey = Keys::generate().public_key();
 
-        let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.shared.database,
-            &whitenoise.user_relay_sync_context(),
-            server_pubkey,
-            &[],
-        )
-        .await
-        .unwrap();
+        let (resolved_relays, relay_source) =
+            resolve_notification_server_relays(&whitenoise.shared, server_pubkey, &[])
+                .await
+                .unwrap();
 
         assert!(resolved_relays.is_empty());
         assert_eq!(relay_source, NotificationRelaySource::HintFallback);
@@ -1187,8 +1179,7 @@ mod tests {
         batches[0].relay_hints.clear();
 
         publish_notification_batches_best_effort(
-            &whitenoise.shared.database,
-            &whitenoise.user_relay_sync_context(),
+            &whitenoise.shared,
             &test_ephemeral_plane(&whitenoise),
             sender_pubkey,
             &notification_token_counts_by_server(&token_tags),
@@ -1522,8 +1513,7 @@ mod tests {
         assert!(batches[0].events.len() > 1);
 
         publish_notification_batches_best_effort(
-            &whitenoise.shared.database,
-            &whitenoise.user_relay_sync_context(),
+            &whitenoise.shared,
             &whitenoise.shared.relay_control.ephemeral(),
             sender_account.pubkey,
             &notification_token_counts_by_server(&token_tags),
@@ -1595,12 +1585,10 @@ mod tests {
         .await
         .unwrap();
         let ephemeral = test_ephemeral_plane(&whitenoise);
-        let user_relay_sync = whitenoise.user_relay_sync_context();
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.shared.database,
-            &user_relay_sync,
+            &whitenoise.shared,
             &ephemeral,
             creator.pubkey,
             &group_id,

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use std::{
     collections::{BTreeMap, HashSet},
     str::FromStr,
+    sync::Arc,
 };
 
 use chrono::{DateTime, Utc};
@@ -21,8 +22,8 @@ use crate::whitenoise::{
     accounts::Account,
     database::Database,
     error::{Result, WhitenoiseError},
+    event_tracker::EventTracker,
     relays::{Relay, RelayType},
-    shared::SharedServices,
     users::relay_sync,
 };
 use crate::{
@@ -373,18 +374,17 @@ fn notification_token_counts_by_server(tokens: &[TokenTag]) -> BTreeMap<PublicKe
 }
 
 async fn resolve_notification_server_relays(
-    shared: &SharedServices,
+    database: &Database,
+    relay_control: &RelayControlPlane,
+    event_tracker: &Arc<dyn EventTracker>,
     server_pubkey: PublicKey,
     relay_hints: &[RelayUrl],
 ) -> Result<(Vec<RelayUrl>, NotificationRelaySource)> {
     let (server_user, _created) =
-        crate::whitenoise::users::User::find_or_create_by_pubkey(&server_pubkey, &shared.database)
-            .await?;
+        crate::whitenoise::users::User::find_or_create_by_pubkey(&server_pubkey, database).await?;
     let deduped_hints = dedupe_relay_urls(relay_hints);
 
-    let cached_relays = server_user
-        .relays(RelayType::Inbox, &shared.database)
-        .await?;
+    let cached_relays = server_user.relays(RelayType::Inbox, database).await?;
     if !cached_relays.is_empty() {
         return Ok((
             dedupe_relay_urls(&Relay::urls(&cached_relays)),
@@ -397,7 +397,9 @@ async fn resolve_notification_server_relays(
     }
 
     let synced_relays = match relay_sync::sync_relay_type_for_pubkey(
-        shared,
+        database,
+        relay_control,
+        event_tracker,
         server_pubkey,
         RelayType::Inbox,
         &deduped_hints,
@@ -414,9 +416,7 @@ async fn resolve_notification_server_relays(
                 error = %error,
                 "Failed to sync notification server inbox relays from relay hints"
             );
-            server_user
-                .relays(RelayType::Inbox, &shared.database)
-                .await?
+            server_user.relays(RelayType::Inbox, database).await?
         }
     };
     if !synced_relays.is_empty() {
@@ -430,7 +430,9 @@ async fn resolve_notification_server_relays(
 }
 
 async fn publish_notification_batches_best_effort(
-    shared: &SharedServices,
+    database: &Database,
+    relay_control: &RelayControlPlane,
+    event_tracker: &Arc<dyn EventTracker>,
     ephemeral: &EphemeralPlane,
     account_pubkey: PublicKey,
     token_counts_by_server: &BTreeMap<PublicKey, usize>,
@@ -442,9 +444,14 @@ async fn publish_notification_batches_best_effort(
             .copied()
             .unwrap_or_default();
         let event_count = batch.events.len();
-        let relay_resolution =
-            resolve_notification_server_relays(shared, batch.server_pubkey, &batch.relay_hints)
-                .await;
+        let relay_resolution = resolve_notification_server_relays(
+            database,
+            relay_control,
+            event_tracker,
+            batch.server_pubkey,
+            &batch.relay_hints,
+        )
+        .await;
 
         let (relay_urls, relay_source) = match relay_resolution {
             Ok(result) => result,
@@ -512,7 +519,9 @@ async fn publish_notification_batches_best_effort(
 
 pub(crate) async fn publish_notification_requests_after_delivery_with(
     config: &WhitenoiseConfig,
-    shared: &SharedServices,
+    database: &Database,
+    relay_control: &RelayControlPlane,
+    event_tracker: &Arc<dyn EventTracker>,
     ephemeral: &EphemeralPlane,
     account_pubkey: PublicKey,
     group_id: &GroupId,
@@ -529,8 +538,7 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
             )
         })?;
     let cached_tokens =
-        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, &shared.database)
-            .await?;
+        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, database).await?;
     let recipient_tokens = prepare_notification_recipient_tokens(
         &account_pubkey,
         &cached_tokens,
@@ -546,7 +554,9 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
     let batches = build_notification_batches(recipient_tokens)?;
 
     publish_notification_batches_best_effort(
-        shared,
+        database,
+        relay_control,
+        event_tracker,
         ephemeral,
         account_pubkey,
         &token_counts_by_server,
@@ -774,7 +784,9 @@ mod tests {
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.shared,
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
             &ephemeral,
             account.pubkey,
             group_id,
@@ -1079,10 +1091,15 @@ mod tests {
             .await
             .unwrap();
 
-        let (resolved_relays, relay_source) =
-            resolve_notification_server_relays(&whitenoise.shared, server_pubkey, &[])
-                .await
-                .unwrap();
+        let (resolved_relays, relay_source) = resolve_notification_server_relays(
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
+            server_pubkey,
+            &[],
+        )
+        .await
+        .unwrap();
 
         assert_eq!(resolved_relays, vec![relay_url]);
         assert_eq!(relay_source, NotificationRelaySource::Cached);
@@ -1111,7 +1128,9 @@ mod tests {
             .unwrap();
 
         let (resolved_relays, relay_source) = resolve_notification_server_relays(
-            &whitenoise.shared,
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
             server_pubkey,
             &[duplicate_cached_hint, fresh_hint.clone()],
         )
@@ -1136,10 +1155,15 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let server_pubkey = Keys::generate().public_key();
 
-        let (resolved_relays, relay_source) =
-            resolve_notification_server_relays(&whitenoise.shared, server_pubkey, &[])
-                .await
-                .unwrap();
+        let (resolved_relays, relay_source) = resolve_notification_server_relays(
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
+            server_pubkey,
+            &[],
+        )
+        .await
+        .unwrap();
 
         assert!(resolved_relays.is_empty());
         assert_eq!(relay_source, NotificationRelaySource::HintFallback);
@@ -1179,7 +1203,9 @@ mod tests {
         batches[0].relay_hints.clear();
 
         publish_notification_batches_best_effort(
-            &whitenoise.shared,
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
             &test_ephemeral_plane(&whitenoise),
             sender_pubkey,
             &notification_token_counts_by_server(&token_tags),
@@ -1513,7 +1539,9 @@ mod tests {
         assert!(batches[0].events.len() > 1);
 
         publish_notification_batches_best_effort(
-            &whitenoise.shared,
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
             &whitenoise.shared.relay_control.ephemeral(),
             sender_account.pubkey,
             &notification_token_counts_by_server(&token_tags),
@@ -1588,7 +1616,9 @@ mod tests {
 
         publish_notification_requests_after_delivery_with(
             &whitenoise.config,
-            &whitenoise.shared,
+            &whitenoise.shared.database,
+            &whitenoise.shared.relay_control,
+            &whitenoise.shared.event_tracker,
             &ephemeral,
             creator.pubkey,
             &group_id,

--- a/src/whitenoise/relays.rs
+++ b/src/whitenoise/relays.rs
@@ -125,7 +125,7 @@ impl Relay {
 impl Whitenoise {
     #[perf_instrument("relays")]
     pub async fn find_or_create_relay_by_url(&self, url: &RelayUrl) -> Result<Relay> {
-        Relay::find_or_create_by_url(url, &self.database).await
+        Relay::find_or_create_by_url(url, &self.shared.database).await
     }
 
     /// Get connection status for all of an account's relays.
@@ -205,7 +205,8 @@ impl Whitenoise {
             lookup_keys_by_url.insert(relay_url.clone(), lookup_keys);
         }
 
-        let status_records = RelayStatusRecord::find_many(&all_lookup_keys, &self.database).await?;
+        let status_records =
+            RelayStatusRecord::find_many(&all_lookup_keys, &self.shared.database).await?;
         let records_by_key = status_records
             .into_iter()
             .map(|record| (record.lookup_key(), record))
@@ -257,7 +258,7 @@ mod tests {
             None => RelayTelemetry::new(RelayTelemetryKind::Connected, plane, relay_url.clone()),
         };
 
-        RelayStatusRecord::upsert_from_telemetry(&telemetry, &whitenoise.database)
+        RelayStatusRecord::upsert_from_telemetry(&telemetry, &whitenoise.shared.database)
             .await
             .unwrap();
     }
@@ -269,8 +270,12 @@ mod tests {
         async fn test_get_account_relay_statuses_empty() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
             // Account with no relays should return an empty list.
             let statuses = whitenoise
@@ -287,18 +292,26 @@ mod tests {
         async fn test_get_account_relay_statuses_with_relays() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
             // Add some relays to the account's user.
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let url1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let url2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
             let relay1 = whitenoise.find_or_create_relay_by_url(&url1).await.unwrap();
             let relay2 = whitenoise.find_or_create_relay_by_url(&url2).await.unwrap();
-            user.add_relays(&[relay1, relay2], RelayType::Nip65, &whitenoise.database)
-                .await
-                .unwrap();
+            user.add_relays(
+                &[relay1, relay2],
+                RelayType::Nip65,
+                &whitenoise.shared.database,
+            )
+            .await
+            .unwrap();
 
             let statuses = whitenoise
                 .get_account_relay_statuses(&account)
@@ -319,21 +332,25 @@ mod tests {
         async fn test_get_account_relay_statuses_deduplicates() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
             // Add the same relay URL to both NIP-65 and Inbox types.
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let url = RelayUrl::parse("wss://shared.relay.example.com").unwrap();
             let relay = whitenoise.find_or_create_relay_by_url(&url).await.unwrap();
             user.add_relays(
                 std::slice::from_ref(&relay),
                 RelayType::Nip65,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
-            user.add_relays(&[relay], RelayType::Inbox, &whitenoise.database)
+            user.add_relays(&[relay], RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -353,16 +370,20 @@ mod tests {
         async fn test_get_account_relay_statuses_ignores_unrelated_discovery_status() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let relay_url = RelayUrl::parse("ws://localhost:7777").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
                 .await
                 .unwrap();
-            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.database)
+            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -380,16 +401,20 @@ mod tests {
         async fn test_get_account_relay_statuses_reads_account_inbox_plane() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let relay_url = RelayUrl::parse("ws://localhost:8080").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
                 .await
                 .unwrap();
-            user.add_relays(&[relay], RelayType::Inbox, &whitenoise.database)
+            user.add_relays(&[relay], RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -413,16 +438,20 @@ mod tests {
         async fn test_get_account_relay_statuses_reads_ephemeral_plane_for_nip65() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let relay_url = RelayUrl::parse("ws://localhost:7777").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
                 .await
                 .unwrap();
-            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.database)
+            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -446,16 +475,20 @@ mod tests {
         async fn test_get_account_relay_statuses_reads_unscoped_ephemeral_plane_for_nip65() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let (account, keys) = create_test_account(&whitenoise).await;
-            let account = account.save(&whitenoise.database).await.unwrap();
-            whitenoise.secrets_store.store_private_key(&keys).unwrap();
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .unwrap();
 
-            let user = account.user(&whitenoise.database).await.unwrap();
+            let user = account.user(&whitenoise.shared.database).await.unwrap();
             let relay_url = RelayUrl::parse("ws://localhost:7777").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
                 .await
                 .unwrap();
-            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.database)
+            user.add_relays(&[relay], RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 

--- a/src/whitenoise/scheduled_tasks/tasks/cached_graph_user_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/cached_graph_user_cleanup.rs
@@ -28,7 +28,7 @@ impl Task for CachedGraphUserCleanup {
 
     #[perf_instrument("scheduled::cached_graph_cleanup")]
     async fn execute(&self, whitenoise: &'static Whitenoise) -> Result<(), WhitenoiseError> {
-        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.database).await?;
+        let deleted = CachedGraphUser::cleanup_stale(&whitenoise.shared.database).await?;
 
         if deleted > 0 {
             tracing::info!(

--- a/src/whitenoise/scheduled_tasks/tasks/consumed_key_package_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/consumed_key_package_cleanup.rs
@@ -46,7 +46,7 @@ impl Task for ConsumedKeyPackageCleanup {
             "Starting consumed key package cleanup"
         );
 
-        let accounts = Account::all(&whitenoise.database).await?;
+        let accounts = Account::all(&whitenoise.shared.database).await?;
 
         if accounts.is_empty() {
             tracing::debug!(
@@ -121,7 +121,7 @@ async fn cleanup_consumed_key_packages(
     let eligible = PublishedKeyPackage::find_eligible_for_cleanup(
         &account.pubkey,
         CONSUMED_KP_QUIET_PERIOD_SECS,
-        &whitenoise.database,
+        &whitenoise.shared.database,
     )
     .await?;
 
@@ -144,7 +144,7 @@ async fn cleanup_consumed_key_packages(
             Ok(()) => {
                 if let Err(e) = PublishedKeyPackage::mark_key_material_deleted(
                     consumed.id,
-                    &whitenoise.database,
+                    &whitenoise.shared.database,
                 )
                 .await
                 {

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -37,7 +37,7 @@ impl Task for KeyPackageMaintenance {
             "Starting key package maintenance"
         );
 
-        let accounts = Account::all(&whitenoise.database).await?;
+        let accounts = Account::all(&whitenoise.shared.database).await?;
 
         if accounts.is_empty() {
             tracing::debug!(
@@ -291,7 +291,7 @@ async fn find_live_published_key_packages(
         match PublishedKeyPackage::find_by_event_id(
             &account.pubkey,
             &event.id.to_hex(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await?
         {
@@ -597,7 +597,7 @@ mod tests {
         let tracked = PublishedKeyPackage::find_by_event_id(
             &account.pubkey,
             &before[0].id.to_hex(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap()
@@ -606,7 +606,7 @@ mod tests {
         let mdk = whitenoise.create_mdk_for_account(account.pubkey).unwrap();
         mdk.delete_key_package_from_storage_by_hash_ref(&tracked.key_package_hash_ref)
             .unwrap();
-        PublishedKeyPackage::mark_key_material_deleted(tracked.id, &whitenoise.database)
+        PublishedKeyPackage::mark_key_material_deleted(tracked.id, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -654,7 +654,7 @@ mod tests {
         PublishedKeyPackage::mark_consumed(
             &account.pubkey,
             &before[0].id.to_hex(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();
@@ -708,7 +708,7 @@ mod tests {
         PublishedKeyPackage::mark_consumed(
             &account.pubkey,
             &before[0].id.to_hex(),
-            &whitenoise.database,
+            &whitenoise.shared.database,
         )
         .await
         .unwrap();

--- a/src/whitenoise/scheduled_tasks/tasks/mute_expiry_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/mute_expiry_cleanup.rs
@@ -32,7 +32,7 @@ impl Task for MuteExpiryCleanup {
 
     #[perf_instrument("scheduled::mute_expiry_cleanup")]
     async fn execute(&self, whitenoise: &'static Whitenoise) -> Result<(), WhitenoiseError> {
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.database).await?;
+        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database).await?;
 
         if cleared.is_empty() {
             tracing::debug!(
@@ -50,7 +50,7 @@ impl Task for MuteExpiryCleanup {
 
         // Emit ChatMuteChanged for each cleared mute so the UI updates.
         for ag in &cleared {
-            match Account::find_by_pubkey(&ag.account_pubkey, &whitenoise.database).await {
+            match Account::find_by_pubkey(&ag.account_pubkey, &whitenoise.shared.database).await {
                 Ok(account) => {
                     whitenoise
                         .emit_chat_list_update(

--- a/src/whitenoise/scheduled_tasks/tasks/relay_list_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/relay_list_maintenance.rs
@@ -46,7 +46,7 @@ impl Task for RelayListMaintenance {
             "Starting relay list maintenance"
         );
 
-        let accounts = Account::all(&whitenoise.database).await?;
+        let accounts = Account::all(&whitenoise.shared.database).await?;
 
         if accounts.is_empty() {
             tracing::debug!(
@@ -183,6 +183,7 @@ async fn check_and_republish(
 
     // 3. Query the network for the existing relay list event
     let network_event = match whitenoise
+        .shared
         .relay_control
         .fetch_user_relays(account.pubkey, relay_type, &source_urls)
         .await
@@ -237,6 +238,7 @@ async fn check_and_republish(
     let target_urls = Relay::urls(&source_relays);
 
     match whitenoise
+        .shared
         .relay_control
         .publish_relay_list_with_signer(&relay_urls, relay_type, &target_urls, signer)
         .await
@@ -278,6 +280,7 @@ mod tests {
 
         loop {
             match whitenoise
+                .shared
                 .relay_control
                 .fetch_user_relays(account.pubkey, relay_type, source_urls)
                 .await
@@ -412,6 +415,7 @@ mod tests {
 
         // Verify relay lists are still discoverable after maintenance (unchanged)
         let inbox_after = whitenoise
+            .shared
             .relay_control
             .fetch_user_relays(account.pubkey, RelayType::Inbox, &nip65_urls)
             .await
@@ -422,6 +426,7 @@ mod tests {
         );
 
         let kp_after = whitenoise
+            .shared
             .relay_control
             .fetch_user_relays(account.pubkey, RelayType::KeyPackage, &nip65_urls)
             .await
@@ -448,7 +453,7 @@ mod tests {
         let account = Account::new_external(whitenoise, keys.public_key())
             .await
             .unwrap();
-        let account = account.save(&whitenoise.database).await.unwrap();
+        let account = account.save(&whitenoise.shared.database).await.unwrap();
 
         // Verify no local relays exist
         let inbox = account.inbox_relays(whitenoise).await.unwrap();

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -74,7 +74,7 @@ impl<'a> ChatListOps<'a> {
         let account_group = AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await?;
         let Some(membership) = account_group else {
@@ -116,7 +116,7 @@ impl<'a> ChatListOps<'a> {
             let infos = GroupInformation::get_by_mls_group_ids_with_mdk(
                 &group_ids,
                 &self.session.mdk,
-                &self.session.database,
+                &self.session.shared.database,
             )
             .await?;
             infos
@@ -127,14 +127,14 @@ impl<'a> ChatListOps<'a> {
 
         let dm_other_users: HashMap<GroupId, PublicKey> = AccountGroup::find_dm_peers_for_account(
             &self.session.account_pubkey,
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await?
         .into_iter()
         .collect();
 
         let last_message_map: HashMap<GroupId, ChatMessageSummary> =
-            AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.database)
+            AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.shared.database)
                 .await?
                 .into_iter()
                 .map(|s| (s.mls_group_id.clone(), s))
@@ -142,7 +142,7 @@ impl<'a> ChatListOps<'a> {
 
         let pubkeys_to_fetch = collect_pubkeys_to_fetch(&dm_other_users, &last_message_map);
         let users_by_pubkey: HashMap<PublicKey, User> =
-            User::find_by_pubkeys(&pubkeys_to_fetch, &self.session.database)
+            User::find_by_pubkeys(&pubkeys_to_fetch, &self.session.shared.database)
                 .await?
                 .into_iter()
                 .map(|u| (u.pubkey, u))
@@ -157,9 +157,11 @@ impl<'a> ChatListOps<'a> {
                 (gid.clone(), ag.last_read_message_id, cleared_ms)
             })
             .collect();
-        let unread_counts =
-            AggregatedMessage::count_unread_for_groups(&group_markers, &self.session.database)
-                .await?;
+        let unread_counts = AggregatedMessage::count_unread_for_groups(
+            &group_markers,
+            &self.session.shared.database,
+        )
+        .await?;
 
         let mut items = assemble_chat_list_items(
             &groups,
@@ -187,13 +189,15 @@ impl<'a> ChatListOps<'a> {
             Ok(wn) => wn,
             Err(_) => return HashMap::new(),
         };
-        let account =
-            match Account::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
-                .await
-            {
-                Ok(account) => account,
-                Err(_) => return HashMap::new(),
-            };
+        let account = match Account::find_by_pubkey(
+            &self.session.account_pubkey,
+            &self.session.shared.database,
+        )
+        .await
+        {
+            Ok(account) => account,
+            Err(_) => return HashMap::new(),
+        };
 
         let group_type_groups: Vec<_> = groups
             .iter()

--- a/src/whitenoise/session/groups/media.rs
+++ b/src/whitenoise/session/groups/media.rs
@@ -414,6 +414,7 @@ impl<'a> MediaOps<'a> {
         // TODO(phase-16): Remove singleton bridge when storage moves to session.
         let wn = Self::wn()?;
         let cache_path = wn
+            .shared
             .storage
             .media_files
             .store_file(&cached_filename, &decrypted_data)

--- a/src/whitenoise/session/groups/media.rs
+++ b/src/whitenoise/session/groups/media.rs
@@ -150,7 +150,7 @@ impl<'a> MediaOps<'a> {
 
         // Try to get the stored blossom_url from the database
         let blossom_url = if let Some(media_file) =
-            MediaFile::find_by_hash(&self.session.database, &image_hash).await?
+            MediaFile::find_by_hash(&self.session.shared.database, &image_hash).await?
         {
             media_file
                 .blossom_url
@@ -378,7 +378,7 @@ impl<'a> MediaOps<'a> {
         original_file_hash: &[u8; 32],
     ) -> Result<MediaFile> {
         let media_file = MediaFile::find_by_original_hash_and_group(
-            &self.session.database,
+            &self.session.shared.database,
             original_file_hash,
             group_id,
             &self.session.account_pubkey,
@@ -424,13 +424,13 @@ impl<'a> MediaOps<'a> {
             WhitenoiseError::MediaCache("MediaFile record missing id".to_string())
         })?;
 
-        MediaFile::update_file_path(&self.session.database, media_file_id, &cache_path).await
+        MediaFile::update_file_path(&self.session.shared.database, media_file_id, &cache_path).await
     }
 
     /// Returns all media files for a group.
     #[perf_instrument("groups")]
     pub async fn get_media_files_for_group(&self, group_id: &GroupId) -> Result<Vec<MediaFile>> {
-        MediaFile::find_by_group(&self.session.database, group_id).await
+        MediaFile::find_by_group(&self.session.shared.database, group_id).await
     }
 
     /// Returns the filesystem path of the cached group image, downloading if needed.
@@ -459,7 +459,7 @@ impl<'a> MediaOps<'a> {
             };
 
         let blossom_url = if let Some(media_file) =
-            MediaFile::find_by_hash(&self.session.database, image_hash).await?
+            MediaFile::find_by_hash(&self.session.shared.database, image_hash).await?
         {
             media_file
                 .blossom_url
@@ -578,7 +578,7 @@ impl<'a> MediaOps<'a> {
         image_key: &[u8; 32],
     ) -> Result<MediaFile> {
         let existing_record_opt =
-            MediaFile::find_by_hash(&self.session.database, image_hash).await?;
+            MediaFile::find_by_hash(&self.session.shared.database, image_hash).await?;
 
         match existing_record_opt {
             Some(existing_record) => {

--- a/src/whitenoise/session/groups/mod.rs
+++ b/src/whitenoise/session/groups/mod.rs
@@ -85,7 +85,7 @@ impl<'a> GroupOps<'a> {
 
         let visible_account_groups = AccountGroup::find_visible_for_account(
             &self.session.account_pubkey,
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await?;
 
@@ -123,7 +123,8 @@ impl<'a> GroupOps<'a> {
             .map(|gwm| gwm.group.mls_group_id.clone())
             .collect();
         let info_list =
-            GroupInformation::find_by_mls_group_ids(&group_ids, &self.session.database).await?;
+            GroupInformation::find_by_mls_group_ids(&group_ids, &self.session.shared.database)
+                .await?;
         let info_by_id: HashMap<_, _> = info_list
             .into_iter()
             .map(|gi| (gi.mls_group_id.clone(), gi))
@@ -641,7 +642,7 @@ impl<'a> GroupOps<'a> {
         let (_group_info, _was_created) = GroupInformation::find_or_create_by_mls_group_id(
             &group.mls_group_id,
             Some(group_type),
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await?;
 
@@ -649,11 +650,11 @@ impl<'a> GroupOps<'a> {
             &self.session.account_pubkey,
             &group.mls_group_id,
             dm_peer,
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await?;
         account_group
-            .update_user_confirmation(true, &self.session.database)
+            .update_user_confirmation(true, &self.session.shared.database)
             .await?;
 
         // Best-effort: share the creator's push token into the new group.

--- a/src/whitenoise/session/groups/mod.rs
+++ b/src/whitenoise/session/groups/mod.rs
@@ -258,13 +258,15 @@ impl<'a> GroupOps<'a> {
             .ok_or(WhitenoiseError::SignerUnavailable(
                 self.session.account_pubkey,
             ))?;
-        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+        let account =
+            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
 
         let mut key_package_events: Vec<Event> = Vec::new();
         let mut users = Vec::new();
 
         for pk in member_pubkeys.iter() {
-            let (user, newly_created) = User::find_or_create_by_pubkey(pk, &wn.database).await?;
+            let (user, newly_created) =
+                User::find_or_create_by_pubkey(pk, &wn.shared.database).await?;
 
             if newly_created && let Err(e) = user.update_relay_lists(wn).await {
                 tracing::warn!(
@@ -275,7 +277,9 @@ impl<'a> GroupOps<'a> {
                 );
             }
 
-            let mut relays_to_use = user.relays(RelayType::KeyPackage, &wn.database).await?;
+            let mut relays_to_use = user
+                .relays(RelayType::KeyPackage, &wn.shared.database)
+                .await?;
             if relays_to_use.is_empty() {
                 tracing::warn!(
                     target: "whitenoise::session::groups",
@@ -286,6 +290,7 @@ impl<'a> GroupOps<'a> {
             }
             let relays_to_use_urls = Relay::urls(&relays_to_use);
             let some_event = wn
+                .shared
                 .relay_control
                 .fetch_user_key_package(*pk, &relays_to_use_urls)
                 .await?;
@@ -355,7 +360,8 @@ impl<'a> GroupOps<'a> {
 
             let relay_urls = Relay::urls(&relays_to_use);
 
-            wn.relay_control
+            wn.shared
+                .relay_control
                 .publish_welcome(
                     &member_pubkey,
                     welcome_rumor.clone(),
@@ -404,7 +410,8 @@ impl<'a> GroupOps<'a> {
             .await?;
 
         let wn = Self::wn()?;
-        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+        let account =
+            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
         wn.background_refresh_account_group_subscriptions(&account);
         Ok(())
     }
@@ -452,7 +459,8 @@ impl<'a> GroupOps<'a> {
         )
         .await?;
 
-        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+        let account =
+            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
 
         if let Err(error) = wn.mark_as_left(&account, group_id).await {
             tracing::warn!(
@@ -531,7 +539,8 @@ impl<'a> GroupOps<'a> {
 
         Self::publish_welcomes(welcome_data, signer, self.session.account_pubkey).await;
 
-        let account = Account::find_by_pubkey(&self.session.account_pubkey, &wn.database).await?;
+        let account =
+            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
         wn.background_refresh_account_group_subscriptions(&account);
 
         Ok(group)
@@ -543,7 +552,7 @@ impl<'a> GroupOps<'a> {
     // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
     async fn resolve_member_key_package(&self, pk: &PublicKey) -> Result<(User, Event)> {
         let wn = Self::wn()?;
-        let (user, created) = User::find_or_create_by_pubkey(pk, &wn.database).await?;
+        let (user, created) = User::find_or_create_by_pubkey(pk, &wn.shared.database).await?;
         if created && let Err(e) = user.update_relay_lists(wn).await {
             tracing::warn!(
                 target: "whitenoise::session::groups",
@@ -691,7 +700,7 @@ impl<'a> GroupOps<'a> {
         };
 
         let creator_account =
-            match Account::find_by_pubkey(&creator_pubkey, &whitenoise.database).await {
+            match Account::find_by_pubkey(&creator_pubkey, &whitenoise.shared.database).await {
                 Ok(account) => account,
                 Err(error) => {
                     tracing::error!(
@@ -721,6 +730,7 @@ impl<'a> GroupOps<'a> {
                         Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
                     whitenoise
+                        .shared
                         .relay_control
                         .publish_welcome(
                             &member_pubkey,

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -331,10 +331,11 @@ impl<'a> KeyPackageOps<'a> {
     }
 
     async fn prepare_relays(&self) -> Result<Vec<Relay>> {
-        let user = User::find_by_pubkey(&self.session.account_pubkey, &self.session.database)
-            .await
-            .map_err(|_| WhitenoiseError::AccountNotFound)?;
-        user.relays(RelayType::KeyPackage, &self.session.database)
+        let user =
+            User::find_by_pubkey(&self.session.account_pubkey, &self.session.shared.database)
+                .await
+                .map_err(|_| WhitenoiseError::AccountNotFound)?;
+        user.relays(RelayType::KeyPackage, &self.session.shared.database)
             .await
     }
 

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -42,7 +42,7 @@ impl<'a> MembershipOps<'a> {
     }
 
     fn db(&self) -> &Arc<Database> {
-        &self.session.database
+        &self.session.shared.database
     }
 
     /// Return all visible (pending + accepted) account-group memberships.
@@ -104,7 +104,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     }
 
     fn db(&self) -> &Arc<Database> {
-        &self.session.database
+        &self.session.shared.database
     }
 
     /// Load the account-group row, returning `GroupNotFound` if absent.

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -14,7 +14,7 @@ use crate::whitenoise::message_aggregator::processor::{
     extract_deletion_target_ids, extract_reaction_target_id,
 };
 use crate::whitenoise::message_aggregator::{
-    ChatMessage, DeliveryStatus, MessageAggregator, SearchResult, emoji_utils, reaction_handler,
+    ChatMessage, DeliveryStatus, SearchResult, emoji_utils, reaction_handler,
 };
 use crate::whitenoise::message_streaming::{MessageStreamManager, MessageUpdate, UpdateTrigger};
 use crate::whitenoise::push_notifications::publish_notification_requests_after_delivery_with;
@@ -303,24 +303,23 @@ impl<'a> MessageOpsForGroup<'a> {
     ) {
         let ephemeral = self.session.ephemeral.clone_inner();
         let account_pubkey = *self.pubkey();
-        let database = self.session.shared.database.clone();
-        let stream_manager = self.session.shared.message_stream_manager.clone();
+        let shared = self.session.shared.clone();
         let group_id = self.group_id.clone();
         let event_id_str = event_id.to_string();
         let tags = mdk_message.tags.clone();
         let author = mdk_message.pubkey;
         let content = mdk_message.content.clone();
 
-        // TODO: Push config and relay sync context should live on AccountSession
-        // instead of reaching back to the singleton. Tracked for Phase 16b.
-        let (push_config, push_relay_sync) = match crate::whitenoise::Whitenoise::get_instance() {
-            Ok(wn) => (Some(wn.config.clone()), Some(wn.user_relay_sync_context())),
+        // TODO: Push config should live on AccountSession instead of reaching
+        // back to the singleton. Tracked for Phase 16b.
+        let push_config = match crate::whitenoise::Whitenoise::get_instance() {
+            Ok(wn) => Some(wn.config.clone()),
             Err(_) => {
                 tracing::debug!(
                     target: "whitenoise::messages",
                     "Whitenoise singleton unavailable, push notifications skipped"
                 );
-                (None, None)
+                None
             }
         };
 
@@ -332,19 +331,17 @@ impl<'a> MessageOpsForGroup<'a> {
                     &group_relays,
                     &event_id_str,
                     &group_id,
-                    &database,
-                    &stream_manager,
+                    &shared.database,
+                    &shared.message_stream_manager,
                 )
                 .await
                 .succeeded();
 
             if ok {
                 if let Some(config) = &push_config
-                    && let Some(sync) = &push_relay_sync
                     && let Err(e) = publish_notification_requests_after_delivery_with(
                         config,
-                        &database,
-                        sync,
+                        &shared,
                         &ephemeral,
                         account_pubkey,
                         &group_id,
@@ -366,8 +363,8 @@ impl<'a> MessageOpsForGroup<'a> {
                     &author,
                     &content,
                     &group_id,
-                    &database,
-                    &stream_manager,
+                    &shared.database,
+                    &shared.message_stream_manager,
                 )
                 .await;
             }
@@ -382,9 +379,10 @@ impl<'a> MessageOpsForGroup<'a> {
             crate::whitenoise::media_files::MediaFile::find_by_group(self.db(), self.group_id)
                 .await?;
 
-        let aggregator =
-            MessageAggregator::with_config(self.session.shared.message_aggregator.config().clone());
-        let chat_message = aggregator
+        let chat_message = self
+            .session
+            .shared
+            .message_aggregator
             .process_single_message(mdk_message, &ContentParser::new(), media_files)
             .await
             .map(|mut msg| {

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -49,7 +49,7 @@ impl<'a> MessageOps<'a> {
     }
 
     fn db(&self) -> &Arc<Database> {
-        &self.session.database
+        &self.session.shared.database
     }
 }
 
@@ -65,11 +65,12 @@ impl<'a> MessageOpsForGroup<'a> {
     }
 
     fn db(&self) -> &Arc<Database> {
-        &self.session.database
+        &self.session.shared.database
     }
 
     fn emit(&self, trigger: UpdateTrigger, message: ChatMessage) {
         self.session
+            .shared
             .message_stream_manager
             .emit(self.group_id, MessageUpdate { trigger, message });
     }
@@ -302,8 +303,8 @@ impl<'a> MessageOpsForGroup<'a> {
     ) {
         let ephemeral = self.session.ephemeral.clone_inner();
         let account_pubkey = *self.pubkey();
-        let database = self.session.database.clone();
-        let stream_manager = self.session.message_stream_manager.clone();
+        let database = self.session.shared.database.clone();
+        let stream_manager = self.session.shared.message_stream_manager.clone();
         let group_id = self.group_id.clone();
         let event_id_str = event_id.to_string();
         let tags = mdk_message.tags.clone();

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -341,7 +341,9 @@ impl<'a> MessageOpsForGroup<'a> {
                 if let Some(config) = &push_config
                     && let Err(e) = publish_notification_requests_after_delivery_with(
                         config,
-                        &shared,
+                        &shared.database,
+                        &shared.relay_control,
+                        &shared.event_tracker,
                         &ephemeral,
                         account_pubkey,
                         &group_id,

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -382,7 +382,8 @@ impl<'a> MessageOpsForGroup<'a> {
             crate::whitenoise::media_files::MediaFile::find_by_group(self.db(), self.group_id)
                 .await?;
 
-        let aggregator = MessageAggregator::with_config(self.session.aggregator_config.clone());
+        let aggregator =
+            MessageAggregator::with_config(self.session.shared.message_aggregator.config().clone());
         let chat_message = aggregator
             .process_single_message(mdk_message, &ContentParser::new(), media_files)
             .await
@@ -419,7 +420,11 @@ impl<'a> MessageOpsForGroup<'a> {
         {
             let emoji = emoji_utils::validate_and_normalize_reaction(
                 &mdk_message.content,
-                self.session.aggregator_config.normalize_emoji,
+                self.session
+                    .shared
+                    .message_aggregator
+                    .config()
+                    .normalize_emoji,
             )?;
             reaction_handler::add_reaction_to_message(
                 &mut target,

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -36,7 +36,6 @@ use crate::relay_control::groups::GroupSubscriptionSpec;
 use crate::types::AccountInboxPlaneStateSnapshot;
 use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
-use crate::whitenoise::database::Database;
 use crate::whitenoise::database::account::AccountRepositories;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::message_aggregator::AggregatorConfig;
@@ -74,10 +73,8 @@ impl AccountInboxState {
 pub struct AccountSession {
     pub account_pubkey: PublicKey,
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
+    pub(crate) shared: Arc<crate::whitenoise::shared::SharedServices>,
     pub(crate) repos: AccountRepositories,
-    pub(crate) database: Arc<Database>,
-    pub(crate) message_stream_manager:
-        Arc<crate::whitenoise::message_streaming::MessageStreamManager>,
     pub(crate) aggregator_config: AggregatorConfig,
     pub(crate) signer: SharedSigner,
     contact_list_guard: Arc<Semaphore>,
@@ -96,27 +93,25 @@ impl AccountSession {
     pub(crate) async fn new(
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
-        database: Arc<Database>,
-        message_stream_manager: Arc<crate::whitenoise::message_streaming::MessageStreamManager>,
+        shared: Arc<crate::whitenoise::shared::SharedServices>,
         aggregator_config: AggregatorConfig,
         signer: Option<Arc<dyn NostrSigner>>,
-        ephemeral_plane: crate::relay_control::ephemeral::EphemeralPlane,
-        relay_control: Arc<crate::relay_control::RelayControlPlane>,
     ) -> Result<Self> {
         let (cancellation, _) = watch::channel(false);
         let signer: SharedSigner = Arc::new(RwLock::new(signer));
         let ephemeral = relay_handles::AccountEphemeralHandle::new(
             account_pubkey,
-            ephemeral_plane,
+            shared.relay_control.ephemeral(),
             signer.clone(),
         );
-        let group_handle = relay_handles::AccountGroupHandle::new(account_pubkey, relay_control);
+        let group_handle =
+            relay_handles::AccountGroupHandle::new(account_pubkey, shared.relay_control.clone());
+        let repos = AccountRepositories::new(account_pubkey, shared.database.clone()).await?;
         Ok(Self {
-            repos: AccountRepositories::new(account_pubkey, database.clone()).await?,
             account_pubkey,
             mdk: Arc::new(mdk),
-            database,
-            message_stream_manager,
+            shared,
+            repos,
             aggregator_config,
             signer,
             contact_list_guard: Arc::new(Semaphore::new(1)),
@@ -141,12 +136,9 @@ impl AccountSession {
         Self::new(
             account.pubkey,
             mdk,
-            wn.shared.database.clone(),
-            wn.shared.message_stream_manager.clone(),
+            wn.shared.clone(),
             wn.shared.message_aggregator.config().clone(),
             signer,
-            wn.shared.relay_control.ephemeral(),
-            wn.shared.relay_control.clone(),
         )
         .await
     }
@@ -253,7 +245,7 @@ impl AccountSession {
         self.pending_push_token_responses.insert(key, ());
 
         let mdk = Arc::clone(&self.mdk);
-        let database = Arc::clone(&self.database);
+        let database = Arc::clone(&self.shared.database);
         let pending = Arc::clone(&self.pending_push_token_responses);
         let relay_control = Arc::clone(self.group_handle.relay_control());
         let account_pubkey = self.account_pubkey;
@@ -583,8 +575,6 @@ pub(crate) mod test_helpers {
 
     use super::*;
     use crate::relay_control::RelayControlPlane;
-    use crate::relay_control::ephemeral::{EphemeralPlane, EphemeralPlaneConfig};
-    use crate::relay_control::observability::{RelayObservability, RelayObservabilityConfig};
     use crate::whitenoise::accounts::test_utils::create_mdk;
     use crate::whitenoise::database::Database;
     use crate::whitenoise::test_utils::insert_test_account;
@@ -612,35 +602,50 @@ pub(crate) mod test_helpers {
         // Insert the account row so AccountFollowsRepo can resolve the account id.
         insert_test_account(&db, &pubkey).await;
 
+        let shared = test_shared(db).await;
+        Arc::new(
+            AccountSession::new(pubkey, mdk, shared, AggregatorConfig::default(), None)
+                .await
+                .expect("create test session"),
+        )
+    }
+
+    /// Build a minimal `SharedServices` for tests.
+    pub async fn test_shared(db: Arc<Database>) -> Arc<crate::whitenoise::shared::SharedServices> {
+        use dashmap::DashMap;
+
+        use crate::whitenoise::discovery_sync_worker::DiscoverySyncWorker;
+        use crate::whitenoise::event_tracker::WhitenoiseEventTracker;
+        use crate::whitenoise::message_aggregator::MessageAggregator;
+        use crate::whitenoise::secrets_store::SecretsStore;
+        use crate::whitenoise::shared::SharedServices;
+        use crate::whitenoise::storage::Storage;
+
         let (event_sender, _) = tokio::sync::mpsc::channel(1);
-        let ephemeral = EphemeralPlane::new(
-            EphemeralPlaneConfig::default(),
-            db.clone(),
-            event_sender.clone(),
-            RelayObservability::new(RelayObservabilityConfig::default()),
-        );
         let relay_control = Arc::new(RelayControlPlane::new(
             db.clone(),
             vec![],
             event_sender,
             [0u8; 16],
         ));
-        let stream_manager =
-            Arc::new(crate::whitenoise::message_streaming::MessageStreamManager::default());
-        Arc::new(
-            AccountSession::new(
-                pubkey,
-                mdk,
-                db,
-                stream_manager,
-                AggregatorConfig::default(),
-                None,
-                ephemeral,
-                relay_control,
-            )
-            .await
-            .expect("create test session"),
-        )
+        Arc::new(SharedServices {
+            database: db.clone(),
+            relay_control,
+            event_tracker: Arc::new(WhitenoiseEventTracker::new(db)),
+            secrets_store: SecretsStore::new("com.whitenoise.test"),
+            storage: Storage::new(std::env::temp_dir().as_path())
+                .await
+                .expect("test storage"),
+            message_aggregator: MessageAggregator::new(),
+            message_stream_manager: Arc::new(Default::default()),
+            user_stream_manager: Default::default(),
+            chat_list_stream_manager: Default::default(),
+            archived_chat_list_stream_manager: Default::default(),
+            notification_stream_manager: Default::default(),
+            user_resolution_guards: DashMap::new(),
+            external_signers: DashMap::new(),
+            discovery_sync_worker: DiscoverySyncWorker::new(),
+        })
     }
 }
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -38,7 +38,6 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
 use crate::whitenoise::database::account::AccountRepositories;
 use crate::whitenoise::error::{Result, WhitenoiseError};
-use crate::whitenoise::message_aggregator::AggregatorConfig;
 
 /// Signer slot shared between `AccountSession` and its relay handles.
 ///
@@ -75,7 +74,6 @@ pub struct AccountSession {
     pub mdk: Arc<MDK<MdkSqliteStorage>>,
     pub(crate) shared: Arc<crate::whitenoise::shared::SharedServices>,
     pub(crate) repos: AccountRepositories,
-    pub(crate) aggregator_config: AggregatorConfig,
     pub(crate) signer: SharedSigner,
     contact_list_guard: Arc<Semaphore>,
     cancellation: watch::Sender<bool>,
@@ -94,7 +92,6 @@ impl AccountSession {
         account_pubkey: PublicKey,
         mdk: MDK<MdkSqliteStorage>,
         shared: Arc<crate::whitenoise::shared::SharedServices>,
-        aggregator_config: AggregatorConfig,
         signer: Option<Arc<dyn NostrSigner>>,
     ) -> Result<Self> {
         let (cancellation, _) = watch::channel(false);
@@ -112,7 +109,6 @@ impl AccountSession {
             mdk: Arc::new(mdk),
             shared,
             repos,
-            aggregator_config,
             signer,
             contact_list_guard: Arc::new(Semaphore::new(1)),
             cancellation,
@@ -133,14 +129,7 @@ impl AccountSession {
         } else {
             None
         };
-        Self::new(
-            account.pubkey,
-            mdk,
-            wn.shared.clone(),
-            wn.shared.message_aggregator.config().clone(),
-            signer,
-        )
-        .await
+        Self::new(account.pubkey, mdk, wn.shared.clone(), signer).await
     }
 
     /// Replace the signer slot (e.g. when an external signer is re-registered).
@@ -604,7 +593,7 @@ pub(crate) mod test_helpers {
 
         let shared = test_shared(db).await;
         Arc::new(
-            AccountSession::new(pubkey, mdk, shared, AggregatorConfig::default(), None)
+            AccountSession::new(pubkey, mdk, shared, None)
                 .await
                 .expect("create test session"),
         )

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -139,9 +139,13 @@ impl AccountSession {
 
     /// Read the current signer, if any.
     ///
-    /// Uses `try_read` to avoid blocking on the rare concurrent `set_signer`
-    /// write. Returns `None` when the write lock is held; callers fall through
-    /// to the legacy signer lookup which produces the same result.
+    /// Returns `None` in two cases: when no signer is set, and when a
+    /// concurrent `set_signer` write momentarily holds the lock (we
+    /// `try_read` to avoid blocking). Callers must handle `None` on their own
+    /// — some fall back to the legacy signer lookup
+    /// (`Whitenoise::get_signer_for_account`), others treat it as
+    /// `SignerUnavailable` and drop the work (e.g. `handle_giftwrap`). See
+    /// issue #777 for the planned disambiguation.
     pub fn get_signer(&self) -> Option<Arc<dyn NostrSigner>> {
         self.signer.try_read().ok().and_then(|g| g.clone())
     }
@@ -608,6 +612,10 @@ pub(crate) mod test_helpers {
     }
 
     /// Build a minimal `SharedServices` for tests.
+    ///
+    /// Diverges from `create_mock_whitenoise_internal` in one behavior: this
+    /// does not call `relay_control.start_telemetry_persistors()`. Tests built
+    /// on `test_shared` therefore do not exercise telemetry persistor paths.
     pub async fn test_shared(db: Arc<Database>) -> Arc<SharedServices> {
         let (event_sender, _) = tokio::sync::mpsc::channel(1);
         let relay_control = Arc::new(RelayControlPlane::new(

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -560,12 +560,19 @@ pub(crate) mod test_helpers {
     use std::sync::Arc;
     use std::time::SystemTime;
 
+    use dashmap::DashMap;
     use sqlx::sqlite::SqlitePoolOptions;
 
     use super::*;
     use crate::relay_control::RelayControlPlane;
     use crate::whitenoise::accounts::test_utils::create_mdk;
     use crate::whitenoise::database::Database;
+    use crate::whitenoise::discovery_sync_worker::DiscoverySyncWorker;
+    use crate::whitenoise::event_tracker::WhitenoiseEventTracker;
+    use crate::whitenoise::message_aggregator::MessageAggregator;
+    use crate::whitenoise::secrets_store::SecretsStore;
+    use crate::whitenoise::shared::SharedServices;
+    use crate::whitenoise::storage::Storage;
     use crate::whitenoise::test_utils::insert_test_account;
 
     pub async fn test_db() -> Arc<Database> {
@@ -600,16 +607,7 @@ pub(crate) mod test_helpers {
     }
 
     /// Build a minimal `SharedServices` for tests.
-    pub async fn test_shared(db: Arc<Database>) -> Arc<crate::whitenoise::shared::SharedServices> {
-        use dashmap::DashMap;
-
-        use crate::whitenoise::discovery_sync_worker::DiscoverySyncWorker;
-        use crate::whitenoise::event_tracker::WhitenoiseEventTracker;
-        use crate::whitenoise::message_aggregator::MessageAggregator;
-        use crate::whitenoise::secrets_store::SecretsStore;
-        use crate::whitenoise::shared::SharedServices;
-        use crate::whitenoise::storage::Storage;
-
+    pub async fn test_shared(db: Arc<Database>) -> Arc<SharedServices> {
         let (event_sender, _) = tokio::sync::mpsc::channel(1);
         let relay_control = Arc::new(RelayControlPlane::new(
             db.clone(),

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -499,6 +499,9 @@ impl AccountManager {
     ///
     /// External-signer accounts get `signer: None` until re-registered.
     /// Local accounts load their signer from the secrets store.
+    // TODO(phase-16b): drop `'static` once the Whitenoise singleton is gone —
+    // `AccountSession::from_account` still needs a static borrow because
+    // singleton-reaching methods are called from spawned tasks.
     pub async fn restore_sessions(&self, wn: &'static Whitenoise) {
         let accounts = match Account::all(&wn.shared.database).await {
             Ok(accounts) => accounts,
@@ -560,14 +563,12 @@ pub(crate) mod test_helpers {
     use std::sync::Arc;
     use std::time::SystemTime;
 
-    use dashmap::DashMap;
     use sqlx::sqlite::SqlitePoolOptions;
 
     use super::*;
     use crate::relay_control::RelayControlPlane;
     use crate::whitenoise::accounts::test_utils::create_mdk;
     use crate::whitenoise::database::Database;
-    use crate::whitenoise::discovery_sync_worker::DiscoverySyncWorker;
     use crate::whitenoise::event_tracker::WhitenoiseEventTracker;
     use crate::whitenoise::message_aggregator::MessageAggregator;
     use crate::whitenoise::secrets_store::SecretsStore;
@@ -615,24 +616,18 @@ pub(crate) mod test_helpers {
             event_sender,
             [0u8; 16],
         ));
-        Arc::new(SharedServices {
-            database: db.clone(),
+        let event_tracker = Arc::new(WhitenoiseEventTracker::new(db.clone()));
+        let storage = Storage::new(std::env::temp_dir().as_path())
+            .await
+            .expect("test storage");
+        Arc::new(SharedServices::new(
+            db,
             relay_control,
-            event_tracker: Arc::new(WhitenoiseEventTracker::new(db)),
-            secrets_store: SecretsStore::new("com.whitenoise.test"),
-            storage: Storage::new(std::env::temp_dir().as_path())
-                .await
-                .expect("test storage"),
-            message_aggregator: MessageAggregator::new(),
-            message_stream_manager: Arc::new(Default::default()),
-            user_stream_manager: Default::default(),
-            chat_list_stream_manager: Default::default(),
-            archived_chat_list_stream_manager: Default::default(),
-            notification_stream_manager: Default::default(),
-            user_resolution_guards: DashMap::new(),
-            external_signers: DashMap::new(),
-            discovery_sync_worker: DiscoverySyncWorker::new(),
-        })
+            event_tracker,
+            SecretsStore::new("com.whitenoise.test"),
+            storage,
+            MessageAggregator::new(),
+        ))
     }
 }
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -141,12 +141,12 @@ impl AccountSession {
         Self::new(
             account.pubkey,
             mdk,
-            wn.database.clone(),
-            wn.message_stream_manager.clone(),
-            wn.message_aggregator.config().clone(),
+            wn.shared.database.clone(),
+            wn.shared.message_stream_manager.clone(),
+            wn.shared.message_aggregator.config().clone(),
             signer,
-            wn.relay_control.ephemeral(),
-            wn.relay_control.clone(),
+            wn.shared.relay_control.ephemeral(),
+            wn.shared.relay_control.clone(),
         )
         .await
     }
@@ -519,7 +519,7 @@ impl AccountManager {
     /// External-signer accounts get `signer: None` until re-registered.
     /// Local accounts load their signer from the secrets store.
     pub async fn restore_sessions(&self, wn: &'static Whitenoise) {
-        let accounts = match Account::all(&wn.database).await {
+        let accounts = match Account::all(&wn.shared.database).await {
             Ok(accounts) => accounts,
             Err(e) => {
                 tracing::error!(

--- a/src/whitenoise/session/push.rs
+++ b/src/whitenoise/session/push.rs
@@ -454,7 +454,7 @@ impl<'a> PushOps<'a> {
         match AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
-            &self.session.database,
+            &self.session.shared.database,
         )
         .await
         {
@@ -528,7 +528,7 @@ impl<'a> PushOps<'a> {
     ) -> Result<()> {
         respond_to_token_request_with(
             &self.session.mdk,
-            &self.session.database,
+            &self.session.shared.database,
             self.session.group_handle.relay_control(),
             &self.session.account_pubkey,
             group_id,

--- a/src/whitenoise/shared.rs
+++ b/src/whitenoise/shared.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use nostr_sdk::PublicKey;
+use nostr_sdk::prelude::NostrSigner;
+use tokio::sync::Mutex;
+
+use crate::relay_control::RelayControlPlane;
+use crate::whitenoise::chat_list_streaming::ChatListStreamManager;
+use crate::whitenoise::database::Database;
+use crate::whitenoise::discovery_sync_worker::DiscoverySyncWorker;
+use crate::whitenoise::event_tracker::EventTracker;
+use crate::whitenoise::message_aggregator::MessageAggregator;
+use crate::whitenoise::message_streaming::MessageStreamManager;
+use crate::whitenoise::notification_streaming::NotificationStreamManager;
+use crate::whitenoise::secrets_store::SecretsStore;
+use crate::whitenoise::storage::Storage;
+use crate::whitenoise::user_streaming::UserStreamManager;
+
+/// Long-lived services and registries shared across every account session.
+///
+/// Held behind `Arc<SharedServices>` on `Whitenoise` and on every
+/// `AccountSession`. Lifecycle plumbing (event and shutdown channels, scheduler
+/// handles, account registry) stays on `Whitenoise` itself.
+pub(crate) struct SharedServices {
+    pub(crate) database: Arc<Database>,
+    pub(crate) relay_control: Arc<RelayControlPlane>,
+    pub(crate) event_tracker: Arc<dyn EventTracker>,
+    pub(crate) secrets_store: SecretsStore,
+    pub(crate) storage: Storage,
+    pub(crate) message_aggregator: MessageAggregator,
+    pub(crate) message_stream_manager: Arc<MessageStreamManager>,
+    pub(crate) user_stream_manager: UserStreamManager,
+    pub(crate) chat_list_stream_manager: ChatListStreamManager,
+    pub(crate) archived_chat_list_stream_manager: ChatListStreamManager,
+    pub(crate) notification_stream_manager: NotificationStreamManager,
+    pub(crate) user_resolution_guards: DashMap<PublicKey, Arc<Mutex<()>>>,
+    pub(crate) external_signers: DashMap<PublicKey, Arc<dyn NostrSigner>>,
+    pub(crate) discovery_sync_worker: DiscoverySyncWorker,
+}

--- a/src/whitenoise/shared.rs
+++ b/src/whitenoise/shared.rs
@@ -29,7 +29,7 @@ pub(crate) struct SharedServices {
     pub(crate) secrets_store: SecretsStore,
     pub(crate) storage: Storage,
     pub(crate) message_aggregator: MessageAggregator,
-    pub(crate) message_stream_manager: Arc<MessageStreamManager>,
+    pub(crate) message_stream_manager: MessageStreamManager,
     pub(crate) user_stream_manager: UserStreamManager,
     pub(crate) chat_list_stream_manager: ChatListStreamManager,
     pub(crate) archived_chat_list_stream_manager: ChatListStreamManager,
@@ -37,4 +37,35 @@ pub(crate) struct SharedServices {
     pub(crate) user_resolution_guards: DashMap<PublicKey, Arc<Mutex<()>>>,
     pub(crate) external_signers: DashMap<PublicKey, Arc<dyn NostrSigner>>,
     pub(crate) discovery_sync_worker: DiscoverySyncWorker,
+}
+
+impl SharedServices {
+    /// Build a `SharedServices` from its externally-configured fields. Stream
+    /// managers, registries, and the discovery worker use their defaults —
+    /// callers never need to supply them.
+    pub(crate) fn new(
+        database: Arc<Database>,
+        relay_control: Arc<RelayControlPlane>,
+        event_tracker: Arc<dyn EventTracker>,
+        secrets_store: SecretsStore,
+        storage: Storage,
+        message_aggregator: MessageAggregator,
+    ) -> Self {
+        Self {
+            database,
+            relay_control,
+            event_tracker,
+            secrets_store,
+            storage,
+            message_aggregator,
+            message_stream_manager: MessageStreamManager::default(),
+            user_stream_manager: UserStreamManager::default(),
+            chat_list_stream_manager: ChatListStreamManager::default(),
+            archived_chat_list_stream_manager: ChatListStreamManager::default(),
+            notification_stream_manager: NotificationStreamManager::default(),
+            user_resolution_guards: DashMap::new(),
+            external_signers: DashMap::new(),
+            discovery_sync_worker: DiscoverySyncWorker::new(),
+        }
+    }
 }

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -15,6 +15,7 @@ impl Whitenoise {
             return Err(WhitenoiseError::ExternalSignerCannotExportNsec);
         }
         Ok(self
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)?
             .secret_key()
@@ -108,13 +109,15 @@ impl Whitenoise {
             "Registering external signer for account: {}",
             pubkey.to_hex()
         );
-        self.external_signers.insert(pubkey, Arc::new(signer));
+        self.shared
+            .external_signers
+            .insert(pubkey, Arc::new(signer));
         Ok(())
     }
 
     /// Gets the external signer for an account, if one is registered.
     pub fn get_external_signer(&self, pubkey: &PublicKey) -> Option<Arc<dyn NostrSigner>> {
-        self.external_signers.get(pubkey).map(|r| r.clone())
+        self.shared.external_signers.get(pubkey).map(|r| r.clone())
     }
 
     /// Gets the appropriate signer for an account.
@@ -146,6 +149,7 @@ impl Whitenoise {
         }
 
         let keys = self
+            .shared
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)?;
         tracing::debug!(
@@ -163,6 +167,6 @@ impl Whitenoise {
             "Removing external signer for account: {}",
             pubkey.to_hex()
         );
-        self.external_signers.remove(pubkey);
+        self.shared.external_signers.remove(pubkey);
     }
 }

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -20,7 +20,7 @@ impl Whitenoise {
     /// Get a reference to the message aggregator for advanced usage
     /// This allows consumers to access the message aggregator directly for custom processing
     pub fn message_aggregator(&self) -> &message_aggregator::MessageAggregator {
-        &self.message_aggregator
+        &self.shared.message_aggregator
     }
 
     /// Subscribe to message updates for a specific group.
@@ -47,18 +47,19 @@ impl Whitenoise {
         limit: Option<u32>,
     ) -> Result<message_streaming::GroupMessageSubscription> {
         // 1. Subscribe FIRST to capture any concurrent updates that arrive during the fetch.
-        let mut updates = self.message_stream_manager.subscribe(group_id);
+        let mut updates = self.shared.message_stream_manager.subscribe(group_id);
 
         // 2. Fetch the most-recent `limit` messages using the paginated query so the initial
         //    snapshot honours the same page size the Flutter side will use for further loads.
         let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(account_pubkey, group_id, &self.database).await?;
+            AccountGroup::chat_cleared_at_ms(account_pubkey, group_id, &self.shared.database)
+                .await?;
 
         let fetched_messages =
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(
                 group_id,
                 account_pubkey,
-                &self.database,
+                &self.shared.database,
                 &PaginationOptions::default(),
                 limit,
                 cleared_at_ms,
@@ -147,7 +148,7 @@ impl Whitenoise {
         &self,
         pubkey: &PublicKey,
     ) -> Result<user_streaming::UserSubscription> {
-        let mut updates = self.user_stream_manager.subscribe(pubkey);
+        let mut updates = self.shared.user_stream_manager.subscribe(pubkey);
         let initial_user = self.resolve_user(pubkey).await?;
         let initial_user = Self::drain_user_updates(initial_user, &mut updates)?;
 
@@ -199,7 +200,10 @@ impl Whitenoise {
         &self,
         account: &Account,
     ) -> Result<chat_list_streaming::ChatListSubscription> {
-        let mut updates = self.chat_list_stream_manager.subscribe(&account.pubkey);
+        let mut updates = self
+            .shared
+            .chat_list_stream_manager
+            .subscribe(&account.pubkey);
 
         let fetched_items = self.get_chat_list(account).await?;
 
@@ -254,6 +258,7 @@ impl Whitenoise {
         account: &Account,
     ) -> Result<chat_list_streaming::ChatListSubscription> {
         let mut updates = self
+            .shared
             .archived_chat_list_stream_manager
             .subscribe(&account.pubkey);
 
@@ -305,7 +310,7 @@ impl Whitenoise {
     /// Notifications are real-time only
     pub fn subscribe_to_notifications(&self) -> notification_streaming::NotificationSubscription {
         notification_streaming::NotificationSubscription {
-            updates: self.notification_stream_manager.subscribe(),
+            updates: self.shared.notification_stream_manager.subscribe(),
         }
     }
 
@@ -314,7 +319,7 @@ impl Whitenoise {
     /// This provides high-level methods that coordinate between the storage layer
     /// (filesystem) and database layer (metadata) for media files.
     pub(crate) fn media_files(&self) -> media_files::MediaFiles<'_> {
-        media_files::MediaFiles::new(&self.storage, &self.database)
+        media_files::MediaFiles::new(&self.shared.storage, &self.shared.database)
     }
 }
 

--- a/src/whitenoise/subscriptions.rs
+++ b/src/whitenoise/subscriptions.rs
@@ -22,6 +22,7 @@ impl Whitenoise {
         // ensure_all_subscriptions task self-heals discovery within minutes.
         let (global_result, accounts_result) = tokio::join!(
             whitenoise_ref
+                .shared
                 .discovery_sync_worker
                 .request_rebuild_and_wait(),
             Self::setup_accounts_subscriptions(whitenoise_ref),
@@ -84,7 +85,7 @@ impl Whitenoise {
     pub(super) async fn setup_accounts_subscriptions(
         whitenoise_ref: &'static Whitenoise,
     ) -> Result<()> {
-        let accounts = Account::all(&whitenoise_ref.database).await?;
+        let accounts = Account::all(&whitenoise_ref.shared.database).await?;
         for account in accounts {
             let inbox_relays = account.effective_inbox_relays(whitenoise_ref).await?;
             // Setup subscriptions for this account
@@ -143,7 +144,7 @@ impl Whitenoise {
                 target: "whitenoise::ensure_global_subscriptions",
                 "Global subscriptions not operational, refreshing..."
             );
-            self.discovery_sync_worker.request_rebuild();
+            self.shared.discovery_sync_worker.request_rebuild();
         }
 
         Ok(())
@@ -193,7 +194,7 @@ impl Whitenoise {
         }
 
         // Fail fast only on database errors (catastrophic)
-        let accounts = Account::all(&self.database).await?;
+        let accounts = Account::all(&self.shared.database).await?;
 
         // Best-effort: log and continue for each account
         for account in &accounts {
@@ -255,18 +256,27 @@ impl Whitenoise {
     /// (the expected state after logout or on a fresh install).
     #[perf_instrument("whitenoise")]
     pub async fn is_global_subscriptions_operational(&self) -> Result<bool> {
-        let has_subscriptions = self.relay_control.has_discovery_subscriptions().await;
+        let has_subscriptions = self
+            .shared
+            .relay_control
+            .has_discovery_subscriptions()
+            .await;
 
         // Zero accounts with zero subscriptions is the correct retired state
         // (fresh install or after last logout). Users may still exist in the
         // DB but discovery subscriptions are correctly torn down.
-        let account_count = Account::all(&self.database).await?.len();
+        let account_count = Account::all(&self.shared.database).await?.len();
         if account_count == 0 && !has_subscriptions {
             return Ok(true);
         }
 
-        let db_user_count = User::all_pubkeys(&self.database).await?.len();
-        let plane_user_count = self.relay_control.discovery().watched_user_count().await;
+        let db_user_count = User::all_pubkeys(&self.shared.database).await?.len();
+        let plane_user_count = self
+            .shared
+            .relay_control
+            .discovery()
+            .watched_user_count()
+            .await;
 
         if !has_subscriptions {
             return Ok(false);
@@ -289,20 +299,20 @@ impl Whitenoise {
     #[perf_instrument("whitenoise")]
     pub async fn get_relay_control_state(&self) -> RelayControlStateSnapshot {
         let inbox_snapshots = self.account_manager.collect_inbox_snapshots().await;
-        self.relay_control.snapshot(inbox_snapshots).await
+        self.shared.relay_control.snapshot(inbox_snapshots).await
     }
 
     #[perf_instrument("whitenoise")]
     pub(crate) async fn sync_discovery_subscriptions(&self) -> Result<()> {
-        let accounts = Account::all(&self.database).await?;
-        let discovery = self.relay_control.discovery();
+        let accounts = Account::all(&self.shared.database).await?;
+        let discovery = self.shared.relay_control.discovery();
 
         if accounts.is_empty() {
             discovery.retire_all().await;
             return Ok(());
         }
 
-        let watched_users = User::all_pubkeys(&self.database).await?;
+        let watched_users = User::all_pubkeys(&self.shared.database).await?;
         let public_since = Self::compute_global_since_timestamp(&accounts);
         let follow_list_accounts: Vec<_> = accounts
             .iter()
@@ -333,6 +343,6 @@ impl Whitenoise {
     /// other relays happen to be connected for unrelated workloads.
     #[perf_instrument("whitenoise")]
     pub(crate) async fn fallback_relay_urls(&self) -> Vec<RelayUrl> {
-        self.relay_control.discovery().relays().to_vec()
+        self.shared.relay_control.discovery().relays().to_vec()
     }
 }

--- a/src/whitenoise/user_search/graph.rs
+++ b/src/whitenoise/user_search/graph.rs
@@ -43,7 +43,8 @@ pub(super) async fn get_group_co_member_pubkeys(
     whitenoise: &Whitenoise,
     searcher_pubkey: &PublicKey,
 ) -> HashSet<PublicKey> {
-    let account = match Account::find_by_pubkey(searcher_pubkey, &whitenoise.database).await {
+    let account = match Account::find_by_pubkey(searcher_pubkey, &whitenoise.shared.database).await
+    {
         Ok(a) => a,
         Err(e) => {
             tracing::debug!(
@@ -56,7 +57,9 @@ pub(super) async fn get_group_co_member_pubkeys(
     };
 
     let groups =
-        match AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.database).await {
+        match AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.shared.database)
+            .await
+        {
             Ok(g) => g,
             Err(e) => {
                 tracing::debug!(
@@ -102,7 +105,12 @@ pub(super) async fn get_group_co_member_pubkeys(
 /// Collect discovery relay URLs to use for user-search queries.
 #[perf_instrument("user_search")]
 async fn connected_relays(whitenoise: &Whitenoise) -> Vec<RelayUrl> {
-    whitenoise.relay_control.discovery().relays().to_vec()
+    whitenoise
+        .shared
+        .relay_control
+        .discovery()
+        .relays()
+        .to_vec()
 }
 
 // ---------------------------------------------------------------------------
@@ -120,7 +128,7 @@ pub(super) async fn check_user_table_metadata(
 ) -> (HashMap<PublicKey, Metadata>, Vec<PublicKey>) {
     let mut found: HashMap<PublicKey, Metadata> = HashMap::new();
 
-    let users = User::find_by_pubkeys(pubkeys, &whitenoise.database)
+    let users = User::find_by_pubkeys(pubkeys, &whitenoise.shared.database)
         .await
         .unwrap_or_default();
 
@@ -156,7 +164,7 @@ pub(super) async fn check_cache_metadata(
     let mut cached_pks: HashSet<PublicKey> = HashSet::new();
 
     if let Ok(cached_users) =
-        CachedGraphUser::find_fresh_metadata_batch(pubkeys, &whitenoise.database).await
+        CachedGraphUser::find_fresh_metadata_batch(pubkeys, &whitenoise.shared.database).await
     {
         for cached in &cached_users {
             if let Some(ref m) = cached.metadata {
@@ -197,6 +205,7 @@ pub(super) async fn try_fetch_network_metadata(
         .kinds([Kind::Metadata]);
 
     let events = whitenoise
+        .shared
         .relay_control
         .ephemeral()
         .fetch_events_from(&all_relays, filter)
@@ -231,7 +240,7 @@ pub(super) async fn try_fetch_network_metadata(
                 &pk,
                 &metadata,
                 CONFIDENT_CACHE_TTL_MS,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
             found.insert(pk, metadata);
@@ -263,6 +272,7 @@ pub(super) async fn try_fetch_relay_lists(
         .kinds([Kind::RelayList]);
 
     let events = whitenoise
+        .shared
         .relay_control
         .ephemeral()
         .fetch_events_from(&all_relays, filter)
@@ -324,6 +334,7 @@ pub(super) async fn try_fetch_user_relay_metadata(
     let filter = Filter::new().authors([*pubkey]).kinds([Kind::Metadata]);
 
     match whitenoise
+        .shared
         .relay_control
         .ephemeral()
         .fetch_events_from(relays, filter)
@@ -340,7 +351,7 @@ pub(super) async fn try_fetch_user_relay_metadata(
                     pubkey,
                     &metadata,
                     CONFIDENT_CACHE_TTL_MS,
-                    &whitenoise.database,
+                    &whitenoise.shared.database,
                 )
                 .await;
                 UserRelayResult::Found(Box::new(metadata))
@@ -405,8 +416,8 @@ pub(super) async fn check_cached_follows_batch(
 
     // 1. Check local accounts
     for pk in pubkeys {
-        if let Ok(account) = Account::find_by_pubkey(pk, &whitenoise.database).await
-            && let Ok(follows) = account.follows(&whitenoise.database).await
+        if let Ok(account) = Account::find_by_pubkey(pk, &whitenoise.shared.database).await
+            && let Ok(follows) = account.follows(&whitenoise.shared.database).await
         {
             results.insert(*pk, follows.into_iter().map(|u| u.pubkey).collect());
             remaining.remove(pk);
@@ -420,7 +431,7 @@ pub(super) async fn check_cached_follows_batch(
     // 2. Batch query cache (skip entries where follows is None — not yet fetched)
     let remaining_vec: Vec<PublicKey> = remaining.iter().copied().collect();
     if let Ok(cached_users) =
-        CachedGraphUser::find_fresh_follows_batch(&remaining_vec, &whitenoise.database).await
+        CachedGraphUser::find_fresh_follows_batch(&remaining_vec, &whitenoise.shared.database).await
     {
         for cached in cached_users {
             if let Some(follows) = cached.follows {
@@ -462,7 +473,8 @@ pub(super) async fn fetch_network_follows(
             .map(parse_follows_from_event)
             .unwrap_or_default();
 
-        let _ = CachedGraphUser::upsert_follows_only(pk, &follows, &whitenoise.database).await;
+        let _ =
+            CachedGraphUser::upsert_follows_only(pk, &follows, &whitenoise.shared.database).await;
         results.insert(*pk, follows);
     }
 
@@ -566,6 +578,7 @@ async fn fetch_events_with_retries(
         for chunk in &pending_chunks {
             let filter = Filter::new().authors(chunk.clone()).kinds([kind]);
             match whitenoise
+                .shared
                 .relay_control
                 .ephemeral()
                 .fetch_events_from(relays, filter)
@@ -652,14 +665,14 @@ mod tests {
             Some(Metadata::new()),
             Some(vec![follow1]),
         );
-        cached1.upsert(&whitenoise.database).await.unwrap();
+        cached1.upsert(&whitenoise.shared.database).await.unwrap();
 
         let cached2 = CachedGraphUser::new(
             keys2.public_key(),
             Some(Metadata::new()),
             Some(vec![follow2]),
         );
-        cached2.upsert(&whitenoise.database).await.unwrap();
+        cached2.upsert(&whitenoise.shared.database).await.unwrap();
 
         let result =
             get_follows_batch(&whitenoise, &[keys1.public_key(), keys2.public_key()]).await;
@@ -686,7 +699,7 @@ mod tests {
         let cached_follow = Keys::generate().public_key();
         let cached =
             CachedGraphUser::new(cached_pk, Some(Metadata::new()), Some(vec![cached_follow]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let result = get_follows_batch(&whitenoise, &[account.pubkey, cached_pk]).await;
 
@@ -720,7 +733,7 @@ mod tests {
         // Pre-populate cache
         let cached_pk = Keys::generate().public_key();
         let cached = CachedGraphUser::new(cached_pk, Some(Metadata::new()), Some(vec![]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let unknown_pk = Keys::generate().public_key();
 
@@ -753,7 +766,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let result = get_metadata_batch(&whitenoise, &[keys.public_key()]).await;
 
@@ -773,7 +786,7 @@ mod tests {
             Some(Metadata::new().name("Bob").about("From cache")),
             Some(vec![]),
         );
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let result = get_metadata_batch(&whitenoise, &[keys.public_key()]).await;
 
@@ -798,7 +811,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Cache has real metadata
         let cached = CachedGraphUser::new(
@@ -806,7 +819,7 @@ mod tests {
             Some(Metadata::new().name("Alice")),
             Some(vec![]),
         );
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let result = get_metadata_batch(&whitenoise, &[keys.public_key()]).await;
 
@@ -835,7 +848,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: chrono::Utc::now(),
             };
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
         }
 
         let result =
@@ -867,7 +880,7 @@ mod tests {
                 Some(Metadata::new().name(format!("User{}", i))),
                 Some(vec![]),
             );
-            cached.upsert(&whitenoise.database).await.unwrap();
+            cached.upsert(&whitenoise.shared.database).await.unwrap();
             pubkeys.push(keys.public_key());
         }
 
@@ -893,7 +906,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Cached user (tier 2)
         let cached_keys = Keys::generate();
@@ -902,7 +915,7 @@ mod tests {
             Some(Metadata::new().name("FromCache")),
             Some(vec![]),
         );
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let result = get_metadata_batch(
             &whitenoise,
@@ -929,7 +942,7 @@ mod tests {
 
         let pk = Keys::generate().public_key();
         let cached = CachedGraphUser::new(pk, Some(Metadata::new().name("CacheHit")), Some(vec![]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let (found, remaining) = check_cache_metadata(&whitenoise, &[pk]).await;
 
@@ -945,7 +958,7 @@ mod tests {
         let pk = Keys::generate().public_key();
         // Simulate confirmed-absent: Some(Metadata::new()) means "fetched, nothing there"
         let cached = CachedGraphUser::new(pk, Some(Metadata::new()), Some(vec![]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let (found, remaining) = check_cache_metadata(&whitenoise, &[pk]).await;
 
@@ -965,7 +978,7 @@ mod tests {
         let pk = Keys::generate().public_key();
         // metadata = None means "not yet fetched" — should forward to tier 3
         let cached = CachedGraphUser::new(pk, None, Some(vec![]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let (found, remaining) = check_cache_metadata(&whitenoise, &[pk]).await;
 
@@ -1001,7 +1014,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let (found, remaining) = check_user_table_metadata(&whitenoise, &[pk]).await;
 
@@ -1022,7 +1035,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let (found, remaining) = check_user_table_metadata(&whitenoise, &[pk]).await;
 
@@ -1160,9 +1173,14 @@ mod tests {
 
         // Insert a pending group (user_confirmation = None)
         let group_id = mdk_core::prelude::GroupId::from_slice(&[1, 2, 3]);
-        AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-            .await
-            .unwrap();
+        AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         let result = get_group_co_member_pubkeys(&whitenoise, &account.pubkey).await;
 
@@ -1176,11 +1194,15 @@ mod tests {
 
         // Insert and decline a group
         let group_id = mdk_core::prelude::GroupId::from_slice(&[4, 5, 6]);
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
-        ag.update_user_confirmation(false, &whitenoise.database)
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        ag.update_user_confirmation(false, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1197,11 +1219,15 @@ mod tests {
         // Insert and accept a group — group_members() will fail because
         // mock whitenoise has no MLS infrastructure, exercising the error branch
         let group_id = mdk_core::prelude::GroupId::from_slice(&[7, 8, 9]);
-        let (ag, _) =
-            AccountGroup::find_or_create(&account.pubkey, &group_id, None, &whitenoise.database)
-                .await
-                .unwrap();
-        ag.update_user_confirmation(true, &whitenoise.database)
+        let (ag, _) = AccountGroup::find_or_create(
+            &account.pubkey,
+            &group_id,
+            None,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        ag.update_user_confirmation(true, &whitenoise.shared.database)
             .await
             .unwrap();
 

--- a/src/whitenoise/user_search/mod.rs
+++ b/src/whitenoise/user_search/mod.rs
@@ -1184,7 +1184,7 @@ async fn process_tier4_result(
                 pk,
                 &Metadata::new(),
                 CONFIDENT_CACHE_TTL_MS,
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await;
         } else {
@@ -1387,7 +1387,7 @@ fn process_tier5_result(
             // Confirmed absent on all known relays — cache empty.
             // Spawn so we don't block the select loop on a DB write.
             let pk = result.pubkey;
-            let db = whitenoise.database.clone();
+            let db = whitenoise.shared.database.clone();
             tokio::spawn(async move {
                 let _ = CachedGraphUser::upsert_metadata_only(
                     &pk,
@@ -1415,7 +1415,7 @@ fn process_tier5_result(
                 // Unlike confident misses (EOSE), relay errors are transient, so
                 // we use a shorter TTL to allow re-discovery soon.
                 let pk = result.pubkey;
-                let db = whitenoise.database.clone();
+                let db = whitenoise.shared.database.clone();
                 tokio::spawn(async move {
                     let _ = CachedGraphUser::upsert_metadata_only(
                         &pk,
@@ -1880,7 +1880,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Now follow this user
         whitenoise
@@ -1920,14 +1920,14 @@ mod tests {
             Some(Metadata::new().name("User1")),
             Some(vec![target_keys.public_key()]),
         );
-        cached1.upsert(&whitenoise.database).await.unwrap();
+        cached1.upsert(&whitenoise.shared.database).await.unwrap();
 
         let cached2 = CachedGraphUser::new(
             user2.public_key(),
             Some(Metadata::new().name("User2")),
             Some(vec![target_keys.public_key()]),
         );
-        cached2.upsert(&whitenoise.database).await.unwrap();
+        cached2.upsert(&whitenoise.shared.database).await.unwrap();
 
         // Follow both users
         whitenoise
@@ -1945,7 +1945,10 @@ mod tests {
             Some(Metadata::new().name("DedupeTarget")),
             Some(vec![]),
         );
-        target_cached.upsert(&whitenoise.database).await.unwrap();
+        target_cached
+            .upsert(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Search at radius 2 should find target only once
         let updates = run_search(&whitenoise, "dedupetarget", account.pubkey, 2, 2).await;
@@ -2230,7 +2233,7 @@ mod tests {
         // Create a cached user with empty metadata (confirmed absent)
         let pk = random_pk();
         let cached = CachedGraphUser::new(pk, Some(Metadata::new()), Some(vec![]));
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let (tx_broadcast, _rx_broadcast) = broadcast::channel(100);
         let (tx_in, rx_in) = mpsc::channel(10);
@@ -2542,7 +2545,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         let unknown_pk = random_pk();
 
@@ -2600,7 +2603,7 @@ mod tests {
             Some(Metadata::new().name("CachedHit")),
             Some(vec![]),
         );
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         let unknown_pk = random_pk();
 
@@ -2668,7 +2671,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: chrono::Utc::now(),
         };
-        user.save(&whitenoise.database).await.unwrap();
+        user.save(&whitenoise.shared.database).await.unwrap();
 
         // Follow the user
         whitenoise
@@ -2682,7 +2685,7 @@ mod tests {
             Some(Metadata::new().name("aleups").display_name("Aleups")),
             Some(vec![]),
         );
-        cached.upsert(&whitenoise.database).await.unwrap();
+        cached.upsert(&whitenoise.shared.database).await.unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
@@ -2719,7 +2722,10 @@ mod tests {
             Some(Metadata::new().name("SeedUser")),
             Some(vec![discoverable_pk]),
         );
-        cached_seed.upsert(&whitenoise.database).await.unwrap();
+        cached_seed
+            .upsert(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Pre-populate the discoverable user's metadata
         let cached_target = CachedGraphUser::new(
@@ -2727,7 +2733,10 @@ mod tests {
             Some(Metadata::new().name("FallbackTarget")),
             Some(vec![]),
         );
-        cached_target.upsert(&whitenoise.database).await.unwrap();
+        cached_target
+            .upsert(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         // Search at radius 0-2: radius 1 should be empty, triggering fallback
         let updates = run_search(&whitenoise, "fallbacktarget", account.pubkey, 0, 2).await;
@@ -2757,7 +2766,10 @@ mod tests {
             Some(Metadata::new().name("SeedAccount")),
             Some(vec![]),
         );
-        cached_seed.upsert(&whitenoise.database).await.unwrap();
+        cached_seed
+            .upsert(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         let updates = run_search(&whitenoise, "seedaccount", account.pubkey, 0, 2).await;
 
@@ -2791,7 +2803,10 @@ mod tests {
             Some(Metadata::new().name("SeedAccount")),
             Some(vec![]),
         );
-        cached_seed.upsert(&whitenoise.database).await.unwrap();
+        cached_seed
+            .upsert(&whitenoise.shared.database)
+            .await
+            .unwrap();
 
         let updates = run_search(&whitenoise, "seedaccount", account.pubkey, 0, 2).await;
 

--- a/src/whitenoise/user_search/nip50.rs
+++ b/src/whitenoise/user_search/nip50.rs
@@ -28,6 +28,7 @@ pub(super) async fn try_nip50_search(
         .limit(limit);
 
     let events = whitenoise
+        .shared
         .relay_control
         .ephemeral()
         .fetch_events_from(std::slice::from_ref(relay), filter)

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -11,13 +11,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     perf_instrument,
-    relay_control::RelayControlPlane,
     whitenoise::{
         Whitenoise,
-        database::Database,
         database::processed_events::ProcessedEvent,
         error::{Result, WhitenoiseError},
-        event_tracker::EventTracker,
         relays::{Relay, RelayType},
         user_streaming::{UserUpdate, UserUpdateTrigger},
         utils::timestamp_to_datetime,
@@ -51,22 +48,12 @@ static USER_RESOLUTION_RUN_COUNTS: LazyLock<DashMap<String, usize>> = LazyLock::
 
 #[derive(Clone)]
 pub(crate) struct UserRelaySyncContext {
-    database: Arc<Database>,
-    event_tracker: Arc<dyn EventTracker>,
-    relay_control: Arc<RelayControlPlane>,
+    shared: Arc<crate::whitenoise::shared::SharedServices>,
 }
 
 impl UserRelaySyncContext {
-    pub(crate) fn new(
-        database: Arc<Database>,
-        event_tracker: Arc<dyn EventTracker>,
-        relay_control: Arc<RelayControlPlane>,
-    ) -> Self {
-        Self {
-            database,
-            event_tracker,
-            relay_control,
-        }
+    pub(crate) fn new(shared: Arc<crate::whitenoise::shared::SharedServices>) -> Self {
+        Self { shared }
     }
 }
 
@@ -200,11 +187,7 @@ impl User {
 
 impl Whitenoise {
     pub(crate) fn user_relay_sync_context(&self) -> UserRelaySyncContext {
-        UserRelaySyncContext::new(
-            Arc::clone(&self.shared.database),
-            Arc::clone(&self.shared.event_tracker),
-            Arc::clone(&self.shared.relay_control),
-        )
+        UserRelaySyncContext::new(self.shared.clone())
     }
 
     /// Retrieves a user by their public key.

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration as StdDuration};
+use std::time::Duration as StdDuration;
 
 #[cfg(any(test, feature = "integration-tests"))]
 use std::sync::LazyLock;
@@ -22,7 +22,7 @@ use crate::{
 };
 
 mod key_package;
-mod relay_sync;
+pub(crate) mod relay_sync;
 
 pub use key_package::KeyPackageStatus;
 
@@ -45,17 +45,6 @@ enum UserResolutionMode {
 
 #[cfg(any(test, feature = "integration-tests"))]
 static USER_RESOLUTION_RUN_COUNTS: LazyLock<DashMap<String, usize>> = LazyLock::new(DashMap::new);
-
-#[derive(Clone)]
-pub(crate) struct UserRelaySyncContext {
-    shared: Arc<crate::whitenoise::shared::SharedServices>,
-}
-
-impl UserRelaySyncContext {
-    pub(crate) fn new(shared: Arc<crate::whitenoise::shared::SharedServices>) -> Self {
-        Self { shared }
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct User {
@@ -186,10 +175,6 @@ impl User {
 }
 
 impl Whitenoise {
-    pub(crate) fn user_relay_sync_context(&self) -> UserRelaySyncContext {
-        UserRelaySyncContext::new(self.shared.clone())
-    }
-
     /// Retrieves a user by their public key.
     ///
     /// This method looks up a user in the database using their Nostr public key.
@@ -235,8 +220,7 @@ impl Whitenoise {
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        self.user_relay_sync_context()
-            .sync_relay_type_for_pubkey(*pubkey, relay_type, query_relay_urls)
+        relay_sync::sync_relay_type_for_pubkey(&self.shared, *pubkey, relay_type, query_relay_urls)
             .await
     }
 

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -220,8 +220,15 @@ impl Whitenoise {
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        relay_sync::sync_relay_type_for_pubkey(&self.shared, *pubkey, relay_type, query_relay_urls)
-            .await
+        relay_sync::sync_relay_type_for_pubkey(
+            &self.shared.database,
+            &self.shared.relay_control,
+            &self.shared.event_tracker,
+            *pubkey,
+            relay_type,
+            query_relay_urls,
+        )
+        .await
     }
 
     fn targeted_discovery_filter(pubkey: PublicKey) -> Filter {

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -99,7 +99,7 @@ impl User {
         relay_type: RelayType,
         whitenoise: &Whitenoise,
     ) -> Result<Vec<Relay>> {
-        self.relays(relay_type, &whitenoise.database).await
+        self.relays(relay_type, &whitenoise.shared.database).await
     }
 
     /// Determines whether a metadata event should be accepted by the guarded processing path.
@@ -201,9 +201,9 @@ impl User {
 impl Whitenoise {
     pub(crate) fn user_relay_sync_context(&self) -> UserRelaySyncContext {
         UserRelaySyncContext::new(
-            Arc::clone(&self.database),
-            Arc::clone(&self.event_tracker),
-            Arc::clone(&self.relay_control),
+            Arc::clone(&self.shared.database),
+            Arc::clone(&self.shared.event_tracker),
+            Arc::clone(&self.shared.relay_control),
         )
     }
 
@@ -242,7 +242,7 @@ impl Whitenoise {
     /// - There's a database connection or query error
     /// - The public key format is invalid (though this is typically caught at the type level)
     pub async fn find_user_by_pubkey(&self, pubkey: &PublicKey) -> Result<User> {
-        User::find_by_pubkey(pubkey, &self.database).await
+        User::find_by_pubkey(pubkey, &self.shared.database).await
     }
 
     #[perf_instrument("users")]
@@ -288,7 +288,7 @@ impl Whitenoise {
     }
 
     async fn fetch_targeted_discovery_events(&self, pubkey: PublicKey) -> Result<Vec<Event>> {
-        if self.relay_control.discovery().relays().is_empty() {
+        if self.shared.relay_control.discovery().relays().is_empty() {
             tracing::warn!(
                 target: "whitenoise::users::targeted_discovery",
                 "Skipping targeted discovery catch-up for {} because no discovery relays are configured",
@@ -298,6 +298,7 @@ impl Whitenoise {
         }
 
         let events = self
+            .shared
             .relay_control
             .discovery()
             .fetch_events(
@@ -336,7 +337,7 @@ impl Whitenoise {
             return;
         }
 
-        self.user_stream_manager.emit(
+        self.shared.user_stream_manager.emit(
             &user.pubkey,
             UserUpdate {
                 trigger: UserUpdateTrigger::UserCreated,
@@ -350,11 +351,12 @@ impl Whitenoise {
             return;
         }
 
-        self.discovery_sync_worker.request_rebuild();
+        self.shared.discovery_sync_worker.request_rebuild();
     }
 
     fn user_resolution_guard(&self, pubkey: PublicKey) -> std::sync::Arc<tokio::sync::Mutex<()>> {
-        self.user_resolution_guards
+        self.shared
+            .user_resolution_guards
             .entry(pubkey)
             .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
             .clone()
@@ -366,7 +368,7 @@ impl Whitenoise {
         pubkey: &PublicKey,
         mode: UserResolutionMode,
     ) -> Result<User> {
-        let (user, created) = User::find_or_create_by_pubkey(pubkey, &self.database).await?;
+        let (user, created) = User::find_or_create_by_pubkey(pubkey, &self.shared.database).await?;
         self.emit_user_created_if_needed(&user, created);
 
         if user.metadata_is_unknown() {
@@ -384,7 +386,7 @@ impl Whitenoise {
 
         self.refresh_discovery_for_new_user_if_needed(created, mode);
 
-        User::find_by_pubkey(pubkey, &self.database).await
+        User::find_by_pubkey(pubkey, &self.shared.database).await
     }
 
     /// Look up a local user row or create an empty unknown-metadata row.
@@ -421,7 +423,7 @@ impl Whitenoise {
     }
 
     async fn resolve_unknown_user_under_guard(&self, pubkey: PublicKey) -> Result<()> {
-        let user = User::find_by_pubkey(&pubkey, &self.database).await?;
+        let user = User::find_by_pubkey(&pubkey, &self.shared.database).await?;
         if user.metadata_is_known() {
             tracing::debug!(
                 target: "whitenoise::users::resolve_unknown_user_under_guard",
@@ -518,7 +520,7 @@ impl Whitenoise {
         sqlx::query("UPDATE users SET metadata_known_at = ? WHERE pubkey = ?")
             .bind(metadata_known_at.map(|timestamp| timestamp.timestamp_millis()))
             .bind(pubkey.to_hex())
-            .execute(&self.database.pool)
+            .execute(&self.shared.database.pool)
             .await
             .map_err(crate::whitenoise::database::DatabaseError::Sqlx)?;
 
@@ -591,7 +593,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
         let initial_relay_url = RelayUrl::parse("ws://localhost:8080").unwrap();
         let initial_relay = whitenoise
             .find_or_create_relay_by_url(&initial_relay_url)
@@ -599,13 +601,17 @@ mod tests {
             .unwrap();
 
         saved_user
-            .add_relay(&initial_relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(
+                &initial_relay,
+                RelayType::Nip65,
+                &whitenoise.shared.database,
+            )
             .await
             .unwrap();
 
         saved_user.update_relay_lists(&whitenoise).await.unwrap();
         let relays = saved_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert_eq!(relays.len(), 1);
@@ -626,12 +632,12 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
         saved_user.update_relay_lists(&whitenoise).await.unwrap();
         assert!(
             saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .is_empty()
@@ -652,7 +658,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
         // Add a relay
         let relay_url = RelayUrl::parse("wss://test.example.com").unwrap();
@@ -661,7 +667,7 @@ mod tests {
             .await
             .unwrap();
         saved_user
-            .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -684,7 +690,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
         let query_relays = saved_user.get_query_relays(&whitenoise).await.unwrap();
         let query_urls: std::collections::HashSet<RelayUrl> =
             Relay::urls(&query_relays).into_iter().collect();
@@ -713,7 +719,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
         let query_relays = saved_user.get_query_relays(&whitenoise).await.unwrap();
         let query_urls: Vec<RelayUrl> = Relay::urls(&query_relays);
 
@@ -747,7 +753,10 @@ mod tests {
     async fn test_get_or_create_user_local_emits_user_created_update() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let test_pubkey = Keys::generate().public_key();
-        let mut updates = whitenoise.user_stream_manager.subscribe(&test_pubkey);
+        let mut updates = whitenoise
+            .shared
+            .user_stream_manager
+            .subscribe(&test_pubkey);
 
         let user = whitenoise
             .get_or_create_user_local(&test_pubkey)
@@ -882,7 +891,7 @@ mod tests {
             updated_at: Utc::now(),
         };
         user.mark_metadata_known_now();
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
         whitenoise.reset_user_resolution_run_count_for_testing(&test_pubkey);
 
@@ -939,14 +948,14 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
         let relay_url = RelayUrl::parse("wss://test.example.com").unwrap();
         let relay = whitenoise
             .find_or_create_relay_by_url(&relay_url)
             .await
             .unwrap();
         saved_user
-            .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -972,7 +981,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         }
-        .save(&whitenoise.database)
+        .save(&whitenoise.shared.database)
         .await
         .unwrap();
 
@@ -984,7 +993,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         }
-        .save(&whitenoise.database)
+        .save(&whitenoise.shared.database)
         .await
         .unwrap();
 
@@ -1002,19 +1011,19 @@ mod tests {
             .unwrap();
 
         user_a
-            .add_relay(&relay1, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay1, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         user_a
-            .add_relay(&relay2, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay2, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         user_b
-            .add_relay(&relay2, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay2, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         user_b
-            .add_relay(&relay3, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay3, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1066,7 +1075,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         }
-        .save(&whitenoise.database)
+        .save(&whitenoise.shared.database)
         .await
         .unwrap();
 
@@ -1078,7 +1087,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         }
-        .save(&whitenoise.database)
+        .save(&whitenoise.shared.database)
         .await
         .unwrap();
 
@@ -1087,7 +1096,7 @@ mod tests {
             .await
             .unwrap();
         user_with
-            .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1121,7 +1130,7 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         }
-        .save(&whitenoise.database)
+        .save(&whitenoise.shared.database)
         .await
         .unwrap();
 
@@ -1129,10 +1138,10 @@ mod tests {
             .find_or_create_relay_by_url(&RelayUrl::parse("wss://inbox.example.com").unwrap())
             .await
             .unwrap();
-        user.add_relay(&relay, RelayType::Inbox, &whitenoise.database)
+        user.add_relay(&relay, RelayType::Inbox, &whitenoise.shared.database)
             .await
             .unwrap();
-        user.add_relay(&relay, RelayType::KeyPackage, &whitenoise.database)
+        user.add_relay(&relay, RelayType::KeyPackage, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1157,17 +1166,17 @@ mod tests {
             metadata_known_at: None,
             updated_at: Utc::now(),
         };
-        let saved_user = user.save(&whitenoise.database).await.unwrap();
+        let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
         // Test 1: No relays - should return None
         let kp_relays = saved_user
-            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(kp_relays.is_empty());
 
         let nip65_relays = saved_user
-            .relays(RelayType::Nip65, &whitenoise.database)
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
         assert!(nip65_relays.is_empty());
@@ -1183,7 +1192,7 @@ mod tests {
             .await
             .unwrap();
         saved_user
-            .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+            .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.shared.database)
             .await
             .unwrap();
 
@@ -1198,7 +1207,11 @@ mod tests {
             .await
             .unwrap();
         saved_user
-            .add_relay(&kp_relay, RelayType::KeyPackage, &whitenoise.database)
+            .add_relay(
+                &kp_relay,
+                RelayType::KeyPackage,
+                &whitenoise.shared.database,
+            )
             .await
             .unwrap();
 
@@ -1222,7 +1235,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let kp_url = RelayUrl::parse("wss://kp.example.com").unwrap();
             let kp_relay = whitenoise
@@ -1230,7 +1243,11 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&kp_relay, RelayType::KeyPackage, &whitenoise.database)
+                .add_relay(
+                    &kp_relay,
+                    RelayType::KeyPackage,
+                    &whitenoise.shared.database,
+                )
                 .await
                 .unwrap();
 
@@ -1241,7 +1258,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1264,7 +1281,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let nip65_url = RelayUrl::parse("wss://nip65.example.com").unwrap();
             let nip65_relay = whitenoise
@@ -1272,7 +1289,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&nip65_relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1295,7 +1312,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let urls = saved_user
                 .key_package_relay_urls(&whitenoise)
@@ -1316,7 +1333,7 @@ mod tests {
 
         async fn create_test_user(whitenoise: &Whitenoise) -> User {
             let keys = Keys::generate();
-            User::find_or_create_by_pubkey(&keys.public_key(), &whitenoise.database)
+            User::find_or_create_by_pubkey(&keys.public_key(), &whitenoise.shared.database)
                 .await
                 .unwrap()
                 .0
@@ -1342,14 +1359,14 @@ mod tests {
                 Some(timestamp_to_datetime(event.created_at).unwrap()),
                 Some(Kind::Metadata), // Metadata kind
                 Some(&user.pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
 
             // Test that already processed event returns false
             let result = user
-                .should_update_metadata(&event, false, &whitenoise.database)
+                .should_update_metadata(&event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1364,7 +1381,7 @@ mod tests {
 
             // Test that newly created user always returns true
             let result = user
-                .should_update_metadata(&event, true, &whitenoise.database)
+                .should_update_metadata(&event, true, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1379,11 +1396,11 @@ mod tests {
 
             // Ensure user has default metadata
             user.metadata = Metadata::default();
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Test that user with default metadata returns true
             let result = user
-                .should_update_metadata(&event, false, &whitenoise.database)
+                .should_update_metadata(&event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1398,11 +1415,11 @@ mod tests {
 
             // Give user some non-default metadata
             user.metadata = Metadata::new().name("Test User");
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Test that with no processed events, returns true
             let result = user
-                .should_update_metadata(&event, false, &whitenoise.database)
+                .should_update_metadata(&event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1417,7 +1434,7 @@ mod tests {
 
             // Give user some non-default metadata
             user.metadata = Metadata::new().name("Test User");
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Create an older processed event
             ProcessedEvent::create(
@@ -1426,7 +1443,7 @@ mod tests {
                 Some(timestamp_to_datetime(old_event.created_at).unwrap()),
                 Some(Kind::Metadata), // Metadata kind
                 Some(&user.pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1437,7 +1454,7 @@ mod tests {
 
             // Test that newer event returns true
             let result = user
-                .should_update_metadata(&new_event, false, &whitenoise.database)
+                .should_update_metadata(&new_event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1452,7 +1469,7 @@ mod tests {
 
             // Give user some non-default metadata
             user.metadata = Metadata::new().name("Test User");
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Create a processed event
             ProcessedEvent::create(
@@ -1461,7 +1478,7 @@ mod tests {
                 Some(timestamp_to_datetime(old_event.created_at).unwrap()),
                 Some(Kind::Metadata), // Metadata kind
                 Some(&user.pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1475,7 +1492,7 @@ mod tests {
 
             // Test that equal timestamp returns true (newer or equal)
             let result = user
-                .should_update_metadata(&new_event, false, &whitenoise.database)
+                .should_update_metadata(&new_event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1490,7 +1507,7 @@ mod tests {
 
             // Give user some non-default metadata
             user.metadata = Metadata::new().name("Test User");
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Create a newer processed event
             ProcessedEvent::create(
@@ -1499,7 +1516,7 @@ mod tests {
                 Some(timestamp_to_datetime(newer_event.created_at).unwrap()),
                 Some(Kind::Metadata), // Metadata kind
                 Some(&user.pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1513,7 +1530,7 @@ mod tests {
 
             // Test that older event returns false
             let result = user
-                .should_update_metadata(&old_event, false, &whitenoise.database)
+                .should_update_metadata(&old_event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1528,7 +1545,7 @@ mod tests {
 
             // Give user some non-default metadata
             user.metadata = Metadata::new().name("Test User");
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Create a processed event entry for this exact event
             ProcessedEvent::create(
@@ -1537,7 +1554,7 @@ mod tests {
                 Some(timestamp_to_datetime(event.created_at).unwrap()),
                 Some(Kind::Metadata), // Metadata kind
                 Some(&user.pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1545,7 +1562,7 @@ mod tests {
             // Test that already processed takes priority over newly_created
             // Even though newly_created=true, it should return false because event is already processed
             let result = user
-                .should_update_metadata(&event, true, &whitenoise.database)
+                .should_update_metadata(&event, true, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1560,12 +1577,12 @@ mod tests {
 
             // Ensure user has default metadata (redundant but explicit)
             user.metadata = Metadata::default();
-            user.save(&whitenoise.database).await.unwrap();
+            user.save(&whitenoise.shared.database).await.unwrap();
 
             // Test that newly created user with default metadata returns true
             // (both conditions would return true, but newly_created takes priority)
             let result = user
-                .should_update_metadata(&event, true, &whitenoise.database)
+                .should_update_metadata(&event, true, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1604,7 +1621,7 @@ mod tests {
                 .unwrap();
 
             let result = user
-                .should_update_metadata(&event, false, &whitenoise.database)
+                .should_update_metadata(&event, false, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1646,7 +1663,10 @@ mod tests {
                 updated_at: Utc::now(),
             };
             original_user.mark_metadata_known_now();
-            let saved_user = original_user.save(&whitenoise.database).await.unwrap();
+            let saved_user = original_user
+                .save(&whitenoise.shared.database)
+                .await
+                .unwrap();
 
             let found_user = whitenoise
                 .get_or_create_user_local(&test_pubkey)
@@ -1684,7 +1704,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let user_from_db = User::find_by_pubkey(&test_pubkey, &whitenoise.database)
+            let user_from_db = User::find_by_pubkey(&test_pubkey, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert!(user_from_db.metadata_is_unknown());
@@ -1711,7 +1731,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay_url = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay = whitenoise
@@ -1719,7 +1739,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1730,7 +1750,7 @@ mod tests {
                 Some(newer_timestamp),
                 Some(Kind::from(10002)),
                 Some(&test_pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1751,7 +1771,7 @@ mod tests {
 
             assert!(!changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -1771,7 +1791,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let old_relay_url = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay = whitenoise
@@ -1779,7 +1799,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1790,7 +1810,7 @@ mod tests {
                 Some(old_timestamp),
                 Some(Kind::from(10002)),
                 Some(&test_pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1811,7 +1831,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -1831,7 +1851,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let r1 = whitenoise
@@ -1839,7 +1859,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&r1, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&r1, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1850,7 +1870,7 @@ mod tests {
                 Some(timestamp),
                 Some(Kind::from(10002)),
                 Some(&test_pubkey),
-                &whitenoise.database,
+                &whitenoise.shared.database,
             )
             .await
             .unwrap();
@@ -1870,7 +1890,7 @@ mod tests {
 
             assert!(!changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -1890,7 +1910,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let new_relay_urls =
                 HashSet::from([RelayUrl::parse("wss://relay1.example.com").unwrap()]);
@@ -1902,7 +1922,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -1921,7 +1941,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay_url = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay = whitenoise
@@ -1929,7 +1949,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1947,7 +1967,7 @@ mod tests {
 
             assert!(!changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -1967,7 +1987,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay = whitenoise
@@ -1975,7 +1995,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -1997,7 +2017,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 3);
@@ -2016,7 +2036,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
@@ -2025,7 +2045,7 @@ mod tests {
             for url in [&relay1, &relay2, &relay3] {
                 let relay = whitenoise.find_or_create_relay_by_url(url).await.unwrap();
                 saved_user
-                    .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                    .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                     .await
                     .unwrap();
             }
@@ -2044,7 +2064,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -2064,7 +2084,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
@@ -2072,7 +2092,7 @@ mod tests {
             for url in [&relay1, &relay2] {
                 let relay = whitenoise.find_or_create_relay_by_url(url).await.unwrap();
                 saved_user
-                    .add_relay(&relay, RelayType::Nip65, &whitenoise.database)
+                    .add_relay(&relay, RelayType::Nip65, &whitenoise.shared.database)
                     .await
                     .unwrap();
             }
@@ -2093,7 +2113,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 3);
@@ -2118,7 +2138,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let relay2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
@@ -2128,7 +2148,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&r1, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&r1, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -2137,7 +2157,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&r2, RelayType::Inbox, &whitenoise.database)
+                .add_relay(&r2, RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -2154,14 +2174,14 @@ mod tests {
 
             assert!(changed);
             let nip65_relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(nip65_relays.len(), 1);
             assert_eq!(nip65_relays[0].url, relay2);
 
             let inbox_relays = saved_user
-                .relays(RelayType::Inbox, &whitenoise.database)
+                .relays(RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(inbox_relays.len(), 1);
@@ -2181,7 +2201,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
             let r1 = whitenoise
@@ -2189,7 +2209,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&r1, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&r1, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -2201,7 +2221,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 0);
@@ -2220,7 +2240,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let new_relay_urls =
                 HashSet::from([RelayUrl::parse("wss://relay1.example.com").unwrap()]);
@@ -2237,7 +2257,7 @@ mod tests {
 
             assert!(changed);
             let relays = saved_user
-                .relays(RelayType::Nip65, &whitenoise.database)
+                .relays(RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
             assert_eq!(relays.len(), 1);
@@ -2261,7 +2281,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = Relay::defaults();
             let result = saved_user
@@ -2288,7 +2308,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = vec![];
             let result = saved_user
@@ -2312,7 +2332,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let initial_relay = RelayUrl::parse("ws://localhost:8080").unwrap();
             let r = whitenoise
@@ -2320,7 +2340,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&r, RelayType::Nip65, &whitenoise.database)
+                .add_relay(&r, RelayType::Nip65, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -2358,7 +2378,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = vec![];
             let result = saved_user
@@ -2381,7 +2401,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = vec![];
             let result = saved_user
@@ -2404,7 +2424,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let relay_url = RelayUrl::parse("ws://localhost:7777").unwrap();
             let query_relays = vec![crate::whitenoise::relays::Relay {
@@ -2535,7 +2555,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = Relay::defaults();
             let changed = saved_user
@@ -2559,7 +2579,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = vec![];
             let result = saved_user
@@ -2582,7 +2602,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let query_relays = Relay::defaults();
 
@@ -2609,7 +2629,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
             let relay_url = RelayUrl::parse("wss://inbox.example.com").unwrap();
             let relay = whitenoise
                 .find_or_create_relay_by_url(&relay_url)
@@ -2617,7 +2637,7 @@ mod tests {
                 .unwrap();
 
             saved_user
-                .add_relay(&relay, RelayType::Inbox, &whitenoise.database)
+                .add_relay(&relay, RelayType::Inbox, &whitenoise.shared.database)
                 .await
                 .unwrap();
 
@@ -2647,7 +2667,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             // User has no relays in DB, so key_package_status should attempt
             // relay sync and retry. With no real relays to reach, the result
@@ -2669,7 +2689,7 @@ mod tests {
                 metadata_known_at: None,
                 updated_at: Utc::now(),
             };
-            let saved_user = user.save(&whitenoise.database).await.unwrap();
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             // Add a key package relay using a local test relay so the connection succeeds
             let relay_url = RelayUrl::parse("ws://localhost:8080").unwrap();
@@ -2678,7 +2698,7 @@ mod tests {
                 .await
                 .unwrap();
             saved_user
-                .add_relay(&relay, RelayType::KeyPackage, &whitenoise.database)
+                .add_relay(&relay, RelayType::KeyPackage, &whitenoise.shared.database)
                 .await
                 .unwrap();
 

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -30,7 +30,7 @@ impl User {
     #[perf_instrument("users")]
     pub async fn key_package_relay_urls(&self, whitenoise: &Whitenoise) -> Result<Vec<RelayUrl>> {
         let kp_relays = self
-            .relays(RelayType::KeyPackage, &whitenoise.database)
+            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
             .await?;
         if !kp_relays.is_empty() {
             return Ok(Relay::urls(&kp_relays));
@@ -42,7 +42,9 @@ impl User {
             self.pubkey
         );
 
-        let nip65_relays = self.relays(RelayType::Nip65, &whitenoise.database).await?;
+        let nip65_relays = self
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
+            .await?;
         if !nip65_relays.is_empty() {
             return Ok(Relay::urls(&nip65_relays));
         }
@@ -89,6 +91,7 @@ impl User {
         }
 
         let event = whitenoise
+            .shared
             .relay_control
             .fetch_user_key_package(self.pubkey, &relay_urls)
             .await?;
@@ -111,7 +114,7 @@ impl User {
         match status {
             KeyPackageStatus::NotFound
                 if self
-                    .relays(RelayType::KeyPackage, &whitenoise.database)
+                    .relays(RelayType::KeyPackage, &whitenoise.shared.database)
                     .await?
                     .is_empty() =>
             {

--- a/src/whitenoise/users/relay_sync.rs
+++ b/src/whitenoise/users/relay_sync.rs
@@ -1,17 +1,19 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use nostr_sdk::prelude::*;
 
 use crate::perf_instrument;
+use crate::relay_control::RelayControlPlane;
 use crate::relay_control::ephemeral::EphemeralScope;
 use crate::whitenoise::{
     Whitenoise,
     database::Database,
     database::processed_events::ProcessedEvent,
     error::Result,
+    event_tracker::EventTracker,
     relays::{Relay, RelayType},
-    shared::SharedServices,
     users::User,
     utils::timestamp_to_datetime,
 };
@@ -333,22 +335,30 @@ impl User {
     #[perf_instrument("relay_sync")]
     pub(crate) async fn sync_relay_type_from_query_urls(
         &self,
-        shared: &SharedServices,
+        database: &Database,
+        relay_control: &RelayControlPlane,
+        event_tracker: &Arc<dyn EventTracker>,
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        let existing_relays = self.relays(relay_type, &shared.database).await?;
+        let existing_relays = self.relays(relay_type, database).await?;
         if query_relay_urls.is_empty() {
             return Ok(existing_relays);
         }
 
         let query_relays: Vec<Relay> = query_relay_urls.iter().map(Relay::new).collect();
-        let scope = shared.relay_control.ephemeral().anonymous_scope();
+        let scope = relay_control.ephemeral().anonymous_scope();
         let _changed = self
-            .sync_relays_for_type_with_context(shared, &scope, relay_type, &query_relays)
+            .sync_relays_for_type_with_context(
+                database,
+                event_tracker,
+                &scope,
+                relay_type,
+                &query_relays,
+            )
             .await?;
 
-        self.relays(relay_type, &shared.database).await
+        self.relays(relay_type, database).await
     }
 
     /// Synchronizes relays for a specific type with the network state.
@@ -366,14 +376,21 @@ impl User {
             .relay_control
             .ephemeral()
             .anonymous_scope();
-        self.sync_relays_for_type_with_context(&whitenoise.shared, &scope, relay_type, query_relays)
-            .await
+        self.sync_relays_for_type_with_context(
+            &whitenoise.shared.database,
+            &whitenoise.shared.event_tracker,
+            &scope,
+            relay_type,
+            query_relays,
+        )
+        .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn sync_relays_for_type_with_context(
         &self,
-        shared: &SharedServices,
+        database: &Database,
+        event_tracker: &Arc<dyn EventTracker>,
         scope: &EphemeralScope,
         relay_type: RelayType,
         query_relays: &[Relay],
@@ -391,7 +408,7 @@ impl User {
                 e
             })?;
 
-        self.apply_relay_event_with_context(shared, relay_type, relay_event)
+        self.apply_relay_event_with_context(database, event_tracker, relay_type, relay_event)
             .await
     }
 
@@ -403,8 +420,14 @@ impl User {
         relay_type: RelayType,
         query_relays: &[Relay],
     ) -> Result<bool> {
-        self.sync_relays_for_type_with_context(&whitenoise.shared, scope, relay_type, query_relays)
-            .await
+        self.sync_relays_for_type_with_context(
+            &whitenoise.shared.database,
+            &whitenoise.shared.event_tracker,
+            scope,
+            relay_type,
+            query_relays,
+        )
+        .await
     }
 
     #[perf_instrument("relay_sync")]
@@ -414,14 +437,20 @@ impl User {
         relay_type: RelayType,
         relay_event: Option<Event>,
     ) -> Result<bool> {
-        self.apply_relay_event_with_context(&whitenoise.shared, relay_type, relay_event)
-            .await
+        self.apply_relay_event_with_context(
+            &whitenoise.shared.database,
+            &whitenoise.shared.event_tracker,
+            relay_type,
+            relay_event,
+        )
+        .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn apply_relay_event_with_context(
         &self,
-        shared: &SharedServices,
+        database: &Database,
+        event_tracker: &Arc<dyn EventTracker>,
         relay_type: RelayType,
         relay_event: Option<Event>,
     ) -> Result<bool> {
@@ -431,7 +460,7 @@ impl User {
                     crate::nostr_manager::utils::relay_urls_from_event(&event);
                 let changed = self
                     .sync_relay_urls_with_database(
-                        &shared.database,
+                        database,
                         relay_type,
                         &relay_hashset,
                         Some(timestamp_to_datetime(event.created_at)?),
@@ -439,10 +468,7 @@ impl User {
                     .await?;
 
                 if changed {
-                    shared
-                        .event_tracker
-                        .track_processed_global_event(&event)
-                        .await?;
+                    event_tracker.track_processed_global_event(&event).await?;
 
                     tracing::debug!(
                         target: "whitenoise::users::sync_relays_for_type",
@@ -474,12 +500,20 @@ impl User {
 
 #[perf_instrument("relay_sync")]
 pub(crate) async fn sync_relay_type_for_pubkey(
-    shared: &SharedServices,
+    database: &Database,
+    relay_control: &RelayControlPlane,
+    event_tracker: &Arc<dyn EventTracker>,
     pubkey: PublicKey,
     relay_type: RelayType,
     query_relay_urls: &[RelayUrl],
 ) -> Result<Vec<Relay>> {
-    let (user, _created) = User::find_or_create_by_pubkey(&pubkey, &shared.database).await?;
-    user.sync_relay_type_from_query_urls(shared, relay_type, query_relay_urls)
-        .await
+    let (user, _created) = User::find_or_create_by_pubkey(&pubkey, database).await?;
+    user.sync_relay_type_from_query_urls(
+        database,
+        relay_control,
+        event_tracker,
+        relay_type,
+        query_relay_urls,
+    )
+    .await
 }

--- a/src/whitenoise/users/relay_sync.rs
+++ b/src/whitenoise/users/relay_sync.rs
@@ -336,18 +336,18 @@ impl User {
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        let existing_relays = self.relays(relay_type, &context.database).await?;
+        let existing_relays = self.relays(relay_type, &context.shared.database).await?;
         if query_relay_urls.is_empty() {
             return Ok(existing_relays);
         }
 
         let query_relays: Vec<Relay> = query_relay_urls.iter().map(Relay::new).collect();
-        let scope = context.relay_control.ephemeral().anonymous_scope();
+        let scope = context.shared.relay_control.ephemeral().anonymous_scope();
         let _changed = self
             .sync_relays_for_type_with_context(context, &scope, relay_type, &query_relays)
             .await?;
 
-        self.relays(relay_type, &context.database).await
+        self.relays(relay_type, &context.shared.database).await
     }
 
     /// Synchronizes relays for a specific type with the network state.
@@ -444,7 +444,7 @@ impl User {
                     crate::nostr_manager::utils::relay_urls_from_event(&event);
                 let changed = self
                     .sync_relay_urls_with_database(
-                        &context.database,
+                        &context.shared.database,
                         relay_type,
                         &relay_hashset,
                         Some(timestamp_to_datetime(event.created_at)?),
@@ -453,6 +453,7 @@ impl User {
 
                 if changed {
                     context
+                        .shared
                         .event_tracker
                         .track_processed_global_event(&event)
                         .await?;
@@ -493,7 +494,8 @@ impl UserRelaySyncContext {
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        let (user, _created) = User::find_or_create_by_pubkey(&pubkey, &self.database).await?;
+        let (user, _created) =
+            User::find_or_create_by_pubkey(&pubkey, &self.shared.database).await?;
         user.sync_relay_type_from_query_urls(self, relay_type, query_relay_urls)
             .await
     }

--- a/src/whitenoise/users/relay_sync.rs
+++ b/src/whitenoise/users/relay_sync.rs
@@ -19,7 +19,11 @@ impl User {
     /// Fetches the latest relay lists for this user from Nostr and updates the local database
     #[perf_instrument("relay_sync")]
     pub(crate) async fn update_relay_lists(&self, whitenoise: &Whitenoise) -> Result<()> {
-        let scope = whitenoise.relay_control.ephemeral().anonymous_scope();
+        let scope = whitenoise
+            .shared
+            .relay_control
+            .ephemeral()
+            .anonymous_scope();
         self.update_relay_lists_with_scope(whitenoise, &scope)
             .await?;
         Ok(())
@@ -57,7 +61,9 @@ impl User {
     }
 
     pub(super) async fn get_query_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let stored_relays = self.relays(RelayType::Nip65, &whitenoise.database).await?;
+        let stored_relays = self
+            .relays(RelayType::Nip65, &whitenoise.shared.database)
+            .await?;
 
         if stored_relays.is_empty() {
             tracing::debug!(
@@ -78,7 +84,11 @@ impl User {
         whitenoise: &Whitenoise,
         query_relays: &[Relay],
     ) -> Result<Vec<Relay>> {
-        let scope = whitenoise.relay_control.ephemeral().anonymous_scope();
+        let scope = whitenoise
+            .shared
+            .relay_control
+            .ephemeral()
+            .anonymous_scope();
         self.update_nip65_relays_with_scope(whitenoise, &scope, query_relays)
             .await
     }
@@ -95,7 +105,9 @@ impl User {
             .await
         {
             Ok(true) => {
-                let refreshed_relays = self.relays(RelayType::Nip65, &whitenoise.database).await?;
+                let refreshed_relays = self
+                    .relays(RelayType::Nip65, &whitenoise.shared.database)
+                    .await?;
                 tracing::info!(
                     target: "whitenoise::users::update_nip65_relays",
                     "Updated NIP-65 relays for user {}, now using {} relays for other types",
@@ -130,7 +142,11 @@ impl User {
         whitenoise: &Whitenoise,
         query_relays: &[Relay],
     ) -> Result<()> {
-        let scope = whitenoise.relay_control.ephemeral().anonymous_scope();
+        let scope = whitenoise
+            .shared
+            .relay_control
+            .ephemeral()
+            .anonymous_scope();
         self.update_secondary_relay_types_with_scope(whitenoise, &scope, query_relays)
             .await
     }
@@ -197,7 +213,7 @@ impl User {
         event_created_at: Option<DateTime<Utc>>,
     ) -> Result<bool> {
         self.sync_relay_urls_with_database(
-            &whitenoise.database,
+            &whitenoise.shared.database,
             relay_type,
             new_relay_urls,
             event_created_at,
@@ -344,7 +360,11 @@ impl User {
         relay_type: RelayType,
         query_relays: &[Relay],
     ) -> Result<bool> {
-        let scope = whitenoise.relay_control.ephemeral().anonymous_scope();
+        let scope = whitenoise
+            .shared
+            .relay_control
+            .ephemeral()
+            .anonymous_scope();
         self.sync_relays_for_type_with_context(
             &whitenoise.user_relay_sync_context(),
             &scope,
@@ -461,7 +481,7 @@ impl User {
     pub(crate) async fn all_users_with_relay_urls(
         whitenoise: &Whitenoise,
     ) -> Result<Vec<(PublicKey, Vec<RelayUrl>)>> {
-        Self::all_with_nip65_relay_urls(&whitenoise.database).await
+        Self::all_with_nip65_relay_urls(&whitenoise.shared.database).await
     }
 }
 

--- a/src/whitenoise/users/relay_sync.rs
+++ b/src/whitenoise/users/relay_sync.rs
@@ -11,7 +11,8 @@ use crate::whitenoise::{
     database::processed_events::ProcessedEvent,
     error::Result,
     relays::{Relay, RelayType},
-    users::{User, UserRelaySyncContext},
+    shared::SharedServices,
+    users::User,
     utils::timestamp_to_datetime,
 };
 
@@ -332,22 +333,22 @@ impl User {
     #[perf_instrument("relay_sync")]
     pub(crate) async fn sync_relay_type_from_query_urls(
         &self,
-        context: &UserRelaySyncContext,
+        shared: &SharedServices,
         relay_type: RelayType,
         query_relay_urls: &[RelayUrl],
     ) -> Result<Vec<Relay>> {
-        let existing_relays = self.relays(relay_type, &context.shared.database).await?;
+        let existing_relays = self.relays(relay_type, &shared.database).await?;
         if query_relay_urls.is_empty() {
             return Ok(existing_relays);
         }
 
         let query_relays: Vec<Relay> = query_relay_urls.iter().map(Relay::new).collect();
-        let scope = context.shared.relay_control.ephemeral().anonymous_scope();
+        let scope = shared.relay_control.ephemeral().anonymous_scope();
         let _changed = self
-            .sync_relays_for_type_with_context(context, &scope, relay_type, &query_relays)
+            .sync_relays_for_type_with_context(shared, &scope, relay_type, &query_relays)
             .await?;
 
-        self.relays(relay_type, &context.shared.database).await
+        self.relays(relay_type, &shared.database).await
     }
 
     /// Synchronizes relays for a specific type with the network state.
@@ -365,19 +366,14 @@ impl User {
             .relay_control
             .ephemeral()
             .anonymous_scope();
-        self.sync_relays_for_type_with_context(
-            &whitenoise.user_relay_sync_context(),
-            &scope,
-            relay_type,
-            query_relays,
-        )
-        .await
+        self.sync_relays_for_type_with_context(&whitenoise.shared, &scope, relay_type, query_relays)
+            .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn sync_relays_for_type_with_context(
         &self,
-        context: &UserRelaySyncContext,
+        shared: &SharedServices,
         scope: &EphemeralScope,
         relay_type: RelayType,
         query_relays: &[Relay],
@@ -395,7 +391,7 @@ impl User {
                 e
             })?;
 
-        self.apply_relay_event_with_context(context, relay_type, relay_event)
+        self.apply_relay_event_with_context(shared, relay_type, relay_event)
             .await
     }
 
@@ -407,13 +403,8 @@ impl User {
         relay_type: RelayType,
         query_relays: &[Relay],
     ) -> Result<bool> {
-        self.sync_relays_for_type_with_context(
-            &whitenoise.user_relay_sync_context(),
-            scope,
-            relay_type,
-            query_relays,
-        )
-        .await
+        self.sync_relays_for_type_with_context(&whitenoise.shared, scope, relay_type, query_relays)
+            .await
     }
 
     #[perf_instrument("relay_sync")]
@@ -423,18 +414,14 @@ impl User {
         relay_type: RelayType,
         relay_event: Option<Event>,
     ) -> Result<bool> {
-        self.apply_relay_event_with_context(
-            &whitenoise.user_relay_sync_context(),
-            relay_type,
-            relay_event,
-        )
-        .await
+        self.apply_relay_event_with_context(&whitenoise.shared, relay_type, relay_event)
+            .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn apply_relay_event_with_context(
         &self,
-        context: &UserRelaySyncContext,
+        shared: &SharedServices,
         relay_type: RelayType,
         relay_event: Option<Event>,
     ) -> Result<bool> {
@@ -444,7 +431,7 @@ impl User {
                     crate::nostr_manager::utils::relay_urls_from_event(&event);
                 let changed = self
                     .sync_relay_urls_with_database(
-                        &context.shared.database,
+                        &shared.database,
                         relay_type,
                         &relay_hashset,
                         Some(timestamp_to_datetime(event.created_at)?),
@@ -452,8 +439,7 @@ impl User {
                     .await?;
 
                 if changed {
-                    context
-                        .shared
+                    shared
                         .event_tracker
                         .track_processed_global_event(&event)
                         .await?;
@@ -486,17 +472,14 @@ impl User {
     }
 }
 
-impl UserRelaySyncContext {
-    #[perf_instrument("relay_sync")]
-    pub(crate) async fn sync_relay_type_for_pubkey(
-        &self,
-        pubkey: PublicKey,
-        relay_type: RelayType,
-        query_relay_urls: &[RelayUrl],
-    ) -> Result<Vec<Relay>> {
-        let (user, _created) =
-            User::find_or_create_by_pubkey(&pubkey, &self.shared.database).await?;
-        user.sync_relay_type_from_query_urls(self, relay_type, query_relay_urls)
-            .await
-    }
+#[perf_instrument("relay_sync")]
+pub(crate) async fn sync_relay_type_for_pubkey(
+    shared: &SharedServices,
+    pubkey: PublicKey,
+    relay_type: RelayType,
+    query_relay_urls: &[RelayUrl],
+) -> Result<Vec<Relay>> {
+    let (user, _created) = User::find_or_create_by_pubkey(&pubkey, &shared.database).await?;
+    user.sync_relay_type_from_query_urls(shared, relay_type, query_relay_urls)
+        .await
 }


### PR DESCRIPTION
![marmot](https://blossom.primal.net/c47448e8cba959ffc647cc1dec85ff905d3f04125b2e8bccf01757d9cea245e6.jpg)

# Phase 16a: Extract SharedServices

`Whitenoise` held 21 fields: long-lived services, lifecycle plumbing, and per-account registries mashed together. This PR groups the 14 shared fields into one `Arc<SharedServices>` holder, leaving `Whitenoise` with 7 fields of real per-process state.

Callers now reach shared state via a stable path (`wn.shared.database`, `session.shared.relay_control`, and so on), so phase 16b can delete the singleton without a second round of call-site churn.

## Scope

Staging move only: singleton compatibility is preserved so `initialize_whitenoise()` and `get_instance()` work exactly as before, with no public API changes and no behavior changes.

## What moved

Into `SharedServices`:
- `database`, `relay_control`, `event_tracker`
- `secrets_store`, `storage`, `message_aggregator`
- All five stream managers (message, user, chat_list, archived_chat_list, notification)
- `user_resolution_guards`, `external_signers`, `discovery_sync_worker`

Stayed on `Whitenoise` (lifecycle plumbing and account registry):
- `config`
- `event_sender`, `shutdown_sender`
- `scheduler_shutdown`, `scheduler_handles`
- `account_manager`

(The old `content_parser` field was also dropped — `ContentParser` is a stateless zero-field struct, so it's now constructed inline at its two call sites.)

## AccountSession update

The second commit wires `AccountSession` through the new holder. The session now owns `Arc<SharedServices>` and drops its redundant `database` and `message_stream_manager` fields. Constructor signature shrinks from 8 args to 5.

## Non-goals (deferred)

- Deleting the singleton (phase 16b)
- Moving DashMaps off SharedServices (Goal 4 follow-up)
- Migrating the 5 remaining `get_instance()` call sites in session code. These reach Whitenoise methods like `config`, `resolve_group_image_paths`, and `emit_chat_list_update`, so they wait for 16b to move those methods

## Verification

`just check` passes (fmt, clippy, docs). `just precommit-quick` shows one pre-existing test failure unrelated to this refactor (`test_archive_chat_emits_to_both_stream_channels`, confirmed failing on master via `git stash`).

## Plan reference

Spec: `docs/session-projection-rearchitecture.md` lines 117-149 and `docs/session-projection-implementation-plan.md` lines 431-451.
