### PR TITLE
Phase 16c: clean up post-singleton residue

### DIFF
--- a/crates/whitenoise-cli/src/cli/dispatch.rs
+++ b/crates/whitenoise-cli/src/cli/dispatch.rs
@@ -1137,10 +1137,11 @@ async fn respond_to_invite(
     let account = find_account(wn, account_str).await?;
     let group_id = parse_group_id(group_id_hex)?;
 
-    let ag = AccountGroup::get(wn, &account.pubkey, &group_id)
-        .await
-        .map_err(|e| Response::err(e.to_string()))?
-        .ok_or_else(|| Response::err("group not found for this account"))?;
+    let ag =
+        AccountGroup::find_by_account_and_group(&account.pubkey, &group_id, &wn.shared.database)
+            .await
+            .map_err(|e| Response::err(e.to_string()))?
+            .ok_or_else(|| Response::err("group not found for this account"))?;
 
     if accept {
         ag.accept(wn).await
@@ -1503,7 +1504,7 @@ async fn relays_list(
     let mut relay_types: HashMap<RelayUrl, Vec<String>> = HashMap::new();
     for rt in &types_to_query {
         let relays = account
-            .relays(*rt, wn)
+            .relays(*rt, &wn.shared)
             .await
             .map_err(|e| Response::err(e.to_string()))?;
         let type_str: String = (*rt).into();
@@ -1576,7 +1577,7 @@ async fn relays_remove(
     let relay_type = parse_relay_type(type_str)?;
     let relay_url = parse_relay_url(url_str)?;
     let relay = account
-        .relays(relay_type, wn)
+        .relays(relay_type, &wn.shared)
         .await
         .map_err(|e| Response::err(e.to_string()))?
         .into_iter()
@@ -2245,7 +2246,7 @@ async fn keys_check(wn: &Whitenoise, pubkey_str: &str) -> Result<Response, Respo
         .await
         .map_err(|e| Response::err(e.to_string()))?;
     let status = user
-        .key_package_status(wn)
+        .key_package_status(&wn.shared)
         .await
         .map_err(|e| Response::err(e.to_string()))?;
     let result = match status {

--- a/src/integration_tests/test_cases/account_management/login.rs
+++ b/src/integration_tests/test_cases/account_management/login.rs
@@ -66,7 +66,7 @@ impl TestCase for LoginTestCase {
 
         assert_eq!(account.pubkey, expected_pubkey);
         let relays = account
-            .relays(RelayType::Nip65, &context.whitenoise)
+            .relays(RelayType::Nip65, &context.whitenoise.shared)
             .await?;
         assert_eq!(relays.len(), self.relays.len());
         for relay in relays {

--- a/src/integration_tests/test_cases/login_flow/login_custom_relay.rs
+++ b/src/integration_tests/test_cases/login_flow/login_custom_relay.rs
@@ -90,7 +90,7 @@ impl TestCase for LoginCustomRelayTestCase {
         // Verify relays were stored.
         let relays = result
             .account
-            .relays(RelayType::Nip65, &context.whitenoise)
+            .relays(RelayType::Nip65, &context.whitenoise.shared)
             .await?;
         assert!(
             !relays.is_empty(),

--- a/src/integration_tests/test_cases/login_flow/login_publish_defaults.rs
+++ b/src/integration_tests/test_cases/login_flow/login_publish_defaults.rs
@@ -48,7 +48,7 @@ impl TestCase for LoginPublishDefaultsTestCase {
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = result
                 .account
-                .relays(relay_type, &context.whitenoise)
+                .relays(relay_type, &context.whitenoise.shared)
                 .await?;
             assert!(
                 !relays.is_empty(),

--- a/src/integration_tests/test_cases/login_flow/login_start_happy_path.rs
+++ b/src/integration_tests/test_cases/login_flow/login_start_happy_path.rs
@@ -45,7 +45,7 @@ impl TestCase for LoginStartHappyPathTestCase {
         // Verify relay lists were stored.
         let relays = result
             .account
-            .relays(RelayType::Nip65, &context.whitenoise)
+            .relays(RelayType::Nip65, &context.whitenoise.shared)
             .await?;
         assert!(
             !relays.is_empty(),

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -39,7 +39,9 @@ impl TestCase for KeyPackageMaintenanceTestCase {
         context.add_account(&self.account_name, account.clone());
 
         // Verify account has key package relays configured
-        let kp_relays = account.key_package_relays(&context.whitenoise).await?;
+        let kp_relays = account
+            .key_package_relays(&context.whitenoise.shared)
+            .await?;
         assert!(
             !kp_relays.is_empty(),
             "Account should have key package relays configured"

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -311,28 +311,44 @@ mod tests {
         let default_relay_count = default_relays.len();
 
         assert_eq!(
-            account.nip65_relays(whitenoise).await.unwrap().len(),
+            account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .len(),
             default_relay_count,
             "Account should have default NIP-65 relays configured"
         );
         assert_eq!(
-            account.inbox_relays(whitenoise).await.unwrap().len(),
+            account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .len(),
             default_relay_count,
             "Account should have default inbox relays configured"
         );
         assert_eq!(
-            account.key_package_relays(whitenoise).await.unwrap().len(),
+            account
+                .key_package_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .len(),
             default_relay_count,
             "Account should have default key package relays configured"
         );
 
         let default_relays_vec: Vec<RelayUrl> = Relay::urls(&default_relays);
         let nip65_relay_urls: Vec<RelayUrl> =
-            Relay::urls(&account.nip65_relays(whitenoise).await.unwrap());
+            Relay::urls(&account.nip65_relays(&whitenoise.shared).await.unwrap());
         let inbox_relay_urls: Vec<RelayUrl> =
-            Relay::urls(&account.inbox_relays(whitenoise).await.unwrap());
-        let key_package_relay_urls: Vec<RelayUrl> =
-            Relay::urls(&account.key_package_relays(whitenoise).await.unwrap());
+            Relay::urls(&account.inbox_relays(&whitenoise.shared).await.unwrap());
+        let key_package_relay_urls: Vec<RelayUrl> = Relay::urls(
+            &account
+                .key_package_relays(&whitenoise.shared)
+                .await
+                .unwrap(),
+        );
         for default_relay in default_relays_vec.iter() {
             assert!(
                 nip65_relay_urls.contains(default_relay),
@@ -394,11 +410,10 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    #[ignore]
     async fn test_login_after_delete_all_data() {
-        let whitenoise = test_get_whitenoise().await;
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
-        let account = setup_login_account(whitenoise).await;
+        let account = setup_login_account(&whitenoise).await;
         whitenoise.delete_all_data().await.unwrap();
         let _acc = whitenoise
             .login(account.1.secret_key().to_secret_hex())
@@ -416,7 +431,7 @@ mod tests {
         // Give the events time to be published and processed
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-        let nip65_relays = account.nip65_relays(&whitenoise).await.unwrap();
+        let nip65_relays = account.nip65_relays(&whitenoise.shared).await.unwrap();
         let nip65_relay_urls = Relay::urls(&nip65_relays);
         // Check that all three event types were published
         let inbox_events = whitenoise
@@ -438,7 +453,7 @@ mod tests {
             .relay_control
             .fetch_user_key_package(
                 account.pubkey,
-                &Relay::urls(&account.nip65_relays(&whitenoise).await.unwrap()),
+                &Relay::urls(&account.nip65_relays(&whitenoise.shared).await.unwrap()),
             )
             .await
             .unwrap();
@@ -706,7 +721,7 @@ mod tests {
 
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-        let nip65_relays = account.nip65_relays(&whitenoise).await.unwrap();
+        let nip65_relays = account.nip65_relays(&whitenoise.shared).await.unwrap();
         let nip65_relay_urls = Relay::urls(&nip65_relays);
         let fetched_metadata = whitenoise
             .shared

--- a/src/whitenoise/accounts/login_external_signer.rs
+++ b/src/whitenoise/accounts/login_external_signer.rs
@@ -709,9 +709,12 @@ mod tests {
             "External account should not have stored private key"
         );
 
-        let nip65 = account.nip65_relays(&whitenoise).await.unwrap();
-        let inbox = account.inbox_relays(&whitenoise).await.unwrap();
-        let kp = account.key_package_relays(&whitenoise).await.unwrap();
+        let nip65 = account.nip65_relays(&whitenoise.shared).await.unwrap();
+        let inbox = account.inbox_relays(&whitenoise.shared).await.unwrap();
+        let kp = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
 
         assert!(!nip65.is_empty(), "Should have NIP-65 relays");
         assert!(!inbox.is_empty(), "Should have inbox relays");

--- a/src/whitenoise/accounts/login_multistep.rs
+++ b/src/whitenoise/accounts/login_multistep.rs
@@ -1398,7 +1398,7 @@ mod tests {
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = result
                 .account
-                .relays(relay_type, &whitenoise)
+                .relays(relay_type, &whitenoise.shared)
                 .await
                 .unwrap();
             assert!(
@@ -1425,7 +1425,11 @@ mod tests {
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(result.account.pubkey, pubkey);
 
-        let nip65 = result.account.nip65_relays(&whitenoise).await.unwrap();
+        let nip65 = result
+            .account
+            .nip65_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert!(
             !nip65.is_empty(),
             "Expected NIP-65 relays to be stored after login"
@@ -1706,7 +1710,7 @@ mod tests {
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = result
                 .account
-                .relays(relay_type, &whitenoise)
+                .relays(relay_type, &whitenoise.shared)
                 .await
                 .unwrap();
             assert!(
@@ -1815,7 +1819,11 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
 
-        let stored_nip65 = result.account.nip65_relays(&whitenoise).await.unwrap();
+        let stored_nip65 = result
+            .account
+            .nip65_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(
             stored_nip65.len(),
             1,
@@ -1829,7 +1837,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -1838,7 +1846,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -1875,7 +1883,11 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
 
-        let stored_inbox = result.account.inbox_relays(&whitenoise).await.unwrap();
+        let stored_inbox = result
+            .account
+            .inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(stored_inbox.len(), 1);
         assert_eq!(
             stored_inbox[0].url, inbox_url,
@@ -1884,7 +1896,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -1893,7 +1905,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -1932,7 +1944,7 @@ mod tests {
 
         let stored_kp = result
             .account
-            .key_package_relays(&whitenoise)
+            .key_package_relays(&whitenoise.shared)
             .await
             .unwrap();
         assert_eq!(stored_kp.len(), 1);
@@ -1943,7 +1955,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1951,7 +1963,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1992,19 +2004,29 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_url,
             "NIP-65 must be preserved"
         );
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_url,
             "Inbox must be preserved"
         );
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2046,14 +2068,19 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_url,
             "NIP-65 must be preserved"
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2063,7 +2090,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2107,21 +2134,26 @@ mod tests {
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
             "NIP-65 must get defaults"
         );
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_url,
             "Inbox must be preserved"
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2385,17 +2417,27 @@ mod tests {
         assert_eq!(result.account.pubkey, pubkey);
 
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_relay.url
         );
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_relay.url
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2472,17 +2514,27 @@ mod tests {
         assert_eq!(result.status, LoginStatus::Complete);
 
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
-            RelayUrl::parse("ws://localhost:7777").unwrap()
-        );
-        assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             RelayUrl::parse("ws://localhost:7777").unwrap()
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
+            RelayUrl::parse("ws://localhost:7777").unwrap()
+        );
+        assert_eq!(
+            result
+                .account
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2606,7 +2658,7 @@ mod tests {
         for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
             let relays = result
                 .account
-                .relays(relay_type, &whitenoise)
+                .relays(relay_type, &whitenoise.shared)
                 .await
                 .unwrap();
             assert!(
@@ -2714,14 +2766,19 @@ mod tests {
         assert_eq!(result.status, LoginStatus::Complete);
 
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_url,
             "NIP-65 must not be overwritten"
         );
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2730,7 +2787,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2769,14 +2826,19 @@ mod tests {
         assert_eq!(result.account.account_type, AccountType::External);
 
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_url,
             "Inbox must not be overwritten"
         );
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2785,7 +2847,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2825,7 +2887,7 @@ mod tests {
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2835,7 +2897,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2844,7 +2906,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2886,19 +2948,29 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_url,
             "NIP-65 must be preserved"
         );
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_url,
             "Inbox must be preserved"
         );
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -2940,14 +3012,19 @@ mod tests {
             .unwrap();
         assert_eq!(result.status, LoginStatus::Complete);
         assert_eq!(
-            result.account.nip65_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             nip65_url,
             "NIP-65 must be preserved"
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -2957,7 +3034,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -3001,21 +3078,26 @@ mod tests {
         assert!(
             !result
                 .account
-                .nip65_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
             "NIP-65 must receive defaults"
         );
         assert_eq!(
-            result.account.inbox_relays(&whitenoise).await.unwrap()[0].url,
+            result
+                .account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()[0]
+                .url,
             inbox_url,
             "Inbox must be preserved"
         );
         assert_eq!(
             result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()[0]
                 .url,
@@ -3263,7 +3345,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .inbox_relays(&whitenoise)
+                .inbox_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -3272,7 +3354,7 @@ mod tests {
         assert!(
             !result
                 .account
-                .key_package_relays(&whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty(),

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
 
 use crate::RelayType;
@@ -19,9 +20,11 @@ use crate::perf_instrument;
 use crate::types::ImageType;
 use crate::whitenoise::error::Result;
 use crate::whitenoise::groups::blossom_error::BlossomError;
+use crate::whitenoise::groups::media::{blossom_client, require_https};
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::secrets_store::SecretsStoreError;
 use crate::whitenoise::session::MediaOps;
+use crate::whitenoise::shared::SharedServices;
 use crate::whitenoise::user_streaming::{UserUpdate, UserUpdateTrigger};
 use crate::whitenoise::users::User;
 use crate::whitenoise::{Whitenoise, WhitenoiseError};
@@ -339,35 +342,31 @@ impl Account {
     ///   - `RelayType::Nip65` - General purpose relays for reading/writing events (kind 10002)
     ///   - `RelayType::Inbox` - Specialized relays for receiving private messages (kind 10050)
     ///   - `RelayType::KeyPackage` - Relays that store MLS key packages (kind 10051)
-    /// * `whitenoise` - The Whitenoise instance for database operations
+    /// * `shared` - The shared services holder (provides database access)
     #[perf_instrument("accounts")]
     pub async fn relays(
         &self,
         relay_type: RelayType,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
     ) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.shared.database).await?;
-        let relays = user.relays(relay_type, &whitenoise.shared.database).await?;
+        let user = self.user(&shared.database).await?;
+        let relays = user.relays(relay_type, &shared.database).await?;
         Ok(relays)
     }
 
     /// Helper method to retrieve the NIP-65 relays for this account.
     #[perf_instrument("accounts")]
-    pub(crate) async fn nip65_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.shared.database).await?;
-        let relays = user
-            .relays(RelayType::Nip65, &whitenoise.shared.database)
-            .await?;
+    pub(crate) async fn nip65_relays(&self, shared: &Arc<SharedServices>) -> Result<Vec<Relay>> {
+        let user = self.user(&shared.database).await?;
+        let relays = user.relays(RelayType::Nip65, &shared.database).await?;
         Ok(relays)
     }
 
     /// Helper method to retrieve the inbox relays for this account.
     #[perf_instrument("accounts")]
-    pub(crate) async fn inbox_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.shared.database).await?;
-        let relays = user
-            .relays(RelayType::Inbox, &whitenoise.shared.database)
-            .await?;
+    pub(crate) async fn inbox_relays(&self, shared: &Arc<SharedServices>) -> Result<Vec<Relay>> {
+        let user = self.user(&shared.database).await?;
+        let relays = user.relays(RelayType::Inbox, &shared.database).await?;
         Ok(relays)
     }
 
@@ -380,9 +379,9 @@ impl Account {
     #[perf_instrument("accounts")]
     pub(crate) async fn effective_inbox_relays(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
     ) -> Result<Vec<Relay>> {
-        let inbox = self.inbox_relays(whitenoise).await?;
+        let inbox = self.inbox_relays(shared).await?;
         if !inbox.is_empty() {
             return Ok(inbox);
         }
@@ -391,16 +390,17 @@ impl Account {
             "Account {} has no inbox relays, falling back to NIP-65 relays for giftwrap subscription",
             self.pubkey.to_hex()
         );
-        self.nip65_relays(whitenoise).await
+        self.nip65_relays(shared).await
     }
 
     /// Helper method to retrieve the key package relays for this account.
     #[perf_instrument("accounts")]
-    pub(crate) async fn key_package_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let user = self.user(&whitenoise.shared.database).await?;
-        let relays = user
-            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
-            .await?;
+    pub(crate) async fn key_package_relays(
+        &self,
+        shared: &Arc<SharedServices>,
+    ) -> Result<Vec<Relay>> {
+        let user = self.user(&shared.database).await?;
+        let relays = user.relays(RelayType::KeyPackage, &shared.database).await?;
         Ok(relays)
     }
 
@@ -532,7 +532,7 @@ impl Account {
         server: Url,
         whitenoise: &Whitenoise,
     ) -> Result<String> {
-        let client = Whitenoise::blossom_client(&server)?;
+        let client = blossom_client(&server)?;
         let signer = whitenoise.get_signer_for_account(self)?;
         let data = tokio::fs::read(file_path).await?;
 
@@ -548,7 +548,7 @@ impl Account {
             .map_err(|_| BlossomError::Timeout(MediaOps::BLOSSOM_TIMEOUT))?
             .map_err(BlossomError::client)?;
 
-        Whitenoise::require_https(&descriptor.url)?;
+        require_https(&descriptor.url)?;
 
         Ok(descriptor.url.to_string())
     }
@@ -615,7 +615,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = account.effective_inbox_relays(&whitenoise).await.unwrap();
+        let result = account
+            .effective_inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].url, inbox_url);
@@ -636,7 +639,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = account.effective_inbox_relays(&whitenoise).await.unwrap();
+        let result = account
+            .effective_inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].url, nip65_url);
@@ -648,7 +654,10 @@ mod tests {
         let (account, _keys) = create_test_account(&whitenoise).await;
 
         // No relays at all
-        let result = account.effective_inbox_relays(&whitenoise).await.unwrap();
+        let result = account
+            .effective_inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
 
         assert!(result.is_empty());
     }
@@ -1086,11 +1095,23 @@ mod tests {
             .store_private_key(&keys)
             .unwrap();
 
-        assert!(account.nip65_relays(&whitenoise).await.unwrap().is_empty());
-        assert!(account.inbox_relays(&whitenoise).await.unwrap().is_empty());
         assert!(
             account
-                .key_package_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            account
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1113,10 +1134,16 @@ mod tests {
             .await
             .unwrap();
 
-        let nip65 = account.relays(RelayType::Nip65, &whitenoise).await.unwrap();
-        let inbox = account.relays(RelayType::Inbox, &whitenoise).await.unwrap();
+        let nip65 = account
+            .relays(RelayType::Nip65, &whitenoise.shared)
+            .await
+            .unwrap();
+        let inbox = account
+            .relays(RelayType::Inbox, &whitenoise.shared)
+            .await
+            .unwrap();
         let kp = account
-            .relays(RelayType::KeyPackage, &whitenoise)
+            .relays(RelayType::KeyPackage, &whitenoise.shared)
             .await
             .unwrap();
         assert_eq!(nip65.len(), default_relays.len());
@@ -1133,14 +1160,14 @@ mod tests {
             .add_relay(&test_relay, RelayType::Nip65, &whitenoise)
             .await
             .unwrap();
-        let relays_after_add = account.nip65_relays(&whitenoise).await.unwrap();
+        let relays_after_add = account.nip65_relays(&whitenoise.shared).await.unwrap();
         assert_eq!(relays_after_add.len(), default_relays.len() + 1);
 
         account
             .remove_relay(&test_relay, RelayType::Nip65, &whitenoise)
             .await
             .unwrap();
-        let relays_after_remove = account.nip65_relays(&whitenoise).await.unwrap();
+        let relays_after_remove = account.nip65_relays(&whitenoise.shared).await.unwrap();
         assert_eq!(relays_after_remove.len(), default_relays.len());
     }
 
@@ -1156,11 +1183,23 @@ mod tests {
             .store_private_key(&keys)
             .unwrap();
 
-        assert!(account.nip65_relays(&whitenoise).await.unwrap().is_empty());
-        assert!(account.inbox_relays(&whitenoise).await.unwrap().is_empty());
         assert!(
             account
-                .key_package_relays(&whitenoise)
+                .nip65_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            account
+                .inbox_relays(&whitenoise.shared)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            account
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1188,19 +1227,25 @@ mod tests {
         .await
         .unwrap();
 
-        let nip65 = account.nip65_relays(&whitenoise).await.unwrap();
+        let nip65 = account.nip65_relays(&whitenoise.shared).await.unwrap();
         assert_eq!(nip65.len(), 1);
         assert_eq!(nip65[0].url, url1);
 
-        let inbox = account.inbox_relays(&whitenoise).await.unwrap();
+        let inbox = account.inbox_relays(&whitenoise.shared).await.unwrap();
         assert_eq!(inbox.len(), 1);
         assert_eq!(inbox[0].url, url2);
 
-        let kp = account.key_package_relays(&whitenoise).await.unwrap();
+        let kp = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(kp.len(), 1);
         assert_eq!(kp[0].url, url3);
 
-        let all_nip65 = account.relays(RelayType::Nip65, &whitenoise).await.unwrap();
+        let all_nip65 = account
+            .relays(RelayType::Nip65, &whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(all_nip65.len(), 1);
         assert_eq!(all_nip65[0].url, url1);
     }

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -527,7 +527,7 @@ impl Whitenoise {
     ) -> Result<()> {
         let user = account.user(&self.shared.database).await?;
         let relay_urls = Relay::urls(relays).into_iter().collect::<HashSet<_>>();
-        user.sync_relay_urls(self, relay_type, &relay_urls, None)
+        user.sync_relay_urls(&self.shared, relay_type, &relay_urls, None)
             .await?;
         Ok(())
     }
@@ -566,7 +566,7 @@ impl Whitenoise {
         let ephemeral = self.shared.relay_control.ephemeral();
         let signer = self.get_signer_for_account(account)?;
         let user = account.user(&self.shared.database).await?;
-        let relays = account.nip65_relays(self).await?;
+        let relays = account.nip65_relays(&self.shared).await?;
 
         tokio::spawn(async move {
             tracing::debug!(target: "whitenoise::accounts", "Background task: Publishing metadata for account: {:?}", account_clone.pubkey);
@@ -602,13 +602,13 @@ impl Whitenoise {
         let relays = if let Some(relays) = relays {
             relays.to_vec()
         } else {
-            account.relays(relay_type, self).await?
+            account.relays(relay_type, &self.shared).await?
         };
         let signer = self.get_signer_for_account(account)?;
         let target_relays = if relay_type == RelayType::Nip65 {
             relays.clone()
         } else {
-            account.nip65_relays(self).await?
+            account.nip65_relays(&self.shared).await?
         };
 
         tokio::spawn(async move {
@@ -639,7 +639,7 @@ impl Whitenoise {
     ) -> Result<()> {
         let account_clone = account.clone();
         let ephemeral = self.shared.relay_control.ephemeral();
-        let relays = account.nip65_relays(self).await?;
+        let relays = account.nip65_relays(&self.shared).await?;
         let signer = self.get_signer_for_account(account)?;
         let follows = account.follows(&self.shared.database).await?;
         let follows_pubkeys = follows.iter().map(|f| f.pubkey).collect::<Vec<_>>();
@@ -925,7 +925,8 @@ impl Whitenoise {
 
         // Gather all inputs before touching existing subscriptions so that a
         // fallible data-fetch cannot leave the account with no active subs.
-        let inbox_relays: Vec<RelayUrl> = Relay::urls(&account.effective_inbox_relays(self).await?);
+        let inbox_relays: Vec<RelayUrl> =
+            Relay::urls(&account.effective_inbox_relays(&self.shared).await?);
 
         let group_specs = self.extract_group_subscription_specs(account).await?;
 
@@ -1020,8 +1021,10 @@ impl Whitenoise {
         account: &Account,
     ) -> Result<Vec<RelayUrl>> {
         let mut warm_relays: HashSet<RelayUrl> = HashSet::new();
-        warm_relays.extend(Relay::urls(&account.nip65_relays(self).await?));
-        warm_relays.extend(Relay::urls(&account.key_package_relays(self).await?));
+        warm_relays.extend(Relay::urls(&account.nip65_relays(&self.shared).await?));
+        warm_relays.extend(Relay::urls(
+            &account.key_package_relays(&self.shared).await?,
+        ));
 
         Ok(warm_relays.into_iter().collect())
     }
@@ -1035,15 +1038,6 @@ mod tests {
     use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
     use crate::whitenoise::test_utils::*;
     use mdk_core::prelude::*;
-
-    #[cfg(feature = "integration-tests")]
-    async fn reset_singleton_whitenoise_for_test(whitenoise: &Whitenoise) {
-        whitenoise.shared.external_signers.clear();
-        whitenoise.account_manager.clear_sessions();
-        whitenoise.account_manager.clear_pending_logins();
-        whitenoise.reset_nostr_client().await.unwrap();
-        whitenoise.wipe_database().await.unwrap();
-    }
 
     #[tokio::test]
     async fn test_active_group_count_no_groups() {
@@ -1152,21 +1146,19 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_create_group_after_startup_restore_refreshes_creator_group_plane() {
-        let whitenoise = test_get_whitenoise().await;
-        reset_singleton_whitenoise_for_test(whitenoise).await;
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let creator_account = whitenoise.create_identity().await.unwrap();
         let member_account = whitenoise.create_identity().await.unwrap();
-        wait_for_key_package_publication(whitenoise, &[&member_account]).await;
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
 
         // Simulate app restart: runtime-only sessions are gone,
         // then startup restores relay subscriptions from persisted accounts.
         whitenoise.account_manager.clear_sessions();
         whitenoise.reset_nostr_client().await.unwrap();
-        let whitenoise_arc = whitenoise.arc().unwrap();
         whitenoise
             .account_manager
-            .restore_sessions(&whitenoise_arc)
+            .restore_sessions(&whitenoise)
             .await;
         whitenoise.setup_accounts_subscriptions().await.unwrap();
 
@@ -1246,7 +1238,7 @@ mod tests {
         .unwrap();
 
         let initial_urls = account
-            .nip65_relays(&whitenoise)
+            .nip65_relays(&whitenoise.shared)
             .await
             .unwrap()
             .into_iter()
@@ -1264,7 +1256,7 @@ mod tests {
             .unwrap();
 
         let stored_urls = account
-            .nip65_relays(&whitenoise)
+            .nip65_relays(&whitenoise.shared)
             .await
             .unwrap()
             .into_iter()

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -242,22 +242,6 @@ impl AccountGroup {
         Ok((account_group, was_created))
     }
 
-    /// Gets an AccountGroup for the given account and group, if it exists.
-    #[perf_instrument("account_groups")]
-    pub async fn get(
-        whitenoise: &Whitenoise,
-        account_pubkey: &PublicKey,
-        mls_group_id: &GroupId,
-    ) -> Result<Option<Self>, WhitenoiseError> {
-        let account_group = Self::find_by_account_and_group(
-            account_pubkey,
-            mls_group_id,
-            &whitenoise.shared.database,
-        )
-        .await?;
-        Ok(account_group)
-    }
-
     /// Gets all visible AccountGroups for the given account.
     /// Visible means: pending or accepted (not declined).
     #[perf_instrument("account_groups")]
@@ -633,7 +617,13 @@ impl Whitenoise {
         group_id: &GroupId,
     ) -> Result<(), WhitenoiseError> {
         // 1. Verify the AccountGroup exists
-        let Some(_account_group) = AccountGroup::get(self, &account.pubkey, group_id).await? else {
+        let Some(_account_group) = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            group_id,
+            &self.shared.database,
+        )
+        .await?
+        else {
             return Err(WhitenoiseError::GroupNotFound);
         };
 
@@ -964,9 +954,13 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[13; 32]);
 
-        let result = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap();
+        let result = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(result.is_none());
     }
@@ -984,9 +978,13 @@ mod tests {
             .unwrap();
 
         // Now get should return it
-        let result = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap();
+        let result = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(result.is_some());
         let ag = result.unwrap();
@@ -2081,10 +2079,14 @@ mod tests {
         re_save.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and confirm muted_until survived
-        let found = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let found = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         assert!(
             found.is_muted(),
@@ -2127,14 +2129,22 @@ mod tests {
         assert_eq!(cleared.len(), 2);
 
         // Verify DB rows are actually cleared
-        let ag1 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id1)
-            .await
-            .unwrap()
-            .unwrap();
-        let ag2 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id2)
-            .await
-            .unwrap()
-            .unwrap();
+        let ag1 = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id1,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let ag2 = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id2,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         assert!(ag1.muted_until.is_none());
         assert!(ag2.muted_until.is_none());
@@ -2163,10 +2173,14 @@ mod tests {
 
         // One expired (set via DB layer), one forever, one future
         let past = Utc::now() - chrono::Duration::seconds(10);
-        let expired_ag = AccountGroup::get(&whitenoise, &account.pubkey, &expired_group)
-            .await
-            .unwrap()
-            .unwrap();
+        let expired_ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &expired_group,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         expired_ag
             .update_muted_until(Some(past), &whitenoise.shared.database)
             .await
@@ -2189,14 +2203,22 @@ mod tests {
         assert_eq!(cleared[0].mls_group_id, expired_group);
 
         // Active mutes must be untouched
-        let forever_ag = AccountGroup::get(&whitenoise, &account.pubkey, &forever_group)
-            .await
-            .unwrap()
-            .unwrap();
-        let future_ag = AccountGroup::get(&whitenoise, &account.pubkey, &future_group)
-            .await
-            .unwrap()
-            .unwrap();
+        let forever_ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &forever_group,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let future_ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &future_group,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         assert!(forever_ag.is_muted_forever());
         assert!(future_ag.is_muted());
@@ -2238,10 +2260,14 @@ mod tests {
         re_save.save(&whitenoise.shared.database).await.unwrap();
 
         // Fetch and confirm removed_at survived
-        let found = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let found = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         assert!(
             found.is_removed(),
@@ -2387,10 +2413,14 @@ mod tests {
             .unwrap();
         let after = Utc::now();
 
-        let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         let cleared_at = ag.chat_cleared_at.expect("chat_cleared_at must be set");
         // Allow 1s tolerance for millisecond truncation in the database layer
@@ -2449,10 +2479,14 @@ mod tests {
             .unwrap();
 
         // Verify last_read_message_id is reset
-        let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(
             ag.last_read_message_id.is_none(),
             "last_read_message_id must be None after clear_chat"
@@ -2479,10 +2513,14 @@ mod tests {
             .clear_chat()
             .await
             .unwrap();
-        let ag1 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let ag1 = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         let first_cleared_at = ag1.chat_cleared_at.unwrap();
 
         // Second clear should also succeed
@@ -2494,10 +2532,14 @@ mod tests {
             .clear_chat()
             .await
             .unwrap();
-        let ag2 = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let ag2 = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         let second_cleared_at = ag2.chat_cleared_at.unwrap();
 
         assert!(

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -2051,10 +2051,6 @@ mod tests {
         );
     }
 
-    // TODO(phase-16): Re-enable once stream managers are moved into AccountSession.
-    // MembershipOpsForGroup::emit_chat_list_update requires the Whitenoise singleton,
-    // which is unavailable in unit tests. The emit never fires so the channel recv times out.
-    #[ignore]
     #[tokio::test]
     async fn test_archive_chat_emits_to_both_stream_channels() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;

--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -119,7 +119,7 @@ where
 impl AccountGroup {
     /// Finds an AccountGroup by account pubkey and MLS group ID.
     #[perf_instrument("db::accounts_groups")]
-    pub(crate) async fn find_by_account_and_group(
+    pub async fn find_by_account_and_group(
         account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         database: &Database,

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -535,7 +535,7 @@ mod tests {
         // Fetch a real key package event for the member from relays
         let relays_urls = Relay::urls(
             &creator_account
-                .key_package_relays(whitenoise)
+                .key_package_relays(&whitenoise.shared)
                 .await
                 .unwrap(),
         );
@@ -742,9 +742,13 @@ mod tests {
         assert!(!groups.is_empty(), "Member should have at least one group");
 
         let group_id = &groups[0].mls_group_id;
-        let account_group = AccountGroup::get(&whitenoise, &member_account.pubkey, group_id)
-            .await
-            .unwrap();
+        let account_group = AccountGroup::find_by_account_and_group(
+            &member_account.pubkey,
+            group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         assert!(
             account_group.is_some(),
@@ -856,9 +860,13 @@ mod tests {
         .await;
 
         // Verify AccountGroup still exists and is pending
-        let account_group = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap();
+        let account_group = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(account_group.is_some(), "AccountGroup should exist");
         assert!(
             account_group.unwrap().is_pending(),
@@ -1079,9 +1087,13 @@ mod tests {
         .await;
 
         // AccountGroup must still exist
-        let ag = AccountGroup::get(&whitenoise, &account.pubkey, &group_id)
-            .await
-            .unwrap();
+        let ag = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            &group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(ag.is_some(), "AccountGroup must survive missing signer");
     }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1923,9 +1923,6 @@ mod tests {
 
     /// Test that auto-committed proposals (e.g., admin auto-commits a
     /// member's self-removal) are published and merged successfully.
-    // TODO(phase-16): publish_and_merge_commit calls Self::wn() which requires the
-    // singleton. Re-enable once relay publishing is threaded through the session.
-    #[ignore]
     #[tokio::test]
     async fn test_handle_mls_message_auto_committed_proposal() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2154,9 +2151,6 @@ mod tests {
     /// Verify MLS state consistency after an auto-committed removal:
     /// the admin can still create messages in the group, confirming
     /// that merge_pending_commit left the state valid.
-    // TODO(phase-16): publish_and_merge_commit calls Self::wn() which requires the
-    // singleton. Re-enable once relay publishing is threaded through the session.
-    #[ignore]
     #[tokio::test]
     async fn test_handle_mls_message_commit_after_auto_committed_proposal() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;

--- a/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
@@ -40,7 +40,7 @@ impl Whitenoise {
         let relay_urls = crate::nostr_manager::utils::relay_urls_from_event(&event);
         let event_created_at = Some(timestamp_to_datetime(event.created_at)?);
         let relays_changed = user
-            .sync_relay_urls(self, relay_type, &relay_urls, event_created_at)
+            .sync_relay_urls(&self.shared, relay_type, &relay_urls, event_created_at)
             .await?;
 
         if relays_changed {

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::future::{join_all, try_join_all};
 use mdk_core::prelude::*;
 use nostr_sdk::prelude::*;
 
@@ -14,15 +13,16 @@ use crate::{
         accounts::Account,
         accounts_groups::AccountGroup,
         error::{Result, WhitenoiseError},
-        group_information::{GroupInformation, GroupType},
+        group_information::GroupType,
         key_packages::{REQUIRED_MLS_PROPOSAL_TAGS, validate_fetched_member_key_package},
         relays::Relay,
+        shared::SharedServices,
         users::User,
     },
 };
 
 pub mod blossom_error;
-mod media;
+pub(crate) mod media;
 mod membership;
 mod publish;
 mod required_proposals;
@@ -30,24 +30,20 @@ mod required_proposals;
 pub use membership::{GroupWithInfoAndMembership, GroupWithMembership};
 pub use required_proposals::RequiredProposal;
 
-impl Whitenoise {
+impl SharedServices {
     #[perf_instrument("groups")]
     pub(crate) async fn resolve_member_delivery_relays(
-        &self,
+        self: &Arc<Self>,
         member: &User,
         fallback_account: &Account,
         context: &'static str,
     ) -> Result<Vec<Relay>> {
-        let inbox_relays = member
-            .relays(RelayType::Inbox, &self.shared.database)
-            .await?;
+        let inbox_relays = member.relays(RelayType::Inbox, &self.database).await?;
         if !inbox_relays.is_empty() {
             return Ok(inbox_relays);
         }
 
-        let nip65_relays = member
-            .relays(RelayType::Nip65, &self.shared.database)
-            .await?;
+        let nip65_relays = member.relays(RelayType::Nip65, &self.database).await?;
         if !nip65_relays.is_empty() {
             return Ok(nip65_relays);
         }
@@ -77,12 +73,14 @@ impl Whitenoise {
 
         Ok(fallback_relays)
     }
+}
 
+impl Whitenoise {
     /// Resolves a single member for group creation: finds or creates the user record,
     /// syncs relay lists for new users, fetches and validates the key package.
     async fn resolve_member_key_package(&self, pk: &PublicKey) -> Result<(User, Event)> {
         let (user, created) = User::find_or_create_by_pubkey(pk, &self.shared.database).await?;
-        if created && let Err(e) = user.update_relay_lists(self).await {
+        if created && let Err(e) = user.update_relay_lists(&self.shared).await {
             tracing::warn!(
                 target: "whitenoise::groups",
                 "Failed to update relay lists for new user {}: {}",
@@ -92,7 +90,7 @@ impl Whitenoise {
         }
 
         let _kp_fetch = perf_span!("groups::fetch_key_package");
-        let lookup = user.key_package_lookup(self).await?;
+        let lookup = user.key_package_lookup(&self.shared).await?;
         drop(_kp_fetch);
 
         let event = match lookup {
@@ -126,62 +124,6 @@ impl Whitenoise {
         Ok((user, event))
     }
 
-    /// Creates local database records for a newly created group.
-    #[allow(deprecated)]
-    #[perf_instrument("groups")]
-    async fn finalize_group_records(
-        &self,
-        group: &group_types::Group,
-        member_pubkeys: &[PublicKey],
-        group_type: Option<GroupType>,
-        group_name: &str,
-        creator_account: &Account,
-    ) -> Result<()> {
-        let group_info = GroupInformation::create_for_group(
-            self,
-            &group.mls_group_id.clone(),
-            group_type,
-            group_name,
-        )
-        .await?;
-
-        let dm_peer = if group_info.group_type == GroupType::DirectMessage {
-            member_pubkeys.first()
-        } else {
-            None
-        };
-
-        let (account_group, _) = AccountGroup::get_or_create(
-            self,
-            &creator_account.pubkey,
-            &group.mls_group_id,
-            dm_peer,
-        )
-        .await?;
-        account_group.accept(self).await?;
-
-        if let Err(error) = self
-            .share_local_push_token_to_group(creator_account, &group.mls_group_id)
-            .await
-        {
-            tracing::warn!(
-                target: "whitenoise::groups",
-                account = %creator_account.pubkey.to_hex(),
-                group = %hex::encode(group.mls_group_id.as_slice()),
-                error = %error,
-                "Failed to share local push token after group creation"
-            );
-        }
-
-        Ok(())
-    }
-
-    // NOTE: Unlike the other deprecated wrappers below (all(), get(), archive_chat(), etc.),
-    // this method retains its own implementation rather than delegating to
-    // `AccountSession::groups().create_group()`. The session path calls `Self::wn()` (the
-    // singleton bridge) which panics in unit tests where no global singleton is registered.
-    // Delegating here would break the existing test suite. Remove this copy when Phase 16
-    // eliminates the singleton.
     #[deprecated(
         since = "0.0.0",
         note = "Use AccountSession::groups().create_group() instead."
@@ -195,134 +137,13 @@ impl Whitenoise {
         config: NostrGroupConfigData,
         group_type: Option<GroupType>,
     ) -> Result<group_types::Group> {
-        let signer = self.get_signer_for_account(creator_account)?;
-
-        let unique: BTreeSet<&PublicKey> = member_pubkeys.iter().collect();
-        if unique.len() != member_pubkeys.len() {
-            return Err(WhitenoiseError::InvalidInput(
-                "member_pubkeys contains duplicates".to_string(),
-            ));
-        }
-
-        let member_futures = member_pubkeys
-            .iter()
-            .map(|pk| self.resolve_member_key_package(pk));
-        let resolved_members = try_join_all(member_futures).await?;
-        let (members, key_package_events): (Vec<User>, Vec<Event>) =
-            resolved_members.into_iter().unzip();
-
-        let mdk = self.create_mdk_for_account(creator_account.pubkey)?;
-        let group_name = config.name.clone();
-
-        let create_group_result =
-            mdk.create_group(&creator_account.pubkey, key_package_events.clone(), config)?;
-
-        let group = create_group_result.group;
-
-        if create_group_result.welcome_rumors.len() != members.len() {
-            return Err(WhitenoiseError::Internal(
-                "Welcome rumours are missing for some of the members".to_string(),
-            ));
-        }
-
-        let kp_pubkey_by_event_id: std::collections::HashMap<EventId, PublicKey> =
-            key_package_events
-                .iter()
-                .map(|event| (event.id, event.pubkey))
-                .collect();
-
-        let mut members_by_pubkey: std::collections::HashMap<PublicKey, User> = members
-            .into_iter()
-            .map(|member| (member.pubkey, member))
-            .collect();
-
-        let welcome_data: Vec<(UnsignedEvent, User, PublicKey)> = create_group_result
-            .welcome_rumors
-            .into_iter()
-            .map(|rumor| {
-                let kp_event_id = rumor.tags.event_ids().next().ok_or_else(|| {
-                    WhitenoiseError::Internal("No event ID found in welcome rumor".to_string())
-                })?;
-                let member_pubkey = kp_pubkey_by_event_id.get(kp_event_id).copied().ok_or(
-                    WhitenoiseError::Internal(
-                        "No public key found in key package event".to_string(),
-                    ),
-                )?;
-                let member =
-                    members_by_pubkey
-                        .remove(&member_pubkey)
-                        .ok_or(WhitenoiseError::Internal(format!(
-                            "No member record found for welcome target {}",
-                            member_pubkey
-                        )))?;
-                Ok((rumor, member, member_pubkey))
-            })
-            .collect::<Result<_>>()?;
-
-        self.finalize_group_records(
-            &group,
-            &member_pubkeys,
-            group_type,
-            &group_name,
-            creator_account,
-        )
-        .await?;
-
-        // Background welcome publishing
-        let creator_account_clone = creator_account.clone();
-        let whitenoise = self.arc()?;
-        tokio::spawn(async move {
-            let futures = welcome_data
-                .into_iter()
-                .map(|(rumor, member, member_pubkey)| {
-                    let signer: Arc<dyn NostrSigner> = signer.clone();
-                    let creator = &creator_account_clone;
-                    let whitenoise = &whitenoise;
-                    async move {
-                        let relays_to_use = whitenoise
-                            .resolve_member_delivery_relays(
-                                &member,
-                                creator,
-                                "whitenoise::groups::create_group",
-                            )
-                            .await?;
-
-                        let one_month_future =
-                            Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
-
-                        whitenoise
-                            .shared
-                            .relay_control
-                            .publish_welcome(
-                                &member_pubkey,
-                                rumor,
-                                &[Tag::expiration(one_month_future)],
-                                creator.pubkey,
-                                &Relay::urls(&relays_to_use),
-                                signer,
-                            )
-                            .await
-                            .map_err(WhitenoiseError::from)?;
-
-                        Ok::<(), WhitenoiseError>(())
-                    }
-                });
-
-            let results = join_all(futures).await;
-            for result in results {
-                if let Err(error) = result {
-                    tracing::warn!(
-                        target: "whitenoise::groups",
-                        "Background welcome publish failed: {}",
-                        error
-                    );
-                }
-            }
-        });
-
-        self.background_refresh_account_group_subscriptions(creator_account);
-
-        Ok(group)
+        let session = self
+            .session(&creator_account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        session
+            .groups()
+            .create_group(member_pubkeys, config, group_type)
+            .await
     }
 
     #[deprecated(since = "0.0.0", note = "Use AccountSession::groups().all() instead.")]
@@ -531,7 +352,12 @@ impl Whitenoise {
             let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
             let relays_to_use = self
-                .resolve_member_delivery_relays(&user, account, "whitenoise::groups")
+                .shared
+                .resolve_member_delivery_relays(
+                    &user,
+                    account,
+                    "whitenoise::accounts::groups::add_members_to_group",
+                )
                 .await?;
 
             let relay_urls = Relay::urls(&relays_to_use);
@@ -635,9 +461,13 @@ impl Whitenoise {
     #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn leave_group(&self, account: &Account, group_id: &GroupId) -> Result<()> {
-        let account_group = AccountGroup::get(self, &account.pubkey, group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
+        let account_group = AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            group_id,
+            &self.shared.database,
+        )
+        .await?
+        .ok_or(WhitenoiseError::GroupNotFound)?;
 
         if account_group.is_removed() {
             return Err(WhitenoiseError::AlreadyDepartedFromGroup);
@@ -678,6 +508,7 @@ mod tests {
     use super::*;
     use crate::whitenoise::Whitenoise;
     use crate::whitenoise::database::media_files::MediaFile;
+    use crate::whitenoise::group_information::GroupInformation;
     use crate::whitenoise::test_utils::*;
     use mdk_core::media_processing::MediaProcessingOptions;
     use mdk_storage_traits::Secret;
@@ -816,10 +647,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(group_info.mls_group_id, group.mls_group_id);
-        assert_eq!(
-            group_info.group_type,
-            crate::whitenoise::group_information::GroupType::Group
-        );
+        assert_eq!(group_info.group_type, GroupType::Group);
         // Note: participant_count is stored separately and managed by the GroupInformation logic
 
         // Verify group members can be retrieved
@@ -855,10 +683,13 @@ mod tests {
         }
 
         // Verify AccountGroup was created and auto-accepted for the creator
-        let account_group =
-            AccountGroup::get(whitenoise, &creator_account.pubkey, &group.mls_group_id)
-                .await
-                .unwrap();
+        let account_group = AccountGroup::find_by_account_and_group(
+            &creator_account.pubkey,
+            &group.mls_group_id,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert!(
             account_group.is_some(),
             "AccountGroup should be created for creator"
@@ -973,10 +804,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(group_info.mls_group_id, group.mls_group_id);
-        assert_eq!(
-            group_info.group_type,
-            crate::whitenoise::group_information::GroupType::DirectMessage
-        );
+        assert_eq!(group_info.group_type, GroupType::DirectMessage);
         // DirectMessage groups should have exactly 2 participants (verified via member count below)
 
         // Verify both participants are admins (standard for DM groups)
@@ -1337,6 +1165,7 @@ mod tests {
         .await;
 
         let resolved_relays = whitenoise
+            .shared
             .resolve_member_delivery_relays(
                 &member_user,
                 &fallback_account,
@@ -1380,6 +1209,7 @@ mod tests {
         set_user_relays(&whitenoise, &member_user, RelayType::Inbox, &[]).await;
 
         let resolved_relays = whitenoise
+            .shared
             .resolve_member_delivery_relays(
                 &member_user,
                 &fallback_account,
@@ -1417,6 +1247,7 @@ mod tests {
         .await;
 
         let resolved_relays = whitenoise
+            .shared
             .resolve_member_delivery_relays(
                 &member_user,
                 &fallback_account,
@@ -1448,6 +1279,7 @@ mod tests {
         set_user_relays(&whitenoise, &fallback_user, RelayType::Nip65, &[]).await;
 
         let error = whitenoise
+            .shared
             .resolve_member_delivery_relays(
                 &member_user,
                 &fallback_account,
@@ -1840,10 +1672,6 @@ mod tests {
         );
     }
 
-    // TODO(phase-16): Re-enable once storage moves into AccountSession.
-    // MediaOps::upload_group_image calls Self::wn() for media_files().store_and_record(),
-    // which requires the Whitenoise singleton unavailable in unit tests.
-    #[ignore]
     #[allow(deprecated)]
     #[tokio::test]
     async fn test_upload_group_image() {
@@ -1994,10 +1822,6 @@ mod tests {
         );
     }
 
-    // TODO(phase-16): Re-enable once storage moves into AccountSession.
-    // MediaOps::check_cached_image calls Self::wn() for media_files().find_file_with_prefix(),
-    // which requires the Whitenoise singleton unavailable in unit tests.
-    #[ignore]
     #[allow(deprecated)]
     #[tokio::test]
     async fn test_sync_group_image_cache() {
@@ -2125,10 +1949,6 @@ mod tests {
         );
     }
 
-    // TODO(phase-16): Re-enable once storage moves into AccountSession.
-    // MediaOps::upload_chat_media calls Self::wn() for media_files().store_and_record(),
-    // which requires the Whitenoise singleton unavailable in unit tests.
-    #[ignore]
     #[allow(deprecated)]
     #[tokio::test]
     async fn test_upload_chat_media() {

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -53,24 +53,25 @@ impl Whitenoise {
     /// # Arguments
     /// * `account` - The account viewing the group
     /// * `group_id` - The MLS group ID
-    #[allow(deprecated)]
     pub(crate) fn background_sync_group_image_cache_if_needed(
         &self,
         account: &Account,
         group_id: &GroupId,
     ) {
-        let Ok(whitenoise) = self.arc() else {
+        let Some(session) = self.session(&account.pubkey) else {
             tracing::error!(
                 target: "whitenoise::groups::background_sync_group_image_cache_if_needed",
-                "Whitenoise instance unavailable for background image cache"
+                account = %account.pubkey,
+                "No active session for background image cache"
             );
             return;
         };
-        let account_clone = account.clone();
-        let group_id_clone = group_id.clone();
+        let group_id = group_id.clone();
         tokio::spawn(async move {
-            if let Err(e) = whitenoise
-                .sync_group_image_cache_if_needed(&account_clone, &group_id_clone)
+            if let Err(e) = session
+                .groups()
+                .media()
+                .sync_group_image_cache_if_needed(&group_id)
                 .await
             {
                 tracing::warn!(
@@ -188,34 +189,34 @@ impl Whitenoise {
             .resolve_group_image_path(group)
             .await
     }
+}
 
-    pub(crate) fn is_debug_local_blossom_url(url: &Url) -> bool {
-        if !cfg!(debug_assertions) {
-            return false;
-        }
+/// Blossom client that enforces HTTPS on the server URL.
+pub(crate) fn blossom_client(url: &Url) -> Result<BlossomClient> {
+    require_https(url)?;
+    Ok(BlossomClient::new(url.clone()))
+}
 
-        match url.host_str() {
-            Some("localhost") => true,
-            Some(host) => host
-                .parse::<std::net::IpAddr>()
-                .is_ok_and(|ip| ip.is_loopback()),
-            None => false,
-        }
+pub(crate) fn is_debug_local_blossom_url(url: &Url) -> bool {
+    if !cfg!(debug_assertions) {
+        return false;
     }
 
-    /// Rejects non-HTTPS Blossom URLs to prevent cleartext metadata leakage.
-    /// Debug builds also allow loopback `http://` URLs for local testing.
-    pub(crate) fn require_https(url: &Url) -> Result<()> {
-        match url.scheme() {
-            "https" => Ok(()),
-            "http" if Self::is_debug_local_blossom_url(url) => Ok(()),
-            _ => Err(WhitenoiseError::BlossomInsecureUrl(url.to_string())),
-        }
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback()),
+        None => false,
     }
+}
 
-    /// Blossom client that enforces HTTPS on the server URL.
-    pub(crate) fn blossom_client(url: &Url) -> Result<BlossomClient> {
-        Self::require_https(url)?;
-        Ok(BlossomClient::new(url.clone()))
+/// Rejects non-HTTPS Blossom URLs to prevent cleartext metadata leakage.
+/// Debug builds also allow loopback `http://` URLs for local testing.
+pub(crate) fn require_https(url: &Url) -> Result<()> {
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if is_debug_local_blossom_url(url) => Ok(()),
+        _ => Err(WhitenoiseError::BlossomInsecureUrl(url.to_string())),
     }
 }

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -239,7 +239,7 @@ impl Whitenoise {
         account: &Account,
         signer: impl NostrSigner + 'static,
     ) -> Result<()> {
-        let relays = account.key_package_relays(self).await?;
+        let relays = account.key_package_relays(&self.shared).await?;
 
         if relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
@@ -579,7 +579,7 @@ impl Whitenoise {
             }
         }
 
-        let key_package_relays = account.key_package_relays(self).await?;
+        let key_package_relays = account.key_package_relays(&self.shared).await?;
         if key_package_relays.is_empty() {
             return Ok(false);
         }
@@ -893,7 +893,7 @@ impl Whitenoise {
 
     #[perf_instrument("key_packages")]
     async fn prepare_key_package_relay_urls(&self, account: &Account) -> Result<Vec<RelayUrl>> {
-        let key_package_relays = account.key_package_relays(self).await?;
+        let key_package_relays = account.key_package_relays(&self.shared).await?;
 
         if key_package_relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
@@ -1181,20 +1181,36 @@ mod tests {
         }
     }
 
-    /// Creates a persisted account with a key package relay and stored keys.
-    async fn create_account_with_relay(whitenoise: &Whitenoise) -> Account {
-        let (account, _keys) = create_account_with_relay_and_keys(whitenoise).await;
-        account
-    }
-
-    async fn create_account_with_relay_and_keys(whitenoise: &Whitenoise) -> (Account, Keys) {
-        let (account, keys) = create_test_account(whitenoise).await;
-        let account = account.save(&whitenoise.shared.database).await.unwrap();
+    /// Persists the account, stores its keys, and registers an `AccountSession`
+    /// so the deprecated key-package wrappers (which require a session) can
+    /// find one. Returns the persisted account.
+    async fn register_session_with_keys(
+        whitenoise: &std::sync::Arc<Whitenoise>,
+        account: Account,
+        keys: &Keys,
+    ) -> Account {
         whitenoise
             .shared
             .secrets_store
-            .store_private_key(&keys)
+            .store_private_key(keys)
             .expect("Should store keys");
+        let account = account
+            .save(&whitenoise.shared.database)
+            .await
+            .expect("Should save account");
+        let session = std::sync::Arc::new(
+            crate::whitenoise::session::AccountSession::from_account(&account, whitenoise)
+                .await
+                .unwrap(),
+        );
+        whitenoise.account_manager.insert_session(session);
+        account
+    }
+
+    /// Creates a persisted account with a key package relay, stored keys, and
+    /// a registered session.
+    async fn create_account_with_relay(whitenoise: &std::sync::Arc<Whitenoise>) -> Account {
+        let (account, keys) = create_test_account(whitenoise).await;
         let user = account.user(&whitenoise.shared.database).await.unwrap();
         // Use a loopback IP so connection refusal is instant (no DNS lookup).
         let relay = crate::whitenoise::relays::Relay::find_or_create_by_url(
@@ -1210,6 +1226,30 @@ mod tests {
         )
         .await
         .unwrap();
+        register_session_with_keys(whitenoise, account, &keys).await
+    }
+
+    /// Like [`create_account_with_relay`] but also returns the generated keys
+    /// for tests that need to sign events as the account.
+    async fn create_account_with_relay_and_keys(
+        whitenoise: &std::sync::Arc<Whitenoise>,
+    ) -> (Account, Keys) {
+        let (account, keys) = create_test_account(whitenoise).await;
+        let user = account.user(&whitenoise.shared.database).await.unwrap();
+        let relay = crate::whitenoise::relays::Relay::find_or_create_by_url(
+            &RelayUrl::parse("ws://127.0.0.1:1").unwrap(),
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        user.add_relay(
+            &relay,
+            crate::RelayType::KeyPackage,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
+        let account = register_session_with_keys(whitenoise, account, &keys).await;
         (account, keys)
     }
 
@@ -1410,16 +1450,13 @@ mod tests {
         }
     }
 
-    // TODO(phase-16): Re-enable once User row creation is guaranteed before session key-package ops.
-    // KeyPackageOps::prepare_relays returns AccountNotFound instead of AccountMissingKeyPackageRelays
-    // for accounts without a User row. Regression from Phase 14 session migration.
-    #[ignore]
     #[tokio::test]
     async fn test_publish_key_package_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         // Create an account without any key package relays using test helper
-        let (account, _keys) = create_test_account(&whitenoise).await;
+        let (account, keys) = create_test_account(&whitenoise).await;
+        let account = register_session_with_keys(&whitenoise, account, &keys).await;
 
         // Attempt to publish key package without relays
         let result = whitenoise.publish_key_package_for_account(&account).await;
@@ -1893,7 +1930,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = create_account_with_relay(&whitenoise).await;
 
-        let relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let relays = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         // Pause time so exponential backoff sleeps complete instantly.
         tokio::time::pause();
         let result = whitenoise
@@ -1917,12 +1957,11 @@ mod tests {
         assert!(result.is_err(), "Should fail when relay is unreachable");
     }
 
-    // TODO(phase-16): Same root cause as test_publish_key_package_without_relays_fails above.
-    #[ignore]
     #[tokio::test]
     async fn test_fetch_all_key_packages_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let (account, _keys) = create_test_account(&whitenoise).await;
+        let (account, keys) = create_test_account(&whitenoise).await;
+        let account = register_session_with_keys(&whitenoise, account, &keys).await;
 
         let result = whitenoise
             .fetch_all_key_packages_for_account(&account)
@@ -1955,11 +1994,6 @@ mod tests {
         assert!(result.is_err(), "Should fail when no signer is available");
     }
 
-    // TODO(phase-16): Re-enable once User row creation is guaranteed before session key-package ops.
-    // KeyPackageOps::prepare_relays calls User::find_by_pubkey which returns AccountNotFound
-    // for accounts without a User row, rather than AccountMissingKeyPackageRelays.
-    // Regression introduced in Phase 14 when delete_all_key_packages was migrated to session.
-    #[ignore]
     #[tokio::test]
     async fn test_delete_legacy_key_packages_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -1968,11 +2002,7 @@ mod tests {
         // Keys are needed because the convergence loop resolves the signer
         // before fetching key packages from relays.
         let (account, keys) = create_test_account(&whitenoise).await;
-        whitenoise
-            .shared
-            .secrets_store
-            .store_private_key(&keys)
-            .expect("Should store keys");
+        let account = register_session_with_keys(&whitenoise, account, &keys).await;
 
         let result = whitenoise
             .delete_legacy_key_packages_for_account(&account)
@@ -1984,12 +2014,11 @@ mod tests {
         ));
     }
 
-    // TODO(phase-16): Same as test_delete_all_key_packages_without_relays_fails above.
-    #[ignore]
     #[tokio::test]
     async fn test_delete_legacy_key_packages_with_signer_without_relays_fails() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let (account, _keys) = create_test_account(&whitenoise).await;
+        let (account, keys) = create_test_account(&whitenoise).await;
+        let account = register_session_with_keys(&whitenoise, account, &keys).await;
         let signer_keys = Keys::generate();
 
         let result = whitenoise
@@ -2002,9 +2031,6 @@ mod tests {
         ));
     }
 
-    // TODO(phase-16): Same root cause as test_delete_all_key_packages_without_relays_fails.
-    // delete_key_packages_for_account delegates to session which fails when storage is unavailable.
-    #[ignore]
     #[tokio::test]
     async fn test_delete_key_packages_with_empty_events_returns_zero() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2021,7 +2047,10 @@ mod tests {
     async fn test_delete_key_packages_from_storage_deduplicates_hash_ref_twins() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = create_account_with_relay_and_keys(&whitenoise).await;
-        let relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let relays = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let key_package_data = whitenoise
             .encoded_key_package(&account, &relays)
             .await

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -420,10 +420,6 @@ mod tests {
     }
 
     /// Test edge cases: empty content, long content, different event kinds
-    // TODO(phase-16): Re-enable once singleton dependency is removed from message sending.
-    // send_message delegates through session, which requires Whitenoise singleton for relay ops.
-    // Pre-existing regression on arch-refactor branch.
-    #[ignore]
     #[tokio::test]
     async fn test_send_message_to_group_edge_cases() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -469,19 +465,23 @@ mod tests {
             long_content.len()
         );
 
-        // Test supported event kinds (7=reaction needs an e-tag, so skip here; 5=deletion is fine)
-        for kind in [5, 9] {
-            let result = whitenoise
-                .send_message_to_group(
-                    &creator_account,
-                    &group.mls_group_id,
-                    format!("Kind {}", kind),
-                    kind,
-                    None,
-                )
-                .await;
-            assert!(result.is_ok(), "Message with kind {} should succeed", kind);
-        }
+        // Test supported event kinds. Kinds 5 (deletion) and 7 (reaction) both
+        // require an `e`-tag pointing at a target message, so they're exercised
+        // separately; here we only validate the no-tag chat-message kind.
+        let result = whitenoise
+            .send_message_to_group(
+                &creator_account,
+                &group.mls_group_id,
+                "Kind 9".to_string(),
+                9,
+                None,
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "Message with kind 9 should succeed: {:?}",
+            result.err()
+        );
 
         // Unsupported kind should fail
         let result = whitenoise

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -145,7 +145,7 @@ impl WhitenoiseConfig {
 }
 
 pub struct Whitenoise {
-    pub(crate) shared: Arc<shared::SharedServices>,
+    pub shared: Arc<shared::SharedServices>,
     event_sender: Sender<ProcessableEvent>,
     shutdown_sender: Sender<()>,
     /// Shutdown signal for scheduled tasks
@@ -1096,24 +1096,6 @@ pub mod test_utils {
         }
     }
 
-    pub(crate) async fn test_get_whitenoise() -> &'static Whitenoise {
-        static TEST_SINGLETON: tokio::sync::OnceCell<&'static Whitenoise> =
-            tokio::sync::OnceCell::const_new();
-
-        // Singleton-backed tests can spawn background tasks that outlive the
-        // helper call, so the temp dirs backing the singleton config must stay
-        // alive for the rest of the process.
-        TEST_SINGLETON
-            .get_or_init(|| async {
-                let (config, data_temp, logs_temp) = create_test_config();
-                std::mem::forget(data_temp);
-                std::mem::forget(logs_temp);
-                let arc = Whitenoise::new(config).await.unwrap();
-                &**Box::leak(Box::new(arc))
-            })
-            .await
-    }
-
     pub(crate) async fn setup_login_account(whitenoise: &Whitenoise) -> (Account, Keys) {
         let keys = create_test_keys();
         let account = whitenoise
@@ -1147,7 +1129,10 @@ pub mod test_utils {
                 .create_test_identity_with_keys(&keys)
                 .await
                 .unwrap();
-            let key_package_relays = account.key_package_relays(whitenoise).await.unwrap();
+            let key_package_relays = account
+                .key_package_relays(&whitenoise.shared)
+                .await
+                .unwrap();
             whitenoise
                 .create_and_publish_key_package(&account, &key_package_relays)
                 .await
@@ -1168,7 +1153,7 @@ pub mod test_utils {
                 for publisher_account in publisher_accounts {
                     let relay_urls = Relay::urls(
                         &publisher_account
-                            .key_package_relays(whitenoise)
+                            .key_package_relays(&whitenoise.shared)
                             .await
                             .unwrap(),
                     );
@@ -1210,8 +1195,12 @@ pub mod test_utils {
     ) -> (GroupId, Vec<UnsignedEvent>) {
         let mut key_package_events = Vec::with_capacity(member_accounts.len());
         for member_account in member_accounts {
-            let relay_urls =
-                Relay::urls(&member_account.key_package_relays(whitenoise).await.unwrap());
+            let relay_urls = Relay::urls(
+                &member_account
+                    .key_package_relays(&whitenoise.shared)
+                    .await
+                    .unwrap(),
+            );
             let key_package_event = whitenoise
                 .shared
                 .relay_control
@@ -2358,19 +2347,29 @@ mod tests {
         //   - New messages are NOT in any fetched historical page (they are newer
         //     than the snapshot window and thus beyond the cursor's reach).
 
-        /// Helper: create a minimal account in the DB (no network calls).
-        /// `fetch_aggregated_messages_for_group` requires an account to exist for its
-        /// security check, but does not need a full session to be active.
-        async fn create_db_account(whitenoise: &Whitenoise) -> accounts::Account {
-            let (account, _keys) = accounts::Account::new(whitenoise, None).await.unwrap();
-            account.save(&whitenoise.shared.database).await.unwrap()
+        /// Helper: create a minimal account in the DB plus a registered session
+        /// (no network calls). `subscribe_to_group_messages` and the chat-list
+        /// view both require an `AccountSession` to be present in the manager.
+        async fn create_db_account(whitenoise: &Arc<Whitenoise>) -> accounts::Account {
+            let (account, keys) = accounts::Account::new(whitenoise, None).await.unwrap();
+            whitenoise
+                .shared
+                .secrets_store
+                .store_private_key(&keys)
+                .expect("store keys");
+            let account = account.save(&whitenoise.shared.database).await.unwrap();
+            let session = Arc::new(
+                session::AccountSession::from_account(&account, whitenoise)
+                    .await
+                    .unwrap(),
+            );
+            whitenoise.account_manager.insert_session(session);
+            account
         }
 
         /// Core happy-path scenario: user opens the chat (snapshot), scrolls up to load
         /// older messages (paginated fetch), and concurrently receives new messages
         /// (updates receiver) that land at the bottom.
-        // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-        #[ignore]
         #[tokio::test]
         async fn test_scroll_up_while_receiving_new_messages() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2569,8 +2568,6 @@ mod tests {
 
         /// Exhausting history: after two full pages the third page is empty, confirming
         /// the cursor correctly signals end-of-history to the client.
-        // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-        #[ignore]
         #[tokio::test]
         async fn test_scroll_up_exhausts_history_cleanly() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2637,8 +2634,6 @@ mod tests {
         /// When the user scrolls up through several pages and then a new message arrives,
         /// the live update is still delivered correctly regardless of how many historical
         /// pages have been fetched.  The updates receiver is independent of pagination.
-        // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-        #[ignore]
         #[tokio::test]
         async fn test_live_updates_independent_of_how_many_pages_were_fetched() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2744,8 +2739,6 @@ mod tests {
         /// Tied timestamps across a page boundary: if several messages share the same
         /// `created_at` second and straddle the snapshot boundary, the compound cursor
         /// ensures the page fetch picks up exactly the right set — no duplicates, no gaps.
-        // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-        #[ignore]
         #[tokio::test]
         async fn test_scroll_up_with_tied_timestamps_at_page_boundary() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2924,7 +2917,7 @@ mod tests {
             let signer = whitenoise.get_signer_for_account(&creator_account).unwrap();
             let inbox_relays = crate::whitenoise::relays::Relay::urls(
                 &creator_account
-                    .effective_inbox_relays(&whitenoise)
+                    .effective_inbox_relays(&whitenoise.shared)
                     .await
                     .unwrap(),
             );
@@ -3712,7 +3705,7 @@ mod tests {
         #[tokio::test]
         async fn test_fallback_relay_urls_uses_discovery_plane_relays() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-            let fallback = whitenoise.fallback_relay_urls().await;
+            let fallback = whitenoise.shared.fallback_relay_urls().await;
             let discovery_urls = whitenoise.config().discovery_relays.clone();
 
             for url in &discovery_urls {
@@ -3730,7 +3723,7 @@ mod tests {
             // A relay URL that was never added to the discovery plane must not appear in fallback.
             let extra_url = RelayUrl::parse("wss://extra.relay.test").unwrap();
 
-            let fallback = whitenoise.fallback_relay_urls().await;
+            let fallback = whitenoise.shared.fallback_relay_urls().await;
             assert!(
                 !fallback.contains(&extra_url),
                 "Fallback should not include a relay that was never added to discovery"
@@ -3740,7 +3733,7 @@ mod tests {
         #[tokio::test]
         async fn test_fallback_relay_urls_deduplicates() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-            let fallback = whitenoise.fallback_relay_urls().await;
+            let fallback = whitenoise.shared.fallback_relay_urls().await;
 
             let unique: HashSet<&RelayUrl> = fallback.iter().collect();
             assert_eq!(

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1094,7 +1094,13 @@ impl Whitenoise {
         if group_state != GroupState::Active {
             return false;
         }
-        match AccountGroup::get(self, &account.pubkey, group_id).await {
+        match AccountGroup::find_by_account_and_group(
+            &account.pubkey,
+            group_id,
+            &self.shared.database,
+        )
+        .await
+        {
             Ok(Some(ag)) => ag.is_accepted() && !ag.is_removed(),
             Ok(None) => false,
             Err(error) => {
@@ -1994,8 +2000,6 @@ mod tests {
         assert!(cached_tokens.is_empty());
     }
 
-    // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-    #[ignore]
     #[tokio::test]
     async fn test_publish_notification_requests_after_delivery_publishes_expected_446_tokens() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2012,7 +2016,10 @@ mod tests {
             &member_account,
         )
         .await;
-        let server_inbox_relays = server_account.inbox_relays(&whitenoise).await.unwrap();
+        let server_inbox_relays = server_account
+            .inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let server_relay_urls = Relay::urls(&server_inbox_relays);
 
         wait_for_user_inbox_relays_on_network(
@@ -2101,8 +2108,6 @@ mod tests {
         assert_eq!(parsed.tokens, vec![recipient_token]);
     }
 
-    // TODO(phase-16): Pre-existing failure on arch-refactor. Requires singleton for relay ops.
-    #[ignore]
     #[tokio::test]
     async fn test_reaction_delivery_publishes_expected_446_tokens() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2119,7 +2124,10 @@ mod tests {
             &member_account,
         )
         .await;
-        let server_inbox_relays = server_account.inbox_relays(&whitenoise).await.unwrap();
+        let server_inbox_relays = server_account
+            .inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let server_relay_urls = Relay::urls(&server_inbox_relays);
 
         wait_for_user_inbox_relays_on_network(
@@ -2231,7 +2239,10 @@ mod tests {
         let sender_account = whitenoise.create_identity().await.unwrap();
         let mut server_accounts = setup_multiple_test_accounts(&whitenoise, 1).await;
         let (server_account, server_keys) = server_accounts.remove(0);
-        let server_inbox_relays = server_account.inbox_relays(&whitenoise).await.unwrap();
+        let server_inbox_relays = server_account
+            .inbox_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let server_relay_urls = Relay::urls(&server_inbox_relays);
 
         wait_for_user_inbox_relays_on_network(

--- a/src/whitenoise/relays.rs
+++ b/src/whitenoise/relays.rs
@@ -157,11 +157,11 @@ impl Whitenoise {
 
         let mut relay_types_by_url: HashMap<RelayUrl, HashSet<RelayType>> = HashMap::new();
         for (relay_type, relays) in [
-            (RelayType::Nip65, account.nip65_relays(self).await?),
-            (RelayType::Inbox, account.inbox_relays(self).await?),
+            (RelayType::Nip65, account.nip65_relays(&self.shared).await?),
+            (RelayType::Inbox, account.inbox_relays(&self.shared).await?),
             (
                 RelayType::KeyPackage,
-                account.key_package_relays(self).await?,
+                account.key_package_relays(&self.shared).await?,
             ),
         ] {
             for relay in relays {

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -574,7 +574,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         let account = whitenoise.create_identity().await.unwrap();
-        let kp_relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let kp_relays = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         let before = whitenoise

--- a/src/whitenoise/scheduled_tasks/tasks/relay_list_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/relay_list_maintenance.rs
@@ -149,7 +149,7 @@ async fn check_and_republish(
     relay_type: RelayType,
 ) -> MaintenanceResult {
     // 1. Read local relay config from DB
-    let local_relays = match account.relays(relay_type, whitenoise).await {
+    let local_relays = match account.relays(relay_type, &whitenoise.shared).await {
         Ok(relays) => relays,
         Err(e) => return MaintenanceResult::Error(e),
     };
@@ -167,7 +167,7 @@ async fn check_and_republish(
     // 2. Determine where to look for the event on the network.
     //    Use NIP-65 relays as the source, falling back to the relay list's own
     //    relays when NIP-65 is empty (e.g. the account only has inbox/kp relays).
-    let source_relays = match account.nip65_relays(whitenoise).await {
+    let source_relays = match account.nip65_relays(&whitenoise.shared).await {
         Ok(nip65) if !nip65.is_empty() => nip65,
         Ok(_) => local_relays.clone(),
         Err(e) => {
@@ -380,17 +380,20 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Verify local relay config exists
-        let inbox_relays = account.inbox_relays(&whitenoise).await.unwrap();
+        let inbox_relays = account.inbox_relays(&whitenoise.shared).await.unwrap();
         assert!(!inbox_relays.is_empty(), "Account should have inbox relays");
 
-        let kp_relays = account.key_package_relays(&whitenoise).await.unwrap();
+        let kp_relays = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert!(
             !kp_relays.is_empty(),
             "Account should have key package relays"
         );
 
         // Verify relay lists are discoverable on the network before maintenance
-        let nip65_urls = Relay::urls(&account.nip65_relays(&whitenoise).await.unwrap());
+        let nip65_urls = Relay::urls(&account.nip65_relays(&whitenoise.shared).await.unwrap());
 
         assert!(
             wait_for_relay_list_on_network(&whitenoise, &account, RelayType::Inbox, &nip65_urls)
@@ -456,8 +459,11 @@ mod tests {
         let account = account.save(&whitenoise.shared.database).await.unwrap();
 
         // Verify no local relays exist
-        let inbox = account.inbox_relays(&whitenoise).await.unwrap();
-        let kp = account.key_package_relays(&whitenoise).await.unwrap();
+        let inbox = account.inbox_relays(&whitenoise.shared).await.unwrap();
+        let kp = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         assert!(inbox.is_empty(), "Should have no inbox relays");
         assert!(kp.is_empty(), "Should have no key package relays");
 

--- a/src/whitenoise/session/groups/media.rs
+++ b/src/whitenoise/session/groups/media.rs
@@ -22,10 +22,10 @@ use sha2::{Digest, Sha256};
 
 use crate::perf_instrument;
 use crate::types::ImageType;
-use crate::whitenoise::Whitenoise;
 use crate::whitenoise::database::media_files::{FileMetadata, MediaFile};
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::groups::blossom_error::BlossomError;
+use crate::whitenoise::groups::media::{is_debug_local_blossom_url, require_https};
 use crate::whitenoise::media_files::MediaFileUpload;
 use crate::whitenoise::session::AccountSession;
 
@@ -64,8 +64,7 @@ static BLOSSOM_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         let url = attempt.url();
         let allowed = match url.scheme() {
             "https" => true,
-            // TODO(phase-16): Move is_debug_local_blossom_url to a free fn to remove Whitenoise coupling.
-            "http" if Whitenoise::is_debug_local_blossom_url(url) => true,
+            "http" if is_debug_local_blossom_url(url) => true,
             _ => false,
         };
         if allowed {
@@ -817,8 +816,7 @@ impl<'a> MediaOps<'a> {
         image_hash: &[u8; 32],
     ) -> Result<Vec<u8>> {
         // Enforce HTTPS before making any network contact.
-        // TODO(phase-16): Move require_https to a free fn to remove Whitenoise coupling.
-        Whitenoise::require_https(blossom_url)?;
+        require_https(blossom_url)?;
 
         // Build the Blossom download URL: <base>/<hex-hash>
         let hash_hex = hex::encode(image_hash);
@@ -886,8 +884,7 @@ impl<'a> MediaOps<'a> {
         mime_type: &str,
         upload_keypair: &Keys,
     ) -> Result<nostr_blossom::bud02::BlobDescriptor> {
-        // TODO(phase-16): Move require_https to a free fn to remove Whitenoise coupling.
-        Whitenoise::require_https(blossom_server_url)?;
+        require_https(blossom_server_url)?;
 
         let sha256 = Sha256Hash::hash(&encrypted_data);
         let expiration = Timestamp::now() + Duration::from_secs(300);
@@ -932,8 +929,7 @@ impl<'a> MediaOps<'a> {
             .await
             .map_err(|_| BlossomError::Timeout(Self::BLOSSOM_TIMEOUT))??;
 
-        // TODO(phase-16): Move require_https to a free fn to remove Whitenoise coupling.
-        Whitenoise::require_https(&descriptor.url)?;
+        require_https(&descriptor.url)?;
 
         Ok(descriptor)
     }
@@ -945,8 +941,8 @@ mod tests {
     use nostr_sdk::prelude::Url;
 
     use super::MediaOps;
-    use crate::whitenoise::Whitenoise;
     use crate::whitenoise::error::WhitenoiseError;
+    use crate::whitenoise::groups::media::blossom_client;
 
     // ── download_blob_from_blossom size-cap tests ─────────────────────────────
     //
@@ -1066,13 +1062,13 @@ mod tests {
     #[test]
     fn blossom_client_accepts_https() {
         let url = Url::parse("https://blossom.primal.net").unwrap();
-        assert!(Whitenoise::blossom_client(&url).is_ok());
+        assert!(blossom_client(&url).is_ok());
     }
 
     #[test]
     fn blossom_client_rejects_http() {
         let url = Url::parse("http://evil.example.com").unwrap();
-        let err = Whitenoise::blossom_client(&url).unwrap_err();
+        let err = blossom_client(&url).unwrap_err();
         assert!(
             matches!(err, WhitenoiseError::BlossomInsecureUrl(_)),
             "Expected BlossomInsecureUrl, got: {err:?}"
@@ -1082,27 +1078,27 @@ mod tests {
     #[test]
     fn blossom_client_rejects_ftp() {
         let url = Url::parse("ftp://files.example.com/blob").unwrap();
-        assert!(Whitenoise::blossom_client(&url).is_err());
+        assert!(blossom_client(&url).is_err());
     }
 
     #[test]
     #[cfg(debug_assertions)]
     fn blossom_client_allows_localhost_http_in_debug() {
         let url = Url::parse("http://localhost:3000").unwrap();
-        assert!(Whitenoise::blossom_client(&url).is_ok());
+        assert!(blossom_client(&url).is_ok());
     }
 
     #[test]
     #[cfg(debug_assertions)]
     fn blossom_client_allows_loopback_http_in_debug() {
         let url = Url::parse("http://127.0.0.1:3000").unwrap();
-        assert!(Whitenoise::blossom_client(&url).is_ok());
+        assert!(blossom_client(&url).is_ok());
     }
 
     #[test]
     #[cfg(debug_assertions)]
     fn blossom_client_rejects_non_localhost_http_in_debug() {
         let url = Url::parse("http://192.168.1.1:3000").unwrap();
-        assert!(Whitenoise::blossom_client(&url).is_err());
+        assert!(blossom_client(&url).is_err());
     }
 }

--- a/src/whitenoise/session/groups/mod.rs
+++ b/src/whitenoise/session/groups/mod.rs
@@ -13,7 +13,6 @@ use mdk_core::prelude::*;
 use nostr_sdk::prelude::*;
 
 use super::AccountSession;
-use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::error::{Result, WhitenoiseError};
@@ -21,6 +20,7 @@ use crate::whitenoise::group_information::{GroupInformation, GroupType};
 use crate::whitenoise::groups::{GroupWithInfoAndMembership, GroupWithMembership};
 use crate::whitenoise::key_packages::validate_fetched_member_key_package;
 use crate::whitenoise::relays::{Relay, RelayType};
+use crate::whitenoise::shared::SharedServices;
 use crate::whitenoise::users::User;
 
 /// View over [`AccountSession`] for group operations.
@@ -199,16 +199,17 @@ impl<'a> GroupOps<'a> {
     /// If all publish attempts fail, the pending commit is cleared via
     /// `clear_pending_commit`, rolling back the MLS group to its pre-commit
     /// state.
-    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
     pub(crate) async fn publish_and_merge_commit(
         &self,
         evolution_event: Event,
         group_id: &GroupId,
         relay_urls: &[RelayUrl],
     ) -> Result<()> {
-        let wn = self.session.whitenoise()?;
-        if let Err(publish_err) = wn
-            .publish_event_with_retry(evolution_event, &self.session.account_pubkey, relay_urls)
+        if let Err(publish_err) = self
+            .session
+            .shared
+            .relay_control
+            .publish_event_to(evolution_event, &self.session.account_pubkey, relay_urls)
             .await
         {
             if let Err(clear_err) = self.session.mdk.clear_pending_commit(group_id) {
@@ -219,7 +220,7 @@ impl<'a> GroupOps<'a> {
                     clear_err,
                 );
             }
-            return Err(publish_err);
+            return Err(publish_err.into());
         }
         self.session.mdk.merge_pending_commit(group_id)?;
         Ok(())
@@ -231,7 +232,6 @@ impl<'a> GroupOps<'a> {
     ///
     /// Performs the complete workflow: fetch key packages, add members via MDK,
     /// publish evolution event, merge commit, and send welcome messages.
-    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
     pub async fn add_members(
         &self,
         group_id: &GroupId,
@@ -239,24 +239,23 @@ impl<'a> GroupOps<'a> {
     ) -> Result<()> {
         self.ensure_admin(group_id)?;
 
-        let wn = self.session.whitenoise()?;
+        let shared = &self.session.shared;
         let signer = self
             .session
             .get_signer()
             .ok_or(WhitenoiseError::SignerUnavailable(
                 self.session.account_pubkey,
             ))?;
-        let account =
-            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
+        let database = &shared.database;
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, database).await?;
 
         let mut key_package_events: Vec<Event> = Vec::new();
         let mut users = Vec::new();
 
         for pk in member_pubkeys.iter() {
-            let (user, newly_created) =
-                User::find_or_create_by_pubkey(pk, &wn.shared.database).await?;
+            let (user, newly_created) = User::find_or_create_by_pubkey(pk, database).await?;
 
-            if newly_created && let Err(e) = user.update_relay_lists(&wn).await {
+            if newly_created && let Err(e) = user.update_relay_lists(shared).await {
                 tracing::warn!(
                     target: "whitenoise::session::groups",
                     "Failed to update relay lists for new user {}: {}",
@@ -265,19 +264,18 @@ impl<'a> GroupOps<'a> {
                 );
             }
 
-            let mut relays_to_use = user
-                .relays(RelayType::KeyPackage, &wn.shared.database)
-                .await?;
+            let mut relays_to_use = user.relays(RelayType::KeyPackage, database).await?;
             if relays_to_use.is_empty() {
                 tracing::warn!(
                     target: "whitenoise::session::groups",
                     "User {} has no relays configured, using account's default relays",
                     user.pubkey
                 );
-                relays_to_use = account.nip65_relays(&wn).await?;
+                relays_to_use = account.nip65_relays(shared).await?;
             }
             let relays_to_use_urls = Relay::urls(&relays_to_use);
-            let some_event = wn
+            let some_event = self
+                .session
                 .shared
                 .relay_control
                 .fetch_user_key_package(*pk, &relays_to_use_urls)
@@ -338,7 +336,7 @@ impl<'a> GroupOps<'a> {
 
             let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
-            let relays_to_use = wn
+            let relays_to_use = shared
                 .resolve_member_delivery_relays(
                     &user,
                     &account,
@@ -348,7 +346,8 @@ impl<'a> GroupOps<'a> {
 
             let relay_urls = Relay::urls(&relays_to_use);
 
-            wn.shared
+            self.session
+                .shared
                 .relay_control
                 .publish_welcome(
                     &member_pubkey,
@@ -383,7 +382,6 @@ impl<'a> GroupOps<'a> {
     ///
     /// Creates an MLS group-data update proposal, publishes the evolution
     /// event, merges the pending commit, and refreshes subscriptions.
-    // TODO(phase-16): Remove singleton bridge when background_refresh moves to session.
     pub async fn update_group_data(
         &self,
         group_id: &GroupId,
@@ -397,10 +395,15 @@ impl<'a> GroupOps<'a> {
         self.publish_and_merge_commit(update_result.evolution_event, group_id, &relay_urls)
             .await?;
 
-        let wn = self.session.whitenoise()?;
         let account =
-            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
-        wn.background_refresh_account_group_subscriptions(&account);
+            Account::find_by_pubkey(&self.session.account_pubkey, &self.session.shared.database)
+                .await?;
+        // background_refresh_account_group_subscriptions still genuinely needs
+        // Whitenoise (account_manager + tokio::spawn). Inline upgrade keeps the
+        // back-ref scoped to a single call rather than a function-wide binding.
+        self.session
+            .whitenoise()?
+            .background_refresh_account_group_subscriptions(&account);
         Ok(())
     }
 
@@ -424,14 +427,16 @@ impl<'a> GroupOps<'a> {
     /// After the proposal is successfully published, the group is
     /// optimistically marked as departed locally. When another member
     /// auto-commits the proposal, the resulting commit converges local state.
-    // TODO(phase-16): Remove singleton bridge when mark_as_left moves to session.
-    #[allow(deprecated)] // wn.mark_as_left() deprecated in Phase 12
     pub async fn leave(&self, group_id: &GroupId) -> Result<()> {
-        let wn = self.session.whitenoise()?;
+        let database = &self.session.shared.database;
 
-        let account_group = AccountGroup::get(&wn, &self.session.account_pubkey, group_id)
-            .await?
-            .ok_or(WhitenoiseError::GroupNotFound)?;
+        let account_group = AccountGroup::find_by_account_and_group(
+            &self.session.account_pubkey,
+            group_id,
+            database,
+        )
+        .await?
+        .ok_or(WhitenoiseError::GroupNotFound)?;
 
         if account_group.is_removed() {
             return Err(WhitenoiseError::AlreadyDepartedFromGroup);
@@ -440,17 +445,25 @@ impl<'a> GroupOps<'a> {
         let relay_urls = self.ensure_relays(group_id)?;
         let update_result = self.session.mdk.leave_group(group_id)?;
 
-        wn.publish_event_with_retry(
-            update_result.evolution_event,
-            &self.session.account_pubkey,
-            &relay_urls,
-        )
-        .await?;
+        self.session
+            .shared
+            .relay_control
+            .publish_event_to(
+                update_result.evolution_event,
+                &self.session.account_pubkey,
+                &relay_urls,
+            )
+            .await?;
 
-        let account =
-            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
+        let account = Account::find_by_pubkey(&self.session.account_pubkey, database).await?;
 
-        if let Err(error) = wn.mark_as_left(&account, group_id).await {
+        if let Err(error) = self
+            .session
+            .membership()
+            .for_group(group_id)
+            .mark_as_left()
+            .await
+        {
             tracing::warn!(
                 target: "whitenoise::session::groups",
                 account_pubkey = %self.session.account_pubkey,
@@ -459,7 +472,12 @@ impl<'a> GroupOps<'a> {
             );
         }
 
-        wn.background_refresh_account_group_subscriptions(&account);
+        // background_refresh_account_group_subscriptions still genuinely needs
+        // Whitenoise (account_manager + tokio::spawn). Inline upgrade keeps the
+        // back-ref scoped to a single call rather than a function-wide binding.
+        self.session
+            .whitenoise()?
+            .background_refresh_account_group_subscriptions(&account);
 
         Ok(())
     }
@@ -471,14 +489,12 @@ impl<'a> GroupOps<'a> {
     /// Welcome messages are delivered inline after the group is committed locally.
     /// If welcome delivery fails for a member, the failure is logged but does not
     /// prevent `Ok(group)` from being returned.
-    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
     pub async fn create_group(
         &self,
         member_pubkeys: Vec<PublicKey>,
         config: NostrGroupConfigData,
         group_type: Option<GroupType>,
     ) -> Result<group_types::Group> {
-        let wn = self.session.whitenoise()?;
         let signer = self
             .session
             .get_signer()
@@ -526,7 +542,7 @@ impl<'a> GroupOps<'a> {
             .await?;
 
         Self::publish_welcomes(
-            wn.clone(),
+            self.session.shared.clone(),
             welcome_data,
             signer,
             self.session.account_pubkey,
@@ -534,8 +550,14 @@ impl<'a> GroupOps<'a> {
         .await;
 
         let account =
-            Account::find_by_pubkey(&self.session.account_pubkey, &wn.shared.database).await?;
-        wn.background_refresh_account_group_subscriptions(&account);
+            Account::find_by_pubkey(&self.session.account_pubkey, &self.session.shared.database)
+                .await?;
+        // background_refresh_account_group_subscriptions still genuinely needs
+        // Whitenoise (account_manager + tokio::spawn). Inline upgrade keeps the
+        // back-ref scoped to a single call rather than a function-wide binding.
+        self.session
+            .whitenoise()?
+            .background_refresh_account_group_subscriptions(&account);
 
         Ok(group)
     }
@@ -543,11 +565,10 @@ impl<'a> GroupOps<'a> {
     /// Resolves a single member for group creation: finds or creates the user
     /// record, syncs relay lists for new users, fetches and validates the key
     /// package.
-    // TODO(phase-16): Remove singleton bridge when relay_control moves to session.
     async fn resolve_member_key_package(&self, pk: &PublicKey) -> Result<(User, Event)> {
-        let wn = self.session.whitenoise()?;
-        let (user, created) = User::find_or_create_by_pubkey(pk, &wn.shared.database).await?;
-        if created && let Err(e) = user.update_relay_lists(&wn).await {
+        let shared = &self.session.shared;
+        let (user, created) = User::find_or_create_by_pubkey(pk, &shared.database).await?;
+        if created && let Err(e) = user.update_relay_lists(shared).await {
             tracing::warn!(
                 target: "whitenoise::session::groups",
                 "Failed to update relay lists for new user {}: {}",
@@ -556,7 +577,7 @@ impl<'a> GroupOps<'a> {
             );
         }
 
-        let some_event = user.key_package_event(&wn).await?;
+        let some_event = user.key_package_event(shared).await?;
         let event = some_event.ok_or(WhitenoiseError::MdkCoreError(
             mdk_core::Error::KeyPackage("Does not exist".to_owned()),
         ))?;
@@ -614,7 +635,6 @@ impl<'a> GroupOps<'a> {
 
     /// Creates local database records for a newly created group:
     /// GroupInformation and AccountGroup (auto-accepted for the creator).
-    // TODO(phase-16): Remove singleton bridge when push ops fully on session.
     async fn finalize_group_records(
         &self,
         group: &group_types::Group,
@@ -676,32 +696,32 @@ impl<'a> GroupOps<'a> {
     /// The caller is responsible for deciding whether to `tokio::spawn` this for
     /// fire-and-forget behaviour. The view itself does not spawn.
     async fn publish_welcomes(
-        whitenoise: Arc<Whitenoise>,
+        shared: Arc<SharedServices>,
         welcome_data: Vec<(UnsignedEvent, User, PublicKey)>,
         signer: Arc<dyn NostrSigner>,
         creator_pubkey: PublicKey,
     ) {
-        let creator_account =
-            match Account::find_by_pubkey(&creator_pubkey, &whitenoise.shared.database).await {
-                Ok(account) => account,
-                Err(error) => {
-                    tracing::error!(
-                        target: "whitenoise::session::groups",
-                        "Failed to find creator account for welcome publishing: {}",
-                        error
-                    );
-                    return;
-                }
-            };
+        let creator_account = match Account::find_by_pubkey(&creator_pubkey, &shared.database).await
+        {
+            Ok(account) => account,
+            Err(error) => {
+                tracing::error!(
+                    target: "whitenoise::session::groups",
+                    "Failed to find creator account for welcome publishing: {}",
+                    error
+                );
+                return;
+            }
+        };
 
         let futures = welcome_data
             .into_iter()
             .map(|(rumor, member, member_pubkey)| {
                 let signer = signer.clone();
                 let creator = &creator_account;
-                let whitenoise = &whitenoise;
+                let shared = &shared;
                 async move {
-                    let relays_to_use = whitenoise
+                    let relays_to_use = shared
                         .resolve_member_delivery_relays(
                             &member,
                             creator,
@@ -712,8 +732,7 @@ impl<'a> GroupOps<'a> {
                     let one_month_future =
                         Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
-                    whitenoise
-                        .shared
+                    shared
                         .relay_control
                         .publish_welcome(
                             &member_pubkey,

--- a/src/whitenoise/session/mute_list.rs
+++ b/src/whitenoise/session/mute_list.rs
@@ -353,32 +353,10 @@ impl<'a> MuteListOps<'a> {
         .await
         {
             Ok(Some(group_id)) => {
-                // Reach back to the Whitenoise handle for the stream managers
-                // that are not yet session-scoped.
-                // TODO(phase-16): Move chat list stream managers to AccountSession.
-                let Ok(wn) = self.session.whitenoise() else {
-                    tracing::debug!(
-                        target: "whitenoise::mute_list",
-                        "Whitenoise handle unavailable for chat list emit"
-                    );
-                    return;
-                };
-                let Ok(account) =
-                    Account::find_by_pubkey(&self.session.account_pubkey, self.db()).await
-                else {
-                    tracing::debug!(
-                        target: "whitenoise::mute_list",
-                        account = %self.session.account_pubkey.to_hex(),
-                        "Account row not found for chat list emit"
-                    );
-                    return;
-                };
-                wn.emit_chat_list_update(
-                    &account,
-                    &group_id,
-                    ChatListUpdateTrigger::UserBlockChanged,
-                )
-                .await;
+                self.session
+                    .chat_list()
+                    .emit_update(&group_id, ChatListUpdateTrigger::UserBlockChanged)
+                    .await;
             }
             Ok(None) => {}
             Err(e) => {

--- a/src/whitenoise/shared.rs
+++ b/src/whitenoise/shared.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use dashmap::DashMap;
-use nostr_sdk::PublicKey;
 use nostr_sdk::prelude::NostrSigner;
+use nostr_sdk::{PublicKey, RelayUrl};
 use tokio::sync::Mutex;
 
 #[cfg(test)]
@@ -12,6 +12,7 @@ use nostr_sdk::EventId;
 use tokio::sync::Semaphore;
 
 use crate::mdk::GroupId;
+use crate::perf_instrument;
 use crate::relay_control::RelayControlPlane;
 use crate::whitenoise::WhitenoiseConfig;
 use crate::whitenoise::chat_list_streaming::ChatListStreamManager;
@@ -30,9 +31,9 @@ use crate::whitenoise::user_streaming::UserStreamManager;
 /// Held behind `Arc<SharedServices>` on `Whitenoise` and on every
 /// `AccountSession`. Lifecycle plumbing (event and shutdown channels, scheduler
 /// handles, account registry) stays on `Whitenoise` itself.
-pub(crate) struct SharedServices {
+pub struct SharedServices {
     pub(crate) config: Arc<WhitenoiseConfig>,
-    pub(crate) database: Arc<Database>,
+    pub database: Arc<Database>,
     pub(crate) relay_control: Arc<RelayControlPlane>,
     pub(crate) event_tracker: Arc<dyn EventTracker>,
     pub(crate) secrets_store: SecretsStore,
@@ -106,5 +107,15 @@ impl SharedServices {
                 super::push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,
             )),
         }
+    }
+
+    /// Returns the union of default relays and currently connected relays.
+    ///
+    /// Used as the fallback relay set when a user has no stored NIP-65 relays.
+    /// Discovery fallback is owned by the discovery plane rather than whatever
+    /// other relays happen to be connected for unrelated workloads.
+    #[perf_instrument("whitenoise")]
+    pub(crate) async fn fallback_relay_urls(&self) -> Vec<RelayUrl> {
+        self.relay_control.discovery().relays().to_vec()
     }
 }

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -58,7 +58,7 @@ impl Whitenoise {
         // Rebuild account subscriptions now that signing/decryption is available.
         // Only inbox_relays is needed by setup_subscriptions; do not gate
         // recovery on the nip65 lookup which is not used here.
-        match account.inbox_relays(self).await {
+        match account.inbox_relays(&self.shared).await {
             Ok(inbox_relays) => {
                 if let Err(e) = self.setup_subscriptions(&account, &inbox_relays).await {
                     tracing::warn!(

--- a/src/whitenoise/subscriptions.rs
+++ b/src/whitenoise/subscriptions.rs
@@ -1,5 +1,3 @@
-use nostr_sdk::RelayUrl;
-
 use crate::perf_instrument;
 use crate::types::RelayControlStateSnapshot;
 use crate::whitenoise::Whitenoise;
@@ -82,7 +80,7 @@ impl Whitenoise {
     pub(super) async fn setup_accounts_subscriptions(&self) -> Result<()> {
         let accounts = Account::all(&self.shared.database).await?;
         for account in accounts {
-            let inbox_relays = account.effective_inbox_relays(self).await?;
+            let inbox_relays = account.effective_inbox_relays(&self.shared).await?;
             // Setup subscriptions for this account
             match self.setup_subscriptions(&account, &inbox_relays).await {
                 Ok(()) => {
@@ -332,31 +330,5 @@ impl Whitenoise {
         .map_err(WhitenoiseError::from)?;
 
         Ok(())
-    }
-
-    /// Returns the union of default relays and currently connected relays.
-    ///
-    /// Used as the fallback relay set when a user has no stored NIP-65 relays.
-    /// Discovery fallback is owned by the discovery plane rather than whatever
-    /// other relays happen to be connected for unrelated workloads.
-    #[perf_instrument("whitenoise")]
-    pub(crate) async fn fallback_relay_urls(&self) -> Vec<RelayUrl> {
-        self.shared.relay_control.discovery().relays().to_vec()
-    }
-
-    /// Returns the NIP-65 relay URLs for the given account, falling back to
-    /// discovery plane relays when no NIP-65 relays are stored.
-    ///
-    /// Use this for publishing or fetching the account's own replaceable events
-    /// (e.g. kind 10000 mute list, kind 10002 relay list).
-    #[perf_instrument("whitenoise")]
-    pub(crate) async fn account_relay_urls(
-        &self,
-        account: &crate::whitenoise::accounts::Account,
-    ) -> Vec<RelayUrl> {
-        match account.nip65_relays(self).await {
-            Ok(relays) if !relays.is_empty() => crate::whitenoise::relays::Relay::urls(&relays),
-            _ => self.fallback_relay_urls().await,
-        }
     }
 }

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -531,7 +531,7 @@ impl Whitenoise {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::whitenoise::test_utils::{create_mock_whitenoise, test_get_whitenoise};
+    use crate::whitenoise::test_utils::create_mock_whitenoise;
     use chrono::{Duration, Utc};
     use std::collections::HashSet;
 
@@ -589,7 +589,10 @@ mod tests {
             .await
             .unwrap();
 
-        saved_user.update_relay_lists(&whitenoise).await.unwrap();
+        saved_user
+            .update_relay_lists(&whitenoise.shared)
+            .await
+            .unwrap();
         let relays = saved_user
             .relays(RelayType::Nip65, &whitenoise.shared.database)
             .await
@@ -614,7 +617,10 @@ mod tests {
 
         let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
-        saved_user.update_relay_lists(&whitenoise).await.unwrap();
+        saved_user
+            .update_relay_lists(&whitenoise.shared)
+            .await
+            .unwrap();
         assert!(
             saved_user
                 .relays(RelayType::Nip65, &whitenoise.shared.database)
@@ -652,7 +658,10 @@ mod tests {
             .unwrap();
 
         // Test get_query_relays
-        let query_relays = saved_user.get_query_relays(&whitenoise).await.unwrap();
+        let query_relays = saved_user
+            .get_query_relays(&whitenoise.shared)
+            .await
+            .unwrap();
 
         assert_eq!(query_relays.len(), 1);
         assert_eq!(query_relays[0].url, relay_url);
@@ -671,7 +680,10 @@ mod tests {
             updated_at: Utc::now(),
         };
         let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
-        let query_relays = saved_user.get_query_relays(&whitenoise).await.unwrap();
+        let query_relays = saved_user
+            .get_query_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let query_urls: std::collections::HashSet<RelayUrl> =
             Relay::urls(&query_relays).into_iter().collect();
 
@@ -700,7 +712,10 @@ mod tests {
             updated_at: Utc::now(),
         };
         let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
-        let query_relays = saved_user.get_query_relays(&whitenoise).await.unwrap();
+        let query_relays = saved_user
+            .get_query_relays(&whitenoise.shared)
+            .await
+            .unwrap();
         let query_urls: Vec<RelayUrl> = Relay::urls(&query_relays);
 
         assert!(
@@ -791,7 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_user_dedupes_background_resolution_for_same_unknown_user() {
-        let whitenoise = test_get_whitenoise().await;
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let metadata = Metadata::new().name("Background Deduped User");
@@ -916,7 +931,9 @@ mod tests {
     #[tokio::test]
     async fn test_all_users_with_relay_urls() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let users_with_relays = User::all_users_with_relay_urls(&whitenoise).await.unwrap();
+        let users_with_relays = User::all_users_with_relay_urls(&whitenoise.shared)
+            .await
+            .unwrap();
         assert!(users_with_relays.is_empty());
 
         let test_pubkey = nostr_sdk::Keys::generate().public_key();
@@ -939,7 +956,9 @@ mod tests {
             .await
             .unwrap();
 
-        let users_with_relays = User::all_users_with_relay_urls(&whitenoise).await.unwrap();
+        let users_with_relays = User::all_users_with_relay_urls(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(users_with_relays.len(), 1);
         assert_eq!(users_with_relays[0].0, test_pubkey);
         assert_eq!(users_with_relays[0].1, vec![relay_url]);
@@ -1007,7 +1026,9 @@ mod tests {
             .await
             .unwrap();
 
-        let results = User::all_users_with_relay_urls(&whitenoise).await.unwrap();
+        let results = User::all_users_with_relay_urls(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2);
 
         // Find each user's entry (order is by pubkey hex, not insertion order)
@@ -1080,7 +1101,9 @@ mod tests {
             .await
             .unwrap();
 
-        let results = User::all_users_with_relay_urls(&whitenoise).await.unwrap();
+        let results = User::all_users_with_relay_urls(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2, "Both users should appear in results");
 
         let with_entry = results.iter().find(|(pk, _)| *pk == pubkey_with).unwrap();
@@ -1125,7 +1148,9 @@ mod tests {
             .await
             .unwrap();
 
-        let results = User::all_users_with_relay_urls(&whitenoise).await.unwrap();
+        let results = User::all_users_with_relay_urls(&whitenoise.shared)
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1, "User should appear in results");
         assert!(
             results[0].1.is_empty(),
@@ -1161,7 +1186,7 @@ mod tests {
             .unwrap();
         assert!(nip65_relays.is_empty());
 
-        let result = saved_user.key_package_event(&whitenoise).await;
+        let result = saved_user.key_package_event(&whitenoise.shared).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
 
@@ -1176,7 +1201,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = saved_user.key_package_event(&whitenoise).await;
+        let result = saved_user.key_package_event(&whitenoise.shared).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
 
@@ -1195,7 +1220,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = saved_user.key_package_event(&whitenoise).await;
+        let result = saved_user.key_package_event(&whitenoise.shared).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
     }
@@ -1243,7 +1268,7 @@ mod tests {
                 .unwrap();
 
             let urls = saved_user
-                .key_package_relay_urls(&whitenoise)
+                .key_package_relay_urls(&whitenoise.shared)
                 .await
                 .unwrap();
             assert_eq!(urls, vec![kp_url]);
@@ -1274,7 +1299,7 @@ mod tests {
                 .unwrap();
 
             let urls = saved_user
-                .key_package_relay_urls(&whitenoise)
+                .key_package_relay_urls(&whitenoise.shared)
                 .await
                 .unwrap();
             assert_eq!(urls, vec![nip65_url]);
@@ -1295,10 +1320,10 @@ mod tests {
             let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
 
             let urls = saved_user
-                .key_package_relay_urls(&whitenoise)
+                .key_package_relay_urls(&whitenoise.shared)
                 .await
                 .unwrap();
-            let expected = whitenoise.fallback_relay_urls().await;
+            let expected = whitenoise.shared.fallback_relay_urls().await;
             assert_eq!(urls, expected);
             assert!(
                 !urls.is_empty(),
@@ -1741,7 +1766,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(stale_timestamp),
@@ -1801,7 +1826,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(newer_timestamp),
@@ -1860,7 +1885,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(timestamp),
@@ -1896,7 +1921,7 @@ mod tests {
                 HashSet::from([RelayUrl::parse("wss://relay1.example.com").unwrap()]);
 
             let changed = saved_user
-                .sync_relay_urls(&whitenoise, RelayType::Nip65, &new_relay_urls, None)
+                .sync_relay_urls(&whitenoise.shared, RelayType::Nip65, &new_relay_urls, None)
                 .await
                 .unwrap();
 
@@ -1937,7 +1962,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &same_relay_urls,
                     Some(Utc::now()),
@@ -1987,7 +2012,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(Utc::now()),
@@ -2034,7 +2059,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(Utc::now()),
@@ -2083,7 +2108,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(Utc::now()),
@@ -2144,7 +2169,7 @@ mod tests {
             let new_nip65_urls = HashSet::from([relay2.clone()]);
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_nip65_urls,
                     Some(Utc::now()),
@@ -2195,7 +2220,12 @@ mod tests {
 
             let empty_urls = HashSet::new();
             let changed = saved_user
-                .sync_relay_urls(&whitenoise, RelayType::Nip65, &empty_urls, Some(Utc::now()))
+                .sync_relay_urls(
+                    &whitenoise.shared,
+                    RelayType::Nip65,
+                    &empty_urls,
+                    Some(Utc::now()),
+                )
                 .await
                 .unwrap();
 
@@ -2227,7 +2257,7 @@ mod tests {
 
             let changed = saved_user
                 .sync_relay_urls(
-                    &whitenoise,
+                    &whitenoise.shared,
                     RelayType::Nip65,
                     &new_relay_urls,
                     Some(Utc::now()),
@@ -2265,7 +2295,7 @@ mod tests {
 
             let query_relays = Relay::defaults();
             let result = saved_user
-                .update_nip65_relays(&whitenoise, &query_relays)
+                .update_nip65_relays(&whitenoise.shared, &query_relays)
                 .await
                 .unwrap();
 
@@ -2292,7 +2322,7 @@ mod tests {
 
             let query_relays = vec![];
             let result = saved_user
-                .update_nip65_relays(&whitenoise, &query_relays)
+                .update_nip65_relays(&whitenoise.shared, &query_relays)
                 .await
                 .unwrap();
 
@@ -2332,7 +2362,7 @@ mod tests {
             }];
 
             let result = saved_user
-                .update_nip65_relays(&whitenoise, &query_relays)
+                .update_nip65_relays(&whitenoise.shared, &query_relays)
                 .await
                 .unwrap();
 
@@ -2362,7 +2392,7 @@ mod tests {
 
             let query_relays = vec![];
             let result = saved_user
-                .update_secondary_relay_types(&whitenoise, &query_relays)
+                .update_secondary_relay_types(&whitenoise.shared, &query_relays)
                 .await;
 
             assert!(result.is_ok());
@@ -2385,7 +2415,7 @@ mod tests {
 
             let query_relays = vec![];
             let result = saved_user
-                .update_secondary_relay_types(&whitenoise, &query_relays)
+                .update_secondary_relay_types(&whitenoise.shared, &query_relays)
                 .await;
 
             assert!(result.is_ok());
@@ -2415,7 +2445,7 @@ mod tests {
             }];
 
             let result = saved_user
-                .update_secondary_relay_types(&whitenoise, &query_relays)
+                .update_secondary_relay_types(&whitenoise.shared, &query_relays)
                 .await;
 
             assert!(result.is_ok());
@@ -2487,7 +2517,7 @@ mod tests {
 
             let query_relays = Relay::defaults();
             let changed = saved_user
-                .sync_relays_for_type(&whitenoise, RelayType::Nip65, &query_relays)
+                .sync_relays_for_type(&whitenoise.shared, RelayType::Nip65, &query_relays)
                 .await
                 .unwrap();
 
@@ -2511,7 +2541,7 @@ mod tests {
 
             let query_relays = vec![];
             let result = saved_user
-                .sync_relays_for_type(&whitenoise, RelayType::Inbox, &query_relays)
+                .sync_relays_for_type(&whitenoise.shared, RelayType::Inbox, &query_relays)
                 .await;
 
             assert!(result.is_err());
@@ -2536,7 +2566,7 @@ mod tests {
 
             for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
                 let changed = saved_user
-                    .sync_relays_for_type(&whitenoise, relay_type, &query_relays)
+                    .sync_relays_for_type(&whitenoise.shared, relay_type, &query_relays)
                     .await
                     .unwrap();
 
@@ -2600,7 +2630,10 @@ mod tests {
             // User has no relays in DB, so key_package_status should attempt
             // relay sync and retry. With no real relays to reach, the result
             // should still be NotFound but the retry path is exercised.
-            let status = saved_user.key_package_status(&whitenoise).await.unwrap();
+            let status = saved_user
+                .key_package_status(&whitenoise.shared)
+                .await
+                .unwrap();
             assert_eq!(status, KeyPackageStatus::NotFound);
         }
 
@@ -2632,7 +2665,10 @@ mod tests {
 
             // With a relay present, key_package_status should return NotFound
             // without attempting relay sync (no retry path).
-            let status = saved_user.key_package_status(&whitenoise).await.unwrap();
+            let status = saved_user
+                .key_package_status(&whitenoise.shared)
+                .await
+                .unwrap();
             assert_eq!(status, KeyPackageStatus::NotFound);
         }
     }

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
 use nostr_sdk::prelude::*;
 
 use crate::perf_instrument;
 use crate::relay_control::ephemeral::KeyPackageLookup;
 use crate::whitenoise::{
-    Whitenoise,
     error::Result,
     relays::{Relay, RelayType},
+    shared::SharedServices,
     users::User,
 };
 
@@ -34,10 +36,11 @@ impl User {
     /// 3. Whitenoise discovery/fallback relays
     /// 4. Default bootstrap relays from `Relay::defaults()`
     #[perf_instrument("users")]
-    pub async fn key_package_relay_urls(&self, whitenoise: &Whitenoise) -> Result<Vec<RelayUrl>> {
-        let kp_relays = self
-            .relays(RelayType::KeyPackage, &whitenoise.shared.database)
-            .await?;
+    pub async fn key_package_relay_urls(
+        &self,
+        shared: &Arc<SharedServices>,
+    ) -> Result<Vec<RelayUrl>> {
+        let kp_relays = self.relays(RelayType::KeyPackage, &shared.database).await?;
         if !kp_relays.is_empty() {
             return Ok(Relay::urls(&kp_relays));
         }
@@ -48,9 +51,7 @@ impl User {
             self.pubkey
         );
 
-        let nip65_relays = self
-            .relays(RelayType::Nip65, &whitenoise.shared.database)
-            .await?;
+        let nip65_relays = self.relays(RelayType::Nip65, &shared.database).await?;
         if !nip65_relays.is_empty() {
             return Ok(Relay::urls(&nip65_relays));
         }
@@ -61,7 +62,7 @@ impl User {
             self.pubkey
         );
 
-        let fallback_relays = whitenoise.fallback_relay_urls().await;
+        let fallback_relays = shared.fallback_relay_urls().await;
         if !fallback_relays.is_empty() {
             return Ok(fallback_relays);
         }
@@ -83,10 +84,10 @@ impl User {
     ///
     /// # Arguments
     ///
-    /// * `whitenoise` - The Whitenoise instance used to access the Nostr client and database
+    /// * `shared` - Shared services used to access the relay control plane and database
     #[perf_instrument("users")]
-    pub async fn key_package_event(&self, whitenoise: &Whitenoise) -> Result<Option<Event>> {
-        match self.key_package_lookup(whitenoise).await? {
+    pub async fn key_package_event(&self, shared: &Arc<SharedServices>) -> Result<Option<Event>> {
+        match self.key_package_lookup(shared).await? {
             KeyPackageLookup::Found(event) => Ok(Some(event)),
             KeyPackageLookup::Incompatible { .. } | KeyPackageLookup::NotFound => Ok(None),
         }
@@ -95,9 +96,9 @@ impl User {
     #[perf_instrument("users")]
     pub(crate) async fn key_package_lookup(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
     ) -> Result<KeyPackageLookup> {
-        let relay_urls = self.key_package_relay_urls(whitenoise).await?;
+        let relay_urls = self.key_package_relay_urls(shared).await?;
         if relay_urls.is_empty() {
             tracing::warn!(
                 target: "whitenoise::users::key_package",
@@ -107,8 +108,7 @@ impl User {
             return Ok(KeyPackageLookup::NotFound);
         }
 
-        let lookup = whitenoise
-            .shared
+        let lookup = shared
             .relay_control
             .fetch_user_key_package_lookup(self.pubkey, &relay_urls)
             .await?;
@@ -124,14 +124,17 @@ impl User {
     /// relay data yet (e.g. created by a background sync that hasn't finished), this
     /// method will perform a blocking relay sync and retry once.
     #[perf_instrument("users")]
-    pub async fn key_package_status(&self, whitenoise: &Whitenoise) -> Result<KeyPackageStatus> {
-        let lookup = self.key_package_lookup(whitenoise).await?;
+    pub async fn key_package_status(
+        &self,
+        shared: &Arc<SharedServices>,
+    ) -> Result<KeyPackageStatus> {
+        let lookup = self.key_package_lookup(shared).await?;
         let status = classify_key_package_lookup(lookup);
 
         match status {
             KeyPackageStatus::NotFound
                 if self
-                    .relays(RelayType::KeyPackage, &whitenoise.shared.database)
+                    .relays(RelayType::KeyPackage, &shared.database)
                     .await?
                     .is_empty() =>
             {
@@ -140,7 +143,7 @@ impl User {
                     "Key package not found for user {} with empty relay list, syncing relays and retrying",
                     self.pubkey
                 );
-                if let Err(e) = self.update_relay_lists(whitenoise).await {
+                if let Err(e) = self.update_relay_lists(shared).await {
                     tracing::warn!(
                         target: "whitenoise::users::key_package",
                         "Failed to sync relay lists for user {}: {}",
@@ -149,7 +152,7 @@ impl User {
                     );
                     return Ok(KeyPackageStatus::NotFound);
                 }
-                let lookup = self.key_package_lookup(whitenoise).await?;
+                let lookup = self.key_package_lookup(shared).await?;
                 Ok(classify_key_package_lookup(lookup))
             }
             other => Ok(other),

--- a/src/whitenoise/users/relay_sync.rs
+++ b/src/whitenoise/users/relay_sync.rs
@@ -8,12 +8,12 @@ use crate::perf_instrument;
 use crate::relay_control::RelayControlPlane;
 use crate::relay_control::ephemeral::EphemeralScope;
 use crate::whitenoise::{
-    Whitenoise,
     database::Database,
     database::processed_events::ProcessedEvent,
     error::Result,
     event_tracker::EventTracker,
     relays::{Relay, RelayType},
+    shared::SharedServices,
     users::User,
     utils::timestamp_to_datetime,
 };
@@ -21,24 +21,19 @@ use crate::whitenoise::{
 impl User {
     /// Fetches the latest relay lists for this user from Nostr and updates the local database
     #[perf_instrument("relay_sync")]
-    pub(crate) async fn update_relay_lists(&self, whitenoise: &Whitenoise) -> Result<()> {
-        let scope = whitenoise
-            .shared
-            .relay_control
-            .ephemeral()
-            .anonymous_scope();
-        self.update_relay_lists_with_scope(whitenoise, &scope)
-            .await?;
+    pub(crate) async fn update_relay_lists(&self, shared: &Arc<SharedServices>) -> Result<()> {
+        let scope = shared.relay_control.ephemeral().anonymous_scope();
+        self.update_relay_lists_with_scope(shared, &scope).await?;
         Ok(())
     }
 
     #[perf_instrument("relay_sync")]
     async fn update_relay_lists_with_scope(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         scope: &EphemeralScope,
     ) -> Result<Vec<Relay>> {
-        let initial_query_relays = self.get_query_relays(whitenoise).await?;
+        let initial_query_relays = self.get_query_relays(shared).await?;
 
         tracing::info!(
             target: "whitenoise::users::update_relay_lists",
@@ -48,10 +43,10 @@ impl User {
         );
 
         let updated_query_relays = self
-            .update_nip65_relays_with_scope(whitenoise, scope, &initial_query_relays)
+            .update_nip65_relays_with_scope(shared, scope, &initial_query_relays)
             .await?;
 
-        self.update_secondary_relay_types_with_scope(whitenoise, scope, &updated_query_relays)
+        self.update_secondary_relay_types_with_scope(shared, scope, &updated_query_relays)
             .await?;
 
         tracing::info!(
@@ -63,10 +58,11 @@ impl User {
         Ok(updated_query_relays)
     }
 
-    pub(super) async fn get_query_relays(&self, whitenoise: &Whitenoise) -> Result<Vec<Relay>> {
-        let stored_relays = self
-            .relays(RelayType::Nip65, &whitenoise.shared.database)
-            .await?;
+    pub(super) async fn get_query_relays(
+        &self,
+        shared: &Arc<SharedServices>,
+    ) -> Result<Vec<Relay>> {
+        let stored_relays = self.relays(RelayType::Nip65, &shared.database).await?;
 
         if stored_relays.is_empty() {
             tracing::debug!(
@@ -74,7 +70,7 @@ impl User {
                 "User {} has no stored NIP-65 relays, using fallback relays",
                 self.pubkey,
             );
-            let urls = whitenoise.fallback_relay_urls().await;
+            let urls = shared.fallback_relay_urls().await;
             Ok(urls.into_iter().map(|url| Relay::new(&url)).collect())
         } else {
             Ok(stored_relays)
@@ -84,33 +80,27 @@ impl User {
     #[cfg(test)]
     pub(super) async fn update_nip65_relays(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         query_relays: &[Relay],
     ) -> Result<Vec<Relay>> {
-        let scope = whitenoise
-            .shared
-            .relay_control
-            .ephemeral()
-            .anonymous_scope();
-        self.update_nip65_relays_with_scope(whitenoise, &scope, query_relays)
+        let scope = shared.relay_control.ephemeral().anonymous_scope();
+        self.update_nip65_relays_with_scope(shared, &scope, query_relays)
             .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn update_nip65_relays_with_scope(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         scope: &EphemeralScope,
         query_relays: &[Relay],
     ) -> Result<Vec<Relay>> {
         match self
-            .sync_relays_for_type_with_scope(whitenoise, scope, RelayType::Nip65, query_relays)
+            .sync_relays_for_type_with_scope(shared, scope, RelayType::Nip65, query_relays)
             .await
         {
             Ok(true) => {
-                let refreshed_relays = self
-                    .relays(RelayType::Nip65, &whitenoise.shared.database)
-                    .await?;
+                let refreshed_relays = self.relays(RelayType::Nip65, &shared.database).await?;
                 tracing::info!(
                     target: "whitenoise::users::update_nip65_relays",
                     "Updated NIP-65 relays for user {}, now using {} relays for other types",
@@ -142,22 +132,18 @@ impl User {
     #[cfg(test)]
     pub(super) async fn update_secondary_relay_types(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         query_relays: &[Relay],
     ) -> Result<()> {
-        let scope = whitenoise
-            .shared
-            .relay_control
-            .ephemeral()
-            .anonymous_scope();
-        self.update_secondary_relay_types_with_scope(whitenoise, &scope, query_relays)
+        let scope = shared.relay_control.ephemeral().anonymous_scope();
+        self.update_secondary_relay_types_with_scope(shared, &scope, query_relays)
             .await
     }
 
     #[perf_instrument("relay_sync")]
     async fn update_secondary_relay_types_with_scope(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         scope: &EphemeralScope,
         query_relays: &[Relay],
     ) -> Result<()> {
@@ -177,7 +163,7 @@ impl User {
             match relay_event_result {
                 Ok(relay_event) => {
                     if let Err(error) = self
-                        .apply_relay_event(whitenoise, relay_type, relay_event)
+                        .apply_relay_event(shared, relay_type, relay_event)
                         .await
                     {
                         tracing::warn!(
@@ -210,13 +196,13 @@ impl User {
     #[perf_instrument("relay_sync")]
     pub(crate) async fn sync_relay_urls(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         relay_type: RelayType,
         new_relay_urls: &HashSet<RelayUrl>,
         event_created_at: Option<DateTime<Utc>>,
     ) -> Result<bool> {
         self.sync_relay_urls_with_database(
-            &whitenoise.shared.database,
+            &shared.database,
             relay_type,
             new_relay_urls,
             event_created_at,
@@ -367,18 +353,14 @@ impl User {
     #[cfg(test)]
     pub(super) async fn sync_relays_for_type(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         relay_type: RelayType,
         query_relays: &[Relay],
     ) -> Result<bool> {
-        let scope = whitenoise
-            .shared
-            .relay_control
-            .ephemeral()
-            .anonymous_scope();
+        let scope = shared.relay_control.ephemeral().anonymous_scope();
         self.sync_relays_for_type_with_context(
-            &whitenoise.shared.database,
-            &whitenoise.shared.event_tracker,
+            &shared.database,
+            &shared.event_tracker,
             &scope,
             relay_type,
             query_relays,
@@ -415,14 +397,14 @@ impl User {
     #[perf_instrument("relay_sync")]
     async fn sync_relays_for_type_with_scope(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         scope: &EphemeralScope,
         relay_type: RelayType,
         query_relays: &[Relay],
     ) -> Result<bool> {
         self.sync_relays_for_type_with_context(
-            &whitenoise.shared.database,
-            &whitenoise.shared.event_tracker,
+            &shared.database,
+            &shared.event_tracker,
             scope,
             relay_type,
             query_relays,
@@ -433,13 +415,13 @@ impl User {
     #[perf_instrument("relay_sync")]
     async fn apply_relay_event(
         &self,
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
         relay_type: RelayType,
         relay_event: Option<Event>,
     ) -> Result<bool> {
         self.apply_relay_event_with_context(
-            &whitenoise.shared.database,
-            &whitenoise.shared.event_tracker,
+            &shared.database,
+            &shared.event_tracker,
             relay_type,
             relay_event,
         )
@@ -492,9 +474,9 @@ impl User {
 
     #[cfg(test)]
     pub(crate) async fn all_users_with_relay_urls(
-        whitenoise: &Whitenoise,
+        shared: &Arc<SharedServices>,
     ) -> Result<Vec<(PublicKey, Vec<RelayUrl>)>> {
-        Self::all_with_nip65_relay_urls(&whitenoise.shared.database).await
+        Self::all_with_nip65_relay_urls(&shared.database).await
     }
 }
 


### PR DESCRIPTION
![marmot](https://blossom.primal.net/b7d974be1089b8e617444589edfc5755a12801b77766f4b9a1bf5a1083d0d38c.jpg)

## What this does

Cleans up the residual phase-16 work after PR #779 killed the singleton.

- Resolves all 29 `TODO(phase-16)` markers across the codebase. 16 ignored tests are now running again, including the four `api_tests` pagination tests, the chat-list stream emit test, the MLS auto-committed proposal tests, the push-notification 446-token tests, and the media upload/sync tests.
- Drops the `test_get_whitenoise()` test-time singleton (`OnceCell<&'static Whitenoise>` plus `Box::leak`). Each of its three callers now constructs its own `Whitenoise` via `create_mock_whitenoise()`. The companion `reset_singleton_whitenoise_for_test` helper goes with it.
- Removes the four `let wn = self.session.whitenoise()?;` back-reference upgrades in `src/whitenoise/session/groups/mod.rs`. The remaining three inline upgrades there are calls to `background_refresh_account_group_subscriptions`, which still lives on `Whitenoise` because it reads `account_manager` and spawns refresh tasks.
- Migrates the helper signatures so the back-refs are no longer needed:
  - `Whitenoise::fallback_relay_urls` and `Whitenoise::resolve_member_delivery_relays` move to `SharedServices`.
  - `Account::nip65_relays`, `Account::inbox_relays`, `Account::effective_inbox_relays`, `Account::key_package_relays` now take `&Arc<SharedServices>` instead of `&Whitenoise`.
  - `User::update_relay_lists`, `User::key_package_event`, `User::key_package_status`, `User::key_package_relay_urls` (and their private helpers) take `&Arc<SharedServices>`.
- Extracts `is_debug_local_blossom_url` and `require_https` from `impl Whitenoise` to module-level free functions.
- Deletes the duplicated `Whitenoise::create_group` body and its private helpers; the deprecated wrapper now delegates to `session.groups().create_group()`.

## Why

Phase 16b removed the runtime singleton but left a trail of dead comments, ignored tests waiting on the singleton's death, and helpers that took `&Whitenoise` purely because that was the singleton-era contract. The session view files still upgraded a `Weak<Whitenoise>` back-reference on every mutation purely to call methods that only needed shared state. This PR closes those threads.

The test-time `OnceCell<&'static Whitenoise>` is the last "no static global mutable application state" violation against the rule in `docs/session-projection-rearchitecture.md`. With it gone, `cargo test --test-threads=4` is structurally unblocked.

## Scope

27 files, +680/-709, net -29 LOC. About 150 call sites updated to pass `&shared` instead of `&whitenoise`.

## Validation

`just precommit-quick` passes (fmt, docs, clippy, dead_code, tests). The pre-existing flake `whitenoise::push_notifications::tests::test_share_and_remove_cover_all_joined_groups` fails identically on a clean stashed `phase-16c`, unrelated to this work.
