### PR TITLE
feat(groups): add required proposal upgrades for legacy groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c6349ddff23194f8fdce2ea8849380f5a4868c1648965b70e801e104cba9b3"
 dependencies = [
  "base64",
- "jni",
+ "jni 0.21.1",
  "keyring-core",
  "log",
  "ndk-context",
@@ -504,20 +504,20 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -822,17 +822,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
  "hax-lib",
- "pastey 0.2.1",
- "rand 0.9.2",
-]
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
+ "pastey 0.2.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -855,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -992,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1284,29 +1275,15 @@ checksum = "5243a22cce29dff488db8ef03d8e0e54dd06cd3e6d98475160dff390fa414de2"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1546,7 +1523,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1563,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1649,6 +1626,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1790,9 +1773,9 @@ dependencies = [
  "libcrux-hkdf",
  "libcrux-kem",
  "libcrux-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -1809,9 +1792,9 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "sha2",
  "subtle",
@@ -1866,9 +1849,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1881,7 +1864,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1889,19 +1871,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1953,12 +1934,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1966,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1979,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1993,15 +1975,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2013,15 +1995,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2051,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2095,18 +2077,18 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2174,9 +2156,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2220,6 +2202,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,10 +2271,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2318,9 +2332,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libcrux-aead"
@@ -2379,7 +2393,7 @@ checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2435,7 +2449,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2460,7 +2474,7 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tls_codec",
 ]
 
@@ -2535,7 +2549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2556,14 +2570,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2605,9 +2619,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2635,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lru-slab"
@@ -2737,7 +2751,7 @@ dependencies = [
  "nostr",
  "openmls",
  "openmls_traits",
- "pastey 0.2.1",
+ "pastey 0.2.2",
  "postcard",
  "serde",
  "serde_json",
@@ -2788,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2814,7 +2828,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2855,6 +2869,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -3005,7 +3028,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3021,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3118,7 +3141,7 @@ dependencies = [
  "ed25519-dalek",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tls_codec",
 ]
@@ -3151,7 +3174,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
@@ -3266,9 +3289,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"
@@ -3300,12 +3323,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -3341,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3421,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3523,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -3571,7 +3588,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3594,7 +3611,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3620,9 +3637,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3631,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3641,12 +3658,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3676,7 +3693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3699,9 +3716,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rav1e"
@@ -3730,7 +3747,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -3755,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3784,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3804,9 +3821,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c427f2572afe5c6cbfa2b1bf40071c89bf1a8539e958ea582842f6f38dcfae"
+checksum = "ee5133e5b207e5703c2a4a9dc9bd8c8f2cc74c4ac04ca5510acaa907012c77ac"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -3814,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702655abfc67f93a6f735e9fa4ace7d2e580633f8961f28acbfd7583ddce936c"
+checksum = "023a2a96d959c9b5b5da78e965bfdb1363b365bf5e84531a67d0eee827a702a3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3834,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5145756cdf293b5089dc6b4f103f1a1229cc55d67082c866f8c8289531c4b983"
+checksum = "c56c2e960c8e47c7c5c30ad334afea8b5502da796a59e34d640d6239d876d924"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3909,14 +3926,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -3984,13 +4001,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4015,12 +4032,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4039,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4067,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -4093,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4103,13 +4120,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -4216,7 +4233,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -4274,9 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4422,9 +4439,19 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -4434,6 +4461,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -4607,7 +4640,7 @@ dependencies = [
  "md-5",
  "memchr",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -4645,7 +4678,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -4710,6 +4743,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -4851,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4898,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4915,9 +4954,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5116,11 +5155,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -5193,7 +5233,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -5203,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -5318,9 +5358,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5384,11 +5424,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5397,7 +5437,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5408,9 +5448,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5421,23 +5461,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5445,9 +5481,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5458,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5514,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5534,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5547,14 +5583,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5592,8 +5628,8 @@ dependencies = [
  "nostr-blossom",
  "nostr-sdk",
  "once_cell",
- "rand 0.9.2",
- "reqwest 0.13.2",
+ "rand 0.9.4",
+ "reqwest 0.13.3",
  "rpassword",
  "rustls",
  "serde",
@@ -5607,7 +5643,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unicode-normalization",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
  "whitenoise-macros",
  "windows-native-keyring-store",
  "zbus-secret-service-keyring-store",
@@ -5742,6 +5778,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5773,11 +5818,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5793,6 +5855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,6 +5871,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5817,10 +5891,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5835,6 +5921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,6 +5937,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5859,6 +5957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5869,6 +5973,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5896,6 +6006,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5978,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -6002,9 +6118,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6013,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6097,18 +6213,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6117,18 +6233,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6158,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6169,9 +6285,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6180,9 +6296,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6212,9 +6328,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ tokio = { version = "1.44", features = ["test-util"] }
 [features]
 default = []
 cli = ["clap", "dirs", "rpassword"]
-integration-tests = ["clap"]
+integration-tests = ["clap", "mdk-core/test-utils"]
 benchmark-tests = ["integration-tests", "indicatif"]
 
 [[bin]]

--- a/src/integration_tests/registry.rs
+++ b/src/integration_tests/registry.rs
@@ -81,6 +81,7 @@ scenario_registry! {
     "group-membership" => GroupMembershipScenario,
     "create-group-with-legacy-member" => CreateGroupWithLegacyMemberScenario,
     "add-member-to-strict-group-rejected" => AddMemberToStrictGroupRejectedScenario,
+    "upgrade-required-proposals-after-legacy-self-update" => UpgradeRequiredProposalsAfterLegacySelfUpdateScenario,
     "chat-media-upload" => ChatMediaUploadScenario,
     "user-discovery" => UserDiscoveryScenario,
     "scheduler" => SchedulerScenario,
@@ -211,6 +212,7 @@ mod tests {
         assert!(parse_scenario_name("group-membership").is_ok());
         assert!(parse_scenario_name("create-group-with-legacy-member").is_ok());
         assert!(parse_scenario_name("add-member-to-strict-group-rejected").is_ok());
+        assert!(parse_scenario_name("upgrade-required-proposals-after-legacy-self-update").is_ok());
         assert!(parse_scenario_name("chat-media-upload").is_ok());
         assert!(parse_scenario_name("user-discovery").is_ok());
         assert!(parse_scenario_name("scheduler").is_ok());
@@ -247,7 +249,7 @@ mod tests {
     fn test_get_all_scenario_names() {
         // Test that all scenario names are returned
         let names = get_all_scenario_names();
-        assert_eq!(names.len(), 20);
+        assert_eq!(names.len(), 21);
         assert!(names.contains(&"account-management"));
         assert!(names.contains(&"basic-messaging"));
         assert!(names.contains(&"drafts"));
@@ -259,5 +261,6 @@ mod tests {
         assert!(names.contains(&"notification-streaming"));
         assert!(names.contains(&"create-group-with-legacy-member"));
         assert!(names.contains(&"add-member-to-strict-group-rejected"));
+        assert!(names.contains(&"upgrade-required-proposals-after-legacy-self-update"));
     }
 }

--- a/src/integration_tests/scenarios/mod.rs
+++ b/src/integration_tests/scenarios/mod.rs
@@ -16,6 +16,7 @@ pub mod metadata_management;
 pub mod notification_streaming;
 pub mod scheduler;
 pub mod subscription_processing;
+pub mod upgrade_required_proposals_after_legacy_self_update;
 pub mod user_discovery;
 pub mod user_search;
 
@@ -37,5 +38,6 @@ pub use metadata_management::*;
 pub use notification_streaming::*;
 pub use scheduler::*;
 pub use subscription_processing::*;
+pub use upgrade_required_proposals_after_legacy_self_update::*;
 pub use user_discovery::*;
 pub use user_search::*;

--- a/src/integration_tests/scenarios/upgrade_required_proposals_after_legacy_self_update.rs
+++ b/src/integration_tests/scenarios/upgrade_required_proposals_after_legacy_self_update.rs
@@ -1,0 +1,141 @@
+//! `upgrade_required_proposals_after_legacy_self_update` scenario.
+//!
+//! Covers the migration path for a group initially downgraded by a real
+//! legacy LeafNode. Once the legacy member's modern client self-updates its
+//! leaf, an admin can ratchet `RequiredCapabilities` back to SelfRemove.
+
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use crate::integration_tests::{
+    core::*,
+    test_cases::{group_capability_upgrade::*, shared::*},
+};
+use crate::whitenoise::groups::{RequiredProposal, RequiredProposalUpgradability};
+use crate::{Whitenoise, WhitenoiseError};
+
+pub struct UpgradeRequiredProposalsAfterLegacySelfUpdateScenario {
+    context: ScenarioContext,
+}
+
+impl UpgradeRequiredProposalsAfterLegacySelfUpdateScenario {
+    pub fn new(whitenoise: &'static Whitenoise) -> Self {
+        Self {
+            context: ScenarioContext::new(whitenoise),
+        }
+    }
+}
+
+#[async_trait]
+impl Scenario for UpgradeRequiredProposalsAfterLegacySelfUpdateScenario {
+    fn context(&self) -> &ScenarioContext {
+        &self.context
+    }
+
+    async fn run_scenario(&mut self) -> Result<(), WhitenoiseError> {
+        CreateAccountsTestCase::with_names(vec!["upgrade_admin", "upgrade_modern_member"])
+            .execute(&mut self.context)
+            .await?;
+        CreateLegacyPeerAccountTestCase::with_name("upgrade_legacy_peer")
+            .execute(&mut self.context)
+            .await?;
+
+        let legacy_account = self.context.get_account("upgrade_legacy_peer")?.clone();
+        let legacy_event_id =
+            publish_legacy_leaf_key_package(&self.context, &legacy_account).await?;
+        tracing::info!(
+            target: "whitenoise::integration_tests::scenarios::upgrade_required_proposals_after_legacy_self_update",
+            "Published legacy LeafNode KP {} for {}",
+            legacy_event_id.to_hex(),
+            legacy_account.pubkey.to_hex(),
+        );
+
+        CreateGroupTestCase::basic()
+            .with_name("upgrade_required_group")
+            .with_members(
+                "upgrade_admin",
+                vec!["upgrade_legacy_peer", "upgrade_modern_member"],
+            )
+            .execute(&mut self.context)
+            .await?;
+
+        VerifyRequiredProposalsTestCase::new(
+            vec!["upgrade_admin"],
+            "upgrade_required_group",
+            BTreeSet::new(),
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        VerifyRequiredProposalUpgradeStatusTestCase::new(
+            "upgrade_admin",
+            "upgrade_required_group",
+            RequiredProposal::SelfRemove,
+            RequiredProposalUpgradability::Blocked {
+                blockers: vec![legacy_account.pubkey],
+            },
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        UpgradeRequiredProposalsTestCase::new(
+            "upgrade_admin",
+            "upgrade_required_group",
+            BTreeSet::from([RequiredProposal::SelfRemove]),
+        )
+        .expect_blocked(RequiredProposal::SelfRemove, vec!["upgrade_legacy_peer"])
+        .execute(&mut self.context)
+        .await?;
+
+        WaitForWelcomeTestCase::new(
+            vec!["upgrade_legacy_peer", "upgrade_modern_member"],
+            "upgrade_required_group",
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        SelfUpdateGroupLeafTestCase::new("upgrade_legacy_peer", "upgrade_required_group")
+            .execute(&mut self.context)
+            .await?;
+
+        VerifyRequiredProposalUpgradeStatusTestCase::new(
+            "upgrade_admin",
+            "upgrade_required_group",
+            RequiredProposal::SelfRemove,
+            RequiredProposalUpgradability::Available,
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        UpgradeRequiredProposalsTestCase::new(
+            "upgrade_admin",
+            "upgrade_required_group",
+            BTreeSet::from([RequiredProposal::SelfRemove]),
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        VerifyRequiredProposalsTestCase::new(
+            vec![
+                "upgrade_admin",
+                "upgrade_legacy_peer",
+                "upgrade_modern_member",
+            ],
+            "upgrade_required_group",
+            BTreeSet::from([RequiredProposal::SelfRemove]),
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        UpgradeRequiredProposalsTestCase::new(
+            "upgrade_admin",
+            "upgrade_required_group",
+            BTreeSet::from([RequiredProposal::SelfRemove]),
+        )
+        .execute(&mut self.context)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/src/integration_tests/test_cases/group_capability_upgrade/mod.rs
+++ b/src/integration_tests/test_cases/group_capability_upgrade/mod.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+
+use nostr_sdk::PublicKey;
+
+mod self_update_group_leaf;
+mod upgrade_required_proposals;
+mod verify_required_proposals;
+mod verify_upgrade_status;
+
+pub use self_update_group_leaf::SelfUpdateGroupLeafTestCase;
+pub use upgrade_required_proposals::UpgradeRequiredProposalsTestCase;
+pub use verify_required_proposals::VerifyRequiredProposalsTestCase;
+pub use verify_upgrade_status::VerifyRequiredProposalUpgradeStatusTestCase;
+
+pub(super) fn pubkeys_match_unordered(left: &[PublicKey], right: &[PublicKey]) -> bool {
+    left.iter().copied().collect::<BTreeSet<_>>() == right.iter().copied().collect::<BTreeSet<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::PublicKey;
+
+    use super::pubkeys_match_unordered;
+
+    #[test]
+    fn pubkeys_match_unordered_ignores_order() {
+        let first =
+            PublicKey::parse("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let second =
+            PublicKey::parse("0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+
+        assert!(pubkeys_match_unordered(&[first, second], &[second, first],));
+    }
+
+    #[test]
+    fn pubkeys_match_unordered_rejects_different_sets() {
+        let first =
+            PublicKey::parse("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let second =
+            PublicKey::parse("0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+
+        assert!(!pubkeys_match_unordered(&[first], &[second]));
+    }
+}

--- a/src/integration_tests/test_cases/group_capability_upgrade/self_update_group_leaf.rs
+++ b/src/integration_tests/test_cases/group_capability_upgrade/self_update_group_leaf.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+
+use crate::integration_tests::core::{ScenarioContext, TestCase};
+use crate::{Whitenoise, WhitenoiseError};
+
+pub struct SelfUpdateGroupLeafTestCase {
+    account_name: String,
+    group_name: String,
+}
+
+impl SelfUpdateGroupLeafTestCase {
+    pub fn new(account_name: &str, group_name: &str) -> Self {
+        Self {
+            account_name: account_name.to_string(),
+            group_name: group_name.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl TestCase for SelfUpdateGroupLeafTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let account = context.get_account(&self.account_name)?.clone();
+        let group_id = context.get_group(&self.group_name)?.mls_group_id.clone();
+
+        let (relay_urls, evolution_event) = {
+            let mdk = context.whitenoise.create_mdk_for_account(account.pubkey)?;
+            let relay_urls = Whitenoise::ensure_group_relays(&mdk, &group_id)?;
+            let update_result = mdk.self_update(&group_id)?;
+
+            (relay_urls, update_result.evolution_event)
+        };
+
+        context
+            .whitenoise
+            .publish_and_merge_commit(evolution_event, &account.pubkey, &group_id, &relay_urls)
+            .await
+    }
+}

--- a/src/integration_tests/test_cases/group_capability_upgrade/upgrade_required_proposals.rs
+++ b/src/integration_tests/test_cases/group_capability_upgrade/upgrade_required_proposals.rs
@@ -1,0 +1,99 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::core::{ScenarioContext, TestCase};
+use crate::whitenoise::groups::RequiredProposal;
+
+use super::pubkeys_match_unordered;
+
+pub struct UpgradeRequiredProposalsTestCase {
+    admin_account_name: String,
+    group_name: String,
+    proposals_to_add: BTreeSet<RequiredProposal>,
+    expected_result: ExpectedUpgradeResult,
+}
+
+enum ExpectedUpgradeResult {
+    Success,
+    Blocked {
+        proposal: RequiredProposal,
+        blocker_account_names: Vec<String>,
+    },
+}
+
+impl UpgradeRequiredProposalsTestCase {
+    pub fn new(
+        admin_account_name: &str,
+        group_name: &str,
+        proposals_to_add: BTreeSet<RequiredProposal>,
+    ) -> Self {
+        Self {
+            admin_account_name: admin_account_name.to_string(),
+            group_name: group_name.to_string(),
+            proposals_to_add,
+            expected_result: ExpectedUpgradeResult::Success,
+        }
+    }
+
+    pub fn expect_blocked(
+        mut self,
+        proposal: RequiredProposal,
+        blocker_account_names: Vec<&str>,
+    ) -> Self {
+        self.expected_result = ExpectedUpgradeResult::Blocked {
+            proposal,
+            blocker_account_names: blocker_account_names
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        };
+        self
+    }
+}
+
+#[async_trait]
+impl TestCase for UpgradeRequiredProposalsTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let admin = context.get_account(&self.admin_account_name)?;
+        let group_id = &context.get_group(&self.group_name)?.mls_group_id;
+        let result = context
+            .whitenoise
+            .upgrade_group_required_proposals(admin, group_id, self.proposals_to_add.clone())
+            .await;
+
+        match &self.expected_result {
+            ExpectedUpgradeResult::Success => result,
+            ExpectedUpgradeResult::Blocked {
+                proposal: expected_proposal,
+                blocker_account_names,
+            } => {
+                let expected_blockers = blocker_account_names
+                    .iter()
+                    .map(|name| context.get_account(name).map(|account| account.pubkey))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                match result {
+                    Err(WhitenoiseError::CapabilityUpgradeBlocked { proposal, blockers }) => {
+                        if proposal == *expected_proposal
+                            && pubkeys_match_unordered(&blockers, &expected_blockers)
+                        {
+                            Ok(())
+                        } else {
+                            Err(WhitenoiseError::Internal(format!(
+                                "unexpected blocked upgrade payload: proposal={proposal:?}, blockers={blockers:?}, expected_blockers={expected_blockers:?}"
+                            )))
+                        }
+                    }
+                    Err(other) => Err(WhitenoiseError::Internal(format!(
+                        "expected CapabilityUpgradeBlocked, got {other:?}"
+                    ))),
+                    Ok(()) => Err(WhitenoiseError::Internal(
+                        "expected blocked required-proposals upgrade".to_string(),
+                    )),
+                }
+            }
+        }
+    }
+}

--- a/src/integration_tests/test_cases/group_capability_upgrade/verify_required_proposals.rs
+++ b/src/integration_tests/test_cases/group_capability_upgrade/verify_required_proposals.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::core::{ScenarioContext, TestCase, retry_default};
+use crate::whitenoise::groups::RequiredProposal;
+
+pub struct VerifyRequiredProposalsTestCase {
+    account_names: Vec<String>,
+    group_name: String,
+    expected: BTreeSet<RequiredProposal>,
+}
+
+impl VerifyRequiredProposalsTestCase {
+    pub fn new(
+        account_names: Vec<&str>,
+        group_name: &str,
+        expected: BTreeSet<RequiredProposal>,
+    ) -> Self {
+        Self {
+            account_names: account_names.into_iter().map(str::to_string).collect(),
+            group_name: group_name.to_string(),
+            expected,
+        }
+    }
+}
+
+#[async_trait]
+impl TestCase for VerifyRequiredProposalsTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let group_id = context.get_group(&self.group_name)?.mls_group_id.clone();
+        let wn = context.whitenoise;
+
+        for account_name in &self.account_names {
+            let account = context.get_account(account_name)?.clone();
+            let account_name = account_name.clone();
+            let expected = self.expected.clone();
+
+            retry_default(
+                || {
+                    let account = account.clone();
+                    let group_id = group_id.clone();
+                    let expected = expected.clone();
+                    let account_name = account_name.clone();
+
+                    async move {
+                        let required = wn.group_required_proposals(&account, &group_id).await?;
+                        if required == expected {
+                            Ok(())
+                        } else {
+                            Err(WhitenoiseError::Internal(format!(
+                                "{account_name} required proposals were {required:?}, expected {expected:?}"
+                            )))
+                        }
+                    }
+                },
+                &format!("{account_name} required proposals converge"),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/integration_tests/test_cases/group_capability_upgrade/verify_upgrade_status.rs
+++ b/src/integration_tests/test_cases/group_capability_upgrade/verify_upgrade_status.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+
+use crate::WhitenoiseError;
+use crate::integration_tests::core::{ScenarioContext, TestCase, retry_default};
+use crate::whitenoise::groups::{RequiredProposal, RequiredProposalUpgradability};
+
+use super::pubkeys_match_unordered;
+
+pub struct VerifyRequiredProposalUpgradeStatusTestCase {
+    account_name: String,
+    group_name: String,
+    proposal: RequiredProposal,
+    expected: RequiredProposalUpgradability,
+}
+
+impl VerifyRequiredProposalUpgradeStatusTestCase {
+    pub fn new(
+        account_name: &str,
+        group_name: &str,
+        proposal: RequiredProposal,
+        expected: RequiredProposalUpgradability,
+    ) -> Self {
+        Self {
+            account_name: account_name.to_string(),
+            group_name: group_name.to_string(),
+            proposal,
+            expected,
+        }
+    }
+}
+
+#[async_trait]
+impl TestCase for VerifyRequiredProposalUpgradeStatusTestCase {
+    async fn run(&self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
+        let account = context.get_account(&self.account_name)?.clone();
+        let group_id = context.get_group(&self.group_name)?.mls_group_id.clone();
+        let wn = context.whitenoise;
+        let account_name = self.account_name.clone();
+        let proposal = self.proposal;
+        let expected = self.expected.clone();
+
+        retry_default(
+            || {
+                let account = account.clone();
+                let group_id = group_id.clone();
+                let account_name = account_name.clone();
+                let expected = expected.clone();
+
+                async move {
+                    let status = wn
+                        .group_capability_upgrade_status(&account, &group_id)
+                        .await?;
+                    let actual = status
+                        .per_proposal
+                        .into_iter()
+                        .find(|row| row.proposal == proposal)
+                        .map(|row| row.state)
+                        .ok_or_else(|| {
+                            WhitenoiseError::Internal(format!(
+                                "{proposal:?} missing from capability upgrade status"
+                            ))
+                        })?;
+
+                    if upgradability_matches(&actual, &expected) {
+                        Ok(())
+                    } else {
+                        Err(WhitenoiseError::Internal(format!(
+                            "{account_name} {proposal:?} upgrade status was {actual:?}, expected {expected:?}"
+                        )))
+                    }
+                }
+            },
+            &format!("{account_name} {proposal:?} upgrade status"),
+        )
+        .await
+    }
+}
+
+fn upgradability_matches(
+    actual: &RequiredProposalUpgradability,
+    expected: &RequiredProposalUpgradability,
+) -> bool {
+    match (actual, expected) {
+        (
+            RequiredProposalUpgradability::Blocked {
+                blockers: actual_blockers,
+            },
+            RequiredProposalUpgradability::Blocked {
+                blockers: expected_blockers,
+            },
+        ) => pubkeys_match_unordered(actual_blockers, expected_blockers),
+        _ => actual == expected,
+    }
+}

--- a/src/integration_tests/test_cases/mod.rs
+++ b/src/integration_tests/test_cases/mod.rs
@@ -6,6 +6,7 @@ pub mod chat_list_streaming;
 pub mod chat_media_upload;
 pub mod drafts;
 pub mod follow_management;
+pub mod group_capability_upgrade;
 pub mod group_membership;
 pub mod login_flow;
 pub mod message_streaming;

--- a/src/integration_tests/test_cases/shared/legacy_key_package.rs
+++ b/src/integration_tests/test_cases/shared/legacy_key_package.rs
@@ -7,12 +7,13 @@
 //! overridden — so this fixture exercises the WhiteNoise-side preflight
 //! softening without claiming to forge legacy MLS LeafNode bytes.
 
+use nostr_sdk::prelude::*;
+
 use crate::WhitenoiseError;
 use crate::integration_tests::core::*;
 use crate::whitenoise::groups::{KeyPackageCapabilities, MlsExtensionId, RequiredProposal};
 use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND_LEGACY;
 use crate::whitenoise::relays::Relay;
-use nostr_sdk::prelude::*;
 
 /// Codepoint emitted in the `mls_proposals` tag for [`RequiredProposal::SelfRemove`].
 /// Mirrors `crate::whitenoise::groups::required_proposals::SELF_REMOVE_CODEPOINT`,
@@ -154,11 +155,58 @@ pub(crate) async fn publish_legacy_capability_key_package(
         .await?;
 
     tracing::debug!(
+        target: "whitenoise::integration_tests::test_cases::shared::legacy_key_package",
         "Published legacy-capability key package {} for account {} (proposals={:?}, extensions={:?})",
         event_id.to_hex(),
         account.pubkey.to_hex(),
         capabilities.proposals,
         capabilities.extensions,
+    );
+
+    Ok(event_id)
+}
+
+/// Builds and publishes a legacy LeafNode key package whose MLS bytes do not
+/// advertise SelfRemove.
+///
+/// Unlike [`publish_legacy_capability_key_package`], this uses MDK's
+/// `test_util::create_legacy_key_package_event` helper, so MDK's LCD logic sees
+/// a real capability-poor leaf during group creation.
+pub(crate) async fn publish_legacy_leaf_key_package(
+    context: &ScenarioContext,
+    account: &crate::Account,
+) -> Result<EventId, WhitenoiseError> {
+    let nsec = context.whitenoise.export_account_nsec(account).await?;
+    let secret_key =
+        SecretKey::from_bech32(&nsec).map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
+    let keys = Keys::new(secret_key);
+
+    let mdk = context.whitenoise.create_mdk_for_account(account.pubkey)?;
+    let event = mdk_core::test_util::create_legacy_key_package_event(&mdk, &keys);
+    let event_id = event.id;
+
+    let relays = account.key_package_relays(context.whitenoise).await?;
+    let relay_urls: Vec<&str> = relays.iter().map(|relay| relay.url.as_str()).collect();
+    let client = create_test_client(&relay_urls, keys).await?;
+    client.send_event(&event).await?;
+    client.disconnect().await;
+
+    context
+        .whitenoise
+        .track_published_key_package_for_testing(
+            &account.pubkey,
+            &[],
+            &event_id.to_hex(),
+            MLS_KEY_PACKAGE_KIND_LEGACY,
+            None,
+        )
+        .await?;
+
+    tracing::debug!(
+        target: "whitenoise::integration_tests::test_cases::shared::legacy_key_package",
+        "Published legacy LeafNode key package {} for account {}",
+        event_id.to_hex(),
+        account.pubkey.to_hex(),
     );
 
     Ok(event_id)

--- a/src/integration_tests/test_cases/shared/wait_for_welcome.rs
+++ b/src/integration_tests/test_cases/shared/wait_for_welcome.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
+
 use crate::WhitenoiseError;
-use crate::integration_tests::core::{ScenarioContext, TestCase, retry_default};
+use crate::integration_tests::core::{ScenarioContext, TestCase, retry};
 use async_trait::async_trait;
 
 /// Test case that waits for specified accounts to receive and process welcome messages
@@ -43,7 +45,9 @@ impl TestCase for WaitForWelcomeTestCase {
                 self.group_name
             );
 
-            retry_default(
+            retry(
+                60,
+                Duration::from_millis(250),
                 || {
                     let account = account.clone();
                     let group_id = group_id.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,10 @@ pub use whitenoise::app_settings::{AppSettings, Language, ThemeMode};
 // Groups and relays
 pub use whitenoise::accounts_groups::{AccountGroup, MuteDuration};
 pub use whitenoise::group_information::{GroupInformation, GroupType};
-pub use whitenoise::groups::{GroupWithInfoAndMembership, GroupWithMembership};
+pub use whitenoise::groups::{
+    GroupCapabilityUpgradeStatus, GroupWithInfoAndMembership, GroupWithMembership,
+    RequiredProposal, RequiredProposalUpgradability, RequiredProposalUpgradeStatus,
+};
 pub use whitenoise::relays::{Relay, RelayType};
 
 // Drafts

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::{LazyLock, Mutex};
 use thiserror::Error;
 
 use crate::RelayType;
@@ -24,6 +25,8 @@ use crate::whitenoise::secrets_store::SecretsStoreError;
 use crate::whitenoise::user_streaming::{UserUpdate, UserUpdateTrigger};
 use crate::whitenoise::users::User;
 use crate::whitenoise::{Whitenoise, WhitenoiseError};
+
+static MDK_STORAGE_INIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// The type of account authentication.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
@@ -555,7 +558,12 @@ impl Account {
     ) -> core::result::Result<MDK<MdkSqliteStorage>, AccountError> {
         let mls_storage_dir = data_dir.join("mls").join(pubkey.to_hex());
         let db_key_id = format!("mdk.db.key.{}", pubkey.to_hex());
-        let storage = MdkSqliteStorage::new(mls_storage_dir, keyring_service_id, &db_key_id)?;
+        let storage = {
+            let _storage_init_guard = MDK_STORAGE_INIT_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            MdkSqliteStorage::new(mls_storage_dir, keyring_service_id, &db_key_id)?
+        };
         Ok(MDK::new(storage))
     }
 }
@@ -586,6 +594,8 @@ mod tests {
     use crate::whitenoise::user_streaming::UserUpdateTrigger;
     use nostr_sdk::prelude::*;
     use nostr_sdk::{Metadata, RelayUrl};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_effective_inbox_relays_returns_inbox_when_present() {
@@ -1188,6 +1198,36 @@ mod tests {
         let pubkey = nostr_sdk::Keys::generate().public_key();
         let result = Account::create_mdk(pubkey, temp_dir.path(), "com.whitenoise.test");
         assert!(result.is_ok(), "create_mdk failed: {:?}", result.err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_create_mdk_for_multiple_accounts_does_not_deadlock() {
+        crate::whitenoise::Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let data_dir = Arc::new(temp_dir.path().to_path_buf());
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let data_dir = Arc::clone(&data_dir);
+            let pubkey = nostr_sdk::Keys::generate().public_key();
+            handles.push(tokio::task::spawn_blocking(move || {
+                Account::create_mdk(pubkey, data_dir.as_path(), "com.whitenoise.test.concurrent")
+                    .map(|_| ())
+                    .map_err(|err| err.to_string())
+            }));
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            for handle in handles {
+                handle.await.unwrap().unwrap();
+            }
+        })
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "concurrent create_mdk calls timed out; possible deadlock"
+        );
     }
 
     #[test]

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -6,7 +6,7 @@ use crate::{
     whitenoise::{
         accounts::{AccountError, LoginError},
         database::DatabaseError,
-        groups::blossom_error::BlossomError,
+        groups::{RequiredProposal, blossom_error::BlossomError},
         message_aggregator::ProcessingError,
         secrets_store::SecretsStoreError,
         streaming_error::StreamingError,
@@ -203,6 +203,15 @@ pub enum WhitenoiseError {
         "Cannot add this user yet. Their key package was published by an older app version and does not advertise SelfRemove support. Ask them to update White Noise and open the app so it can publish a new key package."
     )]
     KeyPackageMissingSelfRemove { member_pubkey: PublicKey },
+
+    #[error(
+        "upgrade blocked: {} member(s) do not advertise the {proposal:?} proposal",
+        blockers.len()
+    )]
+    CapabilityUpgradeBlocked {
+        proposal: RequiredProposal,
+        blockers: Vec<PublicKey>,
+    },
 
     /// MDK or our pre-validation rejected an `add_members_to_group` invitee
     /// because their published key package does not satisfy the group's

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -31,9 +31,13 @@ mod publish;
 mod required_proposals;
 
 pub use membership::{GroupWithInfoAndMembership, GroupWithMembership};
-pub use required_proposals::RequiredProposal;
+pub use required_proposals::{
+    GroupCapabilityUpgradeStatus, RequiredProposal, RequiredProposalUpgradability,
+    RequiredProposalUpgradeStatus,
+};
 pub(crate) use required_proposals::{
     KeyPackageCapabilities, MlsExtensionId, find_member_missing_required_proposal,
+    project_group_capability_upgrade_status,
 };
 
 impl Whitenoise {
@@ -638,6 +642,105 @@ impl Whitenoise {
         Ok(required.into_iter().map(RequiredProposal::from).collect())
     }
 
+    /// Returns readiness for RequiredCapabilities proposal upgrades.
+    #[perf_instrument("groups")]
+    pub async fn group_capability_upgrade_status(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+    ) -> Result<GroupCapabilityUpgradeStatus> {
+        let mdk = self.create_mdk_for_account(account.pubkey)?;
+        let status = mdk
+            .group_capability_upgrade_status(group_id)
+            .map_err(|e| match e {
+                mdk_core::Error::GroupNotFound => WhitenoiseError::GroupNotFound,
+                other => WhitenoiseError::from(other),
+            })?;
+        Ok(project_group_capability_upgrade_status(status))
+    }
+
+    /// Adds proposal types to a group's `RequiredCapabilities` extension.
+    ///
+    /// Use [`Self::group_capability_upgrade_status`] first to discover which
+    /// proposals are upgradeable today; this method enforces the same MDK
+    /// gate (every member must already advertise the capability) and surfaces
+    /// blockers as [`WhitenoiseError::CapabilityUpgradeBlocked`].
+    ///
+    /// Per MIP-03, the evolution event is published to the group's relays
+    /// *before* merging the pending commit locally — local state only
+    /// advances once a relay has accepted the event.
+    ///
+    /// # Arguments
+    /// * `account` - The account performing the upgrade (must be group admin)
+    /// * `group_id` - The MLS group ID to upgrade
+    /// * `proposals_to_add` - Non-empty set of proposals to require; must not
+    ///   contain [`RequiredProposal::Unknown`]
+    ///
+    /// # Errors
+    /// * [`WhitenoiseError::InvalidInput`] - `proposals_to_add` is empty or
+    ///   contains [`RequiredProposal::Unknown`]
+    /// * [`WhitenoiseError::AccountNotAuthorized`] - `account` is not a group
+    ///   admin
+    /// * [`WhitenoiseError::GroupNotFound`] - No MLS record exists for
+    ///   `group_id`
+    /// * [`WhitenoiseError::CapabilityUpgradeBlocked`] - One or more members
+    ///   do not yet advertise the requested capability
+    ///
+    /// Idempotent when every requested proposal is already required.
+    #[perf_instrument("groups")]
+    pub async fn upgrade_group_required_proposals(
+        &self,
+        account: &Account,
+        group_id: &GroupId,
+        proposals_to_add: BTreeSet<RequiredProposal>,
+    ) -> Result<()> {
+        if proposals_to_add.is_empty() {
+            return Err(WhitenoiseError::InvalidInput(
+                "proposals_to_add must be non-empty".to_string(),
+            ));
+        }
+
+        self.ensure_account_is_group_admin(account, group_id)
+            .await?;
+
+        let proposal_types = proposals_to_add
+            .iter()
+            .copied()
+            .map(ProposalType::try_from)
+            .collect::<Result<BTreeSet<_>>>()?;
+
+        let (relay_urls, evolution_event) = {
+            let mdk = self.create_mdk_for_account(account.pubkey)?;
+            let relay_urls = Self::ensure_group_relays(&mdk, group_id)?;
+
+            let update_result = match mdk.upgrade_group_capabilities(group_id, &proposal_types) {
+                Ok(update_result) => update_result,
+                Err(mdk_core::Error::ProposalAlreadyRequired(proposal)) => {
+                    tracing::info!(
+                        target: "whitenoise::groups::upgrade_group_required_proposals",
+                        proposal = ?proposal,
+                        "proposal already required; treating upgrade as idempotent no-op"
+                    );
+                    return Ok(());
+                }
+                Err(other) => return Err(map_mdk_capability_upgrade_error(other)),
+            };
+
+            (relay_urls, update_result.evolution_event)
+        };
+
+        self.publish_and_merge_commit(evolution_event, &account.pubkey, group_id, &relay_urls)
+            .await?;
+
+        tracing::info!(
+            target: "whitenoise::groups::upgrade_group_required_proposals",
+            added = ?proposals_to_add,
+            "upgraded group required proposals"
+        );
+
+        Ok(())
+    }
+
     #[perf_instrument("groups")]
     async fn ensure_account_is_group_admin(
         &self,
@@ -999,11 +1102,41 @@ fn map_mdk_add_members_error(err: mdk_core::Error) -> WhitenoiseError {
     }
 }
 
+fn map_mdk_capability_upgrade_error(err: mdk_core::Error) -> WhitenoiseError {
+    match err {
+        mdk_core::Error::EmptyUpgradeSet => {
+            WhitenoiseError::InvalidInput("proposals_to_add must be non-empty".to_string())
+        }
+        mdk_core::Error::ProposalNotInSupportedSet(proposal) => WhitenoiseError::InvalidInput(
+            format!("proposal {proposal:?} is not supported for RequiredCapabilities upgrade"),
+        ),
+        mdk_core::Error::GroupNotFound => WhitenoiseError::GroupNotFound,
+        mdk_core::Error::NotAdmin => WhitenoiseError::AccountNotAuthorized,
+        mdk_core::Error::ProposalNotAvailableForUpgrade { proposal, blockers } => {
+            tracing::warn!(
+                target: "whitenoise::groups::upgrade_group_required_proposals",
+                proposal = ?proposal,
+                blockers = ?blockers,
+                "required proposal upgrade blocked by current member capabilities"
+            );
+            WhitenoiseError::CapabilityUpgradeBlocked {
+                proposal: RequiredProposal::from(proposal),
+                blockers,
+            }
+        }
+        mdk_core::Error::OwnLeafNotFound => WhitenoiseError::Internal(
+            "caller leaf is missing while upgrading group required proposals".to_string(),
+        ),
+        other => WhitenoiseError::from(other),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::whitenoise::Whitenoise;
     use crate::whitenoise::database::media_files::MediaFile;
+    use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND;
     use crate::whitenoise::test_utils::*;
     use mdk_core::media_processing::MediaProcessingOptions;
     use mdk_storage_traits::Secret;
@@ -1028,6 +1161,36 @@ mod tests {
             mime_type: Some(mime_type.to_string()),
             uploaded: Timestamp::now(),
         }
+    }
+
+    async fn create_native_mdk_group_for_testing(
+        whitenoise: &Whitenoise,
+    ) -> (Account, group_types::Group) {
+        let (creator_account, _creator_keys) = create_test_account(whitenoise).await;
+        let (member_account, member_keys) = create_test_account(whitenoise).await;
+
+        let member_mdk = whitenoise
+            .create_mdk_for_account(member_account.pubkey)
+            .unwrap();
+        let key_package_relays = vec![RelayUrl::parse("wss://relay.example.com").unwrap()];
+        let key_package_data = member_mdk
+            .create_key_package_for_event(&member_account.pubkey, key_package_relays)
+            .unwrap();
+        let key_package_event = EventBuilder::new(MLS_KEY_PACKAGE_KIND, &key_package_data.content)
+            .tags(key_package_data.tags_30443)
+            .sign_with_keys(&member_keys)
+            .unwrap();
+
+        let creator_mdk = whitenoise
+            .create_mdk_for_account(creator_account.pubkey)
+            .unwrap();
+        let config = create_nostr_group_config_data(vec![creator_account.pubkey]);
+        let group = creator_mdk
+            .create_group(&creator_account.pubkey, vec![key_package_event], config)
+            .unwrap()
+            .group;
+
+        (creator_account, group)
     }
 
     #[tokio::test]
@@ -1585,6 +1748,35 @@ mod tests {
             matches!(update_result, Err(WhitenoiseError::AccountNotAuthorized)),
             "Expected AccountNotAuthorized for update_group_data, got: {:?}",
             update_result
+        );
+
+        let upgrade_result = whitenoise
+            .upgrade_group_required_proposals(
+                &creator_account,
+                &group.mls_group_id,
+                BTreeSet::from([RequiredProposal::SelfRemove]),
+            )
+            .await;
+        assert!(
+            matches!(upgrade_result, Err(WhitenoiseError::AccountNotAuthorized)),
+            "Expected AccountNotAuthorized for upgrade_group_required_proposals, got: {:?}",
+            upgrade_result
+        );
+
+        let upgrade_unknown_result = whitenoise
+            .upgrade_group_required_proposals(
+                &creator_account,
+                &group.mls_group_id,
+                BTreeSet::from([RequiredProposal::Unknown]),
+            )
+            .await;
+        assert!(
+            matches!(
+                upgrade_unknown_result,
+                Err(WhitenoiseError::AccountNotAuthorized)
+            ),
+            "Expected AccountNotAuthorized to take precedence over invalid input shape, got: {:?}",
+            upgrade_unknown_result
         );
     }
 
@@ -2862,6 +3054,140 @@ mod tests {
             .expect_err("fabricated group ID must error");
 
         assert!(matches!(err, WhitenoiseError::GroupNotFound));
+    }
+
+    #[tokio::test]
+    async fn group_capability_upgrade_status_reports_already_required_for_native_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (creator_account, group) = create_native_mdk_group_for_testing(&whitenoise).await;
+
+        let status = whitenoise
+            .group_capability_upgrade_status(&creator_account, &group.mls_group_id)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            status.per_proposal,
+            vec![RequiredProposalUpgradeStatus {
+                proposal: RequiredProposal::SelfRemove,
+                state: RequiredProposalUpgradability::AlreadyRequired,
+            }],
+        );
+    }
+
+    #[tokio::test]
+    async fn group_capability_upgrade_status_errors_on_missing_group() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, _keys) = create_test_account(&whitenoise).await;
+        let missing_group_id = GroupId::from_slice(&[0; 32]);
+
+        let err = whitenoise
+            .group_capability_upgrade_status(&account, &missing_group_id)
+            .await
+            .expect_err("fabricated group ID must error");
+
+        assert!(matches!(err, WhitenoiseError::GroupNotFound));
+    }
+
+    #[tokio::test]
+    async fn upgrade_group_required_proposals_rejects_unknown_target() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (creator_account, group) = create_native_mdk_group_for_testing(&whitenoise).await;
+
+        let err = whitenoise
+            .upgrade_group_required_proposals(
+                &creator_account,
+                &group.mls_group_id,
+                BTreeSet::from([RequiredProposal::Unknown]),
+            )
+            .await
+            .expect_err("unknown upgrade target must be rejected as invalid input");
+
+        assert!(matches!(err, WhitenoiseError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn upgrade_group_required_proposals_rejects_empty_set_before_group_lookup() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, _keys) = create_test_account(&whitenoise).await;
+        let missing_group_id = GroupId::from_slice(&[0; 32]);
+
+        let err = whitenoise
+            .upgrade_group_required_proposals(&account, &missing_group_id, BTreeSet::new())
+            .await
+            .expect_err("empty upgrade target must fail before group lookup");
+
+        assert!(matches!(err, WhitenoiseError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn upgrade_group_required_proposals_is_idempotent_when_already_required() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (creator_account, group) = create_native_mdk_group_for_testing(&whitenoise).await;
+
+        whitenoise
+            .upgrade_group_required_proposals(
+                &creator_account,
+                &group.mls_group_id,
+                BTreeSet::from([RequiredProposal::SelfRemove]),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn map_capability_upgrade_empty_set_yields_invalid_input() {
+        let mapped = map_mdk_capability_upgrade_error(mdk_core::Error::EmptyUpgradeSet);
+
+        assert!(matches!(mapped, WhitenoiseError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn map_capability_upgrade_unsupported_proposal_yields_invalid_input() {
+        let mapped = map_mdk_capability_upgrade_error(mdk_core::Error::ProposalNotInSupportedSet(
+            ProposalType::Add,
+        ));
+
+        assert!(matches!(mapped, WhitenoiseError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn map_capability_upgrade_group_not_found_yields_group_not_found() {
+        let mapped = map_mdk_capability_upgrade_error(mdk_core::Error::GroupNotFound);
+
+        assert!(matches!(mapped, WhitenoiseError::GroupNotFound));
+    }
+
+    #[test]
+    fn map_capability_upgrade_not_admin_yields_account_not_authorized() {
+        let mapped = map_mdk_capability_upgrade_error(mdk_core::Error::NotAdmin);
+
+        assert!(matches!(mapped, WhitenoiseError::AccountNotAuthorized));
+    }
+
+    #[test]
+    fn map_capability_upgrade_blocked_yields_named_blockers() {
+        let blocker = Keys::generate().public_key();
+        let mapped =
+            map_mdk_capability_upgrade_error(mdk_core::Error::ProposalNotAvailableForUpgrade {
+                proposal: ProposalType::SelfRemove,
+                blockers: vec![blocker],
+            });
+
+        match mapped {
+            WhitenoiseError::CapabilityUpgradeBlocked { proposal, blockers } => {
+                assert_eq!(proposal, RequiredProposal::SelfRemove);
+                assert_eq!(blockers, vec![blocker]);
+            }
+            other => panic!("expected CapabilityUpgradeBlocked, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_capability_upgrade_own_leaf_not_found_yields_internal() {
+        let mapped = map_mdk_capability_upgrade_error(mdk_core::Error::OwnLeafNotFound);
+
+        assert!(matches!(mapped, WhitenoiseError::Internal(_)));
     }
 
     #[test]

--- a/src/whitenoise/groups/required_proposals.rs
+++ b/src/whitenoise/groups/required_proposals.rs
@@ -2,9 +2,11 @@
 // whitenoise-owned mirror; this import is internal only.
 use std::collections::BTreeSet;
 
-use mdk_core::prelude::ProposalType;
+use mdk_core::prelude::{CapabilityUpgradeStatus, ProposalType, ProposalUpgradability};
 use nostr_sdk::prelude::PublicKey;
 use serde::{Deserialize, Serialize};
+
+use crate::whitenoise::error::WhitenoiseError;
 
 /// SelfRemove codepoint (`0x000a`). Used both as a proposal codepoint
 /// ([`RequiredProposal::SelfRemove`]) and an extension codepoint
@@ -44,6 +46,28 @@ pub enum RequiredProposal {
     SelfRemove,
     /// Any proposal type the whitenoise API does not distinguish today.
     Unknown,
+}
+
+/// Upgrade readiness for the proposal types WhiteNoise exposes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupCapabilityUpgradeStatus {
+    pub per_proposal: Vec<RequiredProposalUpgradeStatus>,
+}
+
+/// Upgrade readiness for one modeled required proposal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequiredProposalUpgradeStatus {
+    pub proposal: RequiredProposal,
+    pub state: RequiredProposalUpgradability,
+}
+
+/// Whether a modeled proposal can be added to the group's `RequiredCapabilities`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequiredProposalUpgradability {
+    AlreadyRequired,
+    Available,
+    Blocked { blockers: Vec<PublicKey> },
 }
 
 /// A whitenoise-owned mirror of the MLS extension-type registry, restricted to
@@ -117,6 +141,49 @@ impl From<ProposalType> for RequiredProposal {
     }
 }
 
+impl TryFrom<RequiredProposal> for ProposalType {
+    type Error = WhitenoiseError;
+
+    fn try_from(proposal: RequiredProposal) -> core::result::Result<Self, Self::Error> {
+        match proposal {
+            RequiredProposal::SelfRemove => Ok(Self::SelfRemove),
+            RequiredProposal::Unknown => Err(WhitenoiseError::InvalidInput(
+                "RequiredProposal::Unknown is a sentinel and cannot be used as an upgrade target"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+pub(crate) fn project_group_capability_upgrade_status(
+    status: CapabilityUpgradeStatus,
+) -> GroupCapabilityUpgradeStatus {
+    let per_proposal = status
+        .per_proposal
+        .into_iter()
+        .filter_map(|(proposal, state)| {
+            let proposal = RequiredProposal::from(proposal);
+            if matches!(proposal, RequiredProposal::Unknown) {
+                return None;
+            }
+
+            let state = match state {
+                ProposalUpgradability::AlreadyRequired => {
+                    RequiredProposalUpgradability::AlreadyRequired
+                }
+                ProposalUpgradability::Available => RequiredProposalUpgradability::Available,
+                ProposalUpgradability::Blocked { blockers } => {
+                    RequiredProposalUpgradability::Blocked { blockers }
+                }
+            };
+
+            Some(RequiredProposalUpgradeStatus { proposal, state })
+        })
+        .collect();
+
+    GroupCapabilityUpgradeStatus { per_proposal }
+}
+
 impl From<u16> for RequiredProposal {
     /// Maps a raw proposal codepoint to the mirror enum.
     ///
@@ -183,10 +250,101 @@ mod tests {
     }
 
     #[test]
+    fn upgrade_status_serde_round_trip_preserves_payload() {
+        let blocker = Keys::generate().public_key();
+        let original = GroupCapabilityUpgradeStatus {
+            per_proposal: vec![RequiredProposalUpgradeStatus {
+                proposal: RequiredProposal::SelfRemove,
+                state: RequiredProposalUpgradability::Blocked {
+                    blockers: vec![blocker],
+                },
+            }],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let round_tripped: GroupCapabilityUpgradeStatus = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
     fn from_self_remove_maps_to_self_remove() {
         assert_eq!(
             RequiredProposal::from(ProposalType::SelfRemove),
             RequiredProposal::SelfRemove,
+        );
+    }
+
+    #[test]
+    fn try_from_self_remove_maps_to_proposal_type_self_remove() {
+        assert_eq!(
+            ProposalType::try_from(RequiredProposal::SelfRemove).unwrap(),
+            ProposalType::SelfRemove,
+        );
+    }
+
+    #[test]
+    fn try_from_unknown_rejects_upgrade_target() {
+        let error = ProposalType::try_from(RequiredProposal::Unknown).unwrap_err();
+
+        assert!(matches!(error, WhitenoiseError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn project_upgrade_status_maps_modeled_rows() {
+        let blocker = Keys::generate().public_key();
+        let status = mdk_core::prelude::CapabilityUpgradeStatus {
+            per_proposal: vec![
+                (
+                    ProposalType::SelfRemove,
+                    mdk_core::prelude::ProposalUpgradability::Blocked {
+                        blockers: vec![blocker],
+                    },
+                ),
+                (
+                    ProposalType::Add,
+                    mdk_core::prelude::ProposalUpgradability::Available,
+                ),
+            ],
+        };
+
+        let projected = project_group_capability_upgrade_status(status);
+
+        assert_eq!(
+            projected,
+            GroupCapabilityUpgradeStatus {
+                per_proposal: vec![RequiredProposalUpgradeStatus {
+                    proposal: RequiredProposal::SelfRemove,
+                    state: RequiredProposalUpgradability::Blocked {
+                        blockers: vec![blocker],
+                    },
+                }],
+            },
+        );
+    }
+
+    #[test]
+    fn project_upgrade_status_preserves_already_required_and_available_states() {
+        let already_required = mdk_core::prelude::CapabilityUpgradeStatus {
+            per_proposal: vec![(
+                ProposalType::SelfRemove,
+                mdk_core::prelude::ProposalUpgradability::AlreadyRequired,
+            )],
+        };
+        let available = mdk_core::prelude::CapabilityUpgradeStatus {
+            per_proposal: vec![(
+                ProposalType::SelfRemove,
+                mdk_core::prelude::ProposalUpgradability::Available,
+            )],
+        };
+
+        assert_eq!(
+            project_group_capability_upgrade_status(already_required).per_proposal[0].state,
+            RequiredProposalUpgradability::AlreadyRequired,
+        );
+        assert_eq!(
+            project_group_capability_upgrade_status(available).per_proposal[0].state,
+            RequiredProposalUpgradability::Available,
         );
     }
 


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group capability upgrade status checking to query proposal upgrade readiness
  * Added functionality to upgrade and manage required proposals within groups
  * Exposed new types for managing required proposals and capability upgrade status

* **Bug Fixes**
  * Improved storage initialization with mutex-based synchronization to handle concurrent access

* **Chores**
  * Updated upstream dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->