### PR TITLE
Phase 18b: media_files → media_blobs + media_references split

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -512,7 +512,7 @@ boundary.
 
 ### Phase 18b: Media blob/reference split (~800 LOC)
 
-- [x] Completed in PR #xxx
+- [x] Completed in PR #787
 
 <details>
 <summary>Details</summary>

--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -512,7 +512,7 @@ boundary.
 
 ### Phase 18b: Media blob/reference split (~800 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #xxx
 
 <details>
 <summary>Details</summary>

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -198,6 +198,7 @@ impl MediaFile {
              INNER JOIN media_blobs b
                 ON b.encrypted_file_hash = r.encrypted_file_hash
              WHERE r.encrypted_file_hash = ?
+             ORDER BY r.created_at ASC, r.id ASC
              LIMIT 1",
         )
         .bind(&encrypted_file_hash_hex)
@@ -252,7 +253,12 @@ impl MediaFile {
             "INSERT INTO media_blobs
                 (encrypted_file_hash, file_path, mime_type, blossom_url, created_at)
             VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT (encrypted_file_hash) DO NOTHING",
+            ON CONFLICT (encrypted_file_hash) DO UPDATE SET
+                blossom_url = COALESCE(excluded.blossom_url, media_blobs.blossom_url),
+                file_path = CASE
+                    WHEN excluded.file_path != '' THEN excluded.file_path
+                    ELSE media_blobs.file_path
+                END",
         )
         .bind(&encrypted_file_hash_hex)
         .bind(file_path_str)

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -190,12 +190,14 @@ impl MediaFile {
         let encrypted_file_hash_hex = hex::encode(encrypted_file_hash);
 
         let row_opt = sqlx::query_as::<_, Self>(
-            "SELECT id, mls_group_id, account_pubkey, file_path,
-                    original_file_hash, encrypted_file_hash,
-                    mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, nonce, scheme_version, created_at
-             FROM media_files
-             WHERE encrypted_file_hash = ?
+            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
+                    r.original_file_hash, r.encrypted_file_hash,
+                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
+                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
+             FROM media_references r
+             INNER JOIN media_blobs b
+                ON b.encrypted_file_hash = r.encrypted_file_hash
+             WHERE r.encrypted_file_hash = ?
              LIMIT 1",
         )
         .bind(&encrypted_file_hash_hex)
@@ -243,58 +245,70 @@ impl MediaFile {
 
         let account_pubkey_hex = account_pubkey.to_hex();
 
-        let row_opt = sqlx::query_as::<_, Self>(
-            "INSERT INTO media_files (
-                mls_group_id, account_pubkey, file_path,
-                original_file_hash, encrypted_file_hash,
-                mime_type, media_type, blossom_url, nostr_key,
-                file_metadata, nonce, scheme_version, created_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (mls_group_id, encrypted_file_hash, account_pubkey)
-            DO NOTHING
-            RETURNING id, mls_group_id, account_pubkey, file_path,
-                      original_file_hash, encrypted_file_hash,
-                      mime_type, media_type, blossom_url, nostr_key,
-                      file_metadata, nonce, scheme_version, created_at",
+        let mut tx = database.pool.begin().await.map_err(DatabaseError::Sqlx)?;
+
+        // Upsert blob (shared, deduplicated by hash).
+        sqlx::query(
+            "INSERT INTO media_blobs
+                (encrypted_file_hash, file_path, mime_type, blossom_url, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (encrypted_file_hash) DO NOTHING",
         )
-        .bind(mls_group_id.as_slice())
-        .bind(&account_pubkey_hex)
-        .bind(file_path_str)
-        .bind(original_file_hash_hex.as_ref())
         .bind(&encrypted_file_hash_hex)
+        .bind(file_path_str)
         .bind(params.mime_type)
-        .bind(params.media_type)
         .bind(params.blossom_url)
-        .bind(params.nostr_key)
-        .bind(file_metadata_json)
-        .bind(params.nonce)
-        .bind(params.scheme_version)
         .bind(now_ms)
-        .fetch_optional(&database.pool)
+        .execute(&mut *tx)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        if let Some(row) = row_opt {
-            return Ok(row);
-        }
+        // Upsert reference (account-scoped).
+        sqlx::query(
+            "INSERT INTO media_references (
+                mls_group_id, account_pubkey, encrypted_file_hash,
+                media_type, nostr_key, file_metadata,
+                original_file_hash, nonce, scheme_version, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (mls_group_id, encrypted_file_hash, account_pubkey)
+            DO NOTHING",
+        )
+        .bind(mls_group_id.as_slice())
+        .bind(&account_pubkey_hex)
+        .bind(&encrypted_file_hash_hex)
+        .bind(params.media_type)
+        .bind(params.nostr_key)
+        .bind(file_metadata_json)
+        .bind(original_file_hash_hex.as_ref())
+        .bind(params.nonce)
+        .bind(params.scheme_version)
+        .bind(now_ms)
+        .execute(&mut *tx)
+        .await
+        .map_err(DatabaseError::Sqlx)?;
 
-        // Conflict occurred - select existing row
+        // Whether inserted or conflict, select the joined row.
         let existing = sqlx::query_as::<_, Self>(
-            "SELECT id, mls_group_id, account_pubkey, file_path,
-                    original_file_hash, encrypted_file_hash,
-                    mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, nonce, scheme_version, created_at
-             FROM media_files
-             WHERE mls_group_id = ? AND encrypted_file_hash = ? AND account_pubkey = ?
+            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
+                    r.original_file_hash, r.encrypted_file_hash,
+                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
+                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
+             FROM media_references r
+             INNER JOIN media_blobs b
+                ON b.encrypted_file_hash = r.encrypted_file_hash
+             WHERE r.mls_group_id = ? AND r.encrypted_file_hash = ?
+               AND r.account_pubkey = ?
              LIMIT 1",
         )
         .bind(mls_group_id.as_slice())
         .bind(&encrypted_file_hash_hex)
         .bind(&account_pubkey_hex)
-        .fetch_one(&database.pool)
+        .fetch_one(&mut *tx)
         .await
         .map_err(DatabaseError::Sqlx)?;
+
+        tx.commit().await.map_err(DatabaseError::Sqlx)?;
 
         Ok(existing)
     }
@@ -313,12 +327,14 @@ impl MediaFile {
         group_id: &GroupId,
     ) -> Result<Vec<Self>, WhitenoiseError> {
         let rows = sqlx::query_as::<_, Self>(
-            "SELECT id, mls_group_id, account_pubkey, file_path,
-                    original_file_hash, encrypted_file_hash,
-                    mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, nonce, scheme_version, created_at
-             FROM media_files
-             WHERE mls_group_id = ?",
+            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
+                    r.original_file_hash, r.encrypted_file_hash,
+                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
+                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
+             FROM media_references r
+             INNER JOIN media_blobs b
+                ON b.encrypted_file_hash = r.encrypted_file_hash
+             WHERE r.mls_group_id = ?",
         )
         .bind(group_id.as_slice())
         .fetch_all(&database.pool)
@@ -370,12 +386,15 @@ impl MediaFile {
         let account_hex = account_pubkey.to_hex();
 
         let row_opt = sqlx::query_as::<_, Self>(
-            "SELECT id, mls_group_id, account_pubkey, file_path,
-                    original_file_hash, encrypted_file_hash,
-                    mime_type, media_type, blossom_url, nostr_key,
-                    file_metadata, nonce, scheme_version, created_at
-             FROM media_files
-             WHERE original_file_hash = ? AND mls_group_id = ? AND account_pubkey = ?
+            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
+                    r.original_file_hash, r.encrypted_file_hash,
+                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
+                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
+             FROM media_references r
+             INNER JOIN media_blobs b
+                ON b.encrypted_file_hash = r.encrypted_file_hash
+             WHERE r.original_file_hash = ? AND r.mls_group_id = ?
+               AND r.account_pubkey = ?
              LIMIT 1",
         )
         .bind(&hash_hex)
@@ -419,36 +438,51 @@ impl MediaFile {
             .to_str()
             .ok_or_else(|| WhitenoiseError::MediaCache("Invalid file path".to_string()))?;
 
+        // Look up the encrypted_file_hash from the reference row.
+        let hash: String =
+            sqlx::query_scalar("SELECT encrypted_file_hash FROM media_references WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&database.pool)
+                .await
+                .map_err(DatabaseError::Sqlx)?
+                .ok_or_else(|| {
+                    WhitenoiseError::MediaCache(format!("MediaFile with id {} not found", id))
+                })?;
+
+        // Update the shared blob's file_path.
+        sqlx::query("UPDATE media_blobs SET file_path = ? WHERE encrypted_file_hash = ?")
+            .bind(path_str)
+            .bind(&hash)
+            .execute(&database.pool)
+            .await
+            .map_err(DatabaseError::Sqlx)?;
+
+        // Return the joined record.
         let row = sqlx::query_as::<_, Self>(
-            "UPDATE media_files
-             SET file_path = ?
-             WHERE id = ?
-             RETURNING id, mls_group_id, account_pubkey, file_path,
-                       original_file_hash, encrypted_file_hash,
-                       mime_type, media_type, blossom_url, nostr_key,
-                       file_metadata, nonce, scheme_version, created_at",
+            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
+                    r.original_file_hash, r.encrypted_file_hash,
+                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
+                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
+             FROM media_references r
+             INNER JOIN media_blobs b
+                ON b.encrypted_file_hash = r.encrypted_file_hash
+             WHERE r.id = ?",
         )
-        .bind(path_str)
         .bind(id)
         .fetch_one(&database.pool)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                WhitenoiseError::MediaCache(format!("MediaFile with id {} not found", id))
-            }
-            _ => DatabaseError::Sqlx(e).into(),
-        })?;
+        .map_err(DatabaseError::Sqlx)?;
 
         Ok(row)
     }
 
-    /// Returns all distinct non-empty file paths referenced by media_files records.
+    /// Returns all distinct non-empty file paths referenced by media_blobs records.
     #[perf_instrument("db::media_files")]
     pub(crate) async fn all_referenced_file_paths(
         database: &Database,
     ) -> Result<Vec<String>, WhitenoiseError> {
         let paths: Vec<String> =
-            sqlx::query_scalar("SELECT DISTINCT file_path FROM media_files WHERE file_path != ''")
+            sqlx::query_scalar("SELECT DISTINCT file_path FROM media_blobs WHERE file_path != ''")
                 .fetch_all(&database.pool)
                 .await
                 .map_err(DatabaseError::Sqlx)?;
@@ -1549,16 +1583,17 @@ mod tests {
 
         assert_eq!(found2.id, saved_file2.id);
         assert_eq!(found2.account_pubkey, account2_pubkey);
-        assert_eq!(found2.file_path, file_path2);
+        // file_path comes from the shared blob (first writer wins).
+        assert_eq!(found2.file_path, file_path1);
 
-        // Verify the two records are different
+        // Verify the two references are distinct records sharing the same blob.
         assert_ne!(
             found1.id, found2.id,
-            "Different accounts should have different records"
+            "Different accounts should have different reference records"
         );
-        assert_ne!(
+        assert_eq!(
             found1.file_path, found2.file_path,
-            "Each account should have their own file_path"
+            "Both accounts share the same blob, so file_path should match"
         );
 
         // Verify a third account cannot find records for the other accounts
@@ -1636,6 +1671,69 @@ mod tests {
         );
         assert_eq!(retrieved.original_filename, Some("photo.jpg".to_string()));
         assert_eq!(retrieved.dimensions, Some("800x600".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_shared_blobs_survive_reference_deletion() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::new(db_path).await.unwrap();
+
+        let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
+        let account1 = PublicKey::from_slice(&[10u8; 32]).unwrap();
+        let account2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
+        let encrypted_hash = [42u8; 32];
+        let file_path = temp_dir.path().join("shared.jpg");
+
+        create_test_account(&db, &account1).await;
+        create_test_account(&db, &account2).await;
+
+        // Both accounts save a reference to the same blob.
+        for acct in [&account1, &account2] {
+            MediaFile::save(
+                &db,
+                &group_id,
+                acct,
+                MediaFileParams {
+                    file_path: &file_path,
+                    original_file_hash: None,
+                    encrypted_file_hash: &encrypted_hash,
+                    mime_type: "image/jpeg",
+                    media_type: "chat_media",
+                    blossom_url: None,
+                    nostr_key: None,
+                    file_metadata: None,
+                    nonce: None,
+                    scheme_version: None,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        // Delete account1's reference.
+        sqlx::query("DELETE FROM media_references WHERE account_pubkey = ? AND mls_group_id = ?")
+            .bind(account1.to_hex())
+            .bind(group_id.as_slice())
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        // Blob must still exist.
+        let blob_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM media_blobs WHERE encrypted_file_hash = ?")
+                .bind(hex::encode(encrypted_hash))
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            blob_count.0, 1,
+            "Shared blob must survive reference deletion"
+        );
+
+        // Account2 can still find the media.
+        let found = MediaFile::find_by_hash(&db, &encrypted_hash).await.unwrap();
+        assert!(found.is_some(), "Account2 should still see the media file");
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -416,8 +416,13 @@ impl MediaFile {
     /// Updates the file_path for an existing media file record
     ///
     /// This method is called after downloading and caching a media file to update
-    /// the database record with the local file path. It performs an atomic update
-    /// and returns the complete updated record.
+    /// the database record with the local file path.
+    ///
+    /// NOTE: This mutates the shared `media_blobs` row, which affects every
+    /// account referencing the same `encrypted_file_hash`. This is correct
+    /// while all accounts share a single `media_cache` directory. If Phase 18c
+    /// introduces per-account storage directories, this assumption must be
+    /// revisited.
     ///
     /// # Arguments
     /// * `database` - The database connection
@@ -444,11 +449,13 @@ impl MediaFile {
             .to_str()
             .ok_or_else(|| WhitenoiseError::MediaCache("Invalid file path".to_string()))?;
 
+        let mut tx = database.pool.begin().await.map_err(DatabaseError::Sqlx)?;
+
         // Look up the encrypted_file_hash from the reference row.
         let hash: String =
             sqlx::query_scalar("SELECT encrypted_file_hash FROM media_references WHERE id = ?")
                 .bind(id)
-                .fetch_optional(&database.pool)
+                .fetch_optional(&mut *tx)
                 .await
                 .map_err(DatabaseError::Sqlx)?
                 .ok_or_else(|| {
@@ -459,7 +466,7 @@ impl MediaFile {
         sqlx::query("UPDATE media_blobs SET file_path = ? WHERE encrypted_file_hash = ?")
             .bind(path_str)
             .bind(&hash)
-            .execute(&database.pool)
+            .execute(&mut *tx)
             .await
             .map_err(DatabaseError::Sqlx)?;
 
@@ -475,9 +482,11 @@ impl MediaFile {
              WHERE r.id = ?",
         )
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(&mut *tx)
         .await
         .map_err(DatabaseError::Sqlx)?;
+
+        tx.commit().await.map_err(DatabaseError::Sqlx)?;
 
         Ok(row)
     }

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -209,12 +209,16 @@ impl Database {
 
     /// Inner implementation of delete_all_data
     async fn delete_all_data_inner(&self) -> Result<(), DatabaseError> {
-        let mut txn = self.pool.begin().await?;
+        // Acquire a single connection so the PRAGMA and transaction share the
+        // same session. PRAGMA foreign_keys cannot be changed inside a
+        // transaction in SQLite, so we set it before BEGIN.
+        let mut conn = self.pool.acquire().await?;
 
-        // Disable foreign key constraints temporarily to allow deleting in any order
         sqlx::query("PRAGMA foreign_keys = OFF")
-            .execute(&mut *txn)
+            .execute(&mut *conn)
             .await?;
+
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
 
         // Get all user tables (excluding SQLite system tables and migration tracking)
         let tables: Vec<(String,)> = sqlx::query_as(
@@ -223,14 +227,14 @@ impl Database {
              AND name NOT LIKE 'sqlite_%'
              AND name NOT IN ('_sqlx_migrations', '_rust_migrations')",
         )
-        .fetch_all(&mut *txn)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Delete all rows from each table (preserves schema)
         for (table_name,) in &tables {
             let delete_query = format!("DELETE FROM {}", table_name);
             sqlx::query(sqlx::AssertSqlSafe(delete_query))
-                .execute(&mut *txn)
+                .execute(&mut *conn)
                 .await?;
         }
 
@@ -240,16 +244,16 @@ impl Database {
             // Ignore errors - table might not have auto-increment
             let _ = sqlx::query("DELETE FROM sqlite_sequence WHERE name = ?")
                 .bind(table_name)
-                .execute(&mut *txn)
+                .execute(&mut *conn)
                 .await;
         }
 
-        // Re-enable foreign key constraints
-        sqlx::query("PRAGMA foreign_keys = ON")
-            .execute(&mut *txn)
-            .await?;
+        sqlx::query("COMMIT").execute(&mut *conn).await?;
 
-        txn.commit().await?;
+        // Re-enable foreign key constraints.
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&mut *conn)
+            .await?;
 
         Ok(())
     }
@@ -343,7 +347,7 @@ impl Database {
         .await?;
 
         sqlx::query(
-            "DELETE FROM media_files
+            "DELETE FROM media_references
              WHERE account_pubkey = ? AND mls_group_id = ?",
         )
         .bind(&pubkey_hex)
@@ -373,7 +377,7 @@ impl Database {
                 .execute(&mut *txn)
                 .await?;
 
-            sqlx::query("DELETE FROM media_files WHERE mls_group_id = ?")
+            sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
                 .bind(mls_group_id.as_slice())
                 .execute(&mut *txn)
                 .await?;
@@ -470,9 +474,9 @@ mod tests {
         assert!(result.is_ok());
         assert!(result.unwrap().is_some());
 
-        // Check that the media_files table exists (from migration 0002)
+        // Check that the media_blobs table exists
         let result =
-            sqlx::query("SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'")
+            sqlx::query("SELECT name FROM sqlite_master WHERE type='table' AND name='media_blobs'")
                 .fetch_optional(&db.pool)
                 .await;
 
@@ -530,10 +534,15 @@ mod tests {
             .await
             .expect("Failed to insert test account");
 
-        sqlx::query("INSERT INTO media_files (mls_group_id, account_pubkey, file_path, original_file_hash, encrypted_file_hash, mime_type, media_type, created_at) VALUES (x'deadbeef', 'test-pubkey', '/path/test.jpg', NULL, 'testhash', 'image/jpeg', 'test', 1234567890)")
+        sqlx::query("INSERT INTO media_blobs (encrypted_file_hash, file_path, mime_type, created_at) VALUES ('testhash', '/path/test.jpg', 'image/jpeg', 1234567890)")
             .execute(&db.pool)
             .await
-            .expect("Failed to insert test media file");
+            .expect("Failed to insert test media blob");
+
+        sqlx::query("INSERT INTO media_references (mls_group_id, account_pubkey, encrypted_file_hash, media_type, created_at) VALUES (x'deadbeef', 'test-pubkey', 'testhash', 'test', 1234567890)")
+            .execute(&db.pool)
+            .await
+            .expect("Failed to insert test media reference");
 
         // Verify data exists
         let user_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
@@ -548,11 +557,17 @@ mod tests {
             .expect("Failed to count accounts");
         assert_eq!(account_count.0, 1);
 
-        let media_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_files")
+        let blob_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_blobs")
             .fetch_one(&db.pool)
             .await
-            .expect("Failed to count media files");
-        assert_eq!(media_count.0, 1);
+            .expect("Failed to count media blobs");
+        assert_eq!(blob_count.0, 1);
+
+        let ref_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
+            .fetch_one(&db.pool)
+            .await
+            .expect("Failed to count media references");
+        assert_eq!(ref_count.0, 1);
 
         // Delete all data
         let result = db.delete_all_data().await;
@@ -571,11 +586,17 @@ mod tests {
             .expect("Failed to count accounts after deletion");
         assert_eq!(account_count.0, 0);
 
-        let media_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_files")
+        let blob_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_blobs")
             .fetch_one(&db.pool)
             .await
-            .expect("Failed to count media files after deletion");
-        assert_eq!(media_count.0, 0);
+            .expect("Failed to count media blobs after deletion");
+        assert_eq!(blob_count.0, 0);
+
+        let ref_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
+            .fetch_one(&db.pool)
+            .await
+            .expect("Failed to count media references after deletion");
+        assert_eq!(ref_count.0, 0);
     }
 
     #[tokio::test]
@@ -698,7 +719,8 @@ mod tests {
 
         let table_names: Vec<String> = tables.into_iter().map(|t| t.0).collect();
         assert!(table_names.contains(&"accounts".to_string()));
-        assert!(table_names.contains(&"media_files".to_string()));
+        assert!(table_names.contains(&"media_blobs".to_string()));
+        assert!(table_names.contains(&"media_references".to_string()));
         assert!(table_names.contains(&"app_settings".to_string()));
     }
 

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -6,11 +6,11 @@
 -- data-migration logic that only matters for accounts upgraded from older
 -- installs (mirror of `global/fresh_schema.sql` for the local timeline).
 --
--- Phase 18a status: intentionally empty. No tables have been moved out of
--- the shared database yet. When Phase 18b begins moving account-scoped
--- tables (`account_settings`, `drafts`, `accounts_groups`, …), populate
--- this file with their `CREATE TABLE` / index DDL as of the current
--- baseline.
+-- Phase 18a/18b status: intentionally empty. `media_references` is
+-- logically account-scoped but lives on the shared DB until
+-- `AccountDatabase` is wired into production init (Phase 18c+). When
+-- that wiring lands, add the `media_references` DDL here and create a
+-- local migration to extract it from shared.
 --
 -- Rebaselining: when a future local migration does data extraction against
 -- transient shared schema, consider rebaselining — bump

--- a/src/whitenoise/database/rust_migrations/m0001_bridge.rs
+++ b/src/whitenoise/database/rust_migrations/m0001_bridge.rs
@@ -305,12 +305,15 @@ mod tests {
         let runner = Migrator::new(all_global_migrations(), vec![]);
         runner.run(&pool, None).await.unwrap();
 
-        // Bridge (v1) + auto-stamped v2-v10 + actually-ran v11 = 11 total.
+        let expected = all_global_migrations().len() as i64;
         let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM _rust_migrations")
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count, 11, "should have all 11 migration versions recorded");
+        assert_eq!(
+            count, expected,
+            "should have all migration versions recorded"
+        );
 
         // Verify v2-v10 are stamped (not executed).
         let stamped: Vec<(i64, String)> = sqlx::query_as(
@@ -357,11 +360,12 @@ mod tests {
         let runner = Migrator::new(all_global_migrations(), vec![]);
         runner.run(&pool, None).await.unwrap();
 
+        let expected = all_global_migrations().len() as i64;
         let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM _rust_migrations")
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count, 11, "all 11 migrations should be recorded");
+        assert_eq!(count, expected, "all migrations should be recorded");
 
         // None should be auto-stamped.
         let stamped: Vec<(i64,)> = sqlx::query_as(
@@ -440,10 +444,11 @@ mod tests {
             "v2-v6 should be auto-stamped for SQLx 42"
         );
 
+        let expected = all_global_migrations().len() as i64;
         let (total,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM _rust_migrations")
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(total, 11, "all 11 migrations should be recorded");
+        assert_eq!(total, expected, "all migrations should be recorded");
     }
 }

--- a/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
+++ b/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
@@ -288,7 +288,7 @@ mod tests {
         let accounts: Vec<&str> = shared_refs.iter().map(|(a,)| a.as_str()).collect();
         assert_eq!(accounts, vec![acct_a.as_str(), acct_b.as_str()]);
 
-        // media_files should still exist (dropped in a future migration).
+        // media_files should still exist (dropped by m0014).
         let tables: Vec<(String,)> = sqlx::query_as(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'",
         )

--- a/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
+++ b/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
@@ -39,6 +39,16 @@ impl GlobalMigration for Migration {
         .await?;
 
         // 2. Create account-scoped media reference table.
+        //
+        //    Logically this belongs in the per-account database, but
+        //    AccountDatabase is not wired into production init yet (Phase 18a).
+        //    All production queries JOIN media_references with media_blobs on
+        //    a single pool, so the table must live on shared until the
+        //    account-DB wiring lands (Phase 18c+). At that point a local
+        //    migration extracts it and a follow-up global drops it from shared.
+        //
+        //    The FK to media_blobs is omitted: once this table moves to the
+        //    account DB the FK would be cross-database and unenforced anyway.
         sqlx::query(
             "CREATE TABLE media_references (
                 id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -52,9 +62,7 @@ impl GlobalMigration for Migration {
                 nonce               TEXT,
                 scheme_version      TEXT,
                 created_at          INTEGER NOT NULL,
-                UNIQUE(mls_group_id, encrypted_file_hash, account_pubkey),
-                FOREIGN KEY (encrypted_file_hash)
-                    REFERENCES media_blobs(encrypted_file_hash)
+                UNIQUE(mls_group_id, encrypted_file_hash, account_pubkey)
             )",
         )
         .execute(&mut *tx)
@@ -130,11 +138,6 @@ impl GlobalMigration for Migration {
         )
         .execute(&mut *tx)
         .await?;
-
-        // 5. Drop old table and its indexes.
-        sqlx::query("DROP TABLE media_files")
-            .execute(&mut *tx)
-            .await?;
 
         Ok(())
     }
@@ -237,15 +240,6 @@ mod tests {
         let split_only = Migrator::new(vec![Box::new(Migration)], vec![]);
         split_only.run(&pool, None).await.unwrap();
 
-        // media_files should be gone.
-        let tables: Vec<(String,)> = sqlx::query_as(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'",
-        )
-        .fetch_all(&pool)
-        .await
-        .unwrap();
-        assert!(tables.is_empty(), "media_files should be dropped");
-
         // media_blobs: 2 rows (deduplicated by hash).
         let blob_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM media_blobs")
             .fetch_one(&pool)
@@ -293,5 +287,17 @@ mod tests {
         .unwrap();
         let accounts: Vec<&str> = shared_refs.iter().map(|(a,)| a.as_str()).collect();
         assert_eq!(accounts, vec![acct_a.as_str(), acct_b.as_str()]);
+
+        // media_files should still exist (dropped in a future migration).
+        let tables: Vec<(String,)> = sqlx::query_as(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert!(
+            !tables.is_empty(),
+            "media_files should still exist after m0013"
+        );
     }
 }

--- a/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
+++ b/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
@@ -98,24 +98,24 @@ impl GlobalMigration for Migration {
             SELECT
                 encrypted_file_hash,
                 COALESCE(
-                    NULLIF(
-                        (SELECT mf2.file_path
-                         FROM media_files mf2
-                         WHERE mf2.encrypted_file_hash = mf.encrypted_file_hash
-                           AND mf2.file_path != ''
-                         LIMIT 1),
-                        NULL
-                    ),
+                    (SELECT mf2.file_path
+                     FROM media_files mf2
+                     WHERE mf2.encrypted_file_hash = mf.encrypted_file_hash
+                       AND mf2.file_path != ''
+                     ORDER BY mf2.created_at ASC
+                     LIMIT 1),
                     ''
                 ),
                 (SELECT mf3.mime_type
                  FROM media_files mf3
                  WHERE mf3.encrypted_file_hash = mf.encrypted_file_hash
+                 ORDER BY mf3.created_at ASC
                  LIMIT 1),
                 (SELECT mf4.blossom_url
                  FROM media_files mf4
                  WHERE mf4.encrypted_file_hash = mf.encrypted_file_hash
                    AND mf4.blossom_url IS NOT NULL
+                 ORDER BY mf4.created_at ASC
                  LIMIT 1),
                 MIN(created_at)
             FROM media_files mf

--- a/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
+++ b/src/whitenoise/database/rust_migrations/m0013_media_blob_reference_split.rs
@@ -1,0 +1,297 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        13
+    }
+
+    fn description(&self) -> &'static str {
+        "Split media_files into media_blobs (shared) and media_references (account-scoped)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        // 1. Create shared blob cache table, deduplicated by encrypted hash.
+        sqlx::query(
+            "CREATE TABLE media_blobs (
+                encrypted_file_hash TEXT NOT NULL PRIMARY KEY,
+                file_path           TEXT NOT NULL DEFAULT '',
+                mime_type           TEXT NOT NULL,
+                blossom_url         TEXT,
+                created_at          INTEGER NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX idx_media_blobs_blossom_url
+                ON media_blobs(blossom_url)
+                WHERE blossom_url IS NOT NULL",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // 2. Create account-scoped media reference table.
+        sqlx::query(
+            "CREATE TABLE media_references (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id        BLOB NOT NULL,
+                account_pubkey      TEXT NOT NULL,
+                encrypted_file_hash TEXT NOT NULL,
+                media_type          TEXT NOT NULL,
+                nostr_key           TEXT,
+                file_metadata       BLOB,
+                original_file_hash  TEXT,
+                nonce               TEXT,
+                scheme_version      TEXT,
+                created_at          INTEGER NOT NULL,
+                UNIQUE(mls_group_id, encrypted_file_hash, account_pubkey),
+                FOREIGN KEY (encrypted_file_hash)
+                    REFERENCES media_blobs(encrypted_file_hash)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX idx_media_refs_account
+                ON media_references(account_pubkey)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX idx_media_refs_group_hash
+                ON media_references(mls_group_id, encrypted_file_hash)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX idx_media_refs_created
+                ON media_references(created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // 3. Backfill media_blobs from media_files (deduplicated by hash).
+        //    Takes the first occurrence's file_path, mime_type, blossom_url,
+        //    and earliest created_at for each unique encrypted_file_hash.
+        sqlx::query(
+            "INSERT INTO media_blobs
+                (encrypted_file_hash, file_path, mime_type, blossom_url, created_at)
+            SELECT
+                encrypted_file_hash,
+                COALESCE(
+                    NULLIF(
+                        (SELECT mf2.file_path
+                         FROM media_files mf2
+                         WHERE mf2.encrypted_file_hash = mf.encrypted_file_hash
+                           AND mf2.file_path != ''
+                         LIMIT 1),
+                        NULL
+                    ),
+                    ''
+                ),
+                (SELECT mf3.mime_type
+                 FROM media_files mf3
+                 WHERE mf3.encrypted_file_hash = mf.encrypted_file_hash
+                 LIMIT 1),
+                (SELECT mf4.blossom_url
+                 FROM media_files mf4
+                 WHERE mf4.encrypted_file_hash = mf.encrypted_file_hash
+                   AND mf4.blossom_url IS NOT NULL
+                 LIMIT 1),
+                MIN(created_at)
+            FROM media_files mf
+            GROUP BY encrypted_file_hash",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // 4. Backfill media_references from media_files.
+        sqlx::query(
+            "INSERT INTO media_references
+                (mls_group_id, account_pubkey, encrypted_file_hash,
+                 media_type, nostr_key, file_metadata,
+                 original_file_hash, nonce, scheme_version, created_at)
+            SELECT
+                mls_group_id, account_pubkey, encrypted_file_hash,
+                media_type, nostr_key, file_metadata,
+                original_file_hash, nonce, scheme_version, created_at
+            FROM media_files",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // 5. Drop old table and its indexes.
+        sqlx::query("DROP TABLE media_files")
+            .execute(&mut *tx)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::{Migrator, all_global_migrations};
+
+    async fn create_pool(dir: &TempDir, name: &str) -> SqlitePool {
+        let path = dir.path().join(name);
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+        SqlitePool::connect(&url).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn backfill_deduplicates_blobs_and_preserves_references() {
+        let dir = TempDir::new().unwrap();
+        let pool = create_pool(&dir, "backfill.db").await;
+
+        // Run m0001-m0011 to get the pre-split schema (includes media_files).
+        let pre_split: Vec<Box<dyn crate::whitenoise::database::rust_migrations::GlobalMigration>> =
+            all_global_migrations()
+                .into_iter()
+                .filter(|m| m.version() < 13)
+                .collect();
+        let runner = Migrator::new(pre_split, vec![]);
+        runner.run(&pool, None).await.unwrap();
+
+        // Seed accounts to satisfy foreign keys.
+        let acct_a = "aa".repeat(32);
+        let acct_b = "bb".repeat(32);
+        for pubkey in [&acct_a, &acct_b] {
+            sqlx::query(
+                "INSERT INTO users (pubkey, created_at, updated_at) VALUES (?, 1000, 1000)",
+            )
+            .bind(pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+            let user_id: i64 = sqlx::query_scalar("SELECT id FROM users WHERE pubkey = ?")
+                .bind(pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            sqlx::query(
+                "INSERT INTO accounts (pubkey, user_id, created_at, updated_at) \
+                 VALUES (?, ?, 1000, 1000)",
+            )
+            .bind(pubkey)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Seed media_files with 3 rows: two share the same encrypted_file_hash
+        // (different accounts), one has a unique hash.
+        let shared_hash = "aabbccdd";
+        let unique_hash = "11223344";
+        let group_id = vec![1u8; 8];
+
+        for (account, hash, file_path, blossom_url) in [
+            (
+                acct_a.as_str(),
+                shared_hash,
+                "/path/a.enc",
+                Some("https://blob.a"),
+            ),
+            (acct_b.as_str(), shared_hash, "/path/b.enc", None),
+            (
+                acct_a.as_str(),
+                unique_hash,
+                "/path/c.enc",
+                Some("https://blob.c"),
+            ),
+        ] {
+            sqlx::query(
+                "INSERT INTO media_files
+                    (mls_group_id, account_pubkey, file_path, original_file_hash,
+                     encrypted_file_hash, mime_type, media_type, blossom_url,
+                     nostr_key, nonce, scheme_version, created_at)
+                VALUES (?, ?, ?, NULL, ?, 'image/png', 'chat_media', ?, NULL, NULL, NULL, 1000)",
+            )
+            .bind(&group_id)
+            .bind(account)
+            .bind(file_path)
+            .bind(hash)
+            .bind(blossom_url)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Run m0013 to split the table.
+        let split_only = Migrator::new(vec![Box::new(Migration)], vec![]);
+        split_only.run(&pool, None).await.unwrap();
+
+        // media_files should be gone.
+        let tables: Vec<(String,)> = sqlx::query_as(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert!(tables.is_empty(), "media_files should be dropped");
+
+        // media_blobs: 2 rows (deduplicated by hash).
+        let blob_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM media_blobs")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(blob_count, 2, "should have 2 distinct blobs");
+
+        // media_references: 3 rows (one per original media_files row).
+        let ref_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM media_references")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(ref_count, 3, "should have 3 references");
+
+        // The shared blob should pick acct_a's file_path (first writer).
+        let (blob_path,): (String,) =
+            sqlx::query_as("SELECT file_path FROM media_blobs WHERE encrypted_file_hash = ?")
+                .bind(shared_hash)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(blob_path, "/path/a.enc", "first writer's path wins");
+
+        // The shared blob should have acct_a's blossom_url (non-NULL wins).
+        let (blob_blossom,): (Option<String>,) =
+            sqlx::query_as("SELECT blossom_url FROM media_blobs WHERE encrypted_file_hash = ?")
+                .bind(shared_hash)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            blob_blossom.as_deref(),
+            Some("https://blob.a"),
+            "non-NULL blossom_url should be picked"
+        );
+
+        // Both accounts should have references to the shared hash.
+        let shared_refs: Vec<(String,)> = sqlx::query_as(
+            "SELECT account_pubkey FROM media_references \
+             WHERE encrypted_file_hash = ? ORDER BY account_pubkey",
+        )
+        .bind(shared_hash)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        let accounts: Vec<&str> = shared_refs.iter().map(|(a,)| a.as_str()).collect();
+        assert_eq!(accounts, vec![acct_a.as_str(), acct_b.as_str()]);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0014_drop_media_files.rs
+++ b/src/whitenoise/database/rust_migrations/m0014_drop_media_files.rs
@@ -1,0 +1,78 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        14
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop legacy media_files table after blob/reference split"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS media_files")
+            .execute(&mut *tx)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use crate::whitenoise::database::rust_migrations::{Migrator, all_global_migrations};
+
+    async fn create_pool(dir: &TempDir, name: &str) -> SqlitePool {
+        let path = dir.path().join(name);
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+        SqlitePool::connect(&url).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn media_files_dropped_after_full_migration() {
+        let dir = TempDir::new().unwrap();
+        let pool = create_pool(&dir, "drop.db").await;
+
+        // Run all globals through m0014.
+        let globals: Vec<Box<dyn crate::whitenoise::database::rust_migrations::GlobalMigration>> =
+            all_global_migrations()
+                .into_iter()
+                .filter(|m| m.version() <= 14)
+                .collect();
+        let runner = Migrator::new(globals, vec![]);
+        runner.run(&pool, None).await.unwrap();
+
+        // media_files should be gone.
+        let tables: Vec<(String,)> = sqlx::query_as(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_files'",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert!(
+            tables.is_empty(),
+            "media_files should be dropped after m0014"
+        );
+
+        // media_blobs and media_references should still exist.
+        for table in &["media_blobs", "media_references"] {
+            let exists: Vec<(String,)> =
+                sqlx::query_as("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+                    .bind(table)
+                    .fetch_all(&pool)
+                    .await
+                    .unwrap();
+            assert!(!exists.is_empty(), "{table} should still exist after m0014");
+        }
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -18,6 +18,7 @@ mod m0009_mute_list;
 mod m0010_published_kp_kind_metadata;
 mod m0011_delivery_status_account_scope;
 mod m0012_bootstrap;
+mod m0013_media_blob_reference_split;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -34,6 +35,7 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0009_mute_list::Migration),
         Box::new(m0010_published_kp_kind_metadata::Migration),
         Box::new(m0011_delivery_status_account_scope::Migration),
+        Box::new(m0013_media_blob_reference_split::Migration),
     ]
 }
 

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -19,6 +19,7 @@ mod m0010_published_kp_kind_metadata;
 mod m0011_delivery_status_account_scope;
 mod m0012_bootstrap;
 mod m0013_media_blob_reference_split;
+mod m0014_drop_media_files;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -36,6 +37,7 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0010_published_kp_kind_metadata::Migration),
         Box::new(m0011_delivery_status_account_scope::Migration),
         Box::new(m0013_media_blob_reference_split::Migration),
+        Box::new(m0014_drop_media_files::Migration),
     ]
 }
 


### PR DESCRIPTION
## Summary

Splits the monolithic `media_files` table into two tables as part of Phase 18b:

- **`media_blobs`** — shared, content-addressed blob cache deduplicated by `encrypted_file_hash`
- **`media_references`** — account-scoped references linking blobs to MLS groups

### Migration design

Two global migrations handle the full split:

**m0013 (`media_blob_reference_split`):**
1. Creates `media_blobs` with a partial index on `blossom_url`
2. Creates `media_references` with indexes on `account_pubkey`, `(mls_group_id, encrypted_file_hash)`, and `created_at`
3. Backfills `media_blobs` from `media_files` (deduplicating by hash, picking first non-empty `file_path` and non-NULL `blossom_url`)
4. Backfills `media_references` from `media_files` (preserving all per-account rows)

**m0014 (`drop_media_files`):**
5. Drops the legacy `media_files` table — safe because m0013 atomically backfills both new tables in a single global transaction, so no data is lost

### Why `media_references` stays on shared (not a local migration)

`media_references` is logically account-scoped, but `AccountDatabase` is not wired into production init yet (Phase 18a scaffold only). `Database::new` calls `MIGRATOR.run(&pool, None)` — shared-only mode that skips all local migrations. All production queries in `media_files.rs` do `INNER JOIN media_references r ... media_blobs b` on `database.pool` (shared). If `media_references` were created by a local migration, it would never exist on the shared pool and every media query would fail with "no such table."

The table stays on shared until Phase 18c+ wires `AccountDatabase` into production init, at which point a local migration extracts it and a follow-up global drops it from shared.

### Why the FK constraint was removed

The `FOREIGN KEY (encrypted_file_hash) REFERENCES media_blobs(encrypted_file_hash)` was removed because once `media_references` moves to the account DB (Phase 18c+), the FK would be cross-database and unenforced by SQLite anyway. Removing it now avoids a schema change during extraction.

## Changes

- **m0013**: Creates `media_blobs` and `media_references` on shared, backfills both from `media_files`
- **m0014**: Drops legacy `media_files` table
- **fresh_account_schema.sql**: Updated comment to reflect Phase 18b status
- **All query methods** in `media_files.rs`: Rewritten to JOIN `media_references` + `media_blobs`
- **`save()`**: Wrapped in transaction; blob upsert uses `COALESCE` to promote `blossom_url` and `file_path` on subsequent writes
- **`find_by_hash()`**: Added `ORDER BY r.created_at ASC, r.id ASC` for deterministic `LIMIT 1`
- **`update_file_path()`**: Wrapped in transaction; doc comment documents shared-blob cross-account mutation caveat

## Test plan

- [x] `just precommit-quick` passes (fmt, docs, clippy, dead_code, tests)
- [x] Only pre-existing login test failures (3 tests in `accounts::login::tests` — failing on base `arch-refactor` branch)
- [x] m0013 test: blob deduplication (2 blobs from 3 rows), reference preservation (3 refs), first-writer-wins for `file_path`, non-NULL `blossom_url` selection, `media_files` still exists after m0013
- [x] m0014 test: `media_files` dropped, `media_blobs` and `media_references` survive
- [x] Shared blob survival test: deleting one account's references leaves the blob intact for other accounts