### PR TITLE
Fix keyring store migration paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5569,6 +5569,7 @@ dependencies = [
  "mockito",
  "nostr-blossom",
  "nostr-sdk",
+ "once_cell",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "rpassword",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1047,7 +1047,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2578,6 +2578,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
+dependencies = [
+ "keyring-core",
+ "linux-keyutils",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,7 +2966,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4041,7 +4061,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4098,7 +4118,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4728,10 +4748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5563,6 +5583,7 @@ dependencies = [
  "indicatif",
  "infer",
  "keyring-core",
+ "linux-keyutils-keyring-store",
  "mdk-core",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
@@ -5616,7 +5637,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,14 +78,18 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-native-keyring-store"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e473c725eac862e418e7c3296059e72cdb7bbfb6ffefe625a452be988b2cd44f"
+checksum = "48c6349ddff23194f8fdce2ea8849380f5a4868c1648965b70e801e104cba9b3"
 dependencies = [
  "base64",
  "jni",
  "keyring-core",
+ "log",
  "ndk-context",
+ "regex",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -157,9 +161,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apple-native-keyring-store"
-version = "0.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afd4ee68bf127d37d2eca62ec6ddb5871b58722273c8b6809119a51b4042111"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
 dependencies = [
  "keyring-core",
  "log",
@@ -207,6 +211,126 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -412,6 +536,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -622,7 +759,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -910,7 +1047,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1018,6 +1155,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1072,6 +1236,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1271,6 +1445,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1514,6 +1701,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2095,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "keyring-core"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8286c3ab222af2fa9e57874fe419893d967f739c7bf1743f98a88678edbf08"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
 ]
@@ -2385,26 +2578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "linux-keyutils-keyring-store"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ce18cd294ff2e5de4ad61a8659a123e068859feafce12525511931f4f3d1a4"
-dependencies = [
- "keyring-core",
- "linux-keyutils",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
 dependencies = [
  "base64",
  "blurhash",
@@ -2512,12 +2685,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2538,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46#0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
 dependencies = [
  "nostr",
  "openmls",
@@ -2556,6 +2729,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2764,7 +2946,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2791,6 +2987,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2872,8 +3077,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb512bfe6a55777518853ea535c6241f069cb0e8984678c117151d2a1e7e903"
+source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "log",
  "openmls_traits",
@@ -2888,8 +3092,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983e8be1457dd6f316f409292cec334af3b57b49a19deadc925c83c3c35e15b6"
+source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -2902,8 +3105,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52c927ddb9940acb96d51aebd54b8b9c601c7119e6609622fb3f2cbe16abe3"
+source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "log",
  "openmls_traits",
@@ -2915,8 +3117,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafcc8a3552b10fbb3ab757cccaf1a34081e826ca819f49aa7e6645b1d95c00f"
+source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2940,8 +3141,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88ccdd53448dfdbfa5b8da8ba4e527c418fdb966418172bace2e3b41eedd56"
+source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "serde",
  "tls_codec",
@@ -2958,6 +3158,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "p256"
@@ -3077,6 +3287,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3341,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3204,6 +3439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3797,7 +4041,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3854,7 +4098,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3966,6 +4210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,6 +4308,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4454,10 +4728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4699,8 +4973,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4713,6 +4987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,9 +5004,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4883,6 +5187,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4988,6 +5303,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5247,7 +5563,6 @@ dependencies = [
  "indicatif",
  "infer",
  "keyring-core",
- "linux-keyutils-keyring-store",
  "mdk-core",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
@@ -5272,6 +5587,7 @@ dependencies = [
  "webpki-roots 1.0.6",
  "whitenoise-macros",
  "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -5299,7 +5615,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5345,9 +5661,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-native-keyring-store"
-version = "0.5.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e26ac29479a4b7f49d46afc9893122fc345430c6307d1fb7ac0d8d066c3f54"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
 dependencies = [
  "byteorder",
  "keyring-core",
@@ -5541,6 +5857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,6 +6001,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5797,4 +6194,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 1.0.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ apple-native-keyring-store = { version = "1", features = ["protected"] }
 windows-native-keyring-store = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+# Secret Service is the durable Linux store. Keyutils is retained only as a
+# legacy migration source for users upgrading from the old Linux backend.
+linux-keyutils-keyring-store = "1"
 zbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,11 +111,14 @@ apple-native-keyring-store = { version = "1", features = ["protected"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = "1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-# Secret Service is the durable Linux store. Keyutils is retained only as a
-# legacy migration source for users upgrading from the old Linux backend.
-linux-keyutils-keyring-store = "1"
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly"))'.dependencies]
+# Secret Service is the durable store for Linux and BSD targets.
 zbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# Keyutils is retained only as a legacy migration source for Linux users
+# upgrading from the old backend.
+linux-keyutils-keyring-store = "1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Keep the v0.5-and-earlier by-service layout for upgraded Android installs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ nostr-sdk = { version = "0.44", features = [
     "nip47",
     "nip59",
 ] }
+once_cell = "1"
 
 # LOCAL MDK FOR DEVELOPMENT
 # mdk-core = { version = "0.7.1", path="../mdk/crates/mdk-core" }
@@ -114,7 +115,9 @@ windows-native-keyring-store = "1"
 zbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-native-keyring-store = "1"
+# Keep the v0.5-and-earlier by-service layout for upgraded Android installs.
+# The v1 default Store uses named stores and cannot see existing MDK DB keys.
+android-native-keyring-store = { version = "1", features = ["legacy"] }
 
 [dev-dependencies]
 mockito = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ hex = "0.4"
 image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
-keyring-core = "0.7"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46", features = [
+keyring-core = "1"
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "0babfa763f93fbd2c12e1f1b9ce9a28ab2516e46" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [
@@ -102,19 +102,19 @@ indicatif = { version = "0.18.3", optional = true }
 # NOTE: apple_native_keyring_store::protected::Store requires the binary to be
 #   code-signed with a provisioning profile. The `cli` feature automatically
 #   selects keychain::Store instead, so CLI builds work without signing.
-apple-native-keyring-store = { version = "0.2", features = ["keychain", "protected"] }
+apple-native-keyring-store = { version = "1", features = ["keychain", "protected"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-apple-native-keyring-store = { version = "0.2", features = ["protected"] }
+apple-native-keyring-store = { version = "1", features = ["protected"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-native-keyring-store = "0.5"
+windows-native-keyring-store = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-linux-keyutils-keyring-store = "0.2"
+zbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-native-keyring-store = "0.5"
+android-native-keyring-store = "1"
 
 [dev-dependencies]
 mockito = "1.2"

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -20,13 +20,13 @@ wn (client)                         wnd (daemon)
 
 **IPC protocol:** Newline-delimited JSON. Request is a serde-tagged enum (`{"method": "...", "params": {...}}`). Response has `result`, `error`, and `stream_end` fields.
 
-## Linux Keyring Requirements
+## Linux and BSD Keyring Requirements
 
-The CLI can be installed on headless Linux, but `wnd` must be able to open a
-Freedesktop Secret Service store at runtime. On Linux, Whitenoise stores new
-secrets in Secret Service and only reads keyutils as a legacy migration source.
-If no Secret Service provider is installed, running, and unlockable, daemon
-startup fails with a keyring unavailable error.
+The CLI can be installed on headless Linux and BSD systems, but `wnd` must be
+able to open a Freedesktop Secret Service store at runtime. On these targets,
+Whitenoise stores new secrets in Secret Service. Linux also reads keyutils as a
+legacy migration source. If no Secret Service provider is installed, running,
+and unlockable, daemon startup fails with a keyring unavailable error.
 
 Install a session D-Bus service and a provider for `org.freedesktop.secrets`.
 GNOME Keyring is the recommended provider for CLI and headless use:
@@ -36,6 +36,10 @@ GNOME Keyring is the recommended provider for CLI and headless use:
 | Debian/Ubuntu | `dbus-user-session gnome-keyring libsecret-tools` |
 | Fedora/RHEL | `dbus gnome-keyring libsecret` |
 | Arch | `dbus gnome-keyring libsecret` |
+| FreeBSD | `dbus gnome-keyring libsecret` |
+| OpenBSD | `dbus gnome-keyring libsecret` |
+| NetBSD/pkgsrc | `dbus gnome-keyring libsecret` |
+| DragonFly BSD | `dbus gnome-keyring libsecret` |
 
 `libsecret-tools`/`libsecret` provides `secret-tool`, which is useful for a
 quick check:

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -20,6 +20,42 @@ wn (client)                         wnd (daemon)
 
 **IPC protocol:** Newline-delimited JSON. Request is a serde-tagged enum (`{"method": "...", "params": {...}}`). Response has `result`, `error`, and `stream_end` fields.
 
+## Linux Keyring Requirements
+
+The CLI can be installed on headless Linux, but `wnd` must be able to open a
+Freedesktop Secret Service store at runtime. On Linux, Whitenoise stores new
+secrets in Secret Service and only reads keyutils as a legacy migration source.
+If no Secret Service provider is installed, running, and unlockable, daemon
+startup fails with a keyring unavailable error.
+
+Install a session D-Bus service and a provider for `org.freedesktop.secrets`.
+GNOME Keyring is the recommended provider for CLI and headless use:
+
+| Distribution | Packages |
+| ------------ | -------- |
+| Debian/Ubuntu | `dbus-user-session gnome-keyring libsecret-tools` |
+| Fedora/RHEL | `dbus gnome-keyring libsecret` |
+| Arch | `dbus gnome-keyring libsecret` |
+
+`libsecret-tools`/`libsecret` provides `secret-tool`, which is useful for a
+quick check:
+
+```sh
+printf 'test-secret' | secret-tool store --label='Whitenoise test' app whitenoise-test
+secret-tool lookup app whitenoise-test
+secret-tool clear app whitenoise-test
+```
+
+Headless systems also need a user session bus and an unlocked keyring. Desktop
+sessions usually start and unlock these through login/PAM. Minimal servers may
+need explicit setup for `gnome-keyring-daemon` and the user D-Bus environment.
+
+Other Secret Service providers can work if they own `org.freedesktop.secrets`.
+KeePassXC works when the app and database are running and Secret Service
+integration is enabled. KWallet/KSecretService is not recommended for Whitenoise
+yet because current MDK database keys are binary secrets, and KWallet-backed
+Secret Service implementations can require UTF-8 encoded values.
+
 ## Commands
 
 ### Identity & Auth

--- a/src/integration_tests/scenarios/follow_management.rs
+++ b/src/integration_tests/scenarios/follow_management.rs
@@ -9,6 +9,8 @@ use crate::integration_tests::{
 };
 use crate::{Whitenoise, WhitenoiseError};
 
+const CONTACT_LIST_SETTLE_DELAY: Duration = Duration::from_secs(2);
+
 pub struct FollowManagementScenario {
     context: ScenarioContext,
 }
@@ -46,24 +48,28 @@ impl Scenario for FollowManagementScenario {
         // Without this, rapid follow/unfollow can produce ContactList events with
         // identical second-precision timestamps, causing the relay to reject the
         // newer event ("replaced: have newer event") and leaving stale state.
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(CONTACT_LIST_SETTLE_DELAY).await;
 
         // Test following a second user
         FollowUserTestCase::new("follow_mgmt_follower", test_contact2)
             .execute(&mut self.context)
             .await?;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(CONTACT_LIST_SETTLE_DELAY).await;
 
         // Test unfollowing the first user
         UnfollowUserTestCase::new("follow_mgmt_follower", test_contact1)
             .execute(&mut self.context)
             .await?;
 
+        tokio::time::sleep(CONTACT_LIST_SETTLE_DELAY).await;
+
         // Test error handling: try to follow the same user again (should succeed without error)
         FollowUserTestCase::new("follow_mgmt_follower", test_contact2)
             .execute(&mut self.context)
             .await?;
+
+        tokio::time::sleep(CONTACT_LIST_SETTLE_DELAY).await;
 
         // Test error handling: try to unfollow a non-existent follow relationship
         let non_existent_contact = Keys::generate().public_key();

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -260,3 +260,28 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for WhitenoiseError {
         Self::Internal(err.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyring_unavailable_display_includes_reason() {
+        let err = WhitenoiseError::KeyringUnavailable("Secret Service locked".to_string());
+
+        assert_eq!(
+            err.to_string(),
+            "Keyring storage unavailable: Secret Service locked"
+        );
+    }
+
+    #[test]
+    fn boxed_error_converts_to_internal_error() {
+        let boxed: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::other("boxed failure"));
+
+        let err = WhitenoiseError::from(boxed);
+
+        assert!(matches!(err, WhitenoiseError::Internal(msg) if msg == "boxed failure"));
+    }
+}

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -29,6 +29,9 @@ pub enum WhitenoiseError {
     #[error("Configuration error: {0}")]
     Configuration(String),
 
+    #[error("Keyring storage unavailable: {0}")]
+    KeyringUnavailable(String),
+
     #[error("Contact list error: {0}")]
     ContactList(String),
 

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -266,16 +266,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn keyring_unavailable_display_includes_reason() {
-        let err = WhitenoiseError::KeyringUnavailable("Secret Service locked".to_string());
-
-        assert_eq!(
-            err.to_string(),
-            "Keyring storage unavailable: Secret Service locked"
-        );
-    }
-
-    #[test]
     fn boxed_error_converts_to_internal_error() {
         let boxed: Box<dyn std::error::Error + Send + Sync> =
             Box::new(std::io::Error::other("boxed failure"));

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -29,9 +29,6 @@ pub enum WhitenoiseError {
     #[error("Configuration error: {0}")]
     Configuration(String),
 
-    #[error("Keyring storage unavailable: {0}")]
-    KeyringUnavailable(String),
-
     #[error("Contact list error: {0}")]
     ContactList(String),
 

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -237,6 +237,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingStore {
         build_modifiers: Mutex<Vec<HashMap<String, String>>>,
+        credentials: Mutex<HashMap<(String, String), Arc<RecordingCredential>>>,
         search_specs: Mutex<Vec<HashMap<String, String>>>,
     }
 
@@ -272,15 +273,26 @@ mod tests {
 
         fn build(
             &self,
-            _service: &str,
-            _user: &str,
+            service: &str,
+            user: &str,
             modifiers: Option<&HashMap<&str, &str>>,
         ) -> Result<Entry> {
             self.build_modifiers
                 .lock()
                 .unwrap()
                 .push(owned_map(modifiers));
-            Ok(Entry::new_with_credential(Arc::new(TestCredential)))
+            let mut credentials = self.credentials.lock().unwrap();
+            let credential = credentials
+                .entry((service.to_string(), user.to_string()))
+                .or_insert_with(|| {
+                    Arc::new(RecordingCredential {
+                        service: service.to_string(),
+                        user: user.to_string(),
+                        secret: Mutex::new(None),
+                    })
+                })
+                .clone();
+            Ok(Entry::new_with_credential(credential))
         }
 
         fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
@@ -289,6 +301,43 @@ mod tests {
                 .unwrap()
                 .push(owned_map(Some(spec)));
             Ok(Vec::new())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingCredential {
+        service: String,
+        user: String,
+        secret: Mutex<Option<Vec<u8>>>,
+    }
+
+    impl CredentialApi for RecordingCredential {
+        fn set_secret(&self, secret: &[u8]) -> Result<()> {
+            *self.secret.lock().unwrap() = Some(secret.to_vec());
+            Ok(())
+        }
+
+        fn get_secret(&self) -> Result<Vec<u8>> {
+            self.secret.lock().unwrap().clone().ok_or(Error::NoEntry)
+        }
+
+        fn delete_credential(&self) -> Result<()> {
+            match self.secret.lock().unwrap().take() {
+                Some(_) => Ok(()),
+                None => Err(Error::NoEntry),
+            }
+        }
+
+        fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
+            Ok(None)
+        }
+
+        fn get_specifiers(&self) -> Option<(String, String)> {
+            Some((self.service.clone(), self.user.clone()))
         }
 
         fn as_any(&self) -> &dyn Any {
@@ -491,6 +540,30 @@ mod tests {
     fn target_is_non_default_for_wsl() {
         assert_eq!(LINUX_SECRET_SERVICE_TARGET, "whitenoise");
         assert_ne!(LINUX_SECRET_SERVICE_TARGET, "default");
+    }
+
+    #[test]
+    fn targeted_primary_store_migrates_legacy_secret() {
+        let primary_inner = Arc::new(RecordingStore::default());
+        let primary: Arc<CredentialStore> =
+            TargetedCredentialStore::new(primary_inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let legacy_entry = legacy
+            .build("com.whitenoise.app", "mdk.db.key.pubkey", None)
+            .unwrap();
+        legacy_entry.set_secret(b"legacy-mdk-key").unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "mdk.db.key.pubkey", None)
+            .unwrap();
+
+        assert_eq!(entry.get_secret().unwrap(), b"legacy-mdk-key");
+        assert_eq!(
+            primary_inner.last_build_modifier("target"),
+            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+        );
+        assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
     }
 
     #[test]

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -375,6 +375,13 @@ mod tests {
         }
 
         fn get_secret(&self) -> Result<Vec<u8>> {
+            if self.secret.is_empty() {
+                return Err(Error::Invalid(
+                    "legacy get".to_string(),
+                    "failed".to_string(),
+                ));
+            }
+
             Ok(self.secret.clone())
         }
 
@@ -420,6 +427,23 @@ mod tests {
     }
 
     #[test]
+    fn targeted_store_delegates_metadata_to_inner_store() {
+        let inner = Arc::new(RecordingStore::default());
+        assert!(format!("{inner:?}").contains("RecordingStore"));
+        let store: Arc<CredentialStore> =
+            TargetedCredentialStore::new(inner, LINUX_SECRET_SERVICE_TARGET);
+
+        assert_eq!(store.vendor(), "test-store");
+        assert_eq!(store.id(), "test-store");
+        assert!(matches!(
+            store.persistence(),
+            CredentialPersistence::UntilDelete
+        ));
+        assert!(store.as_any().is::<TargetedCredentialStore>());
+        assert!(format!("{store:?}").contains("TargetedCredentialStore"));
+    }
+
+    #[test]
     fn build_preserves_explicit_target() {
         let inner = Arc::new(RecordingStore::default());
         let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
@@ -448,9 +472,41 @@ mod tests {
     }
 
     #[test]
+    fn search_preserves_explicit_target() {
+        let inner = Arc::new(RecordingStore::default());
+        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let spec = HashMap::from([("service", "service"), ("target", "explicit")]);
+
+        store.search(&spec).unwrap();
+
+        assert_eq!(
+            inner.last_search_spec("target"),
+            Some("explicit".to_string())
+        );
+    }
+
+    #[test]
     fn target_is_non_default_for_wsl() {
         assert_eq!(LINUX_SECRET_SERVICE_TARGET, "whitenoise");
         assert_ne!(LINUX_SECRET_SERVICE_TARGET, "default");
+    }
+
+    #[test]
+    fn legacy_migration_store_delegates_metadata_and_search_to_primary() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let store: Arc<CredentialStore> = LegacyMigrationCredentialStore::new(primary, legacy);
+        let spec = HashMap::from([("service", "com.whitenoise.app")]);
+
+        assert!(store.vendor().contains("with legacy migration from"));
+        assert!(store.id().contains("with legacy migration"));
+        assert!(matches!(
+            store.persistence(),
+            CredentialPersistence::ProcessOnly
+        ));
+        assert!(store.as_any().is::<LegacyMigrationCredentialStore>());
+        assert!(format!("{store:?}").contains("LegacyMigrationCredentialStore"));
+        assert!(store.search(&spec).unwrap().is_empty());
     }
 
     #[test]
@@ -498,6 +554,129 @@ mod tests {
     }
 
     #[test]
+    fn legacy_migration_store_sets_primary_secret() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary.clone(), legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        entry.set_secret(b"new-db-key").unwrap();
+
+        assert_eq!(
+            primary
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            b"new-db-key"
+        );
+    }
+
+    #[test]
+    fn legacy_migration_store_returns_legacy_get_error() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = Arc::new(DeleteFailureStore { secret: Vec::new() });
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let result = entry.get_secret();
+
+        assert!(matches!(result, Err(Error::Invalid(field, _)) if field == "legacy get"));
+    }
+
+    #[test]
+    fn legacy_migration_credential_exposes_specifiers_and_debug() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap()
+            .set_secret(b"primary-db-key")
+            .unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+
+        assert_eq!(
+            entry.get_credential().unwrap().get_secret().unwrap(),
+            b"primary-db-key"
+        );
+        assert_eq!(
+            entry.get_specifiers(),
+            Some((
+                "com.whitenoise.app".to_string(),
+                "whitenoise.db.key.v1".to_string()
+            ))
+        );
+        assert!(entry.as_any().is::<LegacyMigrationCredential>());
+        assert!(format!("{entry:?}").contains("LegacyMigrationCredential"));
+    }
+
+    #[test]
+    fn legacy_migration_store_deletes_primary_and_legacy_entries() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let primary_entry = primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let legacy_entry = legacy
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        primary_entry.set_secret(b"primary-db-key").unwrap();
+        legacy_entry.set_secret(b"legacy-db-key").unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+
+        entry.delete_credential().unwrap();
+        assert!(matches!(primary_entry.get_secret(), Err(Error::NoEntry)));
+        assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn legacy_migration_store_delete_returns_no_entry_when_both_stores_are_empty() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let result = entry.delete_credential();
+
+        assert!(matches!(result, Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn legacy_migration_store_delete_returns_error_when_legacy_delete_fails() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = Arc::new(DeleteFailureStore {
+            secret: b"legacy-db-key".to_vec(),
+        });
+        let store = LegacyMigrationCredentialStore::new(primary.clone(), legacy);
+        let primary_entry = primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        primary_entry.set_secret(b"primary-db-key").unwrap();
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let result = entry.delete_credential();
+
+        assert!(matches!(result, Err(Error::Invalid(field, _)) if field == "legacy delete"));
+        assert!(matches!(primary_entry.get_secret(), Err(Error::NoEntry)));
+    }
+
+    #[test]
     fn legacy_migration_store_returns_error_when_legacy_delete_fails() {
         let primary = keyring_core::mock::Store::new().unwrap();
         let legacy_secret = b"legacy-db-key".to_vec();
@@ -520,5 +699,56 @@ mod tests {
                 .unwrap(),
             legacy_secret
         );
+    }
+
+    #[test]
+    fn test_credential_methods_are_wired_for_store_boundaries() {
+        let credential = TestCredential;
+
+        credential.set_secret(b"secret").unwrap();
+        assert!(matches!(credential.get_secret(), Err(Error::NoEntry)));
+        credential.delete_credential().unwrap();
+        assert!(credential.get_credential().unwrap().is_none());
+        assert_eq!(credential.get_specifiers(), None);
+        assert!(credential.as_any().is::<TestCredential>());
+        assert!(format!("{credential:?}").contains("TestCredential"));
+    }
+
+    #[test]
+    fn delete_failure_store_reports_metadata_and_specifiers() {
+        let store = DeleteFailureStore {
+            secret: b"legacy-db-key".to_vec(),
+        };
+
+        assert_eq!(store.vendor(), "delete-failure-store");
+        assert_eq!(store.id(), "delete-failure-store");
+        assert!(store.as_any().is::<DeleteFailureStore>());
+        assert!(format!("{store:?}").contains("DeleteFailureStore"));
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+
+        entry.set_secret(b"ignored").unwrap();
+        assert_eq!(entry.get_secret().unwrap(), b"legacy-db-key");
+        assert_eq!(
+            entry.get_credential().unwrap().get_secret().unwrap(),
+            b"legacy-db-key"
+        );
+        assert_eq!(
+            entry.get_specifiers(),
+            Some((
+                "com.whitenoise.app".to_string(),
+                "whitenoise.db.key.v1".to_string()
+            ))
+        );
+        assert!(entry.as_any().is::<DeleteFailureCredential>());
+
+        let credential = DeleteFailureCredential {
+            service: "com.whitenoise.app".to_string(),
+            user: "whitenoise.db.key.v1".to_string(),
+            secret: b"legacy-db-key".to_vec(),
+        };
+        assert!(format!("{credential:?}").contains("DeleteFailureCredential"));
     }
 }

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -567,6 +567,39 @@ mod tests {
     }
 
     #[test]
+    fn recording_store_credentials_preserve_entry_state() {
+        let store = RecordingStore::default();
+        let entry = store
+            .build("com.whitenoise.app", "mdk.db.key.pubkey", None)
+            .unwrap();
+
+        assert!(matches!(entry.get_secret(), Err(Error::NoEntry)));
+
+        entry.set_secret(b"primary-mdk-key").unwrap();
+        assert_eq!(entry.get_secret().unwrap(), b"primary-mdk-key");
+        let rebuilt_entry = store
+            .build("com.whitenoise.app", "mdk.db.key.pubkey", None)
+            .unwrap();
+        assert_eq!(rebuilt_entry.get_secret().unwrap(), b"primary-mdk-key");
+        assert_eq!(
+            entry.get_specifiers(),
+            Some((
+                "com.whitenoise.app".to_string(),
+                "mdk.db.key.pubkey".to_string()
+            ))
+        );
+        let credential = entry
+            .as_any()
+            .downcast_ref::<RecordingCredential>()
+            .unwrap();
+        assert!(credential.get_credential().unwrap().is_none());
+        assert!(format!("{credential:?}").contains("RecordingCredential"));
+
+        entry.delete_credential().unwrap();
+        assert!(matches!(entry.delete_credential(), Err(Error::NoEntry)));
+    }
+
+    #[test]
     fn legacy_migration_store_delegates_metadata_and_search_to_primary() {
         let primary = keyring_core::mock::Store::new().unwrap();
         let legacy = keyring_core::mock::Store::new().unwrap();

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -172,7 +172,9 @@ impl LegacyMigrationCredential {
 
 impl CredentialApi for LegacyMigrationCredential {
     fn set_secret(&self, secret: &[u8]) -> Result<()> {
-        self.primary.set_secret(secret)
+        self.primary.set_secret(secret)?;
+        Self::delete_entry(&self.legacy)?;
+        Ok(())
     }
 
     fn get_secret(&self) -> Result<Vec<u8>> {
@@ -207,7 +209,7 @@ impl CredentialApi for LegacyMigrationCredential {
     }
 
     fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
-        self.get_secret().map(|_| None)
+        Ok(None)
     }
 
     fn get_specifiers(&self) -> Option<(String, String)> {
@@ -572,6 +574,62 @@ mod tests {
                 .unwrap(),
             b"new-db-key"
         );
+    }
+
+    #[test]
+    fn legacy_migration_store_set_secret_removes_stale_legacy_secret() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let legacy_entry = legacy
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        legacy_entry.set_secret(b"stale-legacy-db-key").unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary.clone(), legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        entry.set_secret(b"new-primary-db-key").unwrap();
+
+        assert_eq!(entry.get_secret().unwrap(), b"new-primary-db-key");
+        assert_eq!(
+            primary
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            b"new-primary-db-key"
+        );
+        assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn legacy_migration_store_get_credential_does_not_migrate_legacy_secret() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let primary_entry = primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let legacy_entry = legacy
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        legacy_entry.set_secret(b"legacy-db-key").unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let credential = entry.get_credential().unwrap();
+
+        assert!(matches!(primary_entry.get_secret(), Err(Error::NoEntry)));
+        assert_eq!(legacy_entry.get_secret().unwrap(), b"legacy-db-key");
+        assert_eq!(credential.get_secret().unwrap(), b"legacy-db-key");
+        assert_eq!(
+            primary_entry.get_secret().unwrap(),
+            b"legacy-db-key",
+            "migration should happen on the explicit secret read"
+        );
+        assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
     }
 
     #[test]

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -165,7 +165,7 @@ impl LegacyMigrationCredential {
 
     fn migrate_legacy_secret(&self, secret: Vec<u8>) -> Result<Vec<u8>> {
         self.primary.set_secret(&secret)?;
-        let _ = Self::delete_entry(&self.legacy);
+        Self::delete_entry(&self.legacy)?;
         Ok(secret)
     }
 }
@@ -323,6 +323,81 @@ mod tests {
         }
     }
 
+    struct DeleteFailureStore {
+        secret: Vec<u8>,
+    }
+
+    impl fmt::Debug for DeleteFailureStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("DeleteFailureStore").finish()
+        }
+    }
+
+    impl CredentialStoreApi for DeleteFailureStore {
+        fn vendor(&self) -> String {
+            "delete-failure-store".to_string()
+        }
+
+        fn id(&self) -> String {
+            "delete-failure-store".to_string()
+        }
+
+        fn build(
+            &self,
+            service: &str,
+            user: &str,
+            _modifiers: Option<&HashMap<&str, &str>>,
+        ) -> Result<Entry> {
+            Ok(Entry::new_with_credential(Arc::new(
+                DeleteFailureCredential {
+                    service: service.to_string(),
+                    user: user.to_string(),
+                    secret: self.secret.clone(),
+                },
+            )))
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct DeleteFailureCredential {
+        service: String,
+        user: String,
+        secret: Vec<u8>,
+    }
+
+    impl CredentialApi for DeleteFailureCredential {
+        fn set_secret(&self, _secret: &[u8]) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_secret(&self) -> Result<Vec<u8>> {
+            Ok(self.secret.clone())
+        }
+
+        fn delete_credential(&self) -> Result<()> {
+            Err(Error::Invalid(
+                "legacy delete".to_string(),
+                "failed".to_string(),
+            ))
+        }
+
+        fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
+            Ok(None)
+        }
+
+        fn get_specifiers(&self) -> Option<(String, String)> {
+            Some((self.service.clone(), self.user.clone()))
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
     fn owned_map(modifiers: Option<&HashMap<&str, &str>>) -> HashMap<String, String> {
         modifiers
             .into_iter()
@@ -420,5 +495,30 @@ mod tests {
             .unwrap();
 
         assert_eq!(entry.get_secret().unwrap(), b"primary-db-key");
+    }
+
+    #[test]
+    fn legacy_migration_store_returns_error_when_legacy_delete_fails() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy_secret = b"legacy-db-key".to_vec();
+        let legacy = Arc::new(DeleteFailureStore {
+            secret: legacy_secret.clone(),
+        });
+        let store = LegacyMigrationCredentialStore::new(primary.clone(), legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        let result = entry.get_secret();
+
+        assert!(matches!(result, Err(Error::Invalid(field, _)) if field == "legacy delete"));
+        assert_eq!(
+            primary
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            legacy_secret
+        );
     }
 }

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -1,0 +1,424 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use keyring_core::api::{CredentialApi, CredentialStoreApi};
+use keyring_core::{Credential, CredentialPersistence, CredentialStore, Entry, Error, Result};
+
+pub(crate) const LINUX_SECRET_SERVICE_TARGET: &str = "whitenoise";
+
+pub(crate) struct TargetedCredentialStore {
+    inner: Arc<CredentialStore>,
+    target: &'static str,
+}
+
+impl TargetedCredentialStore {
+    pub(crate) fn new(inner: Arc<CredentialStore>, target: &'static str) -> Arc<Self> {
+        Arc::new(Self { inner, target })
+    }
+
+    fn with_target<'a>(
+        &'a self,
+        modifiers: Option<&HashMap<&'a str, &'a str>>,
+    ) -> HashMap<&'a str, &'a str> {
+        let mut targeted = modifiers.cloned().unwrap_or_default();
+        targeted.entry("target").or_insert(self.target);
+        targeted
+    }
+}
+
+impl fmt::Debug for TargetedCredentialStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TargetedCredentialStore")
+            .field("inner", &self.inner)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+impl CredentialStoreApi for TargetedCredentialStore {
+    fn vendor(&self) -> String {
+        self.inner.vendor()
+    }
+
+    fn id(&self) -> String {
+        self.inner.id()
+    }
+
+    fn build(
+        &self,
+        service: &str,
+        user: &str,
+        modifiers: Option<&HashMap<&str, &str>>,
+    ) -> Result<Entry> {
+        let targeted = self.with_target(modifiers);
+        self.inner.build(service, user, Some(&targeted))
+    }
+
+    fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
+        let targeted = self.with_target(Some(spec));
+        self.inner.search(&targeted)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn persistence(&self) -> CredentialPersistence {
+        self.inner.persistence()
+    }
+
+    fn debug_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+pub(crate) struct LegacyMigrationCredentialStore {
+    primary: Arc<CredentialStore>,
+    legacy: Arc<CredentialStore>,
+}
+
+impl LegacyMigrationCredentialStore {
+    pub(crate) fn new(primary: Arc<CredentialStore>, legacy: Arc<CredentialStore>) -> Arc<Self> {
+        Arc::new(Self { primary, legacy })
+    }
+}
+
+impl fmt::Debug for LegacyMigrationCredentialStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LegacyMigrationCredentialStore")
+            .field("primary", &self.primary)
+            .field("legacy", &self.legacy)
+            .finish()
+    }
+}
+
+impl CredentialStoreApi for LegacyMigrationCredentialStore {
+    fn vendor(&self) -> String {
+        format!(
+            "{} with legacy migration from {}",
+            self.primary.vendor(),
+            self.legacy.vendor()
+        )
+    }
+
+    fn id(&self) -> String {
+        format!(
+            "{} with legacy migration {}",
+            self.primary.id(),
+            self.legacy.id()
+        )
+    }
+
+    fn build(
+        &self,
+        service: &str,
+        user: &str,
+        modifiers: Option<&HashMap<&str, &str>>,
+    ) -> Result<Entry> {
+        let primary = self.primary.build(service, user, modifiers)?;
+        let legacy = self.legacy.build(service, user, modifiers)?;
+        Ok(Entry::new_with_credential(Arc::new(
+            LegacyMigrationCredential {
+                service: service.to_string(),
+                user: user.to_string(),
+                primary,
+                legacy,
+            },
+        )))
+    }
+
+    fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
+        self.primary.search(spec)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn persistence(&self) -> CredentialPersistence {
+        self.primary.persistence()
+    }
+
+    fn debug_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+#[derive(Debug)]
+struct LegacyMigrationCredential {
+    service: String,
+    user: String,
+    primary: Entry,
+    legacy: Entry,
+}
+
+impl LegacyMigrationCredential {
+    fn delete_entry(entry: &Entry) -> Result<bool> {
+        match entry.delete_credential() {
+            Ok(()) => Ok(true),
+            Err(Error::NoEntry) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn migrate_legacy_secret(&self, secret: Vec<u8>) -> Result<Vec<u8>> {
+        self.primary.set_secret(&secret)?;
+        let _ = Self::delete_entry(&self.legacy);
+        Ok(secret)
+    }
+}
+
+impl CredentialApi for LegacyMigrationCredential {
+    fn set_secret(&self, secret: &[u8]) -> Result<()> {
+        self.primary.set_secret(secret)
+    }
+
+    fn get_secret(&self) -> Result<Vec<u8>> {
+        match self.legacy.get_secret() {
+            Ok(secret) => self.migrate_legacy_secret(secret),
+            Err(Error::NoEntry) => self.primary.get_secret(),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn delete_credential(&self) -> Result<()> {
+        let mut deleted = false;
+        let mut first_error = None;
+
+        for result in [
+            Self::delete_entry(&self.primary),
+            Self::delete_entry(&self.legacy),
+        ] {
+            match result {
+                Ok(was_deleted) => deleted |= was_deleted,
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                }
+            };
+        }
+
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+
+        if deleted { Ok(()) } else { Err(Error::NoEntry) }
+    }
+
+    fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
+        self.get_secret().map(|_| None)
+    }
+
+    fn get_specifiers(&self) -> Option<(String, String)> {
+        Some((self.service.clone(), self.user.clone()))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn debug_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use keyring_core::api::CredentialApi;
+    use keyring_core::{Credential, Error};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingStore {
+        build_modifiers: Mutex<Vec<HashMap<String, String>>>,
+        search_specs: Mutex<Vec<HashMap<String, String>>>,
+    }
+
+    impl RecordingStore {
+        fn last_build_modifier(&self, key: &str) -> Option<String> {
+            self.build_modifiers
+                .lock()
+                .unwrap()
+                .last()?
+                .get(key)
+                .cloned()
+        }
+
+        fn last_search_spec(&self, key: &str) -> Option<String> {
+            self.search_specs.lock().unwrap().last()?.get(key).cloned()
+        }
+    }
+
+    impl fmt::Debug for RecordingStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("RecordingStore").finish()
+        }
+    }
+
+    impl CredentialStoreApi for RecordingStore {
+        fn vendor(&self) -> String {
+            "test-store".to_string()
+        }
+
+        fn id(&self) -> String {
+            "test-store".to_string()
+        }
+
+        fn build(
+            &self,
+            _service: &str,
+            _user: &str,
+            modifiers: Option<&HashMap<&str, &str>>,
+        ) -> Result<Entry> {
+            self.build_modifiers
+                .lock()
+                .unwrap()
+                .push(owned_map(modifiers));
+            Ok(Entry::new_with_credential(Arc::new(TestCredential)))
+        }
+
+        fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
+            self.search_specs
+                .lock()
+                .unwrap()
+                .push(owned_map(Some(spec)));
+            Ok(Vec::new())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestCredential;
+
+    impl CredentialApi for TestCredential {
+        fn set_secret(&self, _secret: &[u8]) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_secret(&self) -> Result<Vec<u8>> {
+            Err(Error::NoEntry)
+        }
+
+        fn delete_credential(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
+            Ok(None)
+        }
+
+        fn get_specifiers(&self) -> Option<(String, String)> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn owned_map(modifiers: Option<&HashMap<&str, &str>>) -> HashMap<String, String> {
+        modifiers
+            .into_iter()
+            .flat_map(HashMap::iter)
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn build_injects_default_target() {
+        let inner = Arc::new(RecordingStore::default());
+        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+
+        store.build("service", "user", None).unwrap();
+
+        assert_eq!(
+            inner.last_build_modifier("target"),
+            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+        );
+    }
+
+    #[test]
+    fn build_preserves_explicit_target() {
+        let inner = Arc::new(RecordingStore::default());
+        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let modifiers = HashMap::from([("target", "explicit")]);
+
+        store.build("service", "user", Some(&modifiers)).unwrap();
+
+        assert_eq!(
+            inner.last_build_modifier("target"),
+            Some("explicit".to_string())
+        );
+    }
+
+    #[test]
+    fn search_injects_default_target() {
+        let inner = Arc::new(RecordingStore::default());
+        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let spec = HashMap::from([("service", "service"), ("user", "user")]);
+
+        store.search(&spec).unwrap();
+
+        assert_eq!(
+            inner.last_search_spec("target"),
+            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+        );
+    }
+
+    #[test]
+    fn target_is_non_default_for_wsl() {
+        assert_eq!(LINUX_SECRET_SERVICE_TARGET, "whitenoise");
+        assert_ne!(LINUX_SECRET_SERVICE_TARGET, "default");
+    }
+
+    #[test]
+    fn legacy_migration_store_migrates_legacy_secret_to_primary_and_removes_legacy() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        let legacy_entry = legacy
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+        legacy_entry.set_secret(b"legacy-db-key").unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary.clone(), legacy.clone());
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+
+        assert_eq!(entry.get_secret().unwrap(), b"legacy-db-key");
+        assert_eq!(
+            primary
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            b"legacy-db-key"
+        );
+        assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn legacy_migration_store_reads_primary_when_legacy_secret_is_absent() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        let legacy = keyring_core::mock::Store::new().unwrap();
+        primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap()
+            .set_secret(b"primary-db-key")
+            .unwrap();
+        let store = LegacyMigrationCredentialStore::new(primary, legacy);
+
+        let entry = store
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap();
+
+        assert_eq!(entry.get_secret().unwrap(), b"primary-db-key");
+    }
+}

--- a/src/whitenoise/keyring_store.rs
+++ b/src/whitenoise/keyring_store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use keyring_core::api::{CredentialApi, CredentialStoreApi};
 use keyring_core::{Credential, CredentialPersistence, CredentialStore, Entry, Error, Result};
 
-pub(crate) const LINUX_SECRET_SERVICE_TARGET: &str = "whitenoise";
+pub(crate) const SECRET_SERVICE_TARGET: &str = "whitenoise";
 
 pub(crate) struct TargetedCredentialStore {
     inner: Arc<CredentialStore>,
@@ -467,13 +467,13 @@ mod tests {
     #[test]
     fn build_injects_default_target() {
         let inner = Arc::new(RecordingStore::default());
-        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let store = TargetedCredentialStore::new(inner.clone(), SECRET_SERVICE_TARGET);
 
         store.build("service", "user", None).unwrap();
 
         assert_eq!(
             inner.last_build_modifier("target"),
-            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+            Some(SECRET_SERVICE_TARGET.to_string())
         );
     }
 
@@ -482,7 +482,7 @@ mod tests {
         let inner = Arc::new(RecordingStore::default());
         assert!(format!("{inner:?}").contains("RecordingStore"));
         let store: Arc<CredentialStore> =
-            TargetedCredentialStore::new(inner, LINUX_SECRET_SERVICE_TARGET);
+            TargetedCredentialStore::new(inner, SECRET_SERVICE_TARGET);
 
         assert_eq!(store.vendor(), "test-store");
         assert_eq!(store.id(), "test-store");
@@ -497,7 +497,7 @@ mod tests {
     #[test]
     fn build_preserves_explicit_target() {
         let inner = Arc::new(RecordingStore::default());
-        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let store = TargetedCredentialStore::new(inner.clone(), SECRET_SERVICE_TARGET);
         let modifiers = HashMap::from([("target", "explicit")]);
 
         store.build("service", "user", Some(&modifiers)).unwrap();
@@ -511,21 +511,21 @@ mod tests {
     #[test]
     fn search_injects_default_target() {
         let inner = Arc::new(RecordingStore::default());
-        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let store = TargetedCredentialStore::new(inner.clone(), SECRET_SERVICE_TARGET);
         let spec = HashMap::from([("service", "service"), ("user", "user")]);
 
         store.search(&spec).unwrap();
 
         assert_eq!(
             inner.last_search_spec("target"),
-            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+            Some(SECRET_SERVICE_TARGET.to_string())
         );
     }
 
     #[test]
     fn search_preserves_explicit_target() {
         let inner = Arc::new(RecordingStore::default());
-        let store = TargetedCredentialStore::new(inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+        let store = TargetedCredentialStore::new(inner.clone(), SECRET_SERVICE_TARGET);
         let spec = HashMap::from([("service", "service"), ("target", "explicit")]);
 
         store.search(&spec).unwrap();
@@ -537,16 +537,16 @@ mod tests {
     }
 
     #[test]
-    fn target_is_non_default_for_wsl() {
-        assert_eq!(LINUX_SECRET_SERVICE_TARGET, "whitenoise");
-        assert_ne!(LINUX_SECRET_SERVICE_TARGET, "default");
+    fn secret_service_target_is_non_default() {
+        assert_eq!(SECRET_SERVICE_TARGET, "whitenoise");
+        assert_ne!(SECRET_SERVICE_TARGET, "default");
     }
 
     #[test]
     fn targeted_primary_store_migrates_legacy_secret() {
         let primary_inner = Arc::new(RecordingStore::default());
         let primary: Arc<CredentialStore> =
-            TargetedCredentialStore::new(primary_inner.clone(), LINUX_SECRET_SERVICE_TARGET);
+            TargetedCredentialStore::new(primary_inner.clone(), SECRET_SERVICE_TARGET);
         let legacy = keyring_core::mock::Store::new().unwrap();
         let legacy_entry = legacy
             .build("com.whitenoise.app", "mdk.db.key.pubkey", None)
@@ -561,7 +561,7 @@ mod tests {
         assert_eq!(entry.get_secret().unwrap(), b"legacy-mdk-key");
         assert_eq!(
             primary_inner.last_build_modifier("target"),
-            Some(LINUX_SECRET_SERVICE_TARGET.to_string())
+            Some(SECRET_SERVICE_TARGET.to_string())
         );
         assert!(matches!(legacy_entry.get_secret(), Err(Error::NoEntry)));
     }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1,7 +1,5 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::OnceLock;
 
 use ::rand::RngCore;
 
@@ -38,6 +36,8 @@ pub mod group_information;
 pub mod groups;
 mod init_timing;
 pub mod key_packages;
+// Platform keyring wrappers are only needed where we install a custom
+// keyring-core default store, plus tests that exercise those wrappers.
 #[cfg(any(
     test,
     all(
@@ -451,13 +451,12 @@ impl Whitenoise {
                     android_native_keyring_store::Store::new(),
                     "Android",
                 )?;
-                let legacy = Self::create_keyring_store(
+                let store = Self::create_legacy_migration_keyring_store(
+                    primary,
                     android_native_keyring_store::LegacyStore::from_ndk_context(),
                     "legacy Android",
-                )?;
-                keyring_core::set_default_store(
-                    keyring_store::LegacyMigrationCredentialStore::new(primary, legacy),
                 );
+                keyring_core::set_default_store(store);
             }
             #[cfg(not(any(
                 target_os = "macos",
@@ -491,6 +490,29 @@ impl Whitenoise {
             ))
         })?;
         Ok(store)
+    }
+
+    #[cfg(any(test, target_os = "android"))]
+    fn create_legacy_migration_keyring_store<S>(
+        primary: Arc<keyring_core::CredentialStore>,
+        legacy: keyring_core::Result<Arc<S>>,
+        legacy_store_name: &str,
+    ) -> Arc<keyring_core::CredentialStore>
+    where
+        S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
+    {
+        match Self::create_keyring_store(legacy, legacy_store_name) {
+            Ok(legacy) => keyring_store::LegacyMigrationCredentialStore::new(primary, legacy),
+            Err(err) => {
+                tracing::warn!(
+                    target: "whitenoise::keyring_store",
+                    error = %err,
+                    store = legacy_store_name,
+                    "Failed to create legacy keyring store; continuing with primary store only"
+                );
+                primary
+            }
+        }
     }
 
     fn set_default_keyring_store<S>(
@@ -552,10 +574,6 @@ impl Whitenoise {
     pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<()> {
         init_timing::start();
 
-        // Ensure keyring-core has a credential store before any MDK or
-        // SecretsStore operations attempt to create or read keyring entries.
-        Self::initialize_keyring_store()?;
-
         // Validate keyring_service_id is not empty or whitespace
         let keyring_service_id = config.keyring_service_id.trim().to_string();
         if keyring_service_id.is_empty() {
@@ -563,6 +581,10 @@ impl Whitenoise {
                 "keyring_service_id cannot be empty or whitespace".to_string(),
             ));
         }
+
+        // Ensure keyring-core has a credential store before any MDK or
+        // SecretsStore operations attempt to create or read keyring entries.
+        Self::initialize_keyring_store()?;
 
         // Create event processing channels
         let (event_sender, event_receiver) = mpsc::channel(2000);
@@ -956,6 +978,7 @@ impl Whitenoise {
 
 #[cfg(test)]
 pub mod test_utils {
+    use std::sync::OnceLock;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
@@ -1467,6 +1490,8 @@ pub mod test_utils {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use keyring_core::api::CredentialStoreApi;
+
     use super::test_utils::*;
     use super::*;
     use database::aggregated_messages::PaginationOptions;
@@ -1505,12 +1530,20 @@ mod tests {
     }
 
     #[test]
-    fn keyring_store_init_preserves_existing_default_store() {
+    fn keyring_store_init_skips_initializer_when_default_store_exists() {
         let init = KeyringStoreInit::new();
+        let attempts = AtomicUsize::new(0);
 
-        let result = init.initialize_with(|| true, || panic!("initializer ran for existing store"));
+        let result = init.initialize_with(
+            || true,
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        );
 
         assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -1529,6 +1562,34 @@ mod tests {
                 if msg.contains("Failed to create test credential store")
                     && msg.contains("boom")
         ));
+    }
+
+    #[test]
+    fn legacy_migration_keyring_store_falls_back_to_primary_when_legacy_store_creation_fails() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap()
+            .set_secret(b"primary-db-key")
+            .unwrap();
+
+        let store = Whitenoise::create_legacy_migration_keyring_store::<keyring_core::mock::Store>(
+            primary,
+            Err(keyring_core::Error::Invalid(
+                "legacy Android".to_string(),
+                "missing NDK context".to_string(),
+            )),
+            "legacy Android",
+        );
+
+        assert_eq!(
+            store
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            b"primary-db-key"
+        );
     }
 
     // Configuration Tests

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::OnceLock;
 
 use ::rand::RngCore;
 
@@ -7,6 +9,7 @@ use dashmap::DashMap;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::NostrSigner;
 use nostr_sdk::{EventId, PublicKey, RelayUrl};
+use once_cell::sync::OnceCell as SyncOnceCell;
 use tokio::sync::{
     Mutex, OnceCell, Semaphore,
     mpsc::{self, Sender},
@@ -35,6 +38,8 @@ pub mod group_information;
 pub mod groups;
 mod init_timing;
 pub mod key_packages;
+#[cfg(any(target_os = "linux", target_os = "android", test))]
+mod keyring_store;
 pub mod media_files;
 pub mod message_aggregator;
 pub mod message_streaming;
@@ -75,6 +80,38 @@ use relays::*;
 use secrets_store::SecretsStore;
 #[cfg(test)]
 use users::User;
+
+struct KeyringStoreInit {
+    initialized: SyncOnceCell<()>,
+}
+
+impl KeyringStoreInit {
+    const fn new() -> Self {
+        Self {
+            initialized: SyncOnceCell::new(),
+        }
+    }
+
+    fn initialize_with<DefaultStoreExists, InitializeStore>(
+        &self,
+        default_store_exists: DefaultStoreExists,
+        initialize_store: InitializeStore,
+    ) -> Result<()>
+    where
+        DefaultStoreExists: Fn() -> bool,
+        InitializeStore: FnOnce() -> Result<()>,
+    {
+        self.initialized
+            .get_or_try_init(|| {
+                if default_store_exists() {
+                    return Ok(());
+                }
+
+                initialize_store()
+            })
+            .map(|_| ())
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct WhitenoiseConfig {
@@ -321,99 +358,138 @@ impl Whitenoise {
     /// This function is safe to call multiple times; only the first call has
     /// an effect. If another crate or host application has already configured
     /// a `keyring-core` default store, that store is preserved.
-    fn initialize_keyring_store() {
-        static KEYRING_STORE_INIT: OnceLock<()> = OnceLock::new();
-        KEYRING_STORE_INIT.get_or_init(|| {
-            if keyring_core::get_default_store().is_some() {
-                return;
-            }
+    fn initialize_keyring_store() -> Result<()> {
+        static KEYRING_STORE_INIT: KeyringStoreInit = KeyringStoreInit::new();
+        KEYRING_STORE_INIT.initialize_with(
+            || keyring_core::get_default_store().is_some(),
+            Self::initialize_platform_keyring_store,
+        )
+    }
 
-            // Use the mock (in-memory) store in test, integration-test, and
-            // benchmark-test builds so that `cargo test` and unsigned `cargo run`
-            // binaries never require real platform keychain entitlements.
-            // The real store is reserved for production builds (no feature flags).
-            #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
+    fn initialize_platform_keyring_store() -> Result<()> {
+        // Use the mock (in-memory) store in test, integration-test, and
+        // benchmark-test builds so that `cargo test` and unsigned `cargo run`
+        // binaries never require real platform keychain entitlements.
+        // The real store is reserved for production builds (no feature flags).
+        #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
+        {
+            let store = keyring_core::mock::Store::new().map_err(|e| {
+                WhitenoiseError::KeyringUnavailable(format!(
+                    "Failed to create mock credential store: {e}"
+                ))
+            })?;
+            keyring_core::set_default_store(store);
+        }
+
+        #[cfg(all(
+            not(test),
+            not(feature = "integration-tests"),
+            not(feature = "benchmark-tests")
+        ))]
+        {
+            // CLI builds use the regular Keychain store on all macOS architectures.
+            // The `cli` feature gates the `wn`/`wnd` binaries, which are unsigned
+            // and cannot use the Protected Data store (it requires a provisioning
+            // profile with application-groups entitlement).
+            #[cfg(all(target_os = "macos", feature = "cli"))]
             {
+                let store = apple_native_keyring_store::keychain::Store::new().map_err(|e| {
+                    WhitenoiseError::KeyringUnavailable(format!(
+                        "Failed to create macOS Keychain credential store: {e}"
+                    ))
+                })?;
+                keyring_core::set_default_store(store);
+            }
+            // Intel Macs (non-CLI): use the regular Keychain store.
+            // Protected Data store is not available on x86_64.
+            #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "cli")))]
+            {
+                let store = apple_native_keyring_store::keychain::Store::new().map_err(|e| {
+                    WhitenoiseError::KeyringUnavailable(format!(
+                        "Failed to create macOS Keychain credential store: {e}"
+                    ))
+                })?;
+                keyring_core::set_default_store(store);
+            }
+            // Apple Silicon (non-CLI): use the Protected Data store (audit #630).
+            // Requires code-signing with a provisioning profile that includes the
+            // com.apple.security.application-groups entitlement. The Flutter app
+            // build pipeline satisfies this.
+            #[cfg(all(target_os = "macos", target_arch = "aarch64", not(feature = "cli")))]
+            {
+                let store = apple_native_keyring_store::protected::Store::new().map_err(|e| {
+                    WhitenoiseError::KeyringUnavailable(format!(
+                        "Failed to create macOS protected-data credential store: {e}"
+                    ))
+                })?;
+                keyring_core::set_default_store(store);
+            }
+            #[cfg(target_os = "ios")]
+            {
+                let store = apple_native_keyring_store::protected::Store::new().map_err(|e| {
+                    WhitenoiseError::KeyringUnavailable(format!(
+                        "Failed to create iOS protected-data credential store: {e}"
+                    ))
+                })?;
+                keyring_core::set_default_store(store);
+            }
+            #[cfg(target_os = "windows")]
+            {
+                let store = windows_native_keyring_store::Store::new().map_err(|e| {
+                    WhitenoiseError::KeyringUnavailable(format!(
+                        "Failed to create Windows credential store: {e}"
+                    ))
+                })?;
+                keyring_core::set_default_store(store);
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let store: Arc<keyring_core::CredentialStore> =
+                    zbus_secret_service_keyring_store::Store::new().map_err(|e| {
+                        WhitenoiseError::KeyringUnavailable(format!(
+                            "Failed to create Linux Secret Service credential store: {e}"
+                        ))
+                    })?;
+                keyring_core::set_default_store(keyring_store::TargetedCredentialStore::new(
+                    store,
+                    keyring_store::LINUX_SECRET_SERVICE_TARGET,
+                ));
+            }
+            #[cfg(target_os = "android")]
+            {
+                let primary: Arc<keyring_core::CredentialStore> =
+                    android_native_keyring_store::Store::new().map_err(|e| {
+                        WhitenoiseError::KeyringUnavailable(format!(
+                            "Failed to create Android credential store: {e}"
+                        ))
+                    })?;
+                let legacy: Arc<keyring_core::CredentialStore> =
+                    android_native_keyring_store::LegacyStore::from_ndk_context().map_err(|e| {
+                        WhitenoiseError::KeyringUnavailable(format!(
+                            "Failed to create legacy Android credential store: {e}"
+                        ))
+                    })?;
                 keyring_core::set_default_store(
-                    keyring_core::mock::Store::new()
-                        .expect("Failed to create mock credential store"),
+                    keyring_store::LegacyMigrationCredentialStore::new(primary, legacy),
                 );
             }
-
-            #[cfg(all(
-                not(test),
-                not(feature = "integration-tests"),
-                not(feature = "benchmark-tests")
-            ))]
+            #[cfg(not(any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "windows",
+                target_os = "linux",
+                target_os = "android",
+            )))]
             {
-                // CLI builds use the regular Keychain store on all macOS architectures.
-                // The `cli` feature gates the `wn`/`wnd` binaries, which are unsigned
-                // and cannot use the Protected Data store (it requires a provisioning
-                // profile with application-groups entitlement).
-                #[cfg(all(target_os = "macos", feature = "cli"))]
-                {
-                    let store = apple_native_keyring_store::keychain::Store::new()
-                        .expect("Failed to create macOS Keychain credential store");
-                    keyring_core::set_default_store(store);
-                }
-                // Intel Macs (non-CLI): use the regular Keychain store.
-                // Protected Data store is not available on x86_64.
-                #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "cli")))]
-                {
-                    let store = apple_native_keyring_store::keychain::Store::new()
-                        .expect("Failed to create macOS Keychain credential store");
-                    keyring_core::set_default_store(store);
-                }
-                // Apple Silicon (non-CLI): use the Protected Data store (audit #630).
-                // Requires code-signing with a provisioning profile that includes the
-                // com.apple.security.application-groups entitlement. The Flutter app
-                // build pipeline satisfies this.
-                #[cfg(all(target_os = "macos", target_arch = "aarch64", not(feature = "cli")))]
-                {
-                    let store = apple_native_keyring_store::protected::Store::new()
-                        .expect("Failed to create macOS protected-data credential store");
-                    keyring_core::set_default_store(store);
-                }
-                #[cfg(target_os = "ios")]
-                {
-                    let store = apple_native_keyring_store::protected::Store::new()
-                        .expect("Failed to create iOS protected-data credential store");
-                    keyring_core::set_default_store(store);
-                }
-                #[cfg(target_os = "windows")]
-                {
-                    let store = windows_native_keyring_store::Store::new()
-                        .expect("Failed to create Windows credential store");
-                    keyring_core::set_default_store(store);
-                }
-                #[cfg(target_os = "linux")]
-                {
-                    let store = zbus_secret_service_keyring_store::Store::new()
-                        .expect("Failed to create Linux Secret Service credential store");
-                    keyring_core::set_default_store(store);
-                }
-                #[cfg(target_os = "android")]
-                {
-                    let store = android_native_keyring_store::Store::new()
-                        .expect("Failed to create Android credential store");
-                    keyring_core::set_default_store(store);
-                }
-                #[cfg(not(any(
-                    target_os = "macos",
-                    target_os = "ios",
-                    target_os = "windows",
-                    target_os = "linux",
-                    target_os = "android",
-                )))]
-                {
-                    compile_error!(
-                        "No keyring-core credential store available for this target OS. \
-                         Add a platform-specific store crate to Cargo.toml and handle it \
-                         in initialize_keyring_store()."
-                    );
-                }
+                compile_error!(
+                    "No keyring-core credential store available for this target OS. \
+                     Add a platform-specific store crate to Cargo.toml and handle it \
+                     in initialize_keyring_store()."
+                );
             }
-        });
+        }
+
+        Ok(())
     }
 
     /// Initializes the mock keyring store for testing environments.
@@ -434,7 +510,7 @@ impl Whitenoise {
     /// ```
     #[cfg(any(test, feature = "integration-tests"))]
     pub fn initialize_mock_keyring_store() {
-        Self::initialize_keyring_store();
+        Self::initialize_keyring_store().expect("Failed to initialize mock keyring store");
     }
 
     /// Creates an MDK instance for the given account public key using this
@@ -465,7 +541,7 @@ impl Whitenoise {
 
         // Ensure keyring-core has a credential store before any MDK or
         // SecretsStore operations attempt to create or read keyring entries.
-        Self::initialize_keyring_store();
+        Self::initialize_keyring_store()?;
 
         // Validate keyring_service_id is not empty or whitespace
         let keyring_service_id = config.keyring_service_id.trim().to_string();
@@ -1376,9 +1452,69 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
     use super::test_utils::*;
     use super::*;
     use database::aggregated_messages::PaginationOptions;
+
+    #[test]
+    fn keyring_store_init_retries_after_failed_attempt() {
+        let init = KeyringStoreInit::new();
+        let attempts = AtomicUsize::new(0);
+
+        let first = init.initialize_with(
+            || false,
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(WhitenoiseError::KeyringUnavailable(
+                    "transient failure".to_string(),
+                ))
+            },
+        );
+
+        assert!(matches!(first, Err(WhitenoiseError::KeyringUnavailable(_))));
+
+        let second = init.initialize_with(
+            || false,
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        );
+
+        assert!(second.is_ok());
+
+        let third = init.initialize_with(
+            || false,
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(WhitenoiseError::KeyringUnavailable(
+                    "should not run after success".to_string(),
+                ))
+            },
+        );
+
+        assert!(third.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn keyring_store_init_preserves_existing_default_store() {
+        let init = KeyringStoreInit::new();
+        let initializer_called = AtomicBool::new(false);
+
+        let result = init.initialize_with(
+            || true,
+            || {
+                initializer_called.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(!initializer_called.load(Ordering::SeqCst));
+    }
 
     // Configuration Tests
     mod config_tests {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -527,10 +527,34 @@ impl Whitenoise {
     fn create_secret_service_keyring_store(
         store_name: &str,
     ) -> Result<Arc<keyring_core::CredentialStore>> {
-        let store = Self::create_keyring_store(
+        Self::create_targeted_secret_service_keyring_store(
             zbus_secret_service_keyring_store::Store::new(),
             store_name,
-        )?;
+        )
+    }
+
+    #[cfg(any(
+        test,
+        all(
+            any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "dragonfly"
+            ),
+            not(feature = "integration-tests"),
+            not(feature = "benchmark-tests")
+        )
+    ))]
+    fn create_targeted_secret_service_keyring_store<S>(
+        store: keyring_core::Result<Arc<S>>,
+        store_name: &str,
+    ) -> Result<Arc<keyring_core::CredentialStore>>
+    where
+        S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
+    {
+        let store = Self::create_keyring_store(store, store_name)?;
         Ok(keyring_store::TargetedCredentialStore::new(
             store,
             keyring_store::SECRET_SERVICE_TARGET,
@@ -1620,6 +1644,43 @@ mod tests {
             ))
                 if msg.contains("Failed to create test credential store")
                     && msg.contains("boom")
+        ));
+    }
+
+    #[test]
+    fn secret_service_keyring_store_wraps_store_with_target() {
+        let store = Whitenoise::create_targeted_secret_service_keyring_store(
+            keyring_core::mock::Store::new(),
+            "test Secret Service",
+        )
+        .unwrap();
+
+        assert!(
+            store
+                .as_any()
+                .is::<keyring_store::TargetedCredentialStore>()
+        );
+        assert!(format!("{store:?}").contains(keyring_store::SECRET_SERVICE_TARGET));
+    }
+
+    #[test]
+    fn secret_service_keyring_store_maps_creation_error() {
+        let result =
+            Whitenoise::create_targeted_secret_service_keyring_store::<keyring_core::mock::Store>(
+                Err(keyring_core::Error::Invalid(
+                    "Secret Service".to_string(),
+                    "missing session bus".to_string(),
+                )),
+                "test Secret Service",
+            );
+
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::SecretsStore(
+                SecretsStoreError::KeyringUnavailable(msg)
+            ))
+                if msg.contains("Failed to create test Secret Service credential store")
+                    && msg.contains("missing session bus")
         ));
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -319,10 +319,15 @@ impl Whitenoise {
     /// binaries require real platform keychain entitlements.
     ///
     /// This function is safe to call multiple times; only the first call has
-    /// an effect.
+    /// an effect. If another crate or host application has already configured
+    /// a `keyring-core` default store, that store is preserved.
     fn initialize_keyring_store() {
         static KEYRING_STORE_INIT: OnceLock<()> = OnceLock::new();
         KEYRING_STORE_INIT.get_or_init(|| {
+            if keyring_core::get_default_store().is_some() {
+                return;
+            }
+
             // Use the mock (in-memory) store in test, integration-test, and
             // benchmark-test builds so that `cargo test` and unsigned `cargo run`
             // binaries never require real platform keychain entitlements.
@@ -383,8 +388,8 @@ impl Whitenoise {
                 }
                 #[cfg(target_os = "linux")]
                 {
-                    let store = linux_keyutils_keyring_store::Store::new()
-                        .expect("Failed to create Linux keyutils credential store");
+                    let store = zbus_secret_service_keyring_store::Store::new()
+                        .expect("Failed to create Linux Secret Service credential store");
                     keyring_core::set_default_store(store);
                 }
                 #[cfg(target_os = "android")]

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -84,7 +84,7 @@ use database::*;
 use error::{Result, WhitenoiseError};
 use event_tracker::WhitenoiseEventTracker;
 use relays::*;
-use secrets_store::SecretsStore;
+use secrets_store::{SecretsStore, SecretsStoreError};
 #[cfg(test)]
 use users::User;
 
@@ -485,9 +485,9 @@ impl Whitenoise {
         S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
     {
         let store = store.map_err(|e| {
-            WhitenoiseError::KeyringUnavailable(format!(
+            WhitenoiseError::SecretsStore(SecretsStoreError::KeyringUnavailable(format!(
                 "Failed to create {store_name} credential store: {e}"
-            ))
+            )))
         })?;
         Ok(store)
     }
@@ -1505,13 +1505,16 @@ mod tests {
             || false,
             || {
                 attempts.fetch_add(1, Ordering::SeqCst);
-                Err(WhitenoiseError::KeyringUnavailable(
-                    "transient failure".to_string(),
-                ))
+                Err(SecretsStoreError::KeyringUnavailable("transient failure".to_string()).into())
             },
         );
 
-        assert!(matches!(first, Err(WhitenoiseError::KeyringUnavailable(_))));
+        assert!(matches!(
+            first,
+            Err(WhitenoiseError::SecretsStore(
+                SecretsStoreError::KeyringUnavailable(_)
+            ))
+        ));
 
         let second = init.initialize_with(
             || false,
@@ -1558,7 +1561,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(WhitenoiseError::KeyringUnavailable(msg))
+            Err(WhitenoiseError::SecretsStore(
+                SecretsStoreError::KeyringUnavailable(msg)
+            ))
                 if msg.contains("Failed to create test credential store")
                     && msg.contains("boom")
         ));

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -41,7 +41,14 @@ pub mod key_packages;
 #[cfg(any(
     test,
     all(
-        any(target_os = "linux", target_os = "android"),
+        any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly",
+            target_os = "android"
+        ),
         not(feature = "integration-tests"),
         not(feature = "benchmark-tests")
     )
@@ -436,19 +443,22 @@ impl Whitenoise {
             }
             #[cfg(target_os = "linux")]
             {
-                let primary = Self::create_keyring_store(
-                    zbus_secret_service_keyring_store::Store::new(),
-                    "Linux Secret Service",
-                )?;
-                let primary = keyring_store::TargetedCredentialStore::new(
-                    primary,
-                    keyring_store::LINUX_SECRET_SERVICE_TARGET,
-                );
+                let primary = Self::create_secret_service_keyring_store("Linux Secret Service")?;
                 let store = Self::create_legacy_migration_keyring_store(
                     primary,
                     linux_keyutils_keyring_store::Store::new(),
                     "legacy Linux keyutils",
                 );
+                keyring_core::set_default_store(store);
+            }
+            #[cfg(any(
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "dragonfly"
+            ))]
+            {
+                let store = Self::create_secret_service_keyring_store("BSD Secret Service")?;
                 keyring_core::set_default_store(store);
             }
             #[cfg(target_os = "android")]
@@ -469,6 +479,10 @@ impl Whitenoise {
                 target_os = "ios",
                 target_os = "windows",
                 target_os = "linux",
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "dragonfly",
                 target_os = "android",
             )))]
             {
@@ -496,6 +510,31 @@ impl Whitenoise {
             )))
         })?;
         Ok(store)
+    }
+
+    #[cfg(all(
+        any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ),
+        not(test),
+        not(feature = "integration-tests"),
+        not(feature = "benchmark-tests")
+    ))]
+    fn create_secret_service_keyring_store(
+        store_name: &str,
+    ) -> Result<Arc<keyring_core::CredentialStore>> {
+        let store = Self::create_keyring_store(
+            zbus_secret_service_keyring_store::Store::new(),
+            store_name,
+        )?;
+        Ok(keyring_store::TargetedCredentialStore::new(
+            store,
+            keyring_store::SECRET_SERVICE_TARGET,
+        ))
     }
 
     #[cfg(any(

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -38,7 +38,14 @@ pub mod group_information;
 pub mod groups;
 mod init_timing;
 pub mod key_packages;
-#[cfg(any(target_os = "linux", target_os = "android", test))]
+#[cfg(any(
+    test,
+    all(
+        any(target_os = "linux", target_os = "android"),
+        not(feature = "integration-tests"),
+        not(feature = "benchmark-tests")
+    )
+))]
 mod keyring_store;
 pub mod media_files;
 pub mod message_aggregator;

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -380,12 +380,7 @@ impl Whitenoise {
         // The real store is reserved for production builds (no feature flags).
         #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
         {
-            let store = keyring_core::mock::Store::new().map_err(|e| {
-                WhitenoiseError::KeyringUnavailable(format!(
-                    "Failed to create mock credential store: {e}"
-                ))
-            })?;
-            keyring_core::set_default_store(store);
+            Self::set_default_keyring_store(keyring_core::mock::Store::new(), "mock")?;
         }
 
         #[cfg(all(
@@ -400,23 +395,19 @@ impl Whitenoise {
             // profile with application-groups entitlement).
             #[cfg(all(target_os = "macos", feature = "cli"))]
             {
-                let store = apple_native_keyring_store::keychain::Store::new().map_err(|e| {
-                    WhitenoiseError::KeyringUnavailable(format!(
-                        "Failed to create macOS Keychain credential store: {e}"
-                    ))
-                })?;
-                keyring_core::set_default_store(store);
+                Self::set_default_keyring_store(
+                    apple_native_keyring_store::keychain::Store::new(),
+                    "macOS Keychain",
+                )?;
             }
             // Intel Macs (non-CLI): use the regular Keychain store.
             // Protected Data store is not available on x86_64.
             #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "cli")))]
             {
-                let store = apple_native_keyring_store::keychain::Store::new().map_err(|e| {
-                    WhitenoiseError::KeyringUnavailable(format!(
-                        "Failed to create macOS Keychain credential store: {e}"
-                    ))
-                })?;
-                keyring_core::set_default_store(store);
+                Self::set_default_keyring_store(
+                    apple_native_keyring_store::keychain::Store::new(),
+                    "macOS Keychain",
+                )?;
             }
             // Apple Silicon (non-CLI): use the Protected Data store (audit #630).
             // Requires code-signing with a provisioning profile that includes the
@@ -424,39 +415,31 @@ impl Whitenoise {
             // build pipeline satisfies this.
             #[cfg(all(target_os = "macos", target_arch = "aarch64", not(feature = "cli")))]
             {
-                let store = apple_native_keyring_store::protected::Store::new().map_err(|e| {
-                    WhitenoiseError::KeyringUnavailable(format!(
-                        "Failed to create macOS protected-data credential store: {e}"
-                    ))
-                })?;
-                keyring_core::set_default_store(store);
+                Self::set_default_keyring_store(
+                    apple_native_keyring_store::protected::Store::new(),
+                    "macOS protected-data",
+                )?;
             }
             #[cfg(target_os = "ios")]
             {
-                let store = apple_native_keyring_store::protected::Store::new().map_err(|e| {
-                    WhitenoiseError::KeyringUnavailable(format!(
-                        "Failed to create iOS protected-data credential store: {e}"
-                    ))
-                })?;
-                keyring_core::set_default_store(store);
+                Self::set_default_keyring_store(
+                    apple_native_keyring_store::protected::Store::new(),
+                    "iOS protected-data",
+                )?;
             }
             #[cfg(target_os = "windows")]
             {
-                let store = windows_native_keyring_store::Store::new().map_err(|e| {
-                    WhitenoiseError::KeyringUnavailable(format!(
-                        "Failed to create Windows credential store: {e}"
-                    ))
-                })?;
-                keyring_core::set_default_store(store);
+                Self::set_default_keyring_store(
+                    windows_native_keyring_store::Store::new(),
+                    "Windows",
+                )?;
             }
             #[cfg(target_os = "linux")]
             {
-                let store: Arc<keyring_core::CredentialStore> =
-                    zbus_secret_service_keyring_store::Store::new().map_err(|e| {
-                        WhitenoiseError::KeyringUnavailable(format!(
-                            "Failed to create Linux Secret Service credential store: {e}"
-                        ))
-                    })?;
+                let store = Self::create_keyring_store(
+                    zbus_secret_service_keyring_store::Store::new(),
+                    "Linux Secret Service",
+                )?;
                 keyring_core::set_default_store(keyring_store::TargetedCredentialStore::new(
                     store,
                     keyring_store::LINUX_SECRET_SERVICE_TARGET,
@@ -464,18 +447,14 @@ impl Whitenoise {
             }
             #[cfg(target_os = "android")]
             {
-                let primary: Arc<keyring_core::CredentialStore> =
-                    android_native_keyring_store::Store::new().map_err(|e| {
-                        WhitenoiseError::KeyringUnavailable(format!(
-                            "Failed to create Android credential store: {e}"
-                        ))
-                    })?;
-                let legacy: Arc<keyring_core::CredentialStore> =
-                    android_native_keyring_store::LegacyStore::from_ndk_context().map_err(|e| {
-                        WhitenoiseError::KeyringUnavailable(format!(
-                            "Failed to create legacy Android credential store: {e}"
-                        ))
-                    })?;
+                let primary = Self::create_keyring_store(
+                    android_native_keyring_store::Store::new(),
+                    "Android",
+                )?;
+                let legacy = Self::create_keyring_store(
+                    android_native_keyring_store::LegacyStore::from_ndk_context(),
+                    "legacy Android",
+                )?;
                 keyring_core::set_default_store(
                     keyring_store::LegacyMigrationCredentialStore::new(primary, legacy),
                 );
@@ -496,6 +475,33 @@ impl Whitenoise {
             }
         }
 
+        Ok(())
+    }
+
+    fn create_keyring_store<S>(
+        store: keyring_core::Result<Arc<S>>,
+        store_name: &str,
+    ) -> Result<Arc<keyring_core::CredentialStore>>
+    where
+        S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
+    {
+        let store = store.map_err(|e| {
+            WhitenoiseError::KeyringUnavailable(format!(
+                "Failed to create {store_name} credential store: {e}"
+            ))
+        })?;
+        Ok(store)
+    }
+
+    fn set_default_keyring_store<S>(
+        store: keyring_core::Result<Arc<S>>,
+        store_name: &str,
+    ) -> Result<()>
+    where
+        S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
+    {
+        let store = Self::create_keyring_store(store, store_name)?;
+        keyring_core::set_default_store(store);
         Ok(())
     }
 
@@ -1459,7 +1465,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::test_utils::*;
     use super::*;
@@ -1492,15 +1498,7 @@ mod tests {
 
         assert!(second.is_ok());
 
-        let third = init.initialize_with(
-            || false,
-            || {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                Err(WhitenoiseError::KeyringUnavailable(
-                    "should not run after success".to_string(),
-                ))
-            },
-        );
+        let third = init.initialize_with(|| false, || panic!("initializer ran after success"));
 
         assert!(third.is_ok());
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
@@ -1509,18 +1507,28 @@ mod tests {
     #[test]
     fn keyring_store_init_preserves_existing_default_store() {
         let init = KeyringStoreInit::new();
-        let initializer_called = AtomicBool::new(false);
 
-        let result = init.initialize_with(
-            || true,
-            || {
-                initializer_called.store(true, Ordering::SeqCst);
-                Ok(())
-            },
-        );
+        let result = init.initialize_with(|| true, || panic!("initializer ran for existing store"));
 
         assert!(result.is_ok());
-        assert!(!initializer_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn create_keyring_store_maps_creation_error() {
+        let result = Whitenoise::create_keyring_store::<keyring_core::mock::Store>(
+            Err(keyring_core::Error::Invalid(
+                "store".to_string(),
+                "boom".to_string(),
+            )),
+            "test",
+        );
+
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::KeyringUnavailable(msg))
+                if msg.contains("Failed to create test credential store")
+                    && msg.contains("boom")
+        ));
     }
 
     // Configuration Tests

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1546,10 +1546,12 @@ mod tests {
     }
 
     #[test]
-    fn keyring_store_init_skips_initializer_when_default_store_exists() {
+    fn keyring_store_init_preserves_existing_default_store() {
         let init = KeyringStoreInit::new();
         let attempts = AtomicUsize::new(0);
 
+        // Host apps may configure keyring-core before Whitenoise starts. In
+        // that case initialization should preserve the existing default store.
         let result = init.initialize_with(
             || true,
             || {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -498,7 +498,14 @@ impl Whitenoise {
         Ok(store)
     }
 
-    #[cfg(any(test, target_os = "android", target_os = "linux"))]
+    #[cfg(any(
+        test,
+        all(
+            any(target_os = "linux", target_os = "android"),
+            not(feature = "integration-tests"),
+            not(feature = "benchmark-tests")
+        )
+    ))]
     fn create_legacy_migration_keyring_store<S>(
         primary: Arc<keyring_core::CredentialStore>,
         legacy: keyring_core::Result<Arc<S>>,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -436,14 +436,20 @@ impl Whitenoise {
             }
             #[cfg(target_os = "linux")]
             {
-                let store = Self::create_keyring_store(
+                let primary = Self::create_keyring_store(
                     zbus_secret_service_keyring_store::Store::new(),
                     "Linux Secret Service",
                 )?;
-                keyring_core::set_default_store(keyring_store::TargetedCredentialStore::new(
-                    store,
+                let primary = keyring_store::TargetedCredentialStore::new(
+                    primary,
                     keyring_store::LINUX_SECRET_SERVICE_TARGET,
-                ));
+                );
+                let store = Self::create_legacy_migration_keyring_store(
+                    primary,
+                    linux_keyutils_keyring_store::Store::new(),
+                    "legacy Linux keyutils",
+                );
+                keyring_core::set_default_store(store);
             }
             #[cfg(target_os = "android")]
             {
@@ -492,7 +498,7 @@ impl Whitenoise {
         Ok(store)
     }
 
-    #[cfg(any(test, target_os = "android"))]
+    #[cfg(any(test, target_os = "android", target_os = "linux"))]
     fn create_legacy_migration_keyring_store<S>(
         primary: Arc<keyring_core::CredentialStore>,
         legacy: keyring_core::Result<Arc<S>>,

--- a/src/whitenoise/secrets_store.rs
+++ b/src/whitenoise/secrets_store.rs
@@ -155,20 +155,32 @@ fn map_keyring_error(e: KeyringError) -> SecretsStoreError {
 /// Produces a user-friendly message for `NoStorageAccess` errors, with
 /// platform-specific remediation hints.
 fn format_storage_access_error(inner: &dyn std::error::Error) -> String {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
     {
         format!(
-            "Platform keyring is not available. On Linux, White Noise uses the D-Bus \
-             Secret Service to store secret keys. This error typically occurs on \
-             headless systems, in SSH sessions, in containers, or when no Secret \
-             Service implementation such as GNOME Keyring or KWallet is running and \
-             unlocked. Start and unlock a Secret Service provider before starting \
-             White Noise. \
+            "Platform keyring is not available. On Linux and supported BSD targets, \
+             White Noise uses the D-Bus Secret Service to store secret keys. This \
+             error typically occurs on headless systems, in SSH sessions, in \
+             containers, or when no Secret Service implementation such as GNOME \
+             Keyring or KWallet is running and unlocked. Start and unlock a Secret \
+             Service provider before starting White Noise. \
              (Original error: {inner})"
         )
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )))]
     {
         format!(
             "Platform keyring is not available: {inner}. \

--- a/src/whitenoise/secrets_store.rs
+++ b/src/whitenoise/secrets_store.rs
@@ -52,7 +52,8 @@ impl SecretsStore {
     /// * The Entry creation fails
     /// * Setting the password in the keyring fails
     pub fn store_private_key(&self, keys: &Keys) -> Result<(), SecretsStoreError> {
-        let entry = Entry::new(&self.service_name, keys.public_key().to_hex().as_str())
+        let entry = self
+            .entry_for_user(keys.public_key().to_hex().as_str())
             .map_err(map_keyring_error)?;
         entry
             .set_password(keys.secret_key().to_secret_hex().as_str())
@@ -84,8 +85,9 @@ impl SecretsStore {
     /// * Parsing the private key into a `Keys` object fails
     pub fn get_nostr_keys_for_pubkey(&self, pubkey: &PublicKey) -> Result<Keys, SecretsStoreError> {
         let hex_pubkey = pubkey.to_hex();
-        let entry =
-            Entry::new(&self.service_name, hex_pubkey.as_str()).map_err(map_keyring_error)?;
+        let entry = self
+            .entry_for_user(hex_pubkey.as_str())
+            .map_err(map_keyring_error)?;
 
         match entry.get_password() {
             Ok(private_key) => Keys::parse(&private_key).map_err(SecretsStoreError::KeyError),
@@ -118,14 +120,45 @@ impl SecretsStore {
         pubkey: &PublicKey,
     ) -> Result<(), SecretsStoreError> {
         let hex_pubkey = pubkey.to_hex();
-        let entry =
-            Entry::new(&self.service_name, hex_pubkey.as_str()).map_err(map_keyring_error)?;
+        let entry = self
+            .entry_for_user(hex_pubkey.as_str())
+            .map_err(map_keyring_error)?;
 
         match entry.delete_credential() {
             Ok(()) => Ok(()),
             Err(KeyringError::NoEntry) => Ok(()),
             Err(e) => Err(map_keyring_error(e)),
         }
+    }
+
+    fn entry_for_user(&self, user: &str) -> keyring_core::Result<Entry> {
+        keyring_entry_for_user(&self.service_name, user)
+    }
+}
+
+fn keyring_entry_for_user(service: &str, user: &str) -> keyring_core::Result<Entry> {
+    #[cfg(all(
+        target_os = "linux",
+        not(test),
+        not(feature = "integration-tests"),
+        not(feature = "benchmark-tests")
+    ))]
+    {
+        let modifiers = std::collections::HashMap::from([(
+            "target",
+            super::keyring_store::LINUX_SECRET_SERVICE_TARGET,
+        )]);
+        Entry::new_with_modifiers(service, user, &modifiers)
+    }
+
+    #[cfg(not(all(
+        target_os = "linux",
+        not(test),
+        not(feature = "integration-tests"),
+        not(feature = "benchmark-tests")
+    )))]
+    {
+        Entry::new(service, user)
     }
 }
 

--- a/src/whitenoise/secrets_store.rs
+++ b/src/whitenoise/secrets_store.rs
@@ -137,29 +137,7 @@ impl SecretsStore {
 }
 
 fn keyring_entry_for_user(service: &str, user: &str) -> keyring_core::Result<Entry> {
-    #[cfg(all(
-        target_os = "linux",
-        not(test),
-        not(feature = "integration-tests"),
-        not(feature = "benchmark-tests")
-    ))]
-    {
-        let modifiers = std::collections::HashMap::from([(
-            "target",
-            super::keyring_store::LINUX_SECRET_SERVICE_TARGET,
-        )]);
-        Entry::new_with_modifiers(service, user, &modifiers)
-    }
-
-    #[cfg(not(all(
-        target_os = "linux",
-        not(test),
-        not(feature = "integration-tests"),
-        not(feature = "benchmark-tests")
-    )))]
-    {
-        Entry::new(service, user)
-    }
+    Entry::new(service, user)
 }
 
 /// Maps a `keyring_core::Error` to a `SecretsStoreError`, distinguishing

--- a/src/whitenoise/secrets_store.rs
+++ b/src/whitenoise/secrets_store.rs
@@ -252,6 +252,50 @@ mod tests {
     }
 
     #[test]
+    fn test_get_private_key_maps_keyring_read_errors() {
+        let secrets_store = create_test_secrets_store();
+        let keys = Keys::generate();
+        let pubkey = keys.public_key();
+        let entry = keyring_entry_for_user(
+            secrets_store.service_name.as_str(),
+            pubkey.to_hex().as_str(),
+        )
+        .unwrap();
+        entry.set_secret(&[0xff]).unwrap();
+
+        let result = secrets_store.get_nostr_keys_for_pubkey(&pubkey);
+
+        assert!(matches!(result, Err(SecretsStoreError::KeyringError(_))));
+    }
+
+    #[test]
+    fn test_remove_private_key_maps_keyring_delete_errors() {
+        let secrets_store = create_test_secrets_store();
+        let keys = Keys::generate();
+        let pubkey = keys.public_key();
+        let entry = keyring_entry_for_user(
+            secrets_store.service_name.as_str(),
+            pubkey.to_hex().as_str(),
+        )
+        .unwrap();
+        entry
+            .set_password(keys.secret_key().to_secret_hex().as_str())
+            .unwrap();
+        let mock = entry
+            .as_any()
+            .downcast_ref::<keyring_core::mock::Cred>()
+            .unwrap();
+        mock.set_error(KeyringError::Invalid(
+            "delete".to_string(),
+            "failed".to_string(),
+        ));
+
+        let result = secrets_store.remove_private_key_for_pubkey(&pubkey);
+
+        assert!(matches!(result, Err(SecretsStoreError::KeyringError(_))));
+    }
+
+    #[test]
     fn test_store_multiple_keys() {
         let secrets_store = create_test_secrets_store();
 
@@ -283,41 +327,23 @@ mod tests {
     #[test]
     fn test_map_keyring_error_no_default_store() {
         let err = map_keyring_error(KeyringError::NoDefaultStore);
-        assert!(
-            matches!(err, SecretsStoreError::KeyringNotInitialized(_)),
-            "Expected KeyringNotInitialized, got: {:?}",
-            err
-        );
+        assert!(matches!(err, SecretsStoreError::KeyringNotInitialized(_)));
     }
 
     #[test]
     fn test_map_keyring_error_no_storage_access() {
         let inner = std::io::Error::other("KeyRevoked");
         let err = map_keyring_error(KeyringError::NoStorageAccess(Box::new(inner)));
-        assert!(
-            matches!(err, SecretsStoreError::KeyringUnavailable(_)),
-            "Expected KeyringUnavailable, got: {:?}",
-            err
-        );
+        assert!(matches!(err, SecretsStoreError::KeyringUnavailable(_)));
         let msg = err.to_string();
-        assert!(
-            msg.contains("Platform keyring is not available"),
-            "Expected actionable guidance, got: {msg}"
-        );
-        assert!(
-            msg.contains("KeyRevoked"),
-            "Expected original error in message, got: {msg}"
-        );
+        assert!(msg.contains("Platform keyring is not available"));
+        assert!(msg.contains("KeyRevoked"));
     }
 
     #[test]
     fn test_map_keyring_error_other() {
         let err = map_keyring_error(KeyringError::NoEntry);
-        assert!(
-            matches!(err, SecretsStoreError::KeyringError(_)),
-            "Expected KeyringError, got: {:?}",
-            err
-        );
+        assert!(matches!(err, SecretsStoreError::KeyringError(_)));
     }
 
     #[test]

--- a/src/whitenoise/secrets_store.rs
+++ b/src/whitenoise/secrets_store.rs
@@ -147,11 +147,12 @@ fn format_storage_access_error(inner: &dyn std::error::Error) -> String {
     #[cfg(target_os = "linux")]
     {
         format!(
-            "Platform keyring is not available. On Linux, White Noise uses the kernel \
-             keyutils subsystem (keyctl) to store secret keys. This error typically \
-             occurs on headless systems, in SSH sessions, or in containers where no \
-             session keyring is active. Try running `keyctl session` before starting \
-             the daemon, or ensure your init system provides a session keyring. \
+            "Platform keyring is not available. On Linux, White Noise uses the D-Bus \
+             Secret Service to store secret keys. This error typically occurs on \
+             headless systems, in SSH sessions, in containers, or when no Secret \
+             Service implementation such as GNOME Keyring or KWallet is running and \
+             unlocked. Start and unlock a Secret Service provider before starting \
+             White Noise. \
              (Original error: {inner})"
         )
     }


### PR DESCRIPTION
## Summary
- Update the keyring stack to `keyring-core` v1 and platform-native v1 stores, keeping host-side store initialization for direct `mdk-sqlite-storage` use.
- Replace Linux keyutils with D-Bus Secret Service, inject a stable non-default `whitenoise` target for Linux entries, and refresh Linux keyring-unavailable guidance.
- Add fallible keyring initialization so platform store creation errors propagate as `WhitenoiseError::KeyringUnavailable` instead of panicking.
- Add Android legacy-to-primary keyring migration support so existing v0.5 by-service credentials can be read and moved into the v1 named-store layout before encrypted DBs open.

## Why
The MDK/keyring upgrade changed platform credential behavior. On Android, `android-native-keyring-store` v1 defaults to the new named-store layout, while existing released builds used the v0.5 by-service layout. Existing installs can therefore have encrypted MLS databases on disk but appear to be missing `mdk.db.key.<pubkey>` unless the old layout is consulted. Linux keyutils also is not durable across normal restarts, so Secret Service is the better Linux backend.

## Impact
- Android upgrades can recover known legacy credentials such as `whitenoise.db.key.v1`, account private-key entries, and per-account `mdk.db.key.<pubkey>` entries through the default keyring path.
- Linux uses a durable Secret Service collection target consistently for create/read/delete operations, including MDK's plain `Entry::new(...)` path through the wrapped default store.
- Startup can now surface keyring backend failures as typed White Noise errors.

## Testing
- `just precommit-quick`
- `git diff --check`
- `cargo tree -e features --target aarch64-linux-android -i android-native-keyring-store@1.0.0`
- `cargo check --manifest-path /Users/jeff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/android-native-keyring-store-1.0.0/Cargo.toml --target aarch64-linux-android --features legacy`
- Verified platform dependency graphs for Android, macOS, iOS, Windows, and Linux keyring stores.

## Notes
A full app-level `cargo check --target aarch64-linux-android --lib` still requires the Android SQLCipher/OpenSSL header environment; locally it stopped in `libsqlite3-sys` before reaching whitenoise code.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded keyring libraries to v1, switched Linux storage to D‑Bus Secret Service, and added once-cell support for initialization.
* **New Features**
  * Safer, fallible keyring initialization that preserves an existing default and allows retrying on failure.
  * Scoped credential handling and automatic migration of legacy credentials into the primary store on access.
* **Bug Fixes**
  * Clearer, user-facing guidance when credential storage is unavailable; errors now surface reasons instead of panicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->