### PR TITLE
feat(groups): expose group_required_capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
+source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
 dependencies = [
  "base64",
  "blurhash",
@@ -2512,12 +2512,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
+source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
+source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
+source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
 dependencies = [
  "nostr",
  "openmls",
@@ -2764,7 +2764,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3865,9 +3865,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "0.7"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8a8d06c19d617394b0e268f5f9adfad34db3cdf6", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8a8d06c19d617394b0e268f5f9adfad34db3cdf6" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8a8d06c19d617394b0e268f5f9adfad34db3cdf6" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use mdk_core::prelude::{GroupId, NostrGroupConfigData, NostrGroupDataUpdate};
+use mdk_core::prelude::{GroupId, NostrGroupConfigData, NostrGroupDataUpdate, group_types};
 use nostr_sdk::{PublicKey, RelayUrl, Timestamp};
+use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::Whitenoise;
@@ -9,6 +10,7 @@ use crate::perf_instrument;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::app_settings::{Language, ThemeMode};
 use crate::whitenoise::database::aggregated_messages::PaginationOptions;
+use crate::whitenoise::groups::RequiredProposal;
 use crate::whitenoise::relays::{Relay, RelayType};
 use crate::whitenoise::users::KeyPackageStatus;
 
@@ -1002,6 +1004,12 @@ async fn add_members(
     Ok(Response::ok(serde_json::json!(null)))
 }
 
+#[derive(Serialize)]
+struct GroupShowResponse {
+    group: group_types::Group,
+    required_proposals: Vec<RequiredProposal>,
+}
+
 #[perf_instrument("dispatch")]
 async fn get_group(
     wn: &Whitenoise,
@@ -1014,7 +1022,16 @@ async fn get_group(
         .group(&account, &group_id)
         .await
         .map_err(|e| Response::err(e.to_string()))?;
-    Ok(to_response(&group))
+    let required_proposals = wn
+        .group_required_proposals(&account, &group_id)
+        .await
+        .map_err(|e| Response::err(e.to_string()))?
+        .into_iter()
+        .collect();
+    Ok(to_response(&GroupShowResponse {
+        group,
+        required_proposals,
+    }))
 }
 
 #[perf_instrument("dispatch")]
@@ -2295,6 +2312,9 @@ async fn keys_check(wn: &Whitenoise, pubkey_str: &str) -> Result<Response, Respo
 #[cfg(test)]
 mod tests {
     use nostr_sdk::ToBech32;
+    use std::collections::BTreeSet;
+
+    use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
 
     use super::*;
 
@@ -2359,6 +2379,40 @@ mod tests {
     fn to_response_string() {
         let resp = to_response(&"hello");
         assert_eq!(resp.result.unwrap(), serde_json::json!("hello"));
+    }
+
+    // --- get_group ---
+
+    #[tokio::test]
+    async fn get_group_returns_nested_shape_with_required_proposals() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let member = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![creator.pubkey]);
+        let group = whitenoise
+            .create_group(&creator, vec![member.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let response = get_group(
+            &whitenoise,
+            &creator.pubkey.to_hex(),
+            &hex::encode(group.mls_group_id.as_slice()),
+        )
+        .await
+        .expect("get_group succeeds for a valid account and group");
+
+        let value = response.result.expect("response carries a result");
+        let obj = value.as_object().expect("result serializes as an object");
+
+        let keys: BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+        assert_eq!(keys, BTreeSet::from(["group", "required_proposals"]));
+
+        assert_eq!(
+            obj["required_proposals"],
+            serde_json::json!(["self_remove"]),
+        );
     }
 
     // --- parse_relay_type ---

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -28,8 +28,10 @@ pub mod blossom_error;
 mod media;
 mod membership;
 mod publish;
+mod required_proposals;
 
 pub use membership::{GroupWithInfoAndMembership, GroupWithMembership};
+pub use required_proposals::RequiredProposal;
 
 impl Whitenoise {
     #[perf_instrument("groups")]
@@ -563,6 +565,49 @@ impl Whitenoise {
             .admin_pubkeys
             .into_iter()
             .collect::<Vec<PublicKey>>())
+    }
+
+    /// Returns the set of MLS proposal types required by the group's
+    /// `RequiredCapabilities` extension, projected onto the whitenoise mirror
+    /// enum [`RequiredProposal`].
+    ///
+    /// # Arguments
+    /// * `account` - The account that has access to the group
+    /// * `group_id` - The MLS group ID to inspect
+    ///
+    /// # Returns
+    /// * `Ok(BTreeSet<RequiredProposal>)` - The set of required proposal
+    ///   types. An empty set is the LCD outcome for mixed or empty-invitee
+    ///   groups and is **not** an error — it is distinct from
+    ///   [`WhitenoiseError::GroupNotFound`], which means the MLS record is
+    ///   missing.
+    ///
+    /// # Errors
+    /// * `WhitenoiseError::GroupNotFound` - If no MLS record exists for
+    ///   `group_id`
+    /// * `WhitenoiseError` - If loading the group record fails
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let required = wn.group_required_proposals(&account, &group_id).await?;
+    /// if required.contains(&RequiredProposal::SelfRemove) {
+    ///     // Non-admin members can leave without an admin commit.
+    /// }
+    /// ```
+    #[perf_instrument("groups")]
+    pub async fn group_required_proposals(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<BTreeSet<RequiredProposal>> {
+        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let required = mdk
+            .group_required_proposals(group_id)
+            .map_err(|e| match e {
+                mdk_core::Error::GroupNotFound => WhitenoiseError::GroupNotFound,
+                other => WhitenoiseError::from(other),
+            })?;
+        Ok(required.into_iter().map(RequiredProposal::from).collect())
     }
 
     #[perf_instrument("groups")]
@@ -2681,5 +2726,39 @@ mod tests {
             group_before.description, group_after.description,
             "Group description should be unchanged when publish fails"
         );
+    }
+
+    #[tokio::test]
+    async fn group_required_proposals_returns_self_remove_for_native_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let member_account = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![creator_account.pubkey]);
+        let group = whitenoise
+            .create_group(&creator_account, vec![member_account.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let required = whitenoise
+            .group_required_proposals(&creator_account, &group.mls_group_id)
+            .await
+            .unwrap();
+
+        assert_eq!(required, BTreeSet::from([RequiredProposal::SelfRemove]));
+    }
+
+    #[tokio::test]
+    async fn group_required_proposals_errors_on_missing_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let missing_group_id = GroupId::from_slice(&[0; 32]);
+
+        let err = whitenoise
+            .group_required_proposals(&account, &missing_group_id)
+            .await
+            .expect_err("fabricated group ID must error");
+
+        assert!(matches!(err, WhitenoiseError::GroupNotFound));
     }
 }

--- a/src/whitenoise/groups/required_proposals.rs
+++ b/src/whitenoise/groups/required_proposals.rs
@@ -1,0 +1,144 @@
+// Intentionally not re-exported via `src/mdk.rs` — `RequiredProposal` is the
+// whitenoise-owned mirror; this import is internal only.
+use mdk_core::prelude::ProposalType;
+use serde::{Deserialize, Serialize};
+
+/// A whitenoise-owned mirror of the MLS proposal-type registry, restricted to
+/// the capability surface exposed through [`crate::Whitenoise::group_required_proposals`].
+///
+/// 1. **Wire format:** serialized as snake_case JSON strings (`"self_remove"`,
+///    `"unknown"`). Mirror this contract in any consumer that parses the
+///    response.
+/// 2. **`Unknown` semantics:** a catch-all for any `openmls` proposal type
+///    whitenoise does not model today. Cardinality in the returned set reflects
+///    distinct *mirror* values, not distinct source values — multiple source
+///    variants collapsing here appear as a single `Unknown` entry.
+/// 3. **Set semantics:** an empty set is the LCD outcome for mixed-capability
+///    or empty-invitee groups and is distinct from
+///    [`crate::WhitenoiseError::GroupNotFound`], which means the MLS record is
+///    missing.
+/// 4. **No-wildcard policy:** the [`From`] impl enumerates every
+///    `openmls::prelude::ProposalType` variant explicitly so a future openmls
+///    bump that adds one fails to compile here, forcing a conscious decision
+///    rather than a silent collapse into `Unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequiredProposal {
+    /// MIP-03 `SelfRemove` (`0x000a`) — when present in a group's required
+    /// capabilities, non-admin members can voluntarily leave without an admin
+    /// commit.
+    SelfRemove,
+    /// Any proposal type the whitenoise API does not distinguish today.
+    Unknown,
+}
+
+impl From<ProposalType> for RequiredProposal {
+    fn from(pt: ProposalType) -> Self {
+        match pt {
+            ProposalType::SelfRemove => Self::SelfRemove,
+            ProposalType::Add
+            | ProposalType::Update
+            | ProposalType::Remove
+            | ProposalType::PreSharedKey
+            | ProposalType::Reinit
+            | ProposalType::ExternalInit
+            | ProposalType::GroupContextExtensions
+            | ProposalType::Grease(_)
+            | ProposalType::Custom(_) => Self::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use mdk_core::prelude::ProposalType;
+
+    use super::*;
+
+    #[test]
+    fn snake_case_serde_contract() {
+        assert_eq!(
+            serde_json::to_value(RequiredProposal::SelfRemove).unwrap(),
+            serde_json::json!("self_remove"),
+        );
+        assert_eq!(
+            serde_json::to_value(RequiredProposal::Unknown).unwrap(),
+            serde_json::json!("unknown"),
+        );
+    }
+
+    #[test]
+    fn from_self_remove_maps_to_self_remove() {
+        assert_eq!(
+            RequiredProposal::from(ProposalType::SelfRemove),
+            RequiredProposal::SelfRemove,
+        );
+    }
+
+    #[test]
+    fn from_each_non_selfremove_variant_maps_to_unknown() {
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Add),
+            RequiredProposal::Unknown
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Update),
+            RequiredProposal::Unknown
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Remove),
+            RequiredProposal::Unknown
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::PreSharedKey),
+            RequiredProposal::Unknown,
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Reinit),
+            RequiredProposal::Unknown
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::ExternalInit),
+            RequiredProposal::Unknown,
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::GroupContextExtensions),
+            RequiredProposal::Unknown,
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Grease(0x0A0A)),
+            RequiredProposal::Unknown,
+        );
+        assert_eq!(
+            RequiredProposal::from(ProposalType::Custom(0xF000)),
+            RequiredProposal::Unknown,
+        );
+    }
+
+    #[test]
+    fn from_empty_set_stays_empty() {
+        let mapped: BTreeSet<RequiredProposal> = BTreeSet::<ProposalType>::new()
+            .into_iter()
+            .map(RequiredProposal::from)
+            .collect();
+        assert!(mapped.is_empty());
+    }
+
+    #[test]
+    fn btreeset_collapses_unknown_duplicates() {
+        let source: BTreeSet<ProposalType> = [
+            ProposalType::Add,
+            ProposalType::Remove,
+            ProposalType::Custom(0x100),
+        ]
+        .into_iter()
+        .collect();
+
+        let mapped: BTreeSet<RequiredProposal> =
+            source.into_iter().map(RequiredProposal::from).collect();
+
+        assert_eq!(mapped, BTreeSet::from([RequiredProposal::Unknown]));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group queries now include a top-level required_proposals field alongside group details.
  * New API to fetch a group's required proposal types independently.
  * Proposal types exposed as snake_case strings ("self_remove", "unknown") with predictable set semantics and clear error behavior for missing groups.

* **Chores**
  * Updated pinned revisions for core storage dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->