### PR TITLE
feat: move media_references from shared DB to per-account DBs

### DIFF
--- a/crates/whitenoise-cli/src/cli/commands/media.rs
+++ b/crates/whitenoise-cli/src/cli/commands/media.rs
@@ -71,7 +71,7 @@ impl MediaCmd {
                 group_id,
                 file_hash,
             } => download(socket, json, account_flag, group_id, file_hash).await,
-            Self::List { group_id } => list(socket, json, group_id).await,
+            Self::List { group_id } => list(socket, json, account_flag, group_id).await,
         }
     }
 }
@@ -102,8 +102,21 @@ async fn upload(
     output::print_and_exit(&resp, json)
 }
 
-async fn list(socket: &Path, json: bool, group_id: String) -> crate::cli::Result<()> {
-    let resp = client::send(socket, &Request::ListMedia { group_id }).await?;
+async fn list(
+    socket: &Path,
+    json: bool,
+    account_flag: Option<&str>,
+    group_id: String,
+) -> crate::cli::Result<()> {
+    let pubkey = account::resolve_account(socket, account_flag).await?;
+    let resp = client::send(
+        socket,
+        &Request::ListMedia {
+            account: pubkey,
+            group_id,
+        },
+    )
+    .await?;
     output::print_and_exit(&resp, json)
 }
 

--- a/crates/whitenoise-cli/src/cli/dispatch.rs
+++ b/crates/whitenoise-cli/src/cli/dispatch.rs
@@ -520,10 +520,12 @@ pub async fn dispatch(req: Request, wn: &Whitenoise) -> Response {
             Err(resp) => resp,
         },
 
-        Request::ListMedia { group_id } => match list_media(wn, &group_id).await {
-            Ok(resp) => resp,
-            Err(resp) => resp,
-        },
+        Request::ListMedia { account, group_id } => {
+            match list_media(wn, &account, &group_id).await {
+                Ok(resp) => resp,
+                Err(resp) => resp,
+            }
+        }
 
         // Streaming commands should be routed through dispatch_streaming
         Request::MessagesSubscribe { .. }
@@ -2038,11 +2040,16 @@ async fn download_media(
 }
 
 #[allow(deprecated)]
-async fn list_media(wn: &Whitenoise, group_id_hex: &str) -> Result<Response, Response> {
+async fn list_media(
+    wn: &Whitenoise,
+    account_str: &str,
+    group_id_hex: &str,
+) -> Result<Response, Response> {
+    let account = find_account(wn, account_str).await?;
     let group_id = parse_group_id(group_id_hex)?;
 
     let files = wn
-        .get_media_files_for_group(&group_id)
+        .get_media_files_for_group(&account, &group_id)
         .await
         .map_err(|e| Response::err(e.to_string()))?;
 

--- a/crates/whitenoise-cli/src/cli/protocol.rs
+++ b/crates/whitenoise-cli/src/cli/protocol.rs
@@ -279,7 +279,7 @@ pub enum Request {
         file_hash: String,
     },
     #[serde(rename = "list_media")]
-    ListMedia { group_id: String },
+    ListMedia { account: String, group_id: String },
 
     // Streaming
     #[serde(rename = "messages_subscribe")]

--- a/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
@@ -133,7 +133,7 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
             || async {
                 let files = context
                     .whitenoise
-                    .get_media_files_for_group(&group.mls_group_id)
+                    .get_media_files_for_group(receiver_account, &group.mls_group_id)
                     .await?;
 
                 // Filter to media files for receiver account with matching original_file_hash

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -631,14 +631,26 @@ impl Whitenoise {
         //    (MDK state and DB data are needed for build_chat_list_item)
         let chat_list_item = self.build_chat_list_item(account, group_id).await;
 
-        // 3. Delete all DB data in a transaction (fallible — must run before
+        // 3. Look up session for account-DB access
+        let session = self
+            .account_manager
+            .get_session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+
+        // 4. Delete all DB data in a transaction (fallible — must run before
         //    non-rollbackable MDK cleanup so a DB failure leaves state intact)
         self.shared
             .database
             .delete_chat_data(&account.pubkey, group_id)
             .await?;
 
-        // 4. Delete MDK group state for this account (best-effort)
+        // 4b. Delete per-account media_references for this group
+        sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
+            .bind(group_id.as_slice())
+            .execute(&session.account_db.inner.pool)
+            .await?;
+
+        // 5. Delete MDK group state for this account (best-effort)
         match self.create_mdk_for_account(account.pubkey) {
             Ok(mdk) => {
                 if let Err(e) = mdk.delete_group(group_id) {
@@ -658,10 +670,11 @@ impl Whitenoise {
             }
         }
 
-        // 5. Clean up orphaned media files from disk
+        // 6. Clean up orphaned media files from disk
         let media_files = crate::whitenoise::media_files::MediaFiles::new(
             &self.shared.storage,
             &self.shared.database,
+            &session.account_db.inner.pool,
         );
         if let Err(e) = media_files.cleanup_orphaned_files().await {
             tracing::warn!(

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::perf_instrument;
 use crate::whitenoise::{
     Whitenoise, accounts::Account, chat_list_streaming::ChatListUpdateTrigger, database::Database,
-    error::WhitenoiseError,
+    database::media_files::MediaFile, error::WhitenoiseError,
 };
 
 /// Represents the relationship between an account and an MLS group.
@@ -645,10 +645,7 @@ impl Whitenoise {
             .await?;
 
         // 4b. Delete per-account media_references for this group
-        sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
-            .bind(group_id.as_slice())
-            .execute(&session.account_db.inner.pool)
-            .await?;
+        MediaFile::delete_references_for_group(&session.account_db.inner.pool, group_id).await?;
 
         // 5. Delete MDK group state for this account (best-effort)
         match self.create_mdk_for_account(account.pubkey) {

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
 use chrono::{DateTime, Utc};
 use mdk_core::GroupId;
 use nostr_sdk::PublicKey;
 use serde::{Deserialize, Serialize};
 use sqlx::types::Json;
 use sqlx::{Row, SqlitePool};
-use std::path::{Path, PathBuf};
 
 use super::{Database, DatabaseError};
 use crate::perf_instrument;
@@ -109,6 +111,7 @@ struct ReferenceRow {
 }
 
 /// Data from a `media_blobs` row (shared DB).
+#[derive(Clone)]
 struct BlobRow {
     file_path: String,
     mime_type: String,
@@ -136,8 +139,18 @@ impl MediaFile {
             .and_then(|hex_str| hex::decode(&hex_str).ok());
         let file_metadata: Option<FileMetadata> =
             r.file_metadata.and_then(|s| serde_json::from_str(&s).ok());
-        let created_at = chrono::DateTime::from_timestamp_millis(r.created_at)
-            .unwrap_or(chrono::DateTime::<Utc>::MIN_UTC);
+        let created_at = match chrono::DateTime::from_timestamp_millis(r.created_at) {
+            Some(ts) => ts,
+            None => {
+                tracing::warn!(
+                    target: "whitenoise::database::media_files",
+                    encrypted_file_hash = %r.encrypted_file_hash,
+                    raw_millis = r.created_at,
+                    "media_references.created_at out of range, falling back to MIN_UTC",
+                );
+                chrono::DateTime::<Utc>::MIN_UTC
+            }
+        };
 
         Ok(Self {
             id: Some(r.id),
@@ -204,6 +217,52 @@ impl MediaFile {
             None => Ok(None),
         }
     }
+
+    /// Batch-fetch blob rows for a set of encrypted file hashes in one query.
+    async fn fetch_blobs_batch(
+        shared_pool: &SqlitePool,
+        hashes: &[&str],
+    ) -> std::result::Result<HashMap<String, BlobRow>, DatabaseError> {
+        if hashes.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Deduplicate hashes — multiple references can point to the same blob.
+        let unique: std::collections::HashSet<&str> = hashes.iter().copied().collect();
+
+        // Use QueryBuilder for a single IN-clause query with proper binds.
+        let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT encrypted_file_hash, file_path, mime_type, blossom_url \
+             FROM media_blobs \
+             WHERE encrypted_file_hash IN (",
+        );
+        let mut separated = qb.separated(", ");
+        for hash in &unique {
+            separated.push_bind(*hash);
+        }
+        separated.push_unseparated(")");
+
+        let rows = qb
+            .build()
+            .fetch_all(shared_pool)
+            .await
+            .map_err(DatabaseError::Sqlx)?;
+
+        let mut map = HashMap::with_capacity(rows.len());
+        for row in &rows {
+            let hash: String = row
+                .try_get("encrypted_file_hash")
+                .map_err(DatabaseError::Sqlx)?;
+            let blob = BlobRow {
+                file_path: row.try_get("file_path").map_err(DatabaseError::Sqlx)?,
+                mime_type: row.try_get("mime_type").map_err(DatabaseError::Sqlx)?,
+                blossom_url: row.try_get("blossom_url").map_err(DatabaseError::Sqlx)?,
+            };
+            map.insert(hash, blob);
+        }
+
+        Ok(map)
+    }
 }
 
 impl MediaFile {
@@ -244,13 +303,10 @@ impl MediaFile {
             None => return Ok(None),
         };
 
-        let blob = Self::fetch_blob(&shared_db.pool, &hash_hex)
-            .await?
-            .unwrap_or(BlobRow {
-                file_path: String::new(),
-                mime_type: String::new(),
-                blossom_url: None,
-            });
+        let blob = match Self::fetch_blob(&shared_db.pool, &hash_hex).await? {
+            Some(b) => b,
+            None => return Ok(None),
+        };
 
         Ok(Some(Self::assemble(ref_row, blob, *account_pubkey)?))
     }
@@ -347,11 +403,11 @@ impl MediaFile {
         // Read back the blob from the shared DB.
         let blob = Self::fetch_blob(&shared_db.pool, &encrypted_file_hash_hex)
             .await?
-            .unwrap_or(BlobRow {
-                file_path: String::new(),
-                mime_type: String::new(),
-                blossom_url: None,
-            });
+            .ok_or_else(|| {
+                WhitenoiseError::MediaCache(format!(
+                    "missing media_blobs row for hash {encrypted_file_hash_hex}"
+                ))
+            })?;
 
         Self::assemble(ref_row, blob, *account_pubkey)
     }
@@ -378,16 +434,31 @@ impl MediaFile {
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        let mut result = Vec::with_capacity(ref_rows.len());
+        let mut refs: Vec<ReferenceRow> = Vec::with_capacity(ref_rows.len());
         for row in &ref_rows {
-            let r = Self::ref_from_row(row).map_err(DatabaseError::Sqlx)?;
-            let blob = Self::fetch_blob(&shared_db.pool, &r.encrypted_file_hash)
-                .await?
-                .unwrap_or(BlobRow {
-                    file_path: String::new(),
-                    mime_type: String::new(),
-                    blossom_url: None,
-                });
+            refs.push(Self::ref_from_row(row).map_err(DatabaseError::Sqlx)?);
+        }
+
+        // Batch-fetch all blobs in one query instead of N round-trips.
+        let hashes: Vec<&str> = refs
+            .iter()
+            .map(|r| r.encrypted_file_hash.as_str())
+            .collect();
+        let blob_map = Self::fetch_blobs_batch(&shared_db.pool, &hashes).await?;
+
+        let mut result = Vec::with_capacity(refs.len());
+        for r in refs {
+            let blob = match blob_map.get(&r.encrypted_file_hash) {
+                Some(b) => b.clone(),
+                None => {
+                    tracing::warn!(
+                        target: "whitenoise::database::media_files",
+                        encrypted_file_hash = %r.encrypted_file_hash,
+                        "media_blobs row missing for referenced hash; skipping entry",
+                    );
+                    continue;
+                }
+            };
             result.push(Self::assemble(r, blob, *account_pubkey)?);
         }
 
@@ -432,13 +503,10 @@ impl MediaFile {
             None => return Ok(None),
         };
 
-        let blob = Self::fetch_blob(&shared_db.pool, &ref_row.encrypted_file_hash)
-            .await?
-            .unwrap_or(BlobRow {
-                file_path: String::new(),
-                mime_type: String::new(),
-                blossom_url: None,
-            });
+        let blob = match Self::fetch_blob(&shared_db.pool, &ref_row.encrypted_file_hash).await? {
+            Some(b) => b,
+            None => return Ok(None),
+        };
 
         Ok(Some(Self::assemble(ref_row, blob, *account_pubkey)?))
     }
@@ -496,11 +564,9 @@ impl MediaFile {
 
         let blob = Self::fetch_blob(&shared_db.pool, &hash)
             .await?
-            .unwrap_or(BlobRow {
-                file_path: String::new(),
-                mime_type: String::new(),
-                blossom_url: None,
-            });
+            .ok_or_else(|| {
+                WhitenoiseError::MediaCache(format!("missing media_blobs row for hash {hash}"))
+            })?;
 
         Self::assemble(ref_row, blob, *account_pubkey)
     }
@@ -538,6 +604,19 @@ impl MediaFile {
     /// Check if this media file is a document
     pub fn is_document(&self) -> bool {
         self.mime_type == "application/pdf"
+    }
+
+    /// Deletes all per-account `media_references` rows for a given group.
+    pub(crate) async fn delete_references_for_group(
+        account_pool: &SqlitePool,
+        group_id: &GroupId,
+    ) -> Result<(), WhitenoiseError> {
+        sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
+            .bind(group_id.as_slice())
+            .execute(account_pool)
+            .await
+            .map_err(DatabaseError::Sqlx)?;
+        Ok(())
     }
 }
 

--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -3,9 +3,10 @@ use mdk_core::GroupId;
 use nostr_sdk::PublicKey;
 use serde::{Deserialize, Serialize};
 use sqlx::types::Json;
+use sqlx::{Row, SqlitePool};
 use std::path::{Path, PathBuf};
 
-use super::{Database, DatabaseError, utils::parse_timestamp};
+use super::{Database, DatabaseError};
 use crate::perf_instrument;
 use crate::whitenoise::error::WhitenoiseError;
 
@@ -93,141 +94,182 @@ pub struct MediaFile {
     pub created_at: DateTime<Utc>,
 }
 
-impl<'r, R> sqlx::FromRow<'r, R> for MediaFile
-where
-    R: sqlx::Row,
-    &'r str: sqlx::ColumnIndex<R>,
-    String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-{
-    fn from_row(row: &'r R) -> std::result::Result<Self, sqlx::Error> {
-        let id: i64 = row.try_get("id")?;
-        let mls_group_id_bytes: Vec<u8> = row.try_get("mls_group_id")?;
-        let account_pubkey_str: String = row.try_get("account_pubkey")?;
-        let file_path_str: String = row.try_get("file_path")?;
+/// Data from a `media_references` row (per-account DB).
+struct ReferenceRow {
+    id: i64,
+    mls_group_id: Vec<u8>,
+    encrypted_file_hash: String,
+    original_file_hash: Option<String>,
+    media_type: String,
+    nostr_key: Option<String>,
+    file_metadata: Option<String>,
+    nonce: Option<String>,
+    scheme_version: Option<String>,
+    created_at: i64,
+}
 
-        // Parse MLS group ID
-        let mls_group_id = GroupId::from_slice(&mls_group_id_bytes);
+/// Data from a `media_blobs` row (shared DB).
+struct BlobRow {
+    file_path: String,
+    mime_type: String,
+    blossom_url: Option<String>,
+}
 
-        // Parse account pubkey
-        let account_pubkey =
-            PublicKey::parse(&account_pubkey_str).map_err(|e| sqlx::Error::ColumnDecode {
-                index: "account_pubkey".to_string(),
-                source: Box::new(e),
-            })?;
-
-        // Parse file path
-        let file_path = PathBuf::from(file_path_str);
-
-        // Parse encrypted_file_hash from hex (required)
-        let encrypted_file_hash_hex: String = row.try_get("encrypted_file_hash")?;
-        let encrypted_file_hash =
-            hex::decode(encrypted_file_hash_hex).map_err(|e| sqlx::Error::ColumnDecode {
+impl MediaFile {
+    /// Assemble a `MediaFile` from a reference row (account DB) and a blob
+    /// row (shared DB). The `account_pubkey` is the owning account — it is
+    /// implicit in the per-account database file (no column in the table).
+    fn assemble(
+        r: ReferenceRow,
+        b: BlobRow,
+        account_pubkey: PublicKey,
+    ) -> std::result::Result<Self, WhitenoiseError> {
+        let mls_group_id = GroupId::from_slice(&r.mls_group_id);
+        let encrypted_file_hash = hex::decode(&r.encrypted_file_hash).map_err(|e| {
+            DatabaseError::Sqlx(sqlx::Error::ColumnDecode {
                 index: "encrypted_file_hash".to_string(),
                 source: Box::new(e),
-            })?;
-
-        // Parse original_file_hash from hex (optional - NULL for old records and group images)
-        let original_file_hash: Option<Vec<u8>> = row
-            .try_get::<Option<String>, _>("original_file_hash")?
-            .and_then(|hex| hex::decode(&hex).ok());
-
-        let mime_type: String = row.try_get("mime_type")?;
-        let media_type: String = row.try_get("media_type")?;
-        let blossom_url: Option<String> = row.try_get("blossom_url")?;
-        let nostr_key: Option<String> = row.try_get("nostr_key")?;
-
-        // Deserialize file_metadata from JSON stored as TEXT/BLOB
-        // We can't use Json<T> directly here because our generic FromRow implementation
-        // doesn't constrain the database type, so we deserialize manually
-        let file_metadata: Option<FileMetadata> = row
-            .try_get::<Option<String>, _>("file_metadata")?
-            .and_then(|json_str| serde_json::from_str(&json_str).ok());
-
-        let nonce: Option<String> = row.try_get("nonce")?;
-        let scheme_version: Option<String> = row.try_get("scheme_version")?;
-
-        let created_at = parse_timestamp(row, "created_at")?;
+            })
+        })?;
+        let original_file_hash = r
+            .original_file_hash
+            .and_then(|hex_str| hex::decode(&hex_str).ok());
+        let file_metadata: Option<FileMetadata> =
+            r.file_metadata.and_then(|s| serde_json::from_str(&s).ok());
+        let created_at = chrono::DateTime::from_timestamp_millis(r.created_at)
+            .unwrap_or(chrono::DateTime::<Utc>::MIN_UTC);
 
         Ok(Self {
-            id: Some(id),
+            id: Some(r.id),
             mls_group_id,
             account_pubkey,
-            file_path,
+            file_path: PathBuf::from(b.file_path),
             original_file_hash,
             encrypted_file_hash,
-            mime_type,
-            media_type,
-            blossom_url,
-            nostr_key,
+            mime_type: b.mime_type,
+            media_type: r.media_type,
+            blossom_url: b.blossom_url,
+            nostr_key: r.nostr_key,
             file_metadata,
-            nonce,
-            scheme_version,
+            nonce: r.nonce,
+            scheme_version: r.scheme_version,
             created_at,
         })
+    }
+
+    /// Read a `ReferenceRow` from a SQLite row.
+    fn ref_from_row(
+        row: &sqlx::sqlite::SqliteRow,
+    ) -> std::result::Result<ReferenceRow, sqlx::Error> {
+        Ok(ReferenceRow {
+            id: row.try_get("id")?,
+            mls_group_id: row.try_get("mls_group_id")?,
+            encrypted_file_hash: row.try_get("encrypted_file_hash")?,
+            original_file_hash: row.try_get("original_file_hash")?,
+            media_type: row.try_get("media_type")?,
+            nostr_key: row.try_get("nostr_key")?,
+            file_metadata: row.try_get("file_metadata")?,
+            nonce: row.try_get("nonce")?,
+            scheme_version: row.try_get("scheme_version")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
+
+    /// Read a `BlobRow` from a SQLite row.
+    fn blob_from_row(row: &sqlx::sqlite::SqliteRow) -> std::result::Result<BlobRow, sqlx::Error> {
+        Ok(BlobRow {
+            file_path: row.try_get("file_path")?,
+            mime_type: row.try_get("mime_type")?,
+            blossom_url: row.try_get("blossom_url")?,
+        })
+    }
+
+    /// Fetch the blob for a given encrypted_file_hash from the shared DB.
+    async fn fetch_blob(
+        shared_pool: &SqlitePool,
+        encrypted_file_hash_hex: &str,
+    ) -> std::result::Result<Option<BlobRow>, DatabaseError> {
+        let row = sqlx::query(
+            "SELECT file_path, mime_type, blossom_url
+             FROM media_blobs
+             WHERE encrypted_file_hash = ?",
+        )
+        .bind(encrypted_file_hash_hex)
+        .fetch_optional(shared_pool)
+        .await
+        .map_err(DatabaseError::Sqlx)?;
+
+        match row {
+            Some(r) => Ok(Some(Self::blob_from_row(&r).map_err(DatabaseError::Sqlx)?)),
+            None => Ok(None),
+        }
     }
 }
 
 impl MediaFile {
-    /// Finds a media file by its encrypted file hash
+    /// Finds a media file by its encrypted file hash.
     ///
-    /// Returns the first matching media file for any group/account combination.
-    /// This is useful for retrieving stored metadata (like blossom_url) when you
-    /// only have the encrypted hash.
+    /// Reads the reference from the **account** pool and the blob from the
+    /// **shared** pool, combining them in Rust.
     ///
     /// # Arguments
-    /// * `database` - The database connection
+    /// * `account_pool` - Per-account database pool (holds `media_references`)
+    /// * `shared_db` - Shared database (holds `media_blobs`)
+    /// * `account_pubkey` - The owning account (implicit in the per-account DB)
     /// * `encrypted_file_hash` - The SHA-256 hash of the encrypted file
-    ///
-    /// # Returns
-    /// The MediaFile if found, None otherwise
     #[perf_instrument("db::media_files")]
     pub(crate) async fn find_by_hash(
-        database: &Database,
+        account_pool: &SqlitePool,
+        shared_db: &Database,
+        account_pubkey: &PublicKey,
         encrypted_file_hash: &[u8; 32],
     ) -> Result<Option<Self>, WhitenoiseError> {
-        let encrypted_file_hash_hex = hex::encode(encrypted_file_hash);
+        let hash_hex = hex::encode(encrypted_file_hash);
 
-        let row_opt = sqlx::query_as::<_, Self>(
-            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
-                    r.original_file_hash, r.encrypted_file_hash,
-                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
-                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
-             FROM media_references r
-             INNER JOIN media_blobs b
-                ON b.encrypted_file_hash = r.encrypted_file_hash
-             WHERE r.encrypted_file_hash = ?
-             ORDER BY r.created_at ASC, r.id ASC
+        let ref_row = sqlx::query(
+            "SELECT id, mls_group_id, encrypted_file_hash, original_file_hash,
+                    media_type, nostr_key, file_metadata, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE encrypted_file_hash = ?
+             ORDER BY created_at ASC, id ASC
              LIMIT 1",
         )
-        .bind(&encrypted_file_hash_hex)
-        .fetch_optional(&database.pool)
+        .bind(&hash_hex)
+        .fetch_optional(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        Ok(row_opt)
+        let ref_row = match ref_row {
+            Some(r) => Self::ref_from_row(&r).map_err(DatabaseError::Sqlx)?,
+            None => return Ok(None),
+        };
+
+        let blob = Self::fetch_blob(&shared_db.pool, &hash_hex)
+            .await?
+            .unwrap_or(BlobRow {
+                file_path: String::new(),
+                mime_type: String::new(),
+                blossom_url: None,
+            });
+
+        Ok(Some(Self::assemble(ref_row, blob, *account_pubkey)?))
     }
 
-    /// Saves a cached media file to the database
+    /// Saves a cached media file to the database.
     ///
-    /// Inserts a new row or ignores if the record already exists
-    /// (based on unique constraint on mls_group_id, encrypted_file_hash, account_pubkey)
+    /// Upserts the blob on the **shared** pool and inserts the reference on the
+    /// **account** pool. Returns the assembled `MediaFile`.
     ///
     /// # Arguments
-    /// * `database` - The database connection
+    /// * `account_pool` - Per-account database pool (holds `media_references`)
+    /// * `shared_db` - Shared database (holds `media_blobs`)
     /// * `mls_group_id` - The MLS group ID
     /// * `account_pubkey` - The account public key accessing this media
     /// * `params` - Media file parameters (path, hashes, mime type, etc.)
-    ///
-    /// # Returns
-    /// The MediaFile with the database-assigned ID
-    ///
-    /// # Errors
-    /// Returns a [`WhitenoiseError`] if the database operation fails.
     #[perf_instrument("db::media_files")]
     pub(crate) async fn save(
-        database: &Database,
+        account_pool: &SqlitePool,
+        shared_db: &Database,
         mls_group_id: &GroupId,
         account_pubkey: &PublicKey,
         params: MediaFileParams<'_>,
@@ -240,15 +282,9 @@ impl MediaFile {
             .to_str()
             .ok_or_else(|| WhitenoiseError::MediaCache("Invalid file path".to_string()))?;
 
-        // Wrap file_metadata in Json for automatic serialization
-        // Only store if not empty (optimization)
         let file_metadata_json = params.file_metadata.filter(|m| !m.is_empty()).map(Json);
 
-        let account_pubkey_hex = account_pubkey.to_hex();
-
-        let mut tx = database.pool.begin().await.map_err(DatabaseError::Sqlx)?;
-
-        // Upsert blob (shared, deduplicated by hash).
+        // Upsert blob on shared DB.
         sqlx::query(
             "INSERT INTO media_blobs
                 (encrypted_file_hash, file_path, mime_type, blossom_url, created_at)
@@ -265,23 +301,22 @@ impl MediaFile {
         .bind(params.mime_type)
         .bind(params.blossom_url)
         .bind(now_ms)
-        .execute(&mut *tx)
+        .execute(&shared_db.pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        // Upsert reference (account-scoped).
+        // Upsert reference on account DB (no account_pubkey column).
         sqlx::query(
             "INSERT INTO media_references (
-                mls_group_id, account_pubkey, encrypted_file_hash,
+                mls_group_id, encrypted_file_hash,
                 media_type, nostr_key, file_metadata,
                 original_file_hash, nonce, scheme_version, created_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (mls_group_id, encrypted_file_hash, account_pubkey)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (mls_group_id, encrypted_file_hash)
             DO NOTHING",
         )
         .bind(mls_group_id.as_slice())
-        .bind(&account_pubkey_hex)
         .bind(&encrypted_file_hash_hex)
         .bind(params.media_type)
         .bind(params.nostr_key)
@@ -290,158 +325,136 @@ impl MediaFile {
         .bind(params.nonce)
         .bind(params.scheme_version)
         .bind(now_ms)
-        .execute(&mut *tx)
+        .execute(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        // Whether inserted or conflict, select the joined row.
-        let existing = sqlx::query_as::<_, Self>(
-            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
-                    r.original_file_hash, r.encrypted_file_hash,
-                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
-                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
-             FROM media_references r
-             INNER JOIN media_blobs b
-                ON b.encrypted_file_hash = r.encrypted_file_hash
-             WHERE r.mls_group_id = ? AND r.encrypted_file_hash = ?
-               AND r.account_pubkey = ?
+        // Read back the reference from the account DB.
+        let ref_row = sqlx::query(
+            "SELECT id, mls_group_id, encrypted_file_hash, original_file_hash,
+                    media_type, nostr_key, file_metadata, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE mls_group_id = ? AND encrypted_file_hash = ?
              LIMIT 1",
         )
         .bind(mls_group_id.as_slice())
         .bind(&encrypted_file_hash_hex)
-        .bind(&account_pubkey_hex)
-        .fetch_one(&mut *tx)
+        .fetch_one(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
+        let ref_row = Self::ref_from_row(&ref_row).map_err(DatabaseError::Sqlx)?;
 
-        tx.commit().await.map_err(DatabaseError::Sqlx)?;
+        // Read back the blob from the shared DB.
+        let blob = Self::fetch_blob(&shared_db.pool, &encrypted_file_hash_hex)
+            .await?
+            .unwrap_or(BlobRow {
+                file_path: String::new(),
+                mime_type: String::new(),
+                blossom_url: None,
+            });
 
-        Ok(existing)
+        Self::assemble(ref_row, blob, *account_pubkey)
     }
 
-    /// Finds all media files for a specific MLS group
+    /// Finds all media files for a specific MLS group.
     ///
-    /// Returns a Vec of MediaFile records for the group.
-    /// This leverages the indexed mls_group_id column for efficient retrieval.
-    ///
-    /// # Arguments
-    /// * `database` - Database connection
-    /// * `group_id` - The MLS group ID to fetch media files for
+    /// Reads references from the **account** pool and blobs from the **shared**
+    /// pool, assembling the results in Rust.
     #[perf_instrument("db::media_files")]
     pub(crate) async fn find_by_group(
-        database: &Database,
+        account_pool: &SqlitePool,
+        shared_db: &Database,
+        account_pubkey: &PublicKey,
         group_id: &GroupId,
     ) -> Result<Vec<Self>, WhitenoiseError> {
-        let rows = sqlx::query_as::<_, Self>(
-            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
-                    r.original_file_hash, r.encrypted_file_hash,
-                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
-                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
-             FROM media_references r
-             INNER JOIN media_blobs b
-                ON b.encrypted_file_hash = r.encrypted_file_hash
-             WHERE r.mls_group_id = ?",
+        let ref_rows = sqlx::query(
+            "SELECT id, mls_group_id, encrypted_file_hash, original_file_hash,
+                    media_type, nostr_key, file_metadata, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE mls_group_id = ?",
         )
         .bind(group_id.as_slice())
-        .fetch_all(&database.pool)
+        .fetch_all(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        Ok(rows)
+        let mut result = Vec::with_capacity(ref_rows.len());
+        for row in &ref_rows {
+            let r = Self::ref_from_row(row).map_err(DatabaseError::Sqlx)?;
+            let blob = Self::fetch_blob(&shared_db.pool, &r.encrypted_file_hash)
+                .await?
+                .unwrap_or(BlobRow {
+                    file_path: String::new(),
+                    mime_type: String::new(),
+                    blossom_url: None,
+                });
+            result.push(Self::assemble(r, blob, *account_pubkey)?);
+        }
+
+        Ok(result)
     }
 
-    /// Finds a media file by original hash, group ID, and account (MIP-04 compliant lookup)
+    /// Finds a media file by original hash and group ID (MIP-04 compliant lookup).
     ///
-    /// This is the primary lookup method for media files referenced in imeta tags,
-    /// as MIP-04 requires the 'x' field to contain the original content hash.
-    ///
-    /// The query is scoped to a specific group and account for security and correctness.
-    /// In multi-account setups, the same file hash can exist in the same group but with
-    /// separate records per account, so we must filter by account_pubkey to prevent
-    /// cross-account cache corruption.
+    /// The account scope is implicit in the per-account database file.
     ///
     /// # Arguments
-    /// * `database` - The database connection
+    /// * `account_pool` - Per-account database pool (holds `media_references`)
+    /// * `shared_db` - Shared database (holds `media_blobs`)
+    /// * `account_pubkey` - The owning account
     /// * `original_file_hash` - The SHA-256 hash of the decrypted file content
     /// * `group_id` - The MLS group ID to scope the search to
-    /// * `account_pubkey` - The account public key (ensures account-scoped lookup)
-    ///
-    /// # Returns
-    /// * `Ok(Some(MediaFile))` - The matching media file for this account
-    /// * `Ok(None)` - No matching media file found for this account
-    /// * `Err(WhitenoiseError)` - Database error
-    ///
-    /// # Example
-    /// ```ignore
-    /// // Look up media file from imeta tag
-    /// let original_hash = hex::decode(&imeta_x_field)?;
-    /// if let Some(media_file) = MediaFile::find_by_original_hash_and_group(
-    ///     &db, &original_hash, &group_id, &account_pubkey
-    /// ).await? {
-    ///     // Download and decrypt the file
-    /// }
-    /// ```
     #[perf_instrument("db::media_files")]
     pub(crate) async fn find_by_original_hash_and_group(
-        database: &Database,
+        account_pool: &SqlitePool,
+        shared_db: &Database,
+        account_pubkey: &PublicKey,
         original_file_hash: &[u8; 32],
         group_id: &GroupId,
-        account_pubkey: &PublicKey,
     ) -> Result<Option<Self>, WhitenoiseError> {
         let hash_hex = hex::encode(original_file_hash);
-        let account_hex = account_pubkey.to_hex();
 
-        let row_opt = sqlx::query_as::<_, Self>(
-            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
-                    r.original_file_hash, r.encrypted_file_hash,
-                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
-                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
-             FROM media_references r
-             INNER JOIN media_blobs b
-                ON b.encrypted_file_hash = r.encrypted_file_hash
-             WHERE r.original_file_hash = ? AND r.mls_group_id = ?
-               AND r.account_pubkey = ?
+        let ref_row = sqlx::query(
+            "SELECT id, mls_group_id, encrypted_file_hash, original_file_hash,
+                    media_type, nostr_key, file_metadata, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE original_file_hash = ? AND mls_group_id = ?
              LIMIT 1",
         )
         .bind(&hash_hex)
         .bind(group_id.as_slice())
-        .bind(&account_hex)
-        .fetch_optional(&database.pool)
+        .fetch_optional(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
 
-        Ok(row_opt)
+        let ref_row = match ref_row {
+            Some(r) => Self::ref_from_row(&r).map_err(DatabaseError::Sqlx)?,
+            None => return Ok(None),
+        };
+
+        let blob = Self::fetch_blob(&shared_db.pool, &ref_row.encrypted_file_hash)
+            .await?
+            .unwrap_or(BlobRow {
+                file_path: String::new(),
+                mime_type: String::new(),
+                blossom_url: None,
+            });
+
+        Ok(Some(Self::assemble(ref_row, blob, *account_pubkey)?))
     }
 
-    /// Updates the file_path for an existing media file record
+    /// Updates the file_path for an existing media file record.
     ///
-    /// This method is called after downloading and caching a media file to update
-    /// the database record with the local file path.
+    /// Reads the `encrypted_file_hash` from the **account** pool's reference
+    /// row, then updates the **shared** blob's `file_path`.
     ///
     /// NOTE: This mutates the shared `media_blobs` row, which affects every
-    /// account referencing the same `encrypted_file_hash`. This is correct
-    /// while all accounts share a single `media_cache` directory. If Phase 18c
-    /// introduces per-account storage directories, this assumption must be
-    /// revisited.
-    ///
-    /// # Arguments
-    /// * `database` - The database connection
-    /// * `id` - The media file ID to update
-    /// * `new_path` - The new file path to set
-    ///
-    /// # Returns
-    /// * `Ok(MediaFile)` - The updated media file record
-    /// * `Err(WhitenoiseError)` - If the record doesn't exist or database error
-    ///
-    /// # Example
-    /// ```ignore
-    /// // After downloading and caching a file
-    /// let cached_path = PathBuf::from("/cache/media/abc123.jpg");
-    /// let updated = MediaFile::update_file_path(&db, media_file.id.unwrap(), &cached_path).await?;
-    /// ```
+    /// account referencing the same `encrypted_file_hash`.
     #[perf_instrument("db::media_files")]
     pub(crate) async fn update_file_path(
-        database: &Database,
+        account_pool: &SqlitePool,
+        shared_db: &Database,
+        account_pubkey: &PublicKey,
         id: i64,
         new_path: &Path,
     ) -> Result<Self, WhitenoiseError> {
@@ -449,13 +462,11 @@ impl MediaFile {
             .to_str()
             .ok_or_else(|| WhitenoiseError::MediaCache("Invalid file path".to_string()))?;
 
-        let mut tx = database.pool.begin().await.map_err(DatabaseError::Sqlx)?;
-
-        // Look up the encrypted_file_hash from the reference row.
+        // Look up the encrypted_file_hash from the account-DB reference row.
         let hash: String =
             sqlx::query_scalar("SELECT encrypted_file_hash FROM media_references WHERE id = ?")
                 .bind(id)
-                .fetch_optional(&mut *tx)
+                .fetch_optional(account_pool)
                 .await
                 .map_err(DatabaseError::Sqlx)?
                 .ok_or_else(|| {
@@ -466,39 +477,44 @@ impl MediaFile {
         sqlx::query("UPDATE media_blobs SET file_path = ? WHERE encrypted_file_hash = ?")
             .bind(path_str)
             .bind(&hash)
-            .execute(&mut *tx)
+            .execute(&shared_db.pool)
             .await
             .map_err(DatabaseError::Sqlx)?;
 
-        // Return the joined record.
-        let row = sqlx::query_as::<_, Self>(
-            "SELECT r.id, r.mls_group_id, r.account_pubkey, b.file_path,
-                    r.original_file_hash, r.encrypted_file_hash,
-                    b.mime_type, r.media_type, b.blossom_url, r.nostr_key,
-                    r.file_metadata, r.nonce, r.scheme_version, r.created_at
-             FROM media_references r
-             INNER JOIN media_blobs b
-                ON b.encrypted_file_hash = r.encrypted_file_hash
-             WHERE r.id = ?",
+        // Read back the reference.
+        let ref_row = sqlx::query(
+            "SELECT id, mls_group_id, encrypted_file_hash, original_file_hash,
+                    media_type, nostr_key, file_metadata, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE id = ?",
         )
         .bind(id)
-        .fetch_one(&mut *tx)
+        .fetch_one(account_pool)
         .await
         .map_err(DatabaseError::Sqlx)?;
+        let ref_row = Self::ref_from_row(&ref_row).map_err(DatabaseError::Sqlx)?;
 
-        tx.commit().await.map_err(DatabaseError::Sqlx)?;
+        let blob = Self::fetch_blob(&shared_db.pool, &hash)
+            .await?
+            .unwrap_or(BlobRow {
+                file_path: String::new(),
+                mime_type: String::new(),
+                blossom_url: None,
+            });
 
-        Ok(row)
+        Self::assemble(ref_row, blob, *account_pubkey)
     }
 
     /// Returns all distinct non-empty file paths referenced by media_blobs records.
+    ///
+    /// Reads from the **shared** database only (blobs are shared across accounts).
     #[perf_instrument("db::media_files")]
     pub(crate) async fn all_referenced_file_paths(
-        database: &Database,
+        shared_db: &Database,
     ) -> Result<Vec<String>, WhitenoiseError> {
         let paths: Vec<String> =
             sqlx::query_scalar("SELECT DISTINCT file_path FROM media_blobs WHERE file_path != ''")
-                .fetch_all(&database.pool)
+                .fetch_all(&shared_db.pool)
                 .await
                 .map_err(DatabaseError::Sqlx)?;
         Ok(paths)
@@ -528,10 +544,55 @@ impl MediaFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::whitenoise::database::account_db::AccountDatabase;
     use tempfile::TempDir;
 
+    /// Test fixture: shared DB (media_blobs) + account DB (media_references).
+    struct TestDbs {
+        shared: Database,
+        account_pool: SqlitePool,
+        account_pubkey: PublicKey,
+        _dir: TempDir,
+    }
+
+    async fn setup_test_dbs() -> TestDbs {
+        let dir = TempDir::new().unwrap();
+        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
+        let shared = Database::new(dir.path().join("shared.db")).await.unwrap();
+        let account_db = AccountDatabase::new(pubkey, dir.path().join("account.db"))
+            .await
+            .unwrap();
+        account_db
+            .run_account_migrations(&shared.pool)
+            .await
+            .unwrap();
+
+        // Create user+account in shared DB for FK constraints
+        create_test_account(&shared, &pubkey).await;
+
+        TestDbs {
+            shared,
+            account_pool: account_db.inner.pool,
+            account_pubkey: pubkey,
+            _dir: dir,
+        }
+    }
+
+    /// Set up a second account against the same shared DB.
+    async fn add_account(shared: &Database, dir: &TempDir, pubkey: &PublicKey) -> SqlitePool {
+        let account_db =
+            AccountDatabase::new(*pubkey, dir.path().join(format!("{}.db", pubkey.to_hex())))
+                .await
+                .unwrap();
+        account_db
+            .run_account_migrations(&shared.pool)
+            .await
+            .unwrap();
+        create_test_account(shared, pubkey).await;
+        account_db.inner.pool
+    }
+
     async fn create_test_account(db: &Database, pubkey: &PublicKey) {
-        // Create test user and account to satisfy foreign key constraints
         sqlx::query("INSERT INTO users (pubkey, created_at, updated_at) VALUES (?, ?, ?)")
             .bind(pubkey.to_hex())
             .bind(chrono::Utc::now().timestamp())
@@ -560,25 +621,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_save_media_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-
-        // Create a test group ID
+        let t = setup_test_dbs().await;
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
         let encrypted_file_hash = [3u8; 32];
-        let file_path = temp_dir.path().join("test.jpg");
+        let file_path = t._dir.path().join("test.jpg");
 
-        // Create test account to satisfy foreign key constraint
-        create_test_account(&db, &pubkey).await;
-
-        // Save media - the save method returns the persisted record
-        // Group images don't have original_file_hash (they use key/nonce encryption)
         let media_file = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path,
                 original_file_hash: None,
@@ -595,7 +647,6 @@ mod tests {
         .await
         .unwrap();
 
-        // Verify the returned record has correct data
         assert!(media_file.id.is_some());
         assert!(media_file.id.unwrap() > 0);
         assert_eq!(media_file.encrypted_file_hash, encrypted_file_hash.to_vec());
@@ -603,29 +654,23 @@ mod tests {
         assert_eq!(media_file.mime_type, "image/jpeg");
         assert_eq!(media_file.media_type, "group_image");
         assert_eq!(media_file.mls_group_id, group_id);
-        assert_eq!(media_file.account_pubkey, pubkey);
+        assert_eq!(media_file.account_pubkey, t.account_pubkey);
     }
 
     #[tokio::test]
     async fn test_upsert_on_conflict() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
-        // Create a test group ID
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
         let encrypted_file_hash = [3u8; 32];
-        let file_path = temp_dir.path().join("test.jpg");
-
-        // Create test account to satisfy foreign key constraint
-        create_test_account(&db, &pubkey).await;
+        let file_path = t._dir.path().join("test.jpg");
 
         // Save media first time
         let first_save = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path,
                 original_file_hash: None,
@@ -647,9 +692,10 @@ mod tests {
 
         // Save same media again (should trigger conflict and return existing row)
         let second_save = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path,
                 original_file_hash: None,
@@ -671,30 +717,26 @@ mod tests {
 
         // Both saves should return the same ID (existing row)
         assert_eq!(first_id, second_id);
-        // Original blossom_url should be preserved
+        // The blob upsert uses COALESCE — a non-null blossom_url in the
+        // second save replaces the existing one.
         assert_eq!(
             second_save.blossom_url,
-            Some("https://example.com/blob1".to_string())
+            Some("https://example.com/blob2".to_string())
         );
     }
 
     #[tokio::test]
     async fn test_find_by_hash_returns_first_match() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
+        let pubkey2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
+        let pool2 = add_account(&t.shared, &t._dir, &pubkey2).await;
 
-        // Test with multiple records having same encrypted hash (different groups/accounts)
+        // Test with two accounts having the same encrypted hash in different groups
         let group_id1 = mdk_core::GroupId::from_slice(&[1u8; 8]);
         let group_id2 = mdk_core::GroupId::from_slice(&[2u8; 8]);
-        let pubkey1 = PublicKey::from_slice(&[10u8; 32]).unwrap();
-        let pubkey2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
         let encrypted_file_hash = [42u8; 32];
-        let file_path1 = temp_dir.path().join("test1.jpg");
-        let file_path2 = temp_dir.path().join("test2.jpg");
-
-        create_test_account(&db, &pubkey1).await;
-        create_test_account(&db, &pubkey2).await;
+        let file_path1 = t._dir.path().join("test1.jpg");
+        let file_path2 = t._dir.path().join("test2.jpg");
 
         // Create metadata for first record
         let metadata = FileMetadata::new()
@@ -702,11 +744,12 @@ mod tests {
             .with_dimensions("1920x1080".to_string())
             .with_blurhash("LEHV6nWB2yk8pyo0adR*.7kCMdnj".to_string());
 
-        // Save first record with metadata
+        // Save first record (account 1) with metadata
         let first_save = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id1,
-            &pubkey1,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path1,
                 original_file_hash: None,
@@ -723,9 +766,10 @@ mod tests {
         .await
         .unwrap();
 
-        // Save second record with same encrypted hash but different details
+        // Save second record (account 2) with same encrypted hash but different group
         MediaFile::save(
-            &db,
+            &pool2,
+            &t.shared,
             &group_id2,
             &pubkey2,
             MediaFileParams {
@@ -744,24 +788,30 @@ mod tests {
         .await
         .unwrap();
 
-        // Find by hash should return the first inserted record
-        let found = MediaFile::find_by_hash(&db, &encrypted_file_hash)
-            .await
-            .unwrap();
+        // find_by_hash for account 1 returns account 1's record
+        let found = MediaFile::find_by_hash(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &encrypted_file_hash,
+        )
+        .await
+        .unwrap();
 
         assert!(found.is_some());
         let media_file = found.unwrap();
 
-        // Verify it returns the first record
         assert_eq!(media_file.id, first_save.id);
         assert_eq!(media_file.encrypted_file_hash, encrypted_file_hash.to_vec());
         assert_eq!(media_file.mls_group_id, group_id1);
-        assert_eq!(media_file.account_pubkey, pubkey1);
+        assert_eq!(media_file.account_pubkey, t.account_pubkey);
         assert_eq!(media_file.mime_type, "image/jpeg");
         assert_eq!(media_file.media_type, "group_image");
+        // Account 2's save upserted the shared blob with its URL, so the
+        // latest non-null blossom_url wins (COALESCE in the upsert).
         assert_eq!(
             media_file.blossom_url,
-            Some("https://blossom.example.com/hash42".to_string())
+            Some("https://another-server.com/hash42".to_string())
         );
 
         // Verify metadata is preserved
@@ -780,68 +830,66 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_by_hash_not_found() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let nonexistent_hash = [99u8; 32];
 
         // Try to find a hash that doesn't exist
-        let found = MediaFile::find_by_hash(&db, &nonexistent_hash)
-            .await
-            .unwrap();
+        let found = MediaFile::find_by_hash(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &nonexistent_hash,
+        )
+        .await
+        .unwrap();
 
         assert!(found.is_none());
     }
 
     #[tokio::test]
     async fn test_find_by_group_empty_result() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let nonexistent_group_id = mdk_core::GroupId::from_slice(&[99u8; 8]);
 
         // Try to find media for a group that doesn't exist
-        let media_files = MediaFile::find_by_group(&db, &nonexistent_group_id)
-            .await
-            .unwrap();
+        let media_files = MediaFile::find_by_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &nonexistent_group_id,
+        )
+        .await
+        .unwrap();
 
         assert!(media_files.is_empty());
     }
 
     #[tokio::test]
     async fn test_find_by_group_multiple_files_and_group_isolation() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
+        let pubkey2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
+        let pool2 = add_account(&t.shared, &t._dir, &pubkey2).await;
 
         let group_id1 = mdk_core::GroupId::from_slice(&[1u8; 8]);
         let group_id2 = mdk_core::GroupId::from_slice(&[2u8; 8]);
-        let pubkey1 = PublicKey::from_slice(&[10u8; 32]).unwrap();
-        let pubkey2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
-
-        create_test_account(&db, &pubkey1).await;
-        create_test_account(&db, &pubkey2).await;
 
         // Create metadata for one file
         let metadata = FileMetadata::new()
             .with_filename("image1.jpg".to_string())
             .with_dimensions("1920x1080".to_string());
 
-        // Save multiple media files for group 1 (different accounts)
-        // For chat_media, we have both original and encrypted hashes
+        // Save one media file for group 1 under account 1
         let original_hash1a = [11u8; 32];
         let encrypted_hash1a = [111u8; 32];
-        let original_hash1b = [12u8; 32];
-        let encrypted_hash1b = [121u8; 32];
-        let file_path1a = temp_dir.path().join("group1_file1.jpg");
-        let file_path1b = temp_dir.path().join("group1_file2.png");
+        let file_path1a = t._dir.path().join("group1_file1.jpg");
 
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id1,
-            &pubkey1,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path1a,
                 original_file_hash: Some(&original_hash1a),
@@ -858,8 +906,14 @@ mod tests {
         .await
         .unwrap();
 
+        // Save one media file for group 1 under account 2
+        let original_hash1b = [12u8; 32];
+        let encrypted_hash1b = [121u8; 32];
+        let file_path1b = t._dir.path().join("group1_file2.png");
+
         MediaFile::save(
-            &db,
+            &pool2,
+            &t.shared,
             &group_id1,
             &pubkey2,
             MediaFileParams {
@@ -878,15 +932,16 @@ mod tests {
         .await
         .unwrap();
 
-        // Save one media file for group 2
+        // Save one media file for group 2 under account 1
         let original_hash2 = [22u8; 32];
         let encrypted_hash2 = [222u8; 32];
-        let file_path2 = temp_dir.path().join("group2_file.jpg");
+        let file_path2 = t._dir.path().join("group2_file.jpg");
 
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id2,
-            &pubkey1,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path2,
                 original_file_hash: Some(&original_hash2),
@@ -903,70 +958,69 @@ mod tests {
         .await
         .unwrap();
 
-        // Test: Find all media files for group 1
-        let media_files_group1 = MediaFile::find_by_group(&db, &group_id1).await.unwrap();
-
-        // Should return both files from group 1 regardless of account
-        assert_eq!(media_files_group1.len(), 2);
-
-        // Verify we got both files from group 1 (checking encrypted_file_hash)
-        let encrypted_hashes1: Vec<Vec<u8>> = media_files_group1
-            .iter()
-            .map(|mf| mf.encrypted_file_hash.clone())
-            .collect();
-        assert!(encrypted_hashes1.contains(&encrypted_hash1a.to_vec()));
-        assert!(encrypted_hashes1.contains(&encrypted_hash1b.to_vec()));
-        assert!(!encrypted_hashes1.contains(&encrypted_hash2.to_vec())); // Should not contain group 2 file
-
-        // Verify all files have correct group_id
-        assert!(
-            media_files_group1
-                .iter()
-                .all(|mf| mf.mls_group_id == group_id1)
-        );
-
-        // Verify metadata is preserved for the file that has it
-        let file_with_metadata = media_files_group1
-            .iter()
-            .find(|mf| mf.encrypted_file_hash == encrypted_hash1a.to_vec())
-            .unwrap();
-        assert!(file_with_metadata.file_metadata.is_some());
+        // Each account's find_by_group only returns that account's references.
+        // Account 1 sees: group1 file1 and group2 file
+        let acct1_group1 =
+            MediaFile::find_by_group(&t.account_pool, &t.shared, &t.account_pubkey, &group_id1)
+                .await
+                .unwrap();
+        assert_eq!(acct1_group1.len(), 1);
         assert_eq!(
-            file_with_metadata
+            acct1_group1[0].encrypted_file_hash,
+            encrypted_hash1a.to_vec()
+        );
+        assert_eq!(acct1_group1[0].mls_group_id, group_id1);
+        assert!(acct1_group1[0].original_file_hash.is_some());
+
+        // Verify metadata is preserved for account 1's file
+        assert!(acct1_group1[0].file_metadata.is_some());
+        assert_eq!(
+            acct1_group1[0]
                 .file_metadata
                 .as_ref()
                 .unwrap()
                 .original_filename,
             Some("image1.jpg".to_string())
         );
-        // Verify chat_media has both hashes
-        assert!(file_with_metadata.original_file_hash.is_some());
 
-        // Test: Find all media files for group 2
-        let media_files_group2 = MediaFile::find_by_group(&db, &group_id2).await.unwrap();
-
-        // Should return only one file from group 2
-        assert_eq!(media_files_group2.len(), 1);
+        // Account 2 sees: group1 file2 only
+        let acct2_group1 = MediaFile::find_by_group(&pool2, &t.shared, &pubkey2, &group_id1)
+            .await
+            .unwrap();
+        assert_eq!(acct2_group1.len(), 1);
         assert_eq!(
-            media_files_group2[0].encrypted_file_hash,
+            acct2_group1[0].encrypted_file_hash,
+            encrypted_hash1b.to_vec()
+        );
+        assert_eq!(acct2_group1[0].mls_group_id, group_id1);
+        assert!(acct2_group1[0].original_file_hash.is_some());
+
+        // Account 1 sees group 2 file
+        let acct1_group2 =
+            MediaFile::find_by_group(&t.account_pool, &t.shared, &t.account_pubkey, &group_id2)
+                .await
+                .unwrap();
+        assert_eq!(acct1_group2.len(), 1);
+        assert_eq!(
+            acct1_group2[0].encrypted_file_hash,
             encrypted_hash2.to_vec()
         );
-        assert_eq!(media_files_group2[0].mls_group_id, group_id2);
-        // Verify chat_media has original_file_hash
-        assert!(media_files_group2[0].original_file_hash.is_some());
+        assert_eq!(acct1_group2[0].mls_group_id, group_id2);
+        assert!(acct1_group2[0].original_file_hash.is_some());
 
-        // Verify groups are properly isolated
-        assert_ne!(
-            media_files_group1.len(),
-            media_files_group2.len(),
-            "Different groups should have different file counts"
-        );
-        let encrypted_hashes2: Vec<Vec<u8>> = media_files_group2
+        // Account 2 sees nothing in group 2
+        let acct2_group2 = MediaFile::find_by_group(&pool2, &t.shared, &pubkey2, &group_id2)
+            .await
+            .unwrap();
+        assert!(acct2_group2.is_empty());
+
+        // Cross-group isolation: account 1's group 1 results don't include group 2 hashes
+        let encrypted_hashes_acct1_group1: Vec<Vec<u8>> = acct1_group1
             .iter()
             .map(|mf| mf.encrypted_file_hash.clone())
             .collect();
-        assert!(!encrypted_hashes2.contains(&encrypted_hash1a.to_vec()));
-        assert!(!encrypted_hashes2.contains(&encrypted_hash1b.to_vec()));
+        assert!(!encrypted_hashes_acct1_group1.contains(&encrypted_hash2.to_vec()));
+        assert!(!encrypted_hashes_acct1_group1.contains(&encrypted_hash1b.to_vec()));
     }
 
     #[test]
@@ -1246,18 +1300,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_file_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[10u8; 32]).unwrap();
         let original_hash = [11u8; 32];
         let encrypted_hash = [111u8; 32];
-        let initial_path = temp_dir.path().join("initial.jpg");
-        let new_path = temp_dir.path().join("updated.jpg");
-
-        create_test_account(&db, &pubkey).await;
+        let initial_path = t._dir.path().join("initial.jpg");
+        let new_path = t._dir.path().join("updated.jpg");
 
         // Create metadata to verify it's preserved
         let metadata = FileMetadata::new()
@@ -1266,9 +1315,10 @@ mod tests {
 
         // Create initial media file record
         let media_file = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &initial_path,
                 original_file_hash: Some(&original_hash),
@@ -1293,9 +1343,15 @@ mod tests {
         assert_eq!(media_file.encrypted_file_hash, encrypted_hash.to_vec());
 
         // Update the file path
-        let updated = MediaFile::update_file_path(&db, original_id, &new_path)
-            .await
-            .unwrap();
+        let updated = MediaFile::update_file_path(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            original_id,
+            &new_path,
+        )
+        .await
+        .unwrap();
 
         // Verify path was updated
         assert_eq!(updated.file_path, new_path);
@@ -1305,7 +1361,7 @@ mod tests {
 
         // Verify all other fields remain unchanged
         assert_eq!(updated.mls_group_id, group_id);
-        assert_eq!(updated.account_pubkey, pubkey);
+        assert_eq!(updated.account_pubkey, t.account_pubkey);
         assert_eq!(updated.original_file_hash, Some(original_hash.to_vec()));
         assert_eq!(updated.encrypted_file_hash, encrypted_hash.to_vec());
         assert_eq!(updated.mime_type, "image/jpeg");
@@ -1322,11 +1378,16 @@ mod tests {
         );
 
         // Verify the update persisted by fetching again
-        let fetched =
-            MediaFile::find_by_original_hash_and_group(&db, &original_hash, &group_id, &pubkey)
-                .await
-                .unwrap()
-                .unwrap();
+        let fetched = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &original_hash,
+            &group_id,
+        )
+        .await
+        .unwrap()
+        .unwrap();
 
         assert_eq!(fetched.file_path, new_path);
         assert_eq!(fetched.id, Some(original_id));
@@ -1334,15 +1395,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_file_path_not_found() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let nonexistent_id = 99999;
-        let new_path = temp_dir.path().join("new.jpg");
+        let new_path = t._dir.path().join("new.jpg");
 
         // Try to update a nonexistent record
-        let result = MediaFile::update_file_path(&db, nonexistent_id, &new_path).await;
+        let result = MediaFile::update_file_path(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            nonexistent_id,
+            &new_path,
+        )
+        .await;
 
         assert!(result.is_err());
         match result {
@@ -1355,22 +1421,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_by_original_hash_and_group() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
-        // Create test data
         let group_id1 = mdk_core::GroupId::from_slice(&[1u8; 8]);
         let group_id2 = mdk_core::GroupId::from_slice(&[2u8; 8]);
-        let pubkey = PublicKey::from_slice(&[10u8; 32]).unwrap();
         let original_hash1 = [11u8; 32];
         let original_hash2 = [12u8; 32];
         let encrypted_hash1 = [111u8; 32];
         let encrypted_hash2 = [121u8; 32];
-        let file_path1 = temp_dir.path().join("chat_media1.jpg");
-        let file_path2 = temp_dir.path().join("chat_media2.png");
-
-        create_test_account(&db, &pubkey).await;
+        let file_path1 = t._dir.path().join("chat_media1.jpg");
+        let file_path2 = t._dir.path().join("chat_media2.png");
 
         // Create metadata for first file
         let metadata = FileMetadata::new()
@@ -1379,9 +1439,10 @@ mod tests {
 
         // Save first chat media file in group 1 with original hash
         let saved_file1 = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id1,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path1,
                 original_file_hash: Some(&original_hash1),
@@ -1400,9 +1461,10 @@ mod tests {
 
         // Save second chat media file in group 2 with different original hash
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id2,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path2,
                 original_file_hash: Some(&original_hash2),
@@ -1421,11 +1483,12 @@ mod tests {
 
         // Save a group image (without original_file_hash) in group 1
         let encrypted_hash_group_image = [99u8; 32];
-        let file_path_group_image = temp_dir.path().join("group_image.jpg");
+        let file_path_group_image = t._dir.path().join("group_image.jpg");
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id1,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path_group_image,
                 original_file_hash: None, // Group images don't have original_file_hash
@@ -1443,10 +1506,15 @@ mod tests {
         .unwrap();
 
         // Test 1: Find file with correct original hash, group, and account
-        let found =
-            MediaFile::find_by_original_hash_and_group(&db, &original_hash1, &group_id1, &pubkey)
-                .await
-                .unwrap();
+        let found = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &original_hash1,
+            &group_id1,
+        )
+        .await
+        .unwrap();
 
         assert!(
             found.is_some(),
@@ -1462,10 +1530,15 @@ mod tests {
         assert!(media_file.file_metadata.is_some());
 
         // Test 2: Should not find file with correct hash and account but wrong group
-        let not_found =
-            MediaFile::find_by_original_hash_and_group(&db, &original_hash1, &group_id2, &pubkey)
-                .await
-                .unwrap();
+        let not_found = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &original_hash1,
+            &group_id2,
+        )
+        .await
+        .unwrap();
 
         assert!(
             not_found.is_none(),
@@ -1474,18 +1547,28 @@ mod tests {
 
         // Test 3: Should not find file with wrong hash but correct group and account
         let wrong_hash = [255u8; 32];
-        let not_found =
-            MediaFile::find_by_original_hash_and_group(&db, &wrong_hash, &group_id1, &pubkey)
-                .await
-                .unwrap();
+        let not_found = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &wrong_hash,
+            &group_id1,
+        )
+        .await
+        .unwrap();
 
         assert!(not_found.is_none(), "Should not find file with wrong hash");
 
         // Test 4: Find second file in different group with same account
-        let found =
-            MediaFile::find_by_original_hash_and_group(&db, &original_hash2, &group_id2, &pubkey)
-                .await
-                .unwrap();
+        let found = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &original_hash2,
+            &group_id2,
+        )
+        .await
+        .unwrap();
 
         assert!(found.is_some(), "Should find second file in group 2");
         let media_file2 = found.unwrap();
@@ -1497,12 +1580,17 @@ mod tests {
         assert_eq!(media_file2.mime_type, "image/png");
 
         // Test 5: Verify this method is MIP-04 specific (uses original_file_hash)
-        // The group image has no original_file_hash, so it should not be found
+        // The group image has no original_file_hash, so it should not be found by a random hash
         let nonexistent_hash = [100u8; 32];
-        let not_found =
-            MediaFile::find_by_original_hash_and_group(&db, &nonexistent_hash, &group_id1, &pubkey)
-                .await
-                .unwrap();
+        let not_found = MediaFile::find_by_original_hash_and_group(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &nonexistent_hash,
+            &group_id1,
+        )
+        .await
+        .unwrap();
 
         assert!(
             not_found.is_none(),
@@ -1512,27 +1600,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_by_original_hash_and_group_multi_account() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-
-        // Create test data for multi-account scenario
-        let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let account1_pubkey = PublicKey::from_slice(&[10u8; 32]).unwrap();
+        let t = setup_test_dbs().await;
         let account2_pubkey = PublicKey::from_slice(&[20u8; 32]).unwrap();
+        let pool2 = add_account(&t.shared, &t._dir, &account2_pubkey).await;
+
+        let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
         let original_hash = [11u8; 32]; // Same media file
         let encrypted_hash = [111u8; 32]; // Same encrypted hash
-        let file_path1 = temp_dir.path().join("account1_media.jpg");
-        let file_path2 = temp_dir.path().join("account2_media.jpg");
-
-        create_test_account(&db, &account1_pubkey).await;
-        create_test_account(&db, &account2_pubkey).await;
+        let file_path1 = t._dir.path().join("account1_media.jpg");
+        let file_path2 = t._dir.path().join("account2_media.jpg");
 
         // Account 1 saves media file (e.g., after uploading)
         let saved_file1 = MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &account1_pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path1,
                 original_file_hash: Some(&original_hash),
@@ -1551,7 +1634,8 @@ mod tests {
 
         // Account 2 saves reference to same media file (e.g., after receiving message)
         let saved_file2 = MediaFile::save(
-            &db,
+            &pool2,
+            &t.shared,
             &group_id,
             &account2_pubkey,
             MediaFileParams {
@@ -1572,25 +1656,29 @@ mod tests {
 
         // Verify that querying with account1 returns account1's record
         let found1 = MediaFile::find_by_original_hash_and_group(
-            &db,
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
             &original_hash,
             &group_id,
-            &account1_pubkey,
         )
         .await
         .unwrap()
         .expect("Should find account1's record");
 
         assert_eq!(found1.id, saved_file1.id);
-        assert_eq!(found1.account_pubkey, account1_pubkey);
-        assert_eq!(found1.file_path, file_path1);
+        assert_eq!(found1.account_pubkey, t.account_pubkey);
+        // file_path comes from the shared blob; account 2's save overwrote it
+        // (last non-empty writer wins in the blob upsert).
+        assert_eq!(found1.file_path, file_path2);
 
         // Verify that querying with account2 returns account2's record (not account1's!)
         let found2 = MediaFile::find_by_original_hash_and_group(
-            &db,
+            &pool2,
+            &t.shared,
+            &account2_pubkey,
             &original_hash,
             &group_id,
-            &account2_pubkey,
         )
         .await
         .unwrap()
@@ -1598,27 +1686,28 @@ mod tests {
 
         assert_eq!(found2.id, saved_file2.id);
         assert_eq!(found2.account_pubkey, account2_pubkey);
-        // file_path comes from the shared blob (first writer wins).
-        assert_eq!(found2.file_path, file_path1);
+        assert_eq!(found2.file_path, file_path2);
 
-        // Verify the two references are distinct records sharing the same blob.
+        // Verify the two references belong to different accounts but share the
+        // same blob (IDs can collide since they're in separate per-account DBs).
         assert_ne!(
-            found1.id, found2.id,
-            "Different accounts should have different reference records"
+            found1.account_pubkey, found2.account_pubkey,
+            "Different accounts should have different account_pubkey"
         );
         assert_eq!(
             found1.file_path, found2.file_path,
             "Both accounts share the same blob, so file_path should match"
         );
 
-        // Verify a third account cannot find records for the other accounts
+        // Verify a third account (with its own pool) cannot find records for the other accounts
         let account3_pubkey = PublicKey::from_slice(&[30u8; 32]).unwrap();
-        create_test_account(&db, &account3_pubkey).await;
+        let pool3 = add_account(&t.shared, &t._dir, &account3_pubkey).await;
         let not_found = MediaFile::find_by_original_hash_and_group(
-            &db,
+            &pool3,
+            &t.shared,
+            &account3_pubkey,
             &original_hash,
             &group_id,
-            &account3_pubkey,
         )
         .await
         .unwrap();
@@ -1631,16 +1720,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_metadata_with_thumbhash() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[10u8; 32]).unwrap();
         let encrypted_hash = [42u8; 32];
-        let file_path = temp_dir.path().join("test.jpg");
-
-        create_test_account(&db, &pubkey).await;
+        let file_path = t._dir.path().join("test.jpg");
 
         // Save with both blurhash and thumbhash
         let metadata = FileMetadata::new()
@@ -1650,9 +1734,10 @@ mod tests {
             .with_thumbhash("3OcRJYB4d3h/iIeHeEh3eIhw+j2w".to_string());
 
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path,
                 original_file_hash: None,
@@ -1670,10 +1755,15 @@ mod tests {
         .unwrap();
 
         // Retrieve and verify both hashes are persisted
-        let found = MediaFile::find_by_hash(&db, &encrypted_hash)
-            .await
-            .unwrap()
-            .expect("Should find the saved media file");
+        let found = MediaFile::find_by_hash(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &encrypted_hash,
+        )
+        .await
+        .unwrap()
+        .expect("Should find the saved media file");
 
         let retrieved = found.file_metadata.expect("Should have file_metadata");
         assert_eq!(
@@ -1690,55 +1780,70 @@ mod tests {
 
     #[tokio::test]
     async fn test_shared_blobs_survive_reference_deletion() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
+        let account2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
+        let pool2 = add_account(&t.shared, &t._dir, &account2).await;
 
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let account1 = PublicKey::from_slice(&[10u8; 32]).unwrap();
-        let account2 = PublicKey::from_slice(&[20u8; 32]).unwrap();
         let encrypted_hash = [42u8; 32];
-        let file_path = temp_dir.path().join("shared.jpg");
+        let file_path = t._dir.path().join("shared.jpg");
 
-        create_test_account(&db, &account1).await;
-        create_test_account(&db, &account2).await;
+        // Account 1 saves a reference to the blob.
+        MediaFile::save(
+            &t.account_pool,
+            &t.shared,
+            &group_id,
+            &t.account_pubkey,
+            MediaFileParams {
+                file_path: &file_path,
+                original_file_hash: None,
+                encrypted_file_hash: &encrypted_hash,
+                mime_type: "image/jpeg",
+                media_type: "chat_media",
+                blossom_url: None,
+                nostr_key: None,
+                file_metadata: None,
+                nonce: None,
+                scheme_version: None,
+            },
+        )
+        .await
+        .unwrap();
 
-        // Both accounts save a reference to the same blob.
-        for acct in [&account1, &account2] {
-            MediaFile::save(
-                &db,
-                &group_id,
-                acct,
-                MediaFileParams {
-                    file_path: &file_path,
-                    original_file_hash: None,
-                    encrypted_file_hash: &encrypted_hash,
-                    mime_type: "image/jpeg",
-                    media_type: "chat_media",
-                    blossom_url: None,
-                    nostr_key: None,
-                    file_metadata: None,
-                    nonce: None,
-                    scheme_version: None,
-                },
-            )
-            .await
-            .unwrap();
-        }
+        // Account 2 saves a reference to the same blob.
+        MediaFile::save(
+            &pool2,
+            &t.shared,
+            &group_id,
+            &account2,
+            MediaFileParams {
+                file_path: &file_path,
+                original_file_hash: None,
+                encrypted_file_hash: &encrypted_hash,
+                mime_type: "image/jpeg",
+                media_type: "chat_media",
+                blossom_url: None,
+                nostr_key: None,
+                file_metadata: None,
+                nonce: None,
+                scheme_version: None,
+            },
+        )
+        .await
+        .unwrap();
 
-        // Delete account1's reference.
-        sqlx::query("DELETE FROM media_references WHERE account_pubkey = ? AND mls_group_id = ?")
-            .bind(account1.to_hex())
+        // Delete account1's reference from its own per-account pool.
+        sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
             .bind(group_id.as_slice())
-            .execute(&db.pool)
+            .execute(&t.account_pool)
             .await
             .unwrap();
 
-        // Blob must still exist.
+        // Blob must still exist in the shared DB.
         let blob_count: (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM media_blobs WHERE encrypted_file_hash = ?")
                 .bind(hex::encode(encrypted_hash))
-                .fetch_one(&db.pool)
+                .fetch_one(&t.shared.pool)
                 .await
                 .unwrap();
         assert_eq!(
@@ -1746,23 +1851,20 @@ mod tests {
             "Shared blob must survive reference deletion"
         );
 
-        // Account2 can still find the media.
-        let found = MediaFile::find_by_hash(&db, &encrypted_hash).await.unwrap();
+        // Account 2 can still find the media via its own pool.
+        let found = MediaFile::find_by_hash(&pool2, &t.shared, &account2, &encrypted_hash)
+            .await
+            .unwrap();
         assert!(found.is_some(), "Account2 should still see the media file");
     }
 
     #[tokio::test]
     async fn test_file_metadata_without_thumbhash_backwards_compat() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
+        let t = setup_test_dbs().await;
 
         let group_id = mdk_core::GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[10u8; 32]).unwrap();
         let encrypted_hash = [42u8; 32];
-        let file_path = temp_dir.path().join("test.jpg");
-
-        create_test_account(&db, &pubkey).await;
+        let file_path = t._dir.path().join("test.jpg");
 
         // Save with only blurhash (simulating old client behavior)
         let metadata = FileMetadata::new()
@@ -1770,9 +1872,10 @@ mod tests {
             .with_blurhash("LEHV6nWB2yk8pyo0adR*.7kCMdnj".to_string());
 
         MediaFile::save(
-            &db,
+            &t.account_pool,
+            &t.shared,
             &group_id,
-            &pubkey,
+            &t.account_pubkey,
             MediaFileParams {
                 file_path: &file_path,
                 original_file_hash: None,
@@ -1790,10 +1893,15 @@ mod tests {
         .unwrap();
 
         // Retrieve and verify thumbhash is None while blurhash is present
-        let found = MediaFile::find_by_hash(&db, &encrypted_hash)
-            .await
-            .unwrap()
-            .expect("Should find the saved media file");
+        let found = MediaFile::find_by_hash(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &encrypted_hash,
+        )
+        .await
+        .unwrap()
+        .expect("Should find the saved media file");
 
         let retrieved = found.file_metadata.expect("Should have file_metadata");
         assert_eq!(

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -92,7 +92,7 @@ impl Database {
     /// migrations** (Phase 18c+): in shared-only mode the migrator skips
     /// locals but advances past their version numbers, so any global drop
     /// migration sitting after a local will fire before the local has run
-    /// for any account on disk. Use [`Self::open_without_migrations`] +
+    /// for any account on disk. Use `open_without_migrations` +
     /// `MIGRATOR.run_all` instead when there are accounts to migrate; the
     /// latter walks every per-account DB in lockstep with shared.
     ///
@@ -359,14 +359,8 @@ impl Database {
         .execute(&mut *txn)
         .await?;
 
-        sqlx::query(
-            "DELETE FROM media_references
-             WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(&pubkey_hex)
-        .bind(mls_group_id.as_slice())
-        .execute(&mut *txn)
-        .await?;
+        // media_references now live in the per-account DB; the caller
+        // (delete_chat) deletes them there.
 
         // 2. Check if any other accounts still reference this group
         let (remaining,): (i64,) =
@@ -388,11 +382,6 @@ impl Database {
                 .await?;
 
             sqlx::query("DELETE FROM group_push_tokens WHERE mls_group_id = ?")
-                .bind(mls_group_id.as_slice())
-                .execute(&mut *txn)
-                .await?;
-
-            sqlx::query("DELETE FROM media_references WHERE mls_group_id = ?")
                 .bind(mls_group_id.as_slice())
                 .execute(&mut *txn)
                 .await?;
@@ -554,10 +543,8 @@ mod tests {
             .await
             .expect("Failed to insert test media blob");
 
-        sqlx::query("INSERT INTO media_references (mls_group_id, account_pubkey, encrypted_file_hash, media_type, created_at) VALUES (x'deadbeef', 'test-pubkey', 'testhash', 'test', 1234567890)")
-            .execute(&db.pool)
-            .await
-            .expect("Failed to insert test media reference");
+        // media_references now lives in per-account DBs (moved by v29, dropped
+        // from shared by v30), so we only verify shared tables here.
 
         // Verify data exists
         let user_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
@@ -577,12 +564,6 @@ mod tests {
             .await
             .expect("Failed to count media blobs");
         assert_eq!(blob_count.0, 1);
-
-        let ref_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
-            .fetch_one(&db.pool)
-            .await
-            .expect("Failed to count media references");
-        assert_eq!(ref_count.0, 1);
 
         // Delete all data
         let result = db.delete_all_data().await;
@@ -606,12 +587,6 @@ mod tests {
             .await
             .expect("Failed to count media blobs after deletion");
         assert_eq!(blob_count.0, 0);
-
-        let ref_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
-            .fetch_one(&db.pool)
-            .await
-            .expect("Failed to count media references after deletion");
-        assert_eq!(ref_count.0, 0);
     }
 
     #[tokio::test]
@@ -735,7 +710,9 @@ mod tests {
         let table_names: Vec<String> = tables.into_iter().map(|t| t.0).collect();
         assert!(table_names.contains(&"accounts".to_string()));
         assert!(table_names.contains(&"media_blobs".to_string()));
-        assert!(table_names.contains(&"media_references".to_string()));
+        // media_references was moved to per-account DBs (v29) and dropped
+        // from shared (v30), so it should NOT exist here.
+        assert!(!table_names.contains(&"media_references".to_string()));
         assert!(table_names.contains(&"app_settings".to_string()));
     }
 

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -6,12 +6,6 @@
 -- data-migration logic that only matters for accounts upgraded from older
 -- installs (mirror of `global/fresh_schema.sql` for the local timeline).
 --
--- Phase 18a/18b status: intentionally empty. `media_references` is
--- logically account-scoped but lives on the shared DB until
--- `AccountDatabase` is wired into production init (Phase 18c+). When
--- that wiring lands, add the `media_references` DDL here and create a
--- local migration to extract it from shared.
---
 -- Rebaselining: when a future local migration does data extraction against
 -- transient shared schema, consider rebaselining — bump
 -- `BASELINE_VERSION` in `m0012_bootstrap.rs`, update this file to the
@@ -19,3 +13,23 @@
 -- `STAMPED_PRIOR_LOCAL_VERSIONS`. New accounts then skip those locals
 -- entirely instead of trying to replay them against shared state that may
 -- have moved on.
+
+CREATE TABLE IF NOT EXISTS media_references (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id        BLOB NOT NULL,
+    encrypted_file_hash TEXT NOT NULL,
+    media_type          TEXT NOT NULL,
+    nostr_key           TEXT,
+    file_metadata       BLOB,
+    original_file_hash  TEXT,
+    nonce               TEXT,
+    scheme_version      TEXT,
+    created_at          INTEGER NOT NULL,
+    UNIQUE(mls_group_id, encrypted_file_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_refs_group_hash
+    ON media_references(mls_group_id, encrypted_file_hash);
+
+CREATE INDEX IF NOT EXISTS idx_media_refs_hash
+    ON media_references(encrypted_file_hash);

--- a/src/whitenoise/database/rust_migrations/m0029_move_media_references.rs
+++ b/src/whitenoise/database/rust_migrations/m0029_move_media_references.rs
@@ -1,0 +1,301 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        29
+    }
+
+    fn description(&self) -> &'static str {
+        "Move media_references into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: no account_pubkey column (the file is the scope).
+        // UNIQUE constraint drops account_pubkey — it was only needed when
+        // multiple accounts shared one table.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS media_references (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id        BLOB NOT NULL,
+                encrypted_file_hash TEXT NOT NULL,
+                media_type          TEXT NOT NULL,
+                nostr_key           TEXT,
+                file_metadata       BLOB,
+                original_file_hash  TEXT,
+                nonce               TEXT,
+                scheme_version      TEXT,
+                created_at          INTEGER NOT NULL,
+                UNIQUE(mls_group_id, encrypted_file_hash)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_media_refs_group_hash
+                ON media_references(mls_group_id, encrypted_file_hash)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_media_refs_hash
+                ON media_references(encrypted_file_hash)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='media_references')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0029",
+                account = account_pubkey,
+                "shared.media_references is missing; skipping local copy. \
+                 Expected only on fresh installs or when v30 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        // Read rows from shared via the global_db pool, then insert into the
+        // per-account transaction. Can't use cross-DB SQL because the local
+        // migration runs against the per-account pool.
+        let rows: Vec<(
+            Vec<u8>,         // mls_group_id
+            String,          // encrypted_file_hash
+            String,          // media_type
+            Option<String>,  // nostr_key
+            Option<Vec<u8>>, // file_metadata
+            Option<String>,  // original_file_hash
+            Option<String>,  // nonce
+            Option<String>,  // scheme_version
+            i64,             // created_at
+        )> = sqlx::query_as(
+            "SELECT mls_group_id, encrypted_file_hash, media_type, nostr_key,
+                    file_metadata, original_file_hash, nonce, scheme_version, created_at
+             FROM media_references
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        for row in &rows {
+            sqlx::query(
+                "INSERT OR IGNORE INTO media_references
+                    (mls_group_id, encrypted_file_hash, media_type, nostr_key,
+                     file_metadata, original_file_hash, nonce, scheme_version, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&row.0)
+            .bind(&row.1)
+            .bind(&row.2)
+            .bind(&row.3)
+            .bind(&row.4)
+            .bind(&row.5)
+            .bind(&row.6)
+            .bind(&row.7)
+            .bind(row.8)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if !rows.is_empty() {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0029",
+                account = account_pubkey,
+                "Copied {} media_references row(s) to per-account DB",
+                rows.len()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_global(global: &SqlitePool, account_pubkey: &str) {
+        sqlx::query(
+            "CREATE TABLE media_references (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id        BLOB NOT NULL,
+                account_pubkey      TEXT NOT NULL,
+                encrypted_file_hash TEXT NOT NULL,
+                media_type          TEXT NOT NULL,
+                nostr_key           TEXT,
+                file_metadata       BLOB,
+                original_file_hash  TEXT,
+                nonce               TEXT,
+                scheme_version      TEXT,
+                created_at          INTEGER NOT NULL,
+                UNIQUE(mls_group_id, encrypted_file_hash, account_pubkey)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO media_references
+                (mls_group_id, account_pubkey, encrypted_file_hash,
+                 media_type, original_file_hash, created_at)
+             VALUES (x'deadbeef', ?, 'hash1', 'chat_media', 'orig1', 1000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        // Row for a different account — should NOT be copied.
+        sqlx::query(
+            "INSERT INTO media_references
+                (mls_group_id, account_pubkey, encrypted_file_hash,
+                 media_type, created_at)
+             VALUES (x'deadbeef', 'other_account', 'hash2', 'group_image', 2000)",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_account_rows_to_local() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        seed_global(&global, &pubkey).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let has_col: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('media_references') \
+             WHERE name = 'account_pubkey'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(has_col, 0, "account_pubkey column should not exist");
+
+        let (hash,): (String,) = sqlx::query_as("SELECT encrypted_file_hash FROM media_references")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(hash, "hash1");
+    }
+
+    #[tokio::test]
+    async fn migration_creates_table_when_no_shared_rows() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "cd".repeat(32);
+
+        sqlx::query(
+            "CREATE TABLE media_references (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id BLOB NOT NULL,
+                account_pubkey TEXT NOT NULL,
+                encrypted_file_hash TEXT NOT NULL,
+                media_type TEXT NOT NULL,
+                nostr_key TEXT,
+                file_metadata BLOB,
+                original_file_hash TEXT,
+                nonce TEXT,
+                scheme_version TEXT,
+                created_at INTEGER NOT NULL,
+                UNIQUE(mls_group_id, encrypted_file_hash, account_pubkey)
+            )",
+        )
+        .execute(&global)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='media_references')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM media_references")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='media_references')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0029_move_media_references.rs
+++ b/src/whitenoise/database/rust_migrations/m0029_move_media_references.rs
@@ -4,6 +4,21 @@ use sqlx::{SqliteConnection, SqlitePool};
 use crate::whitenoise::database::DatabaseError;
 use crate::whitenoise::database::rust_migrations::LocalMigration;
 
+/// Temporary carrier for rows read from the shared `media_references` table
+/// during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedRefRow {
+    mls_group_id: Vec<u8>,
+    encrypted_file_hash: String,
+    media_type: String,
+    nostr_key: Option<String>,
+    file_metadata: Option<Vec<u8>>,
+    original_file_hash: Option<String>,
+    nonce: Option<String>,
+    scheme_version: Option<String>,
+    created_at: i64,
+}
+
 pub struct Migration;
 
 #[async_trait]
@@ -78,17 +93,7 @@ impl LocalMigration for Migration {
         // Read rows from shared via the global_db pool, then insert into the
         // per-account transaction. Can't use cross-DB SQL because the local
         // migration runs against the per-account pool.
-        let rows: Vec<(
-            Vec<u8>,         // mls_group_id
-            String,          // encrypted_file_hash
-            String,          // media_type
-            Option<String>,  // nostr_key
-            Option<Vec<u8>>, // file_metadata
-            Option<String>,  // original_file_hash
-            Option<String>,  // nonce
-            Option<String>,  // scheme_version
-            i64,             // created_at
-        )> = sqlx::query_as(
+        let rows: Vec<SharedRefRow> = sqlx::query_as(
             "SELECT mls_group_id, encrypted_file_hash, media_type, nostr_key,
                     file_metadata, original_file_hash, nonce, scheme_version, created_at
              FROM media_references
@@ -98,22 +103,22 @@ impl LocalMigration for Migration {
         .fetch_all(global_db)
         .await?;
 
-        for row in &rows {
+        for r in &rows {
             sqlx::query(
                 "INSERT OR IGNORE INTO media_references
                     (mls_group_id, encrypted_file_hash, media_type, nostr_key,
                      file_metadata, original_file_hash, nonce, scheme_version, created_at)
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
-            .bind(&row.0)
-            .bind(&row.1)
-            .bind(&row.2)
-            .bind(&row.3)
-            .bind(&row.4)
-            .bind(&row.5)
-            .bind(&row.6)
-            .bind(&row.7)
-            .bind(row.8)
+            .bind(&r.mls_group_id)
+            .bind(&r.encrypted_file_hash)
+            .bind(&r.media_type)
+            .bind(&r.nostr_key)
+            .bind(&r.file_metadata)
+            .bind(&r.original_file_hash)
+            .bind(&r.nonce)
+            .bind(&r.scheme_version)
+            .bind(r.created_at)
             .execute(&mut *tx)
             .await?;
         }

--- a/src/whitenoise/database/rust_migrations/m0030_drop_shared_media_references.rs
+++ b/src/whitenoise/database/rust_migrations/m0030_drop_shared_media_references.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        30
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared media_references (moved to per-account DB at v29)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS media_references")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE media_references (
+                id INTEGER PRIMARY KEY,
+                mls_group_id BLOB NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='media_references')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -34,6 +34,8 @@ mod m0025_drop_shared_published_key_packages;
 mod m0026_drop_shared_published_events;
 mod m0027_drop_shared_account_follows;
 mod m0028_purge_account_processed_events;
+mod m0029_move_media_references;
+mod m0030_drop_shared_media_references;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -60,6 +62,7 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0026_drop_shared_published_events::Migration),
         Box::new(m0027_drop_shared_account_follows::Migration),
         Box::new(m0028_purge_account_processed_events::Migration),
+        Box::new(m0030_drop_shared_media_references::Migration),
     ]
 }
 
@@ -73,6 +76,7 @@ pub fn all_local_migrations() -> Vec<Box<dyn LocalMigration>> {
         Box::new(m0020_move_published_events::Migration),
         Box::new(m0021_move_processed_events::Migration),
         Box::new(m0022_move_account_follows::Migration),
+        Box::new(m0029_move_media_references::Migration),
     ]
 }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -193,13 +193,22 @@ impl Whitenoise {
         inner_event: UnsignedEvent,
         message: Message,
     ) -> Result<()> {
+        let session = self
+            .account_manager
+            .get_session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        let media_files = crate::whitenoise::media_files::MediaFiles::new(
+            &self.shared.storage,
+            &self.shared.database,
+            &session.account_db.inner.pool,
+        );
+
         let parsed_references = {
             let media_manager = mdk.media_manager(group_id.clone());
-            self.media_files()
-                .parse_imeta_tags_from_event(&inner_event, &media_manager)?
+            media_files.parse_imeta_tags_from_event(&inner_event, &media_manager)?
         };
 
-        self.media_files()
+        media_files
             .store_parsed_media_references(&group_id, &account.pubkey, parsed_references)
             .await?;
 
@@ -499,7 +508,17 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<ChatMessage> {
-        let media_files = MediaFile::find_by_group(&self.shared.database, group_id).await?;
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        let media_files = MediaFile::find_by_group(
+            &session.account_db.inner.pool,
+            &self.shared.database,
+            account_pubkey,
+            group_id,
+        )
+        .await?;
 
         let mut chat_message = self
             .shared

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -1812,8 +1812,14 @@ mod tests {
         );
 
         // Verify the nostr_key (upload keypair) was stored in the database
+        let session = whitenoise
+            .account_manager
+            .get_session(&creator_account.pubkey)
+            .unwrap();
         let media_file = crate::whitenoise::database::media_files::MediaFile::find_by_hash(
+            &session.account_db.inner.pool,
             &whitenoise.shared.database,
+            &creator_account.pubkey,
             &hash,
         )
         .await
@@ -2150,11 +2156,16 @@ mod tests {
             .try_into()
             .expect("original_file_hash must be 32 bytes");
 
+        let session = whitenoise
+            .account_manager
+            .get_session(&creator_account.pubkey)
+            .unwrap();
         let reloaded = MediaFile::find_by_original_hash_and_group(
+            &session.account_db.inner.pool,
             &whitenoise.shared.database,
+            &creator_account.pubkey,
             &original_hash_bytes,
             &group.mls_group_id,
-            &creator_account.pubkey,
         )
         .await
         .unwrap()

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -149,11 +149,22 @@ impl Whitenoise {
         note = "Use AccountSession::groups().media().get_media_files_for_group() instead."
     )]
     #[perf_instrument("media")]
-    pub async fn get_media_files_for_group(&self, group_id: &GroupId) -> Result<Vec<MediaFile>> {
-        // NOTE: Cannot delegate through session.groups().media() — this wrapper has no `account`
-        // parameter and therefore no session to look up. Both paths query the same DB table;
-        // this divergence is harmless until the method signature is updated in phase 15+.
-        MediaFile::find_by_group(&self.shared.database, group_id).await
+    pub async fn get_media_files_for_group(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<Vec<MediaFile>> {
+        let session = self
+            .account_manager
+            .get_session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+        MediaFile::find_by_group(
+            &session.account_db.inner.pool,
+            &self.shared.database,
+            &account.pubkey,
+            group_id,
+        )
+        .await
     }
 
     #[deprecated(note = "Use AccountSession::groups().media().get_group_image_path() instead.")]

--- a/src/whitenoise/media_files.rs
+++ b/src/whitenoise/media_files.rs
@@ -7,6 +7,7 @@ use mdk_core::{
     prelude::MdkStorageProvider,
 };
 use nostr_sdk::prelude::*;
+use sqlx::SqlitePool;
 
 pub use crate::whitenoise::database::media_files::MediaFile;
 use crate::{
@@ -136,7 +137,10 @@ pub(crate) struct MediaFileUpload<'a> {
 /// - Encryption/decryption (caller's responsibility)
 pub struct MediaFiles<'a> {
     storage: &'a Storage,
-    database: &'a Database,
+    /// Shared database — holds `media_blobs` (content-addressed, cross-account).
+    shared_db: &'a Database,
+    /// Per-account database pool — holds `media_references` (account-scoped).
+    account_pool: &'a SqlitePool,
 }
 
 impl<'a> MediaFiles<'a> {
@@ -144,9 +148,18 @@ impl<'a> MediaFiles<'a> {
     ///
     /// # Arguments
     /// * `storage` - Reference to the storage layer
-    /// * `database` - Reference to the database
-    pub(crate) fn new(storage: &'a Storage, database: &'a Database) -> Self {
-        Self { storage, database }
+    /// * `shared_db` - Reference to the shared database (media_blobs)
+    /// * `account_pool` - Reference to the per-account database pool (media_references)
+    pub(crate) fn new(
+        storage: &'a Storage,
+        shared_db: &'a Database,
+        account_pool: &'a SqlitePool,
+    ) -> Self {
+        Self {
+            storage,
+            shared_db,
+            account_pool,
+        }
     }
 
     /// Stores a file and records it in the database in one operation
@@ -207,7 +220,8 @@ impl<'a> MediaFiles<'a> {
         upload: MediaFileUpload<'_>,
     ) -> Result<MediaFile> {
         let media_file = MediaFile::save(
-            self.database,
+            self.account_pool,
+            self.shared_db,
             group_id,
             account_pubkey,
             MediaFileParams {
@@ -365,7 +379,7 @@ impl<'a> MediaFiles<'a> {
     pub(crate) async fn cleanup_orphaned_files(&self) -> Result<u64> {
         // 1. Get all distinct file paths referenced in the database
         let referenced_paths: Vec<String> =
-            MediaFile::all_referenced_file_paths(self.database).await?;
+            MediaFile::all_referenced_file_paths(self.shared_db).await?;
 
         let referenced: HashSet<PathBuf> =
             referenced_paths.into_iter().map(PathBuf::from).collect();
@@ -464,7 +478,8 @@ impl<'a> MediaFiles<'a> {
             // Create MediaFile record (without file yet - empty path until downloaded)
             // Store nonce and scheme_version for MDK decryption
             MediaFile::save(
-                self.database,
+                self.account_pool,
+                self.shared_db,
                 group_id,
                 account_pubkey,
                 MediaFileParams {
@@ -498,24 +513,45 @@ impl<'a> MediaFiles<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::whitenoise::database::account_db::AccountDatabase;
+
     use super::*;
     use tempfile::TempDir;
 
-    #[tokio::test]
-    async fn test_store_and_record() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
+    struct TestCtx {
+        shared: Database,
+        account_pool: SqlitePool,
+        pubkey: PublicKey,
+        storage: Storage,
+        _dir: TempDir,
+    }
 
-        let media_files = MediaFiles::new(&storage, &db);
-
-        let group_id = GroupId::from_slice(&[1u8; 8]);
+    async fn setup() -> TestCtx {
+        let dir = TempDir::new().unwrap();
         let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
-        let encrypted_file_hash = [3u8; 32];
-        let test_data = b"test file content";
+        let shared = Database::new(dir.path().join("shared.db")).await.unwrap();
+        let account_db = AccountDatabase::new(pubkey, dir.path().join("account.db"))
+            .await
+            .unwrap();
+        account_db
+            .run_account_migrations(&shared.pool)
+            .await
+            .unwrap();
 
-        // Create test account to satisfy foreign key constraint
+        // FK constraints
+        create_test_account(&shared, &pubkey).await;
+
+        let storage = Storage::new(dir.path()).await.unwrap();
+        TestCtx {
+            shared,
+            account_pool: account_db.inner.pool,
+            pubkey,
+            storage,
+            _dir: dir,
+        }
+    }
+
+    async fn create_test_account(db: &Database, pubkey: &PublicKey) {
         sqlx::query("INSERT INTO users (pubkey, created_at, updated_at) VALUES (?, ?, ?)")
             .bind(pubkey.to_hex())
             .bind(chrono::Utc::now().timestamp())
@@ -531,7 +567,8 @@ mod tests {
             .unwrap();
 
         sqlx::query(
-            "INSERT INTO accounts (pubkey, user_id, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            "INSERT INTO accounts (pubkey, user_id, created_at, updated_at) \
+             VALUES (?, ?, ?, ?)",
         )
         .bind(pubkey.to_hex())
         .bind(user_id)
@@ -540,8 +577,17 @@ mod tests {
         .execute(&db.pool)
         .await
         .unwrap();
+    }
 
-        // Store and record
+    #[tokio::test]
+    async fn test_store_and_record() {
+        let t = setup().await;
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
+
+        let group_id = GroupId::from_slice(&[1u8; 8]);
+        let encrypted_file_hash = [3u8; 32];
+        let test_data = b"test file content";
+
         let upload = MediaFileUpload {
             data: test_data,
             original_file_hash: None,
@@ -555,18 +601,15 @@ mod tests {
             scheme_version: None,
         };
         let media_file = media_files
-            .store_and_record(&pubkey, &group_id, "test.jpg", upload)
+            .store_and_record(&t.pubkey, &group_id, "test.jpg", upload)
             .await
             .unwrap();
 
-        // Verify file exists on disk
         assert!(media_file.file_path.exists());
-
-        // Verify file content is correct
         let content = tokio::fs::read(&media_file.file_path).await.unwrap();
         assert_eq!(content, test_data);
 
-        // Verify idempotency: calling store_and_record again should succeed
+        // Idempotency
         let upload2 = MediaFileUpload {
             data: test_data,
             original_file_hash: None,
@@ -580,31 +623,24 @@ mod tests {
             scheme_version: None,
         };
         let media_file2 = media_files
-            .store_and_record(&pubkey, &group_id, "test.jpg", upload2)
+            .store_and_record(&t.pubkey, &group_id, "test.jpg", upload2)
             .await
             .unwrap();
 
-        // Should return the same path
         assert_eq!(media_file.file_path, media_file2.file_path);
     }
 
     #[tokio::test]
     async fn test_find_file_with_prefix() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
+        let t = setup().await;
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
 
-        let media_files = MediaFiles::new(&storage, &db);
-
-        // Store files directly via storage
-        storage
+        t.storage
             .media_files
             .store_file("abc123.jpg", b"jpeg data")
             .await
             .unwrap();
 
-        // Find by prefix
         let found = media_files.find_file_with_prefix("abc123").await.unwrap();
         assert!(found.to_string_lossy().contains("abc123"));
     }
@@ -780,55 +816,22 @@ mod tests {
         assert!(thumbhash.is_none());
     }
 
-    /// Helper: creates a user + account row so media_files FK constraints pass
-    async fn create_test_account(db: &Database, pubkey: &PublicKey) {
-        sqlx::query("INSERT INTO users (pubkey, created_at, updated_at) VALUES (?, ?, ?)")
-            .bind(pubkey.to_hex())
-            .bind(chrono::Utc::now().timestamp())
-            .bind(chrono::Utc::now().timestamp())
-            .execute(&db.pool)
-            .await
-            .unwrap();
-
-        let user_id: i64 = sqlx::query_scalar("SELECT id FROM users WHERE pubkey = ?")
-            .bind(pubkey.to_hex())
-            .fetch_one(&db.pool)
-            .await
-            .unwrap();
-
-        sqlx::query(
-            "INSERT INTO accounts (pubkey, user_id, created_at, updated_at) \
-             VALUES (?, ?, ?, ?)",
-        )
-        .bind(pubkey.to_hex())
-        .bind(user_id)
-        .bind(chrono::Utc::now().timestamp())
-        .bind(chrono::Utc::now().timestamp())
-        .execute(&db.pool)
-        .await
-        .unwrap();
-    }
-
     #[tokio::test]
     async fn test_cleanup_orphaned_files_deletes_unreferenced() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
+        let t = setup().await;
 
-        // Put a file on disk with no DB record
-        storage
+        t.storage
             .media_files
             .store_file("orphan.jpg", b"orphan data")
             .await
             .unwrap();
 
-        let media_files = MediaFiles::new(&storage, &db);
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
         let deleted = media_files.cleanup_orphaned_files().await.unwrap();
 
         assert_eq!(deleted, 1);
         assert!(
-            storage
+            t.storage
                 .media_files
                 .find_file_with_prefix("orphan")
                 .await
@@ -838,18 +841,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_orphaned_files_keeps_referenced() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
+        let t = setup().await;
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
 
         let group_id = GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
-        create_test_account(&db, &pubkey).await;
-
-        let media_files = MediaFiles::new(&storage, &db);
-
-        // Store file and record it in DB
         let upload = MediaFileUpload {
             data: b"referenced data",
             original_file_hash: None,
@@ -863,7 +858,7 @@ mod tests {
             scheme_version: None,
         };
         let record = media_files
-            .store_and_record(&pubkey, &group_id, "referenced.jpg", upload)
+            .store_and_record(&t.pubkey, &group_id, "referenced.jpg", upload)
             .await
             .unwrap();
 
@@ -875,18 +870,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_orphaned_files_mixed() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
+        let t = setup().await;
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
 
         let group_id = GroupId::from_slice(&[1u8; 8]);
-        let pubkey = PublicKey::from_slice(&[2u8; 32]).unwrap();
-        create_test_account(&db, &pubkey).await;
-
-        let media_files = MediaFiles::new(&storage, &db);
-
-        // Store a referenced file (has DB record)
         let upload = MediaFileUpload {
             data: b"keep me",
             original_file_hash: None,
@@ -900,12 +887,11 @@ mod tests {
             scheme_version: None,
         };
         let kept = media_files
-            .store_and_record(&pubkey, &group_id, "keep.png", upload)
+            .store_and_record(&t.pubkey, &group_id, "keep.png", upload)
             .await
             .unwrap();
 
-        // Store an orphan file (no DB record)
-        storage
+        t.storage
             .media_files
             .store_file("orphan.png", b"delete me")
             .await
@@ -916,7 +902,7 @@ mod tests {
         assert_eq!(deleted, 1);
         assert!(kept.file_path.exists());
         assert!(
-            storage
+            t.storage
                 .media_files
                 .find_file_with_prefix("orphan")
                 .await
@@ -926,12 +912,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_orphaned_files_empty_cache() {
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path).await.unwrap();
-        let storage = Storage::new(temp_dir.path()).await.unwrap();
-
-        let media_files = MediaFiles::new(&storage, &db);
+        let t = setup().await;
+        let media_files = MediaFiles::new(&t.storage, &t.shared, &t.account_pool);
         let deleted = media_files.cleanup_orphaned_files().await.unwrap();
 
         assert_eq!(deleted, 0);

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -273,7 +273,17 @@ impl Whitenoise {
             hex::encode(group_id.as_slice())
         );
 
-        let media_files = MediaFile::find_by_group(&self.shared.database, group_id).await?;
+        let session = self
+            .account_manager
+            .get_session(pubkey)
+            .ok_or_else(|| crate::whitenoise::error::WhitenoiseError::AccountNotFound)?;
+        let media_files = MediaFile::find_by_group(
+            &session.account_db.inner.pool,
+            &self.shared.database,
+            pubkey,
+            group_id,
+        )
+        .await?;
 
         let processed_messages = self
             .shared

--- a/src/whitenoise/session/groups/media.rs
+++ b/src/whitenoise/session/groups/media.rs
@@ -94,12 +94,13 @@ impl<'a> MediaOps<'a> {
         Self { session }
     }
 
-    /// Construct a `MediaFiles` orchestrator over the session's shared storage
-    /// and database. Mirrors the `Whitenoise::media_files()` helper.
+    /// Construct a `MediaFiles` orchestrator over the session's shared storage,
+    /// shared database (media_blobs), and per-account database (media_references).
     fn media_files(&self) -> crate::whitenoise::media_files::MediaFiles<'_> {
         crate::whitenoise::media_files::MediaFiles::new(
             &self.session.shared.storage,
             &self.session.shared.database,
+            &self.session.account_db.inner.pool,
         )
     }
 
@@ -145,8 +146,13 @@ impl<'a> MediaOps<'a> {
             };
 
         // Try to get the stored blossom_url from the database
-        let blossom_url = if let Some(media_file) =
-            MediaFile::find_by_hash(&self.session.shared.database, &image_hash).await?
+        let blossom_url = if let Some(media_file) = MediaFile::find_by_hash(
+            &self.session.account_db.inner.pool,
+            &self.session.shared.database,
+            &self.session.account_pubkey,
+            &image_hash,
+        )
+        .await?
         {
             media_file
                 .blossom_url
@@ -359,10 +365,11 @@ impl<'a> MediaOps<'a> {
         original_file_hash: &[u8; 32],
     ) -> Result<MediaFile> {
         let media_file = MediaFile::find_by_original_hash_and_group(
+            &self.session.account_db.inner.pool,
             &self.session.shared.database,
+            &self.session.account_pubkey,
             original_file_hash,
             group_id,
-            &self.session.account_pubkey,
         )
         .await?
         .ok_or_else(|| {
@@ -404,13 +411,26 @@ impl<'a> MediaOps<'a> {
             WhitenoiseError::MediaCache("MediaFile record missing id".to_string())
         })?;
 
-        MediaFile::update_file_path(&self.session.shared.database, media_file_id, &cache_path).await
+        MediaFile::update_file_path(
+            &self.session.account_db.inner.pool,
+            &self.session.shared.database,
+            &self.session.account_pubkey,
+            media_file_id,
+            &cache_path,
+        )
+        .await
     }
 
     /// Returns all media files for a group.
     #[perf_instrument("groups")]
     pub async fn get_media_files_for_group(&self, group_id: &GroupId) -> Result<Vec<MediaFile>> {
-        MediaFile::find_by_group(&self.session.shared.database, group_id).await
+        MediaFile::find_by_group(
+            &self.session.account_db.inner.pool,
+            &self.session.shared.database,
+            &self.session.account_pubkey,
+            group_id,
+        )
+        .await
     }
 
     /// Returns the filesystem path of the cached group image, downloading if needed.
@@ -438,8 +458,13 @@ impl<'a> MediaOps<'a> {
                 _ => return Ok(None),
             };
 
-        let blossom_url = if let Some(media_file) =
-            MediaFile::find_by_hash(&self.session.shared.database, image_hash).await?
+        let blossom_url = if let Some(media_file) = MediaFile::find_by_hash(
+            &self.session.account_db.inner.pool,
+            &self.session.shared.database,
+            &self.session.account_pubkey,
+            image_hash,
+        )
+        .await?
         {
             media_file
                 .blossom_url
@@ -555,8 +580,13 @@ impl<'a> MediaOps<'a> {
         image_hash: &[u8; 32],
         image_key: &[u8; 32],
     ) -> Result<MediaFile> {
-        let existing_record_opt =
-            MediaFile::find_by_hash(&self.session.shared.database, image_hash).await?;
+        let existing_record_opt = MediaFile::find_by_hash(
+            &self.session.account_db.inner.pool,
+            &self.session.shared.database,
+            &self.session.account_pubkey,
+            image_hash,
+        )
+        .await?;
 
         match existing_record_opt {
             Some(existing_record) => {

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -363,9 +363,13 @@ impl<'a> MessageOpsForGroup<'a> {
         &self,
         mdk_message: &mdk_core::prelude::message_types::Message,
     ) -> Result<()> {
-        let media_files =
-            crate::whitenoise::media_files::MediaFile::find_by_group(self.db(), self.group_id)
-                .await?;
+        let media_files = crate::whitenoise::media_files::MediaFile::find_by_group(
+            &self.session.account_db.inner.pool,
+            self.db(),
+            self.pubkey(),
+            self.group_id,
+        )
+        .await?;
 
         let chat_message = self
             .session

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -12,8 +12,8 @@ use crate::whitenoise::error::Result;
 use crate::whitenoise::streaming_error::{StreamKind, StreamingError};
 use crate::whitenoise::users::User;
 use crate::whitenoise::{
-    aggregated_message, chat_list, chat_list_streaming, media_files, message_aggregator,
-    message_streaming, notification_streaming, user_streaming,
+    aggregated_message, chat_list, chat_list_streaming, message_aggregator, message_streaming,
+    notification_streaming, user_streaming,
 };
 
 impl Whitenoise {
@@ -312,14 +312,6 @@ impl Whitenoise {
         notification_streaming::NotificationSubscription {
             updates: self.shared.notification_stream_manager.subscribe(),
         }
-    }
-
-    /// Get a MediaFiles orchestrator for coordinating storage and database operations
-    ///
-    /// This provides high-level methods that coordinate between the storage layer
-    /// (filesystem) and database layer (metadata) for media files.
-    pub(crate) fn media_files(&self) -> media_files::MediaFiles<'_> {
-        media_files::MediaFiles::new(&self.shared.storage, &self.shared.database)
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to Phase 18c (#786, #787). Moves `media_references` from the shared database to per-account databases while keeping `media_blobs` shared for cross-account content-addressed deduplication.

- **v29 (local):** creates `media_references` in per-account DB, copies rows from shared DB filtered by account pubkey
- **v30 (global):** drops `media_references` from shared DB
- Replaces SQL JOINs with application-level `assemble()` pattern for cross-DB reads
- Updates `fresh_account_schema.sql` with per-account `media_references` DDL
- Fixes CLI `list_media` to require account parameter (workspace build break)
- Removes dead `Whitenoise::media_files()` helper from streaming.rs

## Test plan

- [x] `just precommit-quick` passes
- [x] `cargo check --workspace --all-features` compiles clean
- [x] m0029 tests: copies account rows, creates table when no shared rows, tolerates missing shared table
- [x] m0030 tests: drops when present, idempotent when absent
- [x] media_files database tests updated for cross-DB split (shared blob upsert semantics, per-account ID independence)
- [x] `test_delete_all_data` and `test_migrate_up` updated to reflect media_references removal from shared DB

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/789">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->