### PR TITLE
Rebaseline account-DB bootstrap to v31 (stamp v17-22 + v29)

### DIFF
--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -14,6 +14,70 @@
 -- entirely instead of trying to replay them against shared state that may
 -- have moved on.
 
+CREATE TABLE IF NOT EXISTS account_settings (
+    id                    INTEGER PRIMARY KEY CHECK (id = 1),
+    notifications_enabled INTEGER NOT NULL DEFAULT 1,
+    created_at            INTEGER NOT NULL,
+    updated_at            INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS drafts (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id       BLOB NOT NULL UNIQUE,
+    content            TEXT NOT NULL DEFAULT '',
+    reply_to_id        TEXT
+        CHECK (reply_to_id IS NULL OR (length(reply_to_id) = 64 AND reply_to_id NOT GLOB '*[^0-9a-fA-F]*')),
+    media_attachments  JSONB NOT NULL DEFAULT '[]',
+    created_at         INTEGER NOT NULL,
+    updated_at         INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS published_key_packages (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    key_package_hash_ref  BLOB NOT NULL,
+    event_id              TEXT NOT NULL UNIQUE,
+    kind                  INTEGER NOT NULL DEFAULT 443,
+    d_tag                 TEXT NULL,
+    consumed_at           INTEGER,
+    key_material_deleted  INTEGER NOT NULL DEFAULT 0,
+    created_at            INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_published_kp_event_id
+    ON published_key_packages(event_id);
+
+CREATE INDEX IF NOT EXISTS idx_published_kp_cleanup
+    ON published_key_packages(consumed_at, key_material_deleted);
+
+CREATE TABLE IF NOT EXISTS published_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id    TEXT NOT NULL UNIQUE
+        CHECK (length(event_id) = 64 AND event_id NOT GLOB '*[^0-9a-fA-F]*'),
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_published_events_event_id
+    ON published_events(event_id);
+
+CREATE TABLE IF NOT EXISTS processed_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id            TEXT NOT NULL UNIQUE
+        CHECK (length(event_id) = 64 AND event_id NOT GLOB '*[^0-9a-fA-F]*'),
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    event_created_at    INTEGER DEFAULT NULL,
+    event_kind          INTEGER DEFAULT NULL,
+    author              TEXT DEFAULT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_processed_events_kind_timestamp
+    ON processed_events(event_kind, event_created_at);
+
+CREATE TABLE IF NOT EXISTS account_follows (
+    pubkey      TEXT NOT NULL PRIMARY KEY,
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS media_references (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     mls_group_id        BLOB NOT NULL,

--- a/src/whitenoise/database/rust_migrations/m0012_bootstrap.rs
+++ b/src/whitenoise/database/rust_migrations/m0012_bootstrap.rs
@@ -9,17 +9,17 @@ const FRESH_ACCOUNT_SCHEMA: &str = include_str!("fresh_account_schema.sql");
 /// The unified-timeline version this bootstrap occupies.
 ///
 /// Locals share the version space with globals; this is the next free slot
-/// after the existing globals at 1..=11.
-const BOOTSTRAP_VERSION: u32 = 12;
+/// after the existing v30 global (`m0030_drop_shared_media_references`).
+const BOOTSTRAP_VERSION: u32 = 31;
 
 /// Local versions strictly less than `BOOTSTRAP_VERSION` whose effect is
 /// already captured in `fresh_account_schema.sql`. Stamped into a fresh
 /// account's `_rust_migrations` table so the runner skips them.
 ///
-/// Empty until we rebaseline. To rebaseline: update the schema file, bump
-/// the bootstrap to a higher version (or replace this file with a newer
-/// bootstrap migration), and list the now-skipped versions here.
-const STAMPED_PRIOR_LOCAL_VERSIONS: &[u32] = &[];
+/// To rebaseline further: update the schema file, bump the bootstrap to a
+/// higher version (or replace this file with a newer bootstrap migration),
+/// and append the now-skipped versions here.
+const STAMPED_PRIOR_LOCAL_VERSIONS: &[u32] = &[17, 18, 19, 20, 21, 22, 29];
 
 /// Bootstrap a fresh account database with the schema represented by
 /// `fresh_account_schema.sql` and stamp any prior local versions whose
@@ -137,7 +137,7 @@ mod tests {
             .fetch_one(&account)
             .await
             .unwrap();
-        assert_eq!(count, 1);
+        assert_eq!(count, 1 + STAMPED_PRIOR_LOCAL_VERSIONS.len() as i64);
     }
 
     /// Synthesises a rebaseline scenario: the bootstrap's stamping path is


### PR DESCRIPTION
![marmot](https://blossom.primal.net/65f8040ef5956e3080c1fa985282249f703aeb14aa7d579af15bf2b190fab7b9.jpg)

# Bootstrap rebaseline to v31

When PR #789 added `media_references` DDL to `fresh_account_schema.sql`, we forgot two follow-ups: bump `BOOTSTRAP_VERSION` and stamp the prior locals. So fresh accounts kept running the v12 bootstrap, then re-ran v17 through v22 plus v29 against shared tables that may already have been dropped by the v23-v28 / v30 globals. Each migration's `CREATE TABLE IF NOT EXISTS` made it a no-op in practice, but the intent was wrong: those locals are data-extraction steps for upgraders, not setup for new accounts.

This PR finishes the rebaseline.

## What changed

`fresh_account_schema.sql` now holds the full post-Phase-18 per-account schema:

- `account_settings` (v17)
- `drafts` (v18)
- `published_key_packages` and 2 indexes (v19)
- `published_events` and 1 index (v20)
- `processed_events` and 1 index (v21)
- `account_follows` (v22)
- `media_references` and 2 indexes (v29)

`m0012_bootstrap.rs`:

- `BOOTSTRAP_VERSION` 12 to 31 (next free slot after the v30 global `m0030_drop_shared_media_references`)
- `STAMPED_PRIOR_LOCAL_VERSIONS` `&[]` to `&[17, 18, 19, 20, 21, 22, 29]`

The `bootstrap_is_idempotent` test now asserts `1 + STAMPED_PRIOR_LOCAL_VERSIONS.len()` rows instead of a hardcoded `1`.

## Why this is safe for upgraders

Bootstrap is `for_new_accounts_only`. Any account with prior local migration rows in `_rust_migrations` skips the bootstrap entirely. Only accounts created on or after this PR see the new baseline.

## Verification

All 64 `rust_migrations` unit tests pass. Format and clippy are clean. Three failures in `whitenoise::accounts::setup::tests` are pre-existing relay-timeout flakiness on Docker-dependent key-package fetches, unrelated to this change.

The marmot stamps the tickets and the ledger gets shorter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user blocking/unblocking functionality with blocked user list retrieval.
  * Added background notification collection API for push notification scenarios.
  * Added FFI support for iOS integration with push notification collection.

* **Refactor**
  * Restructured CLI into a separate dedicated crate with improved account-scoped operations.
  * Updated media operations to support account resolution for per-account file management.

* **Documentation**
  * Added comprehensive architecture rearchitecture guidance and testing strategy documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->