### PR TITLE
feat: scaffold SharedDatabase and AccountDatabase wrappers (Phase 18a)

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -489,7 +489,7 @@ boundary.
 
 ### Phase 18a: Database split audit + scaffolding (~600 LOC)
 
-- [x] Completed in PR #XXX
+- [x] Completed in PR #776
 
 <details>
 <summary>Details</summary>

--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -489,7 +489,7 @@ boundary.
 
 ### Phase 18a: Database split audit + scaffolding (~600 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #XXX
 
 <details>
 <summary>Details</summary>

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -30,21 +30,40 @@ use crate::whitenoise::database::{Database, DatabaseError};
 /// These FKs cross the account/shared boundary and will require
 /// application-level enforcement after the physical split in Phases 18b–18e:
 ///
-/// - `accounts_groups.account_pubkey → accounts.pubkey`
-///   (`accounts_groups` moves to `account.sqlite`; `accounts` stays in
-///   `shared.sqlite`)
-/// - `accounts_groups.mls_group_id → group_information.mls_group_id`
-///   (both FK targets live in `shared.sqlite`)
+/// ## Integer-keyed FKs (require schema migration before split)
+///
+/// These use `accounts(id)` (integer rowid) as the FK target. Integer IDs
+/// from `shared.sqlite` won't transfer meaningfully to per-account files,
+/// so these tables need a schema migration to switch to pubkey-keyed FKs
+/// before the physical split:
+///
+/// - `published_events.account_id → accounts(id)` (migration 0011)
+/// - `processed_events.account_id → accounts(id)` (migration 0012)
+///
+/// ## Pubkey-keyed FKs (application-level enforcement only)
+///
+/// - `accounts_groups.account_pubkey → accounts.pubkey` (migration 0018)
 /// - `account_settings.account_pubkey → accounts.pubkey`
-///   (same cross-boundary reference)
+/// - `media_files.account_pubkey → accounts.pubkey` (migration 0015)
+/// - `push_registrations.account_pubkey → accounts.pubkey` (migration 0039)
+/// - `group_push_tokens.account_pubkey → accounts.pubkey` (migration 0041)
+/// - `published_key_packages.account_pubkey → accounts.pubkey` (migration 0029)
+/// - `drafts.account_pubkey → accounts.pubkey` (migration 0028)
+///
+/// ## Cross-scope data references (no schema FK, but logical dependency)
+///
 /// - `aggregated_messages.mls_group_id → group_information.mls_group_id`
 ///   (`group_information` is shared; `aggregated_messages` is account-scoped)
-/// - `message_delivery_status.aggregated_message_id → aggregated_messages.id`
-///   (both are account-scoped — no cross-boundary issue here)
 /// - `media_references.encrypted_file_hash → media_blobs.hash`
 ///   (`media_blobs` is shared; `media_references` is account-scoped)
 /// - `drafts.mls_group_id → group_information.mls_group_id`
-///   (`group_information` is shared; `drafts` is account-scoped)
+///   (`group_information` is shared; `drafts` is account-scoped;
+///   migration 0028)
+///
+/// ## Intra-account FKs (no cross-boundary issue)
+///
+/// - `message_delivery_status.aggregated_message_id → aggregated_messages.id`
+///   (both account-scoped — will stay together)
 ///
 /// # Current implementation
 ///

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -16,8 +16,35 @@ use crate::whitenoise::database::{Database, DatabaseError};
 /// A connection to a per-account SQLite database.
 ///
 /// Each account will have its own file, identified by the account's hex public
-/// key. Account-scoped tables (settings, follows, drafts, key packages,
-/// published events, group membership, push tokens) will live here.
+/// key. Account-scoped tables: `account_settings`, `account_follows`,
+/// `accounts_groups`, `drafts`, `push_registrations`, `group_push_tokens`,
+/// `published_key_packages`, `published_events`,
+/// `processed_events` (account-level), `aggregated_messages`,
+/// `message_delivery_status`, and `media_references`.
+///
+/// See `rearchitecture.md` Appendix B for the authoritative table ownership
+/// map.
+///
+/// # Cross-scope FK audit
+///
+/// These FKs cross the account/shared boundary and will require
+/// application-level enforcement after the physical split in Phases 18b–18e:
+///
+/// - `accounts_groups.account_pubkey → accounts.pubkey`
+///   (`accounts_groups` moves to `account.sqlite`; `accounts` stays in
+///   `shared.sqlite`)
+/// - `accounts_groups.mls_group_id → group_information.mls_group_id`
+///   (both FK targets live in `shared.sqlite`)
+/// - `account_settings.account_pubkey → accounts.pubkey`
+///   (same cross-boundary reference)
+/// - `aggregated_messages.mls_group_id → group_information.mls_group_id`
+///   (`group_information` is shared; `aggregated_messages` is account-scoped)
+/// - `message_delivery_status.aggregated_message_id → aggregated_messages.id`
+///   (both are account-scoped — no cross-boundary issue here)
+/// - `media_references.encrypted_file_hash → media_blobs.hash`
+///   (`media_blobs` is shared; `media_references` is account-scoped)
+/// - `drafts.mls_group_id → group_information.mls_group_id`
+///   (`group_information` is shared; `drafts` is account-scoped)
 ///
 /// # Current implementation
 ///

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -1,0 +1,97 @@
+//! Per-account database wrapper — future home of the account-scoped SQLite file.
+//!
+//! This is a scaffold for the Phase 18 database split. See
+//! `docs/session-projection-implementation-plan.md` for the full table
+//! ownership audit and migration plan.
+//!
+//! **Current status:** thin newtype over [`Database`]. No tables have moved
+//! yet; the physical split happens in Phases 18b–18e.
+
+use std::path::PathBuf;
+
+use nostr_sdk::PublicKey;
+
+use crate::whitenoise::database::{Database, DatabaseError};
+
+/// A connection to a per-account SQLite database.
+///
+/// Each account will have its own file, identified by the account's hex public
+/// key. Account-scoped tables (settings, follows, drafts, key packages,
+/// published events, group membership, push tokens) will live here.
+///
+/// # Current implementation
+///
+/// Thin newtype wrapper around [`Database`]. The split into separate files
+/// happens in Phases 18b–18e.
+#[derive(Clone, Debug)]
+pub struct AccountDatabase {
+    /// The account this database belongs to.
+    pub(crate) account_pubkey: PublicKey,
+    /// Underlying connection; will become its own `<pubkey>.db` pool post-split.
+    pub(crate) inner: Database,
+}
+
+impl AccountDatabase {
+    /// Open (or create) the account database for `account_pubkey` at `db_path`.
+    ///
+    /// Runs all pending migrations on first open.
+    pub async fn new(account_pubkey: PublicKey, db_path: PathBuf) -> Result<Self, DatabaseError> {
+        let inner = Database::new(db_path).await?;
+        Ok(Self {
+            account_pubkey,
+            inner,
+        })
+    }
+
+    /// The public key that owns this database.
+    pub fn account_pubkey(&self) -> &PublicKey {
+        &self.account_pubkey
+    }
+
+    /// Path to the underlying SQLite file.
+    pub fn path(&self) -> &PathBuf {
+        &self.inner.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_pubkey() -> PublicKey {
+        PublicKey::from_hex("000000000000000000000000000000000000000000000000000000000000cafe")
+            .expect("valid test pubkey")
+    }
+
+    #[tokio::test]
+    async fn test_account_database_opens_and_migrates() {
+        let dir = TempDir::new().expect("temp dir");
+        let pubkey = test_pubkey();
+        let path = dir.path().join(format!("{}.db", pubkey.to_hex()));
+
+        let db = AccountDatabase::new(pubkey, path.clone()).await;
+        assert!(db.is_ok(), "expected Ok, got {db:?}");
+
+        let db = db.unwrap();
+        assert_eq!(db.path(), &path);
+        assert_eq!(db.account_pubkey(), &test_pubkey());
+    }
+
+    #[tokio::test]
+    async fn test_account_database_is_idempotent_across_opens() {
+        let dir = TempDir::new().expect("temp dir");
+        let pubkey = test_pubkey();
+        let path = dir.path().join(format!("{}.db", pubkey.to_hex()));
+
+        // First open.
+        let _ = AccountDatabase::new(pubkey, path.clone())
+            .await
+            .expect("first open");
+
+        // Second open — migrations already applied.
+        let db = AccountDatabase::new(test_pubkey(), path).await;
+        assert!(db.is_ok(), "expected Ok on second open, got {db:?}");
+    }
+}

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -12,6 +12,7 @@ use sqlx::{
 use thiserror::Error;
 
 pub mod account;
+pub mod account_db;
 pub mod account_settings;
 pub mod accounts;
 pub mod accounts_groups;
@@ -30,6 +31,7 @@ pub mod push_registrations;
 pub mod relay_events;
 pub mod relay_status;
 pub mod relays;
+pub mod shared_db;
 pub mod user_relays;
 pub mod users;
 pub mod utils;

--- a/src/whitenoise/database/shared_db.rs
+++ b/src/whitenoise/database/shared_db.rs
@@ -1,0 +1,75 @@
+//! Shared database wrapper — future home of the cross-account SQLite file.
+//!
+//! This is a scaffold for the Phase 18 database split. See
+//! `docs/session-projection-implementation-plan.md` for the full table
+//! ownership audit and migration plan.
+//!
+//! **Current status:** thin newtype over [`Database`]. No tables have moved
+//! yet; the physical split happens in Phases 18b–18e.
+
+use std::path::PathBuf;
+
+use crate::whitenoise::database::{Database, DatabaseError};
+
+/// A connection to the shared SQLite database.
+///
+/// Holds data that is not tied to any single account: users, relays,
+/// group information, aggregated messages, app settings, and the media blob
+/// cache. See the implementation plan for the full table list.
+///
+/// # Current implementation
+///
+/// Thin newtype wrapper around [`Database`]. The split into a separate file
+/// happens in Phases 18b–18e.
+#[derive(Clone, Debug)]
+pub struct SharedDatabase {
+    /// Underlying connection; will become its own `shared.db` pool post-split.
+    pub(crate) inner: Database,
+}
+
+impl SharedDatabase {
+    /// Open (or create) the shared database at `db_path`.
+    ///
+    /// Runs all pending migrations in `./db_migrations` on first open.
+    pub async fn new(db_path: PathBuf) -> Result<Self, DatabaseError> {
+        let inner = Database::new(db_path).await?;
+        Ok(Self { inner })
+    }
+
+    /// Path to the underlying SQLite file.
+    pub fn path(&self) -> &PathBuf {
+        &self.inner.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_shared_database_opens_and_migrates() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("shared.db");
+
+        let db = SharedDatabase::new(path.clone()).await;
+        assert!(db.is_ok(), "expected Ok, got {db:?}");
+
+        let db = db.unwrap();
+        assert_eq!(db.path(), &path);
+    }
+
+    #[tokio::test]
+    async fn test_shared_database_is_idempotent_across_opens() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("shared.db");
+
+        // First open — creates file and runs migrations.
+        let _ = SharedDatabase::new(path.clone()).await.expect("first open");
+
+        // Second open — should not fail (migrations already applied).
+        let db = SharedDatabase::new(path.clone()).await;
+        assert!(db.is_ok(), "expected Ok on second open, got {db:?}");
+    }
+}

--- a/src/whitenoise/database/shared_db.rs
+++ b/src/whitenoise/database/shared_db.rs
@@ -13,9 +13,28 @@ use crate::whitenoise::database::{Database, DatabaseError};
 
 /// A connection to the shared SQLite database.
 ///
-/// Holds data that is not tied to any single account: users, relays,
-/// group information, aggregated messages, app settings, and the media blob
-/// cache. See the implementation plan for the full table list.
+/// Holds data that is not tied to any single account: `app_settings`,
+/// `accounts` (registry), `users`, `relays`, `user_relays`,
+/// `cached_graph_users`, `group_information`, `processed_events` (global),
+/// `media_blobs`, `relay_status`, and `relay_events`.
+///
+/// See `rearchitecture.md` Appendix B for the authoritative table ownership
+/// map.
+///
+/// # Cross-scope FK audit
+///
+/// These FKs cross the shared/account boundary and will require
+/// application-level enforcement after the physical split in Phases 18b–18e:
+///
+/// - `accounts_groups.mls_group_id → group_information.mls_group_id`
+///   (`accounts_groups` moves to `account.sqlite`; `group_information` stays
+///   in `shared.sqlite`)
+/// - `aggregated_messages.mls_group_id → group_information.mls_group_id`
+///   (same cross-boundary reference)
+/// - `media_references.encrypted_file_hash → media_blobs.hash`
+///   (`media_references` is account-scoped; `media_blobs` is shared)
+/// - `drafts.mls_group_id → group_information.mls_group_id`
+///   (`drafts` is account-scoped; `group_information` is shared)
 ///
 /// # Current implementation
 ///

--- a/src/whitenoise/database/shared_db.rs
+++ b/src/whitenoise/database/shared_db.rs
@@ -26,15 +26,35 @@ use crate::whitenoise::database::{Database, DatabaseError};
 /// These FKs cross the shared/account boundary and will require
 /// application-level enforcement after the physical split in Phases 18b–18e:
 ///
-/// - `accounts_groups.mls_group_id → group_information.mls_group_id`
-///   (`accounts_groups` moves to `account.sqlite`; `group_information` stays
-///   in `shared.sqlite`)
+/// ## Integer-keyed FKs (require schema migration before split)
+///
+/// These use `accounts(id)` (integer rowid) as the FK target. Integer IDs
+/// from `shared.sqlite` won't transfer meaningfully to per-account files,
+/// so these tables need a schema migration to switch to pubkey-keyed FKs
+/// before the physical split:
+///
+/// - `published_events.account_id → accounts(id)` (migration 0011)
+/// - `processed_events.account_id → accounts(id)` (migration 0012)
+///
+/// ## Pubkey-keyed FKs (application-level enforcement only)
+///
+/// - `accounts_groups.account_pubkey → accounts.pubkey` (migration 0018)
+/// - `account_settings.account_pubkey → accounts.pubkey`
+/// - `media_files.account_pubkey → accounts.pubkey` (migration 0015)
+/// - `push_registrations.account_pubkey → accounts.pubkey` (migration 0039)
+/// - `group_push_tokens.account_pubkey → accounts.pubkey` (migration 0041)
+/// - `published_key_packages.account_pubkey → accounts.pubkey` (migration 0029)
+/// - `drafts.account_pubkey → accounts.pubkey` (migration 0028)
+///
+/// ## Cross-scope data references (no schema FK, but logical dependency)
+///
 /// - `aggregated_messages.mls_group_id → group_information.mls_group_id`
-///   (same cross-boundary reference)
+///   (`aggregated_messages` is account-scoped; `group_information` is shared)
 /// - `media_references.encrypted_file_hash → media_blobs.hash`
 ///   (`media_references` is account-scoped; `media_blobs` is shared)
 /// - `drafts.mls_group_id → group_information.mls_group_id`
-///   (`drafts` is account-scoped; `group_information` is shared)
+///   (`drafts` is account-scoped; `group_information` is shared;
+///   migration 0028)
 ///
 /// # Current implementation
 ///


### PR DESCRIPTION
## Summary

- Introduces `SharedDatabase` (`src/whitenoise/database/shared_db.rs`) — future home of all cross-account tables (users, relays, group_information, app_settings, media blob cache).
- Introduces `AccountDatabase` (`src/whitenoise/database/account_db.rs`) — future home of per-account tables (settings, follows, drafts, key_packages, published_events, accounts_groups, aggregated_messages, message_delivery_status, media_references, push tokens).
- Registers both modules in `database/mod.rs`.
- Both structs are thin newtypes over the existing `Database` pool — **no tables have moved**; the physical split happens in Phases 18b–18e.
- Each module includes a comprehensive cross-scope FK audit in its doc comments, organized by category:
  - **Integer-keyed FKs** (`published_events`, `processed_events` → `accounts(id)`) — require schema migration before split
  - **Pubkey-keyed FKs** (`accounts_groups`, `account_settings`, `media_files`, `push_registrations`, `group_push_tokens`, `published_key_packages`, `drafts` → `accounts.pubkey`) — application-level enforcement
  - **Cross-scope data references** (`aggregated_messages`, `media_references`, `drafts` → shared tables) — logical dependencies
  - **Intra-account FKs** (`message_delivery_status` → `aggregated_messages`) — no cross-boundary issue
- Two smoke tests per module: open + idempotent re-open.

## Deferred to Phase 18b+

- Constructor rename (`new()` → `open()`) and `open_in_memory()` variant
- Separate migration directories (`db_migrations_shared/`, `db_migrations_account/`)

## Pre-existing test failure

`whitenoise::chat_list::tests::test_archive_chat_emits_to_both_stream_channels` fails on the `arch-refactor` base before this branch. Not introduced here.

## Test plan

- [x] `just precommit-quick` passes (fmt, docs, clippy, dead_code, unit tests minus pre-existing failure)
- [x] `SharedDatabase::new` opens a fresh DB, runs migrations, returns `Ok`
- [x] `AccountDatabase::new` opens a fresh per-account DB, returns `Ok` with correct pubkey
- [x] Both wrappers are idempotent across multiple opens of the same file