### PR TITLE
feat: move membership and push tables to per-account DBs

### DIFF
--- a/docs/session-projection-implementation-plan.md
+++ b/docs/session-projection-implementation-plan.md
@@ -615,7 +615,7 @@ publications.
 
 ### Phase 18d: Move membership and push account tables to account DB (~800 LOC)
 
-- [ ] Not started
+- [x] Completed in PR #792
 
 <details>
 <summary>Details</summary>

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -695,6 +695,14 @@ impl Whitenoise {
         // 4c. Delete per-account media_references for this group
         MediaFile::delete_references_for_group(&session.account_db.inner.pool, group_id).await?;
 
+        // 4d. Delete per-account drafts for this group (best-effort)
+        if let Err(e) = session.repos.drafts.delete(group_id).await {
+            tracing::warn!(
+                target: "whitenoise::accounts_groups",
+                "Failed to delete draft during delete_chat: {e}"
+            );
+        }
+
         // 5. Delete MDK group state for this account (best-effort)
         match self.create_mdk_for_account(account.pubkey) {
             Ok(mdk) => {

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -7,9 +7,12 @@ use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::perf_instrument;
+use sqlx::SqlitePool;
+
 use crate::whitenoise::{
-    Whitenoise, accounts::Account, chat_list_streaming::ChatListUpdateTrigger, database::Database,
-    database::media_files::MediaFile, error::WhitenoiseError,
+    Whitenoise, accounts::Account, chat_list_streaming::ChatListUpdateTrigger,
+    database::media_files::MediaFile, error::WhitenoiseError, group_information::GroupInformation,
+    push_notifications::GroupPushToken,
 };
 
 /// Represents the relationship between an account and an MLS group.
@@ -210,9 +213,9 @@ impl AccountGroup {
     pub(crate) async fn chat_cleared_at_ms(
         pubkey: &PublicKey,
         group_id: &GroupId,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<i64>, WhitenoiseError> {
-        let account_group = Self::find_by_account_and_group(pubkey, group_id, database)
+        let account_group = Self::find_by_account_and_group(pubkey, group_id, pool)
             .await?
             .ok_or(WhitenoiseError::GroupNotFound)?;
         Ok(account_group
@@ -232,11 +235,12 @@ impl AccountGroup {
         mls_group_id: &GroupId,
         dm_peer_pubkey: Option<&PublicKey>,
     ) -> Result<(Self, bool), WhitenoiseError> {
+        let session = whitenoise.require_session(account_pubkey)?;
         let (account_group, was_created) = Self::find_or_create(
             account_pubkey,
             mls_group_id,
             dm_peer_pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?;
         Ok((account_group, was_created))
@@ -249,8 +253,9 @@ impl AccountGroup {
         whitenoise: &Whitenoise,
         account_pubkey: &PublicKey,
     ) -> Result<Vec<Self>, WhitenoiseError> {
+        let session = whitenoise.require_session(account_pubkey)?;
         let groups =
-            Self::find_visible_for_account(account_pubkey, &whitenoise.shared.database).await?;
+            Self::find_visible_for_account(account_pubkey, &session.account_db.inner.pool).await?;
         Ok(groups)
     }
 
@@ -260,16 +265,18 @@ impl AccountGroup {
         whitenoise: &Whitenoise,
         account_pubkey: &PublicKey,
     ) -> Result<Vec<Self>, WhitenoiseError> {
+        let session = whitenoise.require_session(account_pubkey)?;
         let groups =
-            Self::find_pending_for_account(account_pubkey, &whitenoise.shared.database).await?;
+            Self::find_pending_for_account(account_pubkey, &session.account_db.inner.pool).await?;
         Ok(groups)
     }
 
     /// Accepts this group invite by setting user_confirmation to true.
     #[perf_instrument("account_groups")]
     pub async fn accept(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_user_confirmation(true, &whitenoise.shared.database)
+            .update_user_confirmation(true, &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -285,12 +292,9 @@ impl AccountGroup {
         account_pubkey: &PublicKey,
         peer_pubkey: &PublicKey,
     ) -> Result<Option<GroupId>, WhitenoiseError> {
-        let group_id = Self::find_dm_group_id_by_peer(
-            account_pubkey,
-            peer_pubkey,
-            &whitenoise.shared.database,
-        )
-        .await?;
+        let session = whitenoise.require_session(account_pubkey)?;
+        let group_id =
+            Self::find_dm_group_id_by_peer(peer_pubkey, &session.account_db.inner.pool).await?;
         Ok(group_id)
     }
 
@@ -298,8 +302,9 @@ impl AccountGroup {
     /// The group will be hidden from the UI but remains in MLS.
     #[perf_instrument("account_groups")]
     pub async fn decline(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_user_confirmation(false, &whitenoise.shared.database)
+            .update_user_confirmation(false, &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -307,8 +312,9 @@ impl AccountGroup {
     /// Archives this chat by setting archived_at to the current time.
     #[perf_instrument("account_groups")]
     pub async fn archive(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
+            .update_archived_at(Some(Utc::now()), &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -316,8 +322,9 @@ impl AccountGroup {
     /// Unarchives this chat by clearing archived_at.
     #[perf_instrument("account_groups")]
     pub async fn unarchive(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_archived_at(None, &whitenoise.shared.database)
+            .update_archived_at(None, &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -329,8 +336,9 @@ impl AccountGroup {
         until: DateTime<Utc>,
         whitenoise: &Whitenoise,
     ) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_muted_until(Some(until), &whitenoise.shared.database)
+            .update_muted_until(Some(until), &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -338,8 +346,9 @@ impl AccountGroup {
     /// Unmutes this chat by clearing muted_until.
     #[perf_instrument("account_groups")]
     pub async fn unmute(&self, whitenoise: &Whitenoise) -> Result<Self, WhitenoiseError> {
+        let session = whitenoise.require_session(&self.account_pubkey)?;
         let updated = self
-            .update_muted_until(None, &whitenoise.shared.database)
+            .update_muted_until(None, &session.account_db.inner.pool)
             .await?;
         Ok(updated)
     }
@@ -351,7 +360,8 @@ impl AccountGroup {
         &self,
         whitenoise: &Whitenoise,
     ) -> Result<Option<Self>, WhitenoiseError> {
-        self.mark_removed_atomic(&whitenoise.shared.database)
+        let session = whitenoise.require_session(&self.account_pubkey)?;
+        self.mark_removed_atomic(&session.account_db.inner.pool)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -363,7 +373,8 @@ impl AccountGroup {
         &self,
         whitenoise: &Whitenoise,
     ) -> Result<Option<Self>, WhitenoiseError> {
-        self.mark_left_atomic(&whitenoise.shared.database)
+        let session = whitenoise.require_session(&self.account_pubkey)?;
+        self.mark_left_atomic(&session.account_db.inner.pool)
             .await
             .map_err(WhitenoiseError::from)
     }
@@ -616,35 +627,72 @@ impl Whitenoise {
         account: &Account,
         group_id: &GroupId,
     ) -> Result<(), WhitenoiseError> {
-        // 1. Verify the AccountGroup exists
+        // 1. Look up session for account-DB access
+        let session = self
+            .account_manager
+            .get_session(&account.pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
+
+        // 2. Verify the AccountGroup exists
         let Some(_account_group) = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?
         else {
             return Err(WhitenoiseError::GroupNotFound);
         };
 
-        // 2. Pre-build the ChatListItem while data still exists
+        // 3. Pre-build the ChatListItem while data still exists
         //    (MDK state and DB data are needed for build_chat_list_item)
         let chat_list_item = self.build_chat_list_item(account, group_id).await;
 
-        // 3. Look up session for account-DB access
-        let session = self
-            .account_manager
-            .get_session(&account.pubkey)
-            .ok_or(WhitenoiseError::AccountNotFound)?;
+        // 4. Delete per-account accounts_groups row
+        AccountGroup::delete_for_group(group_id, &session.account_db.inner.pool).await?;
 
-        // 4. Delete all DB data in a transaction (fallible — must run before
-        //    non-rollbackable MDK cleanup so a DB failure leaves state intact)
+        // 4a. Check if any other account still has this group.
+        // We can only inspect active sessions, not every persisted account.
+        // If inactive accounts exist, conservatively keep shared data — the
+        // orphaned rows will be cleaned up on next login or full GC pass.
+        let total_accounts = Account::count(&self.shared.database).await?;
+        let mut sessions_checked: i64 = 0;
+        let mut other_has_group = false;
+        for other_session in self.account_manager.sessions_iter() {
+            if other_session.account_pubkey == account.pubkey {
+                continue;
+            }
+            sessions_checked += 1;
+            let exists =
+                AccountGroup::exists_for_group(group_id, &other_session.account_db.inner.pool)
+                    .await?;
+            if exists {
+                other_has_group = true;
+                break;
+            }
+        }
+        // If we couldn't verify all other accounts, be conservative.
+        if !other_has_group && sessions_checked + 1 < total_accounts {
+            tracing::warn!(
+                target: "whitenoise::accounts_groups",
+                checked = sessions_checked,
+                total = total_accounts,
+                "Not all accounts have active sessions; \
+                 skipping shared data deletion to be safe"
+            );
+            other_has_group = true;
+        }
+
+        // 4b. Delete shared group data if this was the last account
         self.shared
             .database
-            .delete_chat_data(&account.pubkey, group_id)
+            .delete_shared_group_data(group_id, !other_has_group)
             .await?;
 
-        // 4b. Delete per-account media_references for this group
+        // 4b. Delete per-account group_push_tokens for this group
+        GroupPushToken::delete_by_group(group_id, &session.account_db.inner.pool).await?;
+
+        // 4c. Delete per-account media_references for this group
         MediaFile::delete_references_for_group(&session.account_db.inner.pool, group_id).await?;
 
         // 5. Delete MDK group state for this account (best-effort)
@@ -708,42 +756,51 @@ impl Whitenoise {
     /// `dm_peer_pubkey`, then resolves the peer from MLS membership. Intended
     /// to be called once at startup.
     pub(crate) async fn backfill_dm_peer_pubkeys(&self) -> Result<(), WhitenoiseError> {
-        let accounts = crate::whitenoise::accounts::Account::all(&self.shared.database).await?;
+        for session in self.account_manager.sessions_iter() {
+            let candidates =
+                AccountGroup::find_groups_missing_peer(&session.account_db.inner.pool).await?;
 
-        for account in &accounts {
-            let group_ids =
-                AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &self.shared.database)
-                    .await?;
-
-            if group_ids.is_empty() {
+            if candidates.is_empty() {
                 continue;
             }
 
-            let mdk = match self.create_mdk_for_account(account.pubkey) {
+            let mdk = match self.create_mdk_for_account(session.account_pubkey) {
                 Ok(mdk) => mdk,
                 Err(e) => {
                     tracing::warn!(
                         target: "whitenoise::accounts_groups",
                         "Failed to create MDK for account {}: {}",
-                        account.pubkey, e
+                        session.account_pubkey, e
                     );
                     continue;
                 }
             };
 
-            for group_id in group_ids {
+            for group_id in candidates {
+                // Filter to DM groups using shared DB
+                let is_dm = GroupInformation::is_dm(&group_id, &self.shared.database).await?;
+                if !is_dm {
+                    continue;
+                }
+
                 let members = match mdk.get_members(&group_id) {
                     Ok(m) => m,
-                    Err(_) => continue,
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "whitenoise::accounts_groups",
+                            group = %hex::encode(group_id.as_slice()),
+                            "get_members failed during DM peer backfill: {e}"
+                        );
+                        continue;
+                    }
                 };
 
-                let peer = members.iter().find(|pk| **pk != account.pubkey);
+                let peer = members.iter().find(|pk| **pk != session.account_pubkey);
                 if let Some(peer_pubkey) = peer
                     && let Err(e) = AccountGroup::update_dm_peer_pubkey(
-                        &account.pubkey,
                         &group_id,
                         peer_pubkey,
-                        &self.shared.database,
+                        &session.account_db.inner.pool,
                     )
                     .await
                 {
@@ -768,6 +825,17 @@ mod tests {
     use crate::whitenoise::aggregated_message::AggregatedMessage;
     use crate::whitenoise::group_information::{GroupInformation, GroupType};
     use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
+
+    /// Helper to get the per-account pool from a Whitenoise instance + account pubkey.
+    fn account_pool(whitenoise: &Whitenoise, pubkey: &PublicKey) -> SqlitePool {
+        whitenoise
+            .require_session(pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool
+            .clone()
+    }
 
     #[tokio::test]
     async fn test_account_group_visibility_methods() {
@@ -967,7 +1035,7 @@ mod tests {
         let result = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap();
@@ -991,7 +1059,7 @@ mod tests {
         let result = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap();
@@ -1040,8 +1108,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Different records for different accounts
-        assert_ne!(ag1.id, ag2.id);
+        // Both accounts have the group (in separate per-account DBs)
+        assert_eq!(ag1.mls_group_id, ag2.mls_group_id);
 
         // Can have different confirmation states
         let accepted = ag1.accept(&whitenoise).await.unwrap();
@@ -2086,13 +2154,16 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        re_save.save(&whitenoise.shared.database).await.unwrap();
+        re_save
+            .save(&account_pool(&whitenoise, &account.pubkey))
+            .await
+            .unwrap();
 
         // Fetch and confirm muted_until survived
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2124,17 +2195,20 @@ mod tests {
             .unwrap();
 
         let past = Utc::now() - chrono::Duration::seconds(10);
-        ag1.update_muted_until(Some(past), &whitenoise.shared.database)
+        ag1.update_muted_until(Some(past), &account_pool(&whitenoise, &account.pubkey))
             .await
             .unwrap();
-        ag2.update_muted_until(Some(past), &whitenoise.shared.database)
+        ag2.update_muted_until(Some(past), &account_pool(&whitenoise, &account.pubkey))
             .await
             .unwrap();
 
         // Run cleanup
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database)
-            .await
-            .unwrap();
+        let cleared = AccountGroup::clear_expired_mutes(
+            &account.pubkey,
+            &account_pool(&whitenoise, &account.pubkey),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(cleared.len(), 2);
 
@@ -2142,7 +2216,7 @@ mod tests {
         let ag1 = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id1,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2150,7 +2224,7 @@ mod tests {
         let ag2 = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id2,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2186,13 +2260,13 @@ mod tests {
         let expired_ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &expired_group,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
         .unwrap();
         expired_ag
-            .update_muted_until(Some(past), &whitenoise.shared.database)
+            .update_muted_until(Some(past), &account_pool(&whitenoise, &account.pubkey))
             .await
             .unwrap();
         whitenoise
@@ -2205,9 +2279,12 @@ mod tests {
             .unwrap();
 
         // Run cleanup — should only clear the expired one
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database)
-            .await
-            .unwrap();
+        let cleared = AccountGroup::clear_expired_mutes(
+            &account.pubkey,
+            &account_pool(&whitenoise, &account.pubkey),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(cleared.len(), 1);
         assert_eq!(cleared[0].mls_group_id, expired_group);
@@ -2216,7 +2293,7 @@ mod tests {
         let forever_ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &forever_group,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2224,7 +2301,7 @@ mod tests {
         let future_ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &future_group,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2267,13 +2344,16 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        re_save.save(&whitenoise.shared.database).await.unwrap();
+        re_save
+            .save(&account_pool(&whitenoise, &account.pubkey))
+            .await
+            .unwrap();
 
         // Fetch and confirm removed_at survived
         let found = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2394,7 +2474,7 @@ mod tests {
         let result = AccountGroup::chat_cleared_at_ms(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await;
 
@@ -2426,7 +2506,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2492,7 +2572,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2526,7 +2606,7 @@ mod tests {
         let ag1 = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2545,7 +2625,7 @@ mod tests {
         let ag2 = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap()
@@ -2585,7 +2665,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap();
@@ -2651,7 +2731,7 @@ mod tests {
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account.pubkey),
         )
         .await
         .unwrap();
@@ -2692,7 +2772,7 @@ mod tests {
         let ag_a = AccountGroup::find_by_account_and_group(
             &account_a.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account_a.pubkey),
         )
         .await
         .unwrap();
@@ -2702,7 +2782,7 @@ mod tests {
         let ag_b = AccountGroup::find_by_account_and_group(
             &account_b.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account_b.pubkey),
         )
         .await
         .unwrap();
@@ -2730,7 +2810,7 @@ mod tests {
         let ag_a_after = AccountGroup::find_by_account_and_group(
             &account_a.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account_a.pubkey),
         )
         .await
         .unwrap();
@@ -2742,7 +2822,7 @@ mod tests {
         let ag_b_after = AccountGroup::find_by_account_and_group(
             &account_b.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &account_pool(&whitenoise, &account_b.pubkey),
         )
         .await
         .unwrap();

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -296,10 +296,11 @@ impl Whitenoise {
                 Err(_) => return Ok(None),
             };
 
+        let session = self.require_session(&account.pubkey)?;
         let account_group = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?;
         let Some(account_group) = account_group else {
@@ -435,32 +436,38 @@ impl Whitenoise {
         group_id: &GroupId,
         trigger: ChatListUpdateTrigger,
     ) {
-        let account_groups =
-            match AccountGroup::find_by_group(group_id, &self.shared.database).await {
-                Ok(groups) => groups,
+        for session in self.account_manager.sessions_iter() {
+            let account_pubkey = session.account_pubkey;
+            match AccountGroup::find_by_account_and_group(
+                &account_pubkey,
+                group_id,
+                &session.account_db.inner.pool,
+            )
+            .await
+            {
+                Ok(Some(_)) => {}
+                Ok(None) => continue,
                 Err(e) => {
                     tracing::warn!(
-                        target: "whitenoise::chat_list_streaming",
-                        "Failed to find accounts in group {}: {}",
-                        hex::encode(group_id.as_slice()),
-                        e
+                        target: "whitenoise::chat_list",
+                        account = %account_pubkey,
+                        "find_by_account_and_group failed: {e}"
                     );
-                    return;
+                    continue;
                 }
-            };
+            }
 
-        for ag in account_groups {
             let has_active = self
                 .shared
                 .chat_list_stream_manager
-                .has_subscribers(&ag.account_pubkey);
+                .has_subscribers(&account_pubkey);
             let has_archived = self
                 .shared
                 .archived_chat_list_stream_manager
-                .has_subscribers(&ag.account_pubkey);
+                .has_subscribers(&account_pubkey);
 
             if has_active || has_archived {
-                self.emit_chat_list_update_for_account(&ag.account_pubkey, group_id, trigger)
+                self.emit_chat_list_update_for_account(&account_pubkey, group_id, trigger)
                     .await;
             }
         }

--- a/src/whitenoise/database/account/group_push_tokens.rs
+++ b/src/whitenoise/database/account/group_push_tokens.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::{PublicKey, RelayUrl};
 
-use crate::whitenoise::database::Database;
+use crate::whitenoise::database::account_db::AccountDatabase;
 use crate::whitenoise::error::Result;
 use crate::whitenoise::push_notifications::GroupPushToken;
 
@@ -18,21 +18,23 @@ use crate::whitenoise::push_notifications::GroupPushToken;
 #[derive(Clone, Debug)]
 pub struct GroupPushTokensRepo {
     account_pubkey: PublicKey,
-    db: Arc<Database>,
+    db: Arc<AccountDatabase>,
 }
 
 impl GroupPushTokensRepo {
     /// Construct a new [`GroupPushTokensRepo`] for `account_pubkey`.
-    pub(crate) fn new(account_pubkey: PublicKey, db: Arc<Database>) -> Self {
+    pub(crate) fn new(account_pubkey: PublicKey, db: Arc<AccountDatabase>) -> Self {
         Self { account_pubkey, db }
     }
 
     /// Return all cached push tokens for a specific group.
     pub async fn find_by_group(&self, group_id: &GroupId) -> Result<Vec<GroupPushToken>> {
-        Ok(
-            GroupPushToken::find_by_account_and_group(&self.account_pubkey, group_id, &self.db)
-                .await?,
+        Ok(GroupPushToken::find_by_account_and_group(
+            &self.account_pubkey,
+            group_id,
+            &self.db.inner.pool,
         )
+        .await?)
     }
 
     /// Insert or update a single cached push token for a group member.
@@ -53,14 +55,14 @@ impl GroupPushTokensRepo {
             server_pubkey,
             relay_hint,
             encrypted_token,
-            &self.db,
+            &self.db.inner.pool,
         )
         .await?)
     }
 
     /// Delete the cached token for a specific leaf index in a group.
     pub async fn delete(&self, group_id: &GroupId, leaf_index: u32) -> Result<bool> {
-        Ok(GroupPushToken::delete(&self.account_pubkey, group_id, leaf_index, &self.db).await?)
+        Ok(GroupPushToken::delete(group_id, leaf_index, &self.db.inner.pool).await?)
     }
 
     /// Delete all cached tokens for a specific member in a group.
@@ -69,13 +71,10 @@ impl GroupPushTokensRepo {
         group_id: &GroupId,
         member_pubkey: &PublicKey,
     ) -> Result<bool> {
-        Ok(GroupPushToken::delete_by_member_pubkey(
-            &self.account_pubkey,
-            group_id,
-            member_pubkey,
-            &self.db,
+        Ok(
+            GroupPushToken::delete_by_member_pubkey(group_id, member_pubkey, &self.db.inner.pool)
+                .await?,
         )
-        .await?)
     }
 
     /// Bulk upsert tokens from a token-list response, filtering to active
@@ -87,11 +86,10 @@ impl GroupPushTokensRepo {
         tokens: Vec<mdk_core::mip05::LeafTokenTag>,
     ) -> Result<()> {
         Ok(GroupPushToken::upsert_active_token_list_response(
-            &self.account_pubkey,
             group_id,
             active_leaf_map,
             tokens,
-            &self.db,
+            &self.db.inner.pool,
         )
         .await?)
     }

--- a/src/whitenoise/database/account/mod.rs
+++ b/src/whitenoise/database/account/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! This module exposes a small set of account-scoped repositories that wrap the
 //! existing DB functions. Each repository stores an `account_pubkey` and an
-//! `Arc<Database>`, and delegates to the underlying DB functions without
-//! re-exposing the pubkey argument to callers.
+//! `Arc<AccountDatabase>` (some also hold `Arc<Database>` for shared lookups),
+//! and delegates to the underlying DB functions without re-exposing the pubkey
+//! argument to callers.
 //!
 //! Additional repositories will be added here as their domains migrate to
 //! session-scoped operations (see the session/projection implementation plan).

--- a/src/whitenoise/database/account/mod.rs
+++ b/src/whitenoise/database/account/mod.rs
@@ -58,10 +58,10 @@ impl AccountRepositories {
         Ok(Self {
             drafts: DraftsRepo::new(account_db.clone()),
             settings: AccountSettingsRepo::new(account_db.clone()),
-            follows: AccountFollowsRepo::new(account_db.clone(), db.clone()),
-            published_key_packages: PublishedKeyPackagesRepo::new(account_db),
-            push_registrations: PushRegistrationsRepo::new(account_pubkey, db.clone()),
-            group_push_tokens: GroupPushTokensRepo::new(account_pubkey, db),
+            follows: AccountFollowsRepo::new(account_db.clone(), db),
+            push_registrations: PushRegistrationsRepo::new(account_pubkey, account_db.clone()),
+            published_key_packages: PublishedKeyPackagesRepo::new(account_db.clone()),
+            group_push_tokens: GroupPushTokensRepo::new(account_pubkey, account_db),
         })
     }
 }

--- a/src/whitenoise/database/account/push_registrations.rs
+++ b/src/whitenoise/database/account/push_registrations.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use nostr_sdk::{PublicKey, RelayUrl};
 
-use crate::whitenoise::database::Database;
+use crate::whitenoise::database::account_db::AccountDatabase;
 use crate::whitenoise::error::Result;
 use crate::whitenoise::push_notifications::{PushPlatform, PushRegistration};
 
@@ -16,18 +16,18 @@ use crate::whitenoise::push_notifications::{PushPlatform, PushRegistration};
 #[derive(Clone, Debug)]
 pub struct PushRegistrationsRepo {
     account_pubkey: PublicKey,
-    db: Arc<Database>,
+    db: Arc<AccountDatabase>,
 }
 
 impl PushRegistrationsRepo {
     /// Construct a new [`PushRegistrationsRepo`] for `account_pubkey`.
-    pub(crate) fn new(account_pubkey: PublicKey, db: Arc<Database>) -> Self {
+    pub(crate) fn new(account_pubkey: PublicKey, db: Arc<AccountDatabase>) -> Self {
         Self { account_pubkey, db }
     }
 
     /// Return the push registration for this account, if one exists.
     pub async fn find(&self) -> Result<Option<PushRegistration>> {
-        Ok(PushRegistration::find_by_account_pubkey(&self.account_pubkey, &self.db).await?)
+        Ok(PushRegistration::find(&self.account_pubkey, &self.db.inner.pool).await?)
     }
 
     /// Create or replace the push registration for this account.
@@ -44,7 +44,7 @@ impl PushRegistrationsRepo {
             raw_token,
             server_pubkey,
             relay_hint,
-            &self.db,
+            &self.db.inner.pool,
         )
         .await?)
     }
@@ -52,6 +52,6 @@ impl PushRegistrationsRepo {
     /// Delete the push registration for this account. Returns `true` if a row
     /// was removed.
     pub async fn delete(&self) -> Result<bool> {
-        Ok(PushRegistration::delete_by_account_pubkey(&self.account_pubkey, &self.db).await?)
+        Ok(PushRegistration::delete(&self.db.inner.pool).await?)
     }
 }

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -70,9 +70,11 @@ pub struct AccountDatabase {
 impl AccountDatabase {
     /// Open (or create) the account database for `account_pubkey` at `db_path`.
     ///
-    /// Runs all pending migrations on first open.
+    /// Does **not** run migrations. Call [`run_account_migrations`](Self::run_account_migrations)
+    /// with the real shared pool immediately after construction to apply
+    /// pending globals (against shared) and locals (against this pool).
     pub async fn new(account_pubkey: PublicKey, db_path: PathBuf) -> Result<Self, DatabaseError> {
-        let inner = Database::new(db_path).await?;
+        let inner = Database::open_without_migrations(db_path).await?;
         Ok(Self {
             account_pubkey,
             inner,
@@ -128,7 +130,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_account_database_opens_and_migrates() {
+    async fn test_account_database_opens_without_migrations() {
         let dir = TempDir::new().expect("temp dir");
         let pubkey = test_pubkey();
         let path = dir.path().join(format!("{}.db", pubkey.to_hex()));
@@ -152,13 +154,13 @@ mod tests {
             .await
             .expect("first open");
 
-        // Second open — migrations already applied.
+        // Second open — no migrations run, just file reopen.
         let db = AccountDatabase::new(test_pubkey(), path).await;
         assert!(db.is_ok(), "expected Ok on second open, got {db:?}");
     }
 
     /// Opening an account DB and then running `run_account_migrations`
-    /// against a separate shared DB stamps the bootstrap (v=12) onto the
+    /// against a separate shared DB stamps the bootstrap (v=31) onto the
     /// account's `_rust_migrations` — proving the per-user-DB-creation
     /// hook fires the new-accounts-only timeline as designed.
     #[tokio::test]
@@ -167,12 +169,12 @@ mod tests {
         let shared_path = dir.path().join("shared.db");
         let account_path = dir.path().join(format!("{}.db", test_pubkey().to_hex()));
 
-        // Open shared first so it has globals 1..=11 stamped against
-        // `shared.db` (the realistic Phase 18b ordering).
+        // Open shared first so it has globals stamped against `shared.db`
+        // (the realistic Phase 18b ordering).
         let shared = Database::new(shared_path).await.expect("open shared");
 
-        // Open the per-user DB; `Database::new` runs globals against this
-        // pool too (as today). The bootstrap must still fire.
+        // Open the per-user DB without migrations (the production path).
+        // The bootstrap must fire when `run_account_migrations` is called.
         let account = AccountDatabase::new(test_pubkey(), account_path)
             .await
             .expect("open account");
@@ -183,19 +185,19 @@ mod tests {
             .expect("run account migrations");
 
         let (count,): (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM _rust_migrations WHERE version = 12")
+            sqlx::query_as("SELECT COUNT(*) FROM _rust_migrations WHERE version = 31")
                 .fetch_one(&account.inner.pool)
                 .await
                 .expect("query account tracking table");
         assert_eq!(
             count, 1,
-            "bootstrap (v=12) must be recorded on the per-user DB"
+            "bootstrap (v=31) must be recorded on the per-user DB"
         );
 
         // Description should be the bootstrap's regular one, not an
         // auto-stamp marker — proving `run_local` actually executed.
         let (desc,): (String,) =
-            sqlx::query_as("SELECT description FROM _rust_migrations WHERE version = 12")
+            sqlx::query_as("SELECT description FROM _rust_migrations WHERE version = 31")
                 .fetch_one(&account.inner.pool)
                 .await
                 .unwrap();
@@ -203,5 +205,79 @@ mod tests {
             !desc.contains("auto-stamped"),
             "bootstrap must run (not stamp) on a fresh per-user file; got desc: {desc}"
         );
+    }
+
+    /// Reopening an account DB must not drop tables that local migrations
+    /// created (e.g. `accounts_groups`, `push_registrations`,
+    /// `group_push_tokens`).
+    ///
+    /// Guards against `AccountDatabase::new` accidentally running global
+    /// drop migrations (m0033, m0035, m0037) against the account pool.
+    #[tokio::test]
+    async fn test_account_tables_survive_reopen() {
+        let dir = TempDir::new().expect("temp dir");
+        let pubkey = test_pubkey();
+        let pubkey_hex = pubkey.to_hex();
+        let shared_path = dir.path().join("shared.db");
+        let account_path = dir.path().join(format!("{pubkey_hex}.db"));
+
+        // 1. Open shared + account without migrations.
+        let shared = Database::open_without_migrations(shared_path)
+            .await
+            .expect("open shared");
+        let account_pool = Database::open_without_migrations(account_path.clone())
+            .await
+            .expect("open account");
+
+        // 2. Run lockstep migration (the boot path).
+        let accounts = vec![(account_pool.pool.clone(), pubkey_hex.clone())];
+        rust_migrations::MIGRATOR
+            .run_all(&shared.pool, &accounts)
+            .await
+            .expect("run_all");
+
+        // 3. Assert per-account tables exist.
+        let account_tables = ["accounts_groups", "push_registrations", "group_push_tokens"];
+        for table in &account_tables {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+                 WHERE type='table' AND name=?)",
+            )
+            .bind(*table)
+            .fetch_one(&account_pool.pool)
+            .await
+            .expect("check table exists");
+            assert!(exists, "{table} must exist after run_all");
+        }
+
+        // 4. Drop the pool to simulate process restart.
+        drop(account_pool);
+        drop(accounts);
+
+        // 5. Reopen via the production path.
+        let account_db = AccountDatabase::new(pubkey, account_path)
+            .await
+            .expect("reopen account");
+        account_db
+            .run_account_migrations(&shared.pool)
+            .await
+            .expect("run_account_migrations after reopen");
+
+        // 6. Assert tables still exist (the bug would have dropped them).
+        for table in &account_tables {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+                 WHERE type='table' AND name=?)",
+            )
+            .bind(*table)
+            .fetch_one(&account_db.inner.pool)
+            .await
+            .expect("check table after reopen");
+            assert!(
+                exists,
+                "{table} must survive reopen — global drops must not \
+                 run against the account pool"
+            );
+        }
     }
 }

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -3,11 +3,11 @@
 //! See `docs/session-projection-implementation-plan.md` for the full table
 //! ownership audit and the per-phase migration plan.
 //!
-//! **Current status (Phase 18c shipped):** physically separate file per
+//! **Current status (Phase 18d shipped):** physically separate file per
 //! account holding `account_settings`, `drafts`, `published_key_packages`,
-//! `published_events`, `account_follows`, and the account-scoped subset of
-//! `processed_events`. Phase 18d will move membership and push tables;
-//! 18e moves message projections.
+//! `published_events`, `account_follows`, the account-scoped subset of
+//! `processed_events`, plus `accounts_groups`, `push_registrations`, and
+//! `group_push_tokens`. Phase 18e will move message projections.
 
 use std::path::PathBuf;
 
@@ -33,15 +33,16 @@ use crate::whitenoise::database::{Database, DatabaseError, rust_migrations};
 /// These FKs cross the account/shared boundary and require application-level
 /// enforcement after the physical split. Phase 18c moved
 /// `account_settings`, `drafts`, `published_key_packages`, `published_events`,
-/// and `account_follows` out of shared (their FKs are no longer relevant).
-/// Phase 18d/18e will move the rest.
+/// and `account_follows` out of shared. Phase 18d moved `accounts_groups`,
+/// `push_registrations`, and `group_push_tokens`. Phase 18e will move
+/// message projections.
 ///
 /// ## Pubkey-keyed FKs (application-level enforcement only — Phase 18d)
 ///
-/// - `accounts_groups.account_pubkey → accounts.pubkey` (migration 0018)
+/// - `accounts_groups.account_pubkey → accounts.pubkey` (moved in m0036)
 /// - `media_files.account_pubkey → accounts.pubkey` (migration 0015)
-/// - `push_registrations.account_pubkey → accounts.pubkey` (migration 0039)
-/// - `group_push_tokens.account_pubkey → accounts.pubkey` (migration 0041)
+/// - `push_registrations.account_pubkey → accounts.pubkey` (moved in m0032)
+/// - `group_push_tokens.account_pubkey → accounts.pubkey` (moved in m0034)
 ///
 /// ## Cross-scope data references (no schema FK, but logical dependency)
 ///

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -82,6 +82,37 @@ impl Account {
         Ok(accounts)
     }
 
+    /// Returns the number of persisted accounts in the shared database.
+    #[perf_instrument("db::accounts")]
+    pub(crate) async fn count(database: &Database) -> Result<i64, WhitenoiseError> {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&database.pool)
+            .await
+            .map_err(DatabaseError::Sqlx)?;
+        Ok(count)
+    }
+
+    /// Returns all persisted account pubkeys as hex strings.
+    ///
+    /// Best-effort: returns an empty vec if the `accounts` table doesn't
+    /// exist yet (fresh install).
+    #[perf_instrument("db::accounts")]
+    pub(crate) async fn all_pubkeys_hex(database: &Database) -> Vec<String> {
+        match sqlx::query_scalar::<_, String>("SELECT pubkey FROM accounts")
+            .fetch_all(&database.pool)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::debug!(
+                    target: "whitenoise::database::accounts",
+                    "Could not read accounts table (fresh install?): {e}"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// Gets the oldest account from the database.
     ///
     /// # Arguments

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -95,20 +95,28 @@ impl Account {
     /// Returns all persisted account pubkeys as hex strings.
     ///
     /// Best-effort: returns an empty vec if the `accounts` table doesn't
-    /// exist yet (fresh install).
+    /// exist yet (fresh install). Propagates all other DB errors.
     #[perf_instrument("db::accounts")]
-    pub(crate) async fn all_pubkeys_hex(database: &Database) -> Vec<String> {
+    pub(crate) async fn all_pubkeys_hex(
+        database: &Database,
+    ) -> Result<Vec<String>, WhitenoiseError> {
         match sqlx::query_scalar::<_, String>("SELECT pubkey FROM accounts")
             .fetch_all(&database.pool)
             .await
         {
-            Ok(rows) => rows,
+            Ok(rows) => Ok(rows),
             Err(e) => {
-                tracing::debug!(
-                    target: "whitenoise::database::accounts",
-                    "Could not read accounts table (fresh install?): {e}"
-                );
-                Vec::new()
+                // "no such table" → fresh install, not an error.
+                let msg = e.to_string();
+                if msg.contains("no such table") {
+                    tracing::debug!(
+                        target: "whitenoise::database::accounts",
+                        "accounts table does not exist (fresh install)"
+                    );
+                    Ok(Vec::new())
+                } else {
+                    Err(DatabaseError::Sqlx(e).into())
+                }
             }
         }
     }

--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -1,30 +1,36 @@
 use chrono::{DateTime, Utc};
 use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::*;
+use sqlx::SqlitePool;
 
-use super::{
-    Database,
-    utils::{parse_optional_timestamp, parse_timestamp},
-};
 use crate::perf_instrument;
 use crate::whitenoise::accounts_groups::AccountGroup;
 
-impl<'r, R> sqlx::FromRow<'r, R> for AccountGroup
-where
-    R: sqlx::Row,
-    &'r str: sqlx::ColumnIndex<R>,
-    String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Option<i64>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-{
-    fn from_row(row: &'r R) -> Result<Self, sqlx::Error> {
-        let id: i64 = row.try_get("id")?;
-        let account_pubkey_str: String = row.try_get("account_pubkey")?;
-        let mls_group_id_bytes: Vec<u8> = row.try_get("mls_group_id")?;
-        let user_confirmation_int: Option<i64> = row.try_get("user_confirmation")?;
-        let welcomer_pubkey_str: Option<String> = row.try_get("welcomer_pubkey")?;
-        let welcomer_pubkey = match welcomer_pubkey_str {
+/// Per-account row shape. The per-account DB does not store `account_pubkey`
+/// (the file *is* the scope), so this intermediate struct decodes what the DB
+/// actually contains and converts to the domain `AccountGroup` via
+/// `into_account_group`.
+#[derive(sqlx::FromRow)]
+struct LocalAccountGroupRow {
+    id: i64,
+    mls_group_id: Vec<u8>,
+    user_confirmation: Option<i64>,
+    welcomer_pubkey: Option<String>,
+    last_read_message_id: Option<String>,
+    pin_order: Option<i64>,
+    dm_peer_pubkey: Option<String>,
+    archived_at: Option<i64>,
+    removed_at: Option<i64>,
+    self_removed: i64,
+    muted_until: Option<i64>,
+    chat_cleared_at: Option<i64>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+impl LocalAccountGroupRow {
+    fn into_account_group(self, account_pubkey: PublicKey) -> Result<AccountGroup, sqlx::Error> {
+        let welcomer_pubkey = match self.welcomer_pubkey {
             Some(s) => Some(PublicKey::parse(&s).map_err(|e| sqlx::Error::ColumnDecode {
                 index: "welcomer_pubkey".to_string(),
                 source: Box::new(e),
@@ -32,8 +38,7 @@ where
             None => None,
         };
 
-        let last_read_message_id_str: Option<String> = row.try_get("last_read_message_id")?;
-        let last_read_message_id = match last_read_message_id_str {
+        let last_read_message_id = match self.last_read_message_id {
             Some(hex) => Some(
                 EventId::from_hex(&hex).map_err(|e| sqlx::Error::ColumnDecode {
                     index: "last_read_message_id".to_string(),
@@ -43,10 +48,7 @@ where
             None => None,
         };
 
-        let pin_order: Option<i64> = row.try_get("pin_order")?;
-
-        let dm_peer_pubkey_str: Option<String> = row.try_get("dm_peer_pubkey")?;
-        let dm_peer_pubkey = match dm_peer_pubkey_str {
+        let dm_peer_pubkey = match self.dm_peer_pubkey {
             Some(s) => Some(PublicKey::parse(&s).map_err(|e| sqlx::Error::ColumnDecode {
                 index: "dm_peer_pubkey".to_string(),
                 source: Box::new(e),
@@ -54,28 +56,7 @@ where
             None => None,
         };
 
-        let archived_at = parse_optional_timestamp(row, "archived_at")?;
-        let removed_at = parse_optional_timestamp(row, "removed_at")?;
-        let self_removed_int: i64 = row.try_get("self_removed")?;
-        let self_removed = self_removed_int != 0;
-        let muted_until = parse_optional_timestamp(row, "muted_until")?;
-        let chat_cleared_at = parse_optional_timestamp(row, "chat_cleared_at")?;
-
-        // Parse pubkey from hex string
-        let account_pubkey =
-            PublicKey::parse(&account_pubkey_str).map_err(|e| sqlx::Error::ColumnDecode {
-                index: "account_pubkey".to_string(),
-                source: Box::new(e),
-            })?;
-
-        // `mls_group_id_bytes` is length-checked by the database schema
-        // (see the `group_information.mls_group_id` CHECK constraint), so
-        // `GroupId::from_slice` is safe here without an additional length
-        // check in this decoder.
-        let mls_group_id = GroupId::from_slice(&mls_group_id_bytes);
-
-        // Validate user_confirmation: only 0, 1, or NULL are valid
-        let user_confirmation = match user_confirmation_int {
+        let user_confirmation = match self.user_confirmation {
             None => None,
             Some(0) => Some(false),
             Some(1) => Some(true),
@@ -93,21 +74,27 @@ where
             }
         };
 
-        let created_at = parse_timestamp(row, "created_at")?;
-        let updated_at = parse_timestamp(row, "updated_at")?;
+        let mls_group_id = GroupId::from_slice(&self.mls_group_id);
 
-        Ok(Self {
-            id: Some(id),
+        let archived_at = parse_optional_timestamp_from_millis(self.archived_at)?;
+        let removed_at = parse_optional_timestamp_from_millis(self.removed_at)?;
+        let muted_until = parse_optional_timestamp_from_millis(self.muted_until)?;
+        let chat_cleared_at = parse_optional_timestamp_from_millis(self.chat_cleared_at)?;
+        let created_at = parse_timestamp_from_millis(self.created_at)?;
+        let updated_at = parse_timestamp_from_millis(self.updated_at)?;
+
+        Ok(AccountGroup {
+            id: Some(self.id),
             account_pubkey,
             mls_group_id,
             user_confirmation,
             welcomer_pubkey,
             last_read_message_id,
-            pin_order,
+            pin_order: self.pin_order,
             dm_peer_pubkey,
             archived_at,
             removed_at,
-            self_removed,
+            self_removed: self.self_removed != 0,
             muted_until,
             chat_cleared_at,
             created_at,
@@ -116,28 +103,55 @@ where
     }
 }
 
+fn parse_timestamp_from_millis(ms: i64) -> Result<DateTime<Utc>, sqlx::Error> {
+    DateTime::from_timestamp_millis(ms).ok_or_else(|| sqlx::Error::ColumnDecode {
+        index: "timestamp".to_string(),
+        source: Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid timestamp millis: {}", ms),
+        )),
+    })
+}
+
+fn parse_optional_timestamp_from_millis(
+    ms: Option<i64>,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+    match ms {
+        None => Ok(None),
+        Some(v) => Ok(Some(parse_timestamp_from_millis(v)?)),
+    }
+}
+
 impl AccountGroup {
-    /// Finds an AccountGroup by account pubkey and MLS group ID.
+    /// Finds an AccountGroup by MLS group ID in the per-account database.
+    ///
+    /// `account_pubkey` is used to populate the returned struct but is NOT
+    /// used as a SQL filter (the per-account DB is implicitly scoped).
     #[perf_instrument("db::accounts_groups")]
     pub async fn find_by_account_and_group(
         account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
-        let row = sqlx::query_as::<_, Self>(
-            "SELECT *
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
+            "SELECT id, mls_group_id, user_confirmation, welcomer_pubkey,
+                    last_read_message_id, pin_order, dm_peer_pubkey,
+                    archived_at, removed_at, self_removed, muted_until,
+                    chat_cleared_at, created_at, updated_at
              FROM accounts_groups
-             WHERE account_pubkey = ? AND mls_group_id = ?",
+             WHERE mls_group_id = ?",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
-        .fetch_optional(&database.pool)
+        .fetch_optional(pool)
         .await?;
 
-        Ok(row)
+        match row {
+            Some(r) => Ok(Some(r.into_account_group(*account_pubkey)?)),
+            None => Ok(None),
+        }
     }
 
-    /// Finds or creates an AccountGroup for the given account and group.
+    /// Finds or creates an AccountGroup for the given group.
     /// Returns the AccountGroup and a boolean indicating if it was newly created.
     ///
     /// This uses an insert-first approach to avoid TOCTOU race conditions:
@@ -148,82 +162,69 @@ impl AccountGroup {
         account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         dm_peer_pubkey: Option<&PublicKey>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<(Self, bool), sqlx::Error> {
         // Try to create first - this handles the race condition properly
-        match Self::create(account_pubkey, mls_group_id, None, dm_peer_pubkey, database).await {
+        match Self::create(account_pubkey, mls_group_id, None, dm_peer_pubkey, pool).await {
             Ok(created) => Ok((created, true)),
             Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
                 // Insert failed due to unique constraint - a concurrent task already created the row
                 // Fall back to fetching the existing record
-                let existing =
-                    Self::find_by_account_and_group(account_pubkey, mls_group_id, database)
-                        .await?
-                        .ok_or(sqlx::Error::RowNotFound)?;
+                let existing = Self::find_by_account_and_group(account_pubkey, mls_group_id, pool)
+                    .await?
+                    .ok_or(sqlx::Error::RowNotFound)?;
                 Ok((existing, false))
             }
             Err(e) => Err(e),
         }
     }
 
-    /// Finds all visible AccountGroups for a given account.
+    /// Finds all visible AccountGroups for the account.
     /// Visible means: user_confirmation is NULL (pending) or true (accepted).
     /// Declined groups (user_confirmation = false) are hidden.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn find_visible_for_account(
         account_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Vec<Self>, sqlx::Error> {
-        let rows = sqlx::query_as::<_, Self>(
-            "SELECT *
+        let rows = sqlx::query_as::<_, LocalAccountGroupRow>(
+            "SELECT id, mls_group_id, user_confirmation, welcomer_pubkey,
+                    last_read_message_id, pin_order, dm_peer_pubkey,
+                    archived_at, removed_at, self_removed, muted_until,
+                    chat_cleared_at, created_at, updated_at
              FROM accounts_groups
-             WHERE account_pubkey = ?
-               AND (user_confirmation IS NULL OR user_confirmation = 1)",
+             WHERE user_confirmation IS NULL OR user_confirmation = 1",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
-        Ok(rows)
+        rows.into_iter()
+            .map(|r| r.into_account_group(*account_pubkey))
+            .collect()
     }
 
-    /// Finds all pending AccountGroups for a given account.
+    /// Finds all pending AccountGroups for the account.
     /// Pending means: user_confirmation is NULL.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn find_pending_for_account(
         account_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Vec<Self>, sqlx::Error> {
-        let rows = sqlx::query_as::<_, Self>(
-            "SELECT *
+        let rows = sqlx::query_as::<_, LocalAccountGroupRow>(
+            "SELECT id, mls_group_id, user_confirmation, welcomer_pubkey,
+                    last_read_message_id, pin_order, dm_peer_pubkey,
+                    archived_at, removed_at, self_removed, muted_until,
+                    chat_cleared_at, created_at, updated_at
              FROM accounts_groups
-             WHERE account_pubkey = ?
-               AND user_confirmation IS NULL
+             WHERE user_confirmation IS NULL
                AND removed_at IS NULL",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
-        Ok(rows)
-    }
-
-    /// Finds all AccountGroups for a specific MLS group.
-    #[perf_instrument("db::accounts_groups")]
-    pub(crate) async fn find_by_group(
-        mls_group_id: &GroupId,
-        database: &Database,
-    ) -> Result<Vec<Self>, sqlx::Error> {
-        let rows = sqlx::query_as::<_, Self>(
-            "SELECT *
-             FROM accounts_groups
-             WHERE mls_group_id = ?",
-        )
-        .bind(mls_group_id.as_slice())
-        .fetch_all(&database.pool)
-        .await?;
-
-        Ok(rows)
+        rows.into_iter()
+            .map(|r| r.into_account_group(*account_pubkey))
+            .collect()
     }
 
     /// Updates the user_confirmation status for this AccountGroup.
@@ -231,14 +232,14 @@ impl AccountGroup {
     pub(crate) async fn update_user_confirmation(
         &self,
         user_confirmation: bool,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
 
         let now_ms = Utc::now().timestamp_millis();
         let confirmation_int: i64 = if user_confirmation { 1 } else { 0 };
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET user_confirmation = ?, updated_at = ?
              WHERE id = ?
@@ -247,10 +248,10 @@ impl AccountGroup {
         .bind(confirmation_int)
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Saves the AccountGroup to the database (upsert).
@@ -258,13 +259,13 @@ impl AccountGroup {
     /// - If the record doesn't exist, inserts it
     /// - If it exists, updates all mutable fields to match the provided values
     #[perf_instrument("db::accounts_groups")]
-    pub(crate) async fn save(&self, database: &Database) -> Result<Self, sqlx::Error> {
+    pub(crate) async fn save(&self, pool: &SqlitePool) -> Result<Self, sqlx::Error> {
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
-            "INSERT INTO accounts_groups (account_pubkey, mls_group_id, user_confirmation, welcomer_pubkey, last_read_message_id, pin_order, dm_peer_pubkey, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(account_pubkey, mls_group_id) DO UPDATE SET
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
+            "INSERT INTO accounts_groups (mls_group_id, user_confirmation, welcomer_pubkey, last_read_message_id, pin_order, dm_peer_pubkey, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(mls_group_id) DO UPDATE SET
                user_confirmation = excluded.user_confirmation,
                welcomer_pubkey = excluded.welcomer_pubkey,
                last_read_message_id = excluded.last_read_message_id,
@@ -283,7 +284,6 @@ impl AccountGroup {
                updated_at = excluded.updated_at
              RETURNING *",
         )
-        .bind(self.account_pubkey.to_hex())
         .bind(self.mls_group_id.as_slice())
         .bind(self.user_confirmation.map(|b| if b { 1i64 } else { 0i64 }))
         .bind(self.welcomer_pubkey.as_ref().map(|pk| pk.to_hex()))
@@ -292,10 +292,10 @@ impl AccountGroup {
         .bind(self.dm_peer_pubkey.as_ref().map(|pk| pk.to_hex()))
         .bind(self.created_at.timestamp_millis())
         .bind(now_ms)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Updates the pin_order for this AccountGroup.
@@ -303,12 +303,12 @@ impl AccountGroup {
     pub(crate) async fn update_pin_order(
         &self,
         pin_order: Option<i64>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET pin_order = ?, updated_at = ?
              WHERE id = ?
@@ -317,10 +317,10 @@ impl AccountGroup {
         .bind(pin_order)
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Updates the archived_at timestamp for this AccountGroup.
@@ -328,12 +328,12 @@ impl AccountGroup {
     pub(crate) async fn update_archived_at(
         &self,
         archived_at: Option<DateTime<Utc>>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET archived_at = ?, updated_at = ?
              WHERE id = ?
@@ -342,10 +342,10 @@ impl AccountGroup {
         .bind(archived_at.map(|dt| dt.timestamp_millis()))
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Updates the muted_until timestamp for this AccountGroup.
@@ -356,12 +356,12 @@ impl AccountGroup {
     pub(crate) async fn update_muted_until(
         &self,
         muted_until: Option<DateTime<Utc>>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET muted_until = ?, updated_at = ?
              WHERE id = ?
@@ -370,10 +370,10 @@ impl AccountGroup {
         .bind(muted_until.map(|dt| dt.timestamp_millis()))
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Updates the chat_cleared_at timestamp for this AccountGroup.
@@ -384,12 +384,12 @@ impl AccountGroup {
     pub(crate) async fn update_chat_cleared_at(
         &self,
         chat_cleared_at: Option<DateTime<Utc>>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET chat_cleared_at = ?, updated_at = ?
              WHERE id = ?
@@ -398,22 +398,22 @@ impl AccountGroup {
         .bind(chat_cleared_at.map(|dt| dt.timestamp_millis()))
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Clears the last_read_message_id for this AccountGroup.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn reset_last_read_message_id(
         &self,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET last_read_message_id = NULL, updated_at = ?
              WHERE id = ?
@@ -421,10 +421,10 @@ impl AccountGroup {
         )
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
     /// Sets `chat_cleared_at` and resets `last_read_message_id` in a single atomic write.
@@ -435,13 +435,13 @@ impl AccountGroup {
     pub(crate) async fn clear_chat_state(
         &self,
         chat_cleared_at: DateTime<Utc>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
         let cleared_ms = chat_cleared_at.timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET chat_cleared_at = ?, last_read_message_id = NULL, updated_at = ?
              WHERE id = ?
@@ -450,20 +450,25 @@ impl AccountGroup {
         .bind(cleared_ms)
         .bind(now_ms)
         .bind(id)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(self.account_pubkey)
     }
 
-    /// Clears `muted_until` for all rows whose mute has expired.
+    /// Clears `muted_until` for all rows whose mute has expired in this
+    /// per-account database.
     ///
     /// Returns the affected rows so callers can emit stream updates.
+    /// Callers that need cross-account behaviour must iterate all sessions.
     #[perf_instrument("db::accounts_groups")]
-    pub(crate) async fn clear_expired_mutes(database: &Database) -> Result<Vec<Self>, sqlx::Error> {
+    pub(crate) async fn clear_expired_mutes(
+        account_pubkey: &PublicKey,
+        pool: &SqlitePool,
+    ) -> Result<Vec<Self>, sqlx::Error> {
         let now_ms = Utc::now().timestamp_millis();
 
-        let rows = sqlx::query_as::<_, Self>(
+        let rows = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET muted_until = NULL, updated_at = ?
              WHERE muted_until IS NOT NULL AND muted_until <= ?
@@ -471,10 +476,12 @@ impl AccountGroup {
         )
         .bind(now_ms)
         .bind(now_ms)
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
-        Ok(rows)
+        rows.into_iter()
+            .map(|r| r.into_account_group(*account_pubkey))
+            .collect()
     }
 
     /// Atomically marks this AccountGroup as voluntarily departed
@@ -486,12 +493,12 @@ impl AccountGroup {
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn mark_left_atomic(
         &self,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET removed_at = ?, self_removed = 1, updated_at = ?
              WHERE id = ? AND removed_at IS NULL
@@ -500,10 +507,13 @@ impl AccountGroup {
         .bind(now_ms)
         .bind(now_ms)
         .bind(id)
-        .fetch_optional(&database.pool)
+        .fetch_optional(pool)
         .await?;
 
-        Ok(row)
+        match row {
+            Some(r) => Ok(Some(r.into_account_group(self.account_pubkey)?)),
+            None => Ok(None),
+        }
     }
 
     /// Atomically marks this AccountGroup as removed (`UPDATE … WHERE removed_at IS NULL`).
@@ -512,12 +522,12 @@ impl AccountGroup {
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn mark_removed_atomic(
         &self,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET removed_at = ?, updated_at = ?
              WHERE id = ? AND removed_at IS NULL
@@ -526,10 +536,13 @@ impl AccountGroup {
         .bind(now_ms)
         .bind(now_ms)
         .bind(id)
-        .fetch_optional(&database.pool)
+        .fetch_optional(pool)
         .await?;
 
-        Ok(row)
+        match row {
+            Some(r) => Ok(Some(r.into_account_group(self.account_pubkey)?)),
+            None => Ok(None),
+        }
     }
 
     /// Atomically updates last_read_message_id only if the new message is newer.
@@ -537,33 +550,27 @@ impl AccountGroup {
     /// Returns `Some(updated)` if the update was applied, `None` if skipped
     /// because the new message is not newer than the current read marker.
     ///
-    /// This is atomic: the timestamp comparison and update happen in a single
-    /// SQL statement, preventing race conditions between concurrent calls.
+    /// `current_marker_created_at_ms` is the `created_at` timestamp of the
+    /// current `last_read_message_id` (looked up from `aggregated_messages` in
+    /// the shared DB by the caller). Pass `0` if there is no current marker.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn update_last_read_if_newer(
         &self,
         message_id: &EventId,
         message_created_at_ms: i64,
-        database: &Database,
+        current_marker_created_at_ms: i64,
+        pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
         let id = self.id.expect("AccountGroup must be persisted");
         let now_ms = Utc::now().timestamp_millis();
 
-        // Atomic compare-and-update: only update if the new message is newer
-        // than the current read marker. Uses a subquery to get the current
-        // marker's timestamp from aggregated_messages, scoped to the same group.
-        let row = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
             "UPDATE accounts_groups
              SET last_read_message_id = ?, updated_at = ?
              WHERE id = ?
                AND (
                  last_read_message_id IS NULL
-                 OR ? > COALESCE(
-                   (SELECT created_at FROM aggregated_messages
-                    WHERE message_id = accounts_groups.last_read_message_id
-                      AND mls_group_id = accounts_groups.mls_group_id),
-                   0
-                 )
+                 OR ? > ?
                )
              RETURNING *",
         )
@@ -571,58 +578,56 @@ impl AccountGroup {
         .bind(now_ms)
         .bind(id)
         .bind(message_created_at_ms)
-        .fetch_optional(&database.pool)
+        .bind(current_marker_created_at_ms)
+        .fetch_optional(pool)
         .await?;
 
-        Ok(row)
+        match row {
+            Some(r) => Ok(Some(r.into_account_group(self.account_pubkey)?)),
+            None => Ok(None),
+        }
     }
 
-    /// Finds the most recently created visible DM group between an account and a peer.
+    /// Finds the most recently created visible DM group with a given peer.
     ///
     /// Uses the `dm_peer_pubkey` column for an efficient single-query lookup
     /// without requiring MLS/MDK calls. Returns `None` if no DM group exists
-    /// between these users, or if the group has been declined.
+    /// with this peer, or if the group has been declined.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn find_dm_group_id_by_peer(
-        account_pubkey: &PublicKey,
         peer_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<GroupId>, sqlx::Error> {
         let row: Option<(Vec<u8>,)> = sqlx::query_as(
-            "SELECT ag.mls_group_id
-             FROM accounts_groups ag
-             WHERE ag.account_pubkey = ?
-               AND ag.dm_peer_pubkey = ?
-               AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)
-             ORDER BY ag.created_at DESC
+            "SELECT mls_group_id
+             FROM accounts_groups
+             WHERE dm_peer_pubkey = ?
+               AND (user_confirmation IS NULL OR user_confirmation = 1)
+             ORDER BY created_at DESC
              LIMIT 1",
         )
-        .bind(account_pubkey.to_hex())
         .bind(peer_pubkey.to_hex())
-        .fetch_optional(&database.pool)
+        .fetch_optional(pool)
         .await?;
 
         Ok(row.map(|(bytes,)| GroupId::from_slice(&bytes)))
     }
 
-    /// Returns DM peer pubkeys for all visible DM groups belonging to an account.
+    /// Returns DM peer pubkeys for all visible DM groups in this account.
     ///
     /// Returns `(mls_group_id, dm_peer_pubkey)` pairs for groups where
     /// `dm_peer_pubkey` is populated and the group is visible (not declined).
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn find_dm_peers_for_account(
-        account_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Vec<(GroupId, PublicKey)>, sqlx::Error> {
         let rows: Vec<(Vec<u8>, String)> = sqlx::query_as(
-            "SELECT ag.mls_group_id, ag.dm_peer_pubkey
-             FROM accounts_groups ag
-             WHERE ag.account_pubkey = ?
-               AND ag.dm_peer_pubkey IS NOT NULL
-               AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)",
+            "SELECT mls_group_id, dm_peer_pubkey
+             FROM accounts_groups
+             WHERE dm_peer_pubkey IS NOT NULL
+               AND (user_confirmation IS NULL OR user_confirmation = 1)",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
         let mut results = Vec::with_capacity(rows.len());
@@ -642,27 +647,23 @@ impl AccountGroup {
         Ok(results)
     }
 
-    /// Finds visible DM groups for an account that are missing `dm_peer_pubkey`.
+    /// Finds visible groups that are missing `dm_peer_pubkey`.
     ///
     /// Used by the startup backfill to identify records that need population.
-    /// Pushes all filtering to SQL (joins with `group_information`) so the caller
-    /// only receives rows that actually need MDK membership resolution.
+    /// Returns all visible groups with `dm_peer_pubkey IS NULL`; the caller
+    /// filters against `group_information` in the shared DB to find only DM
+    /// groups (cross-DB join replaced by application-level join).
     #[perf_instrument("db::accounts_groups")]
-    pub(crate) async fn find_dm_groups_missing_peer(
-        account_pubkey: &PublicKey,
-        database: &Database,
+    pub(crate) async fn find_groups_missing_peer(
+        pool: &SqlitePool,
     ) -> Result<Vec<GroupId>, sqlx::Error> {
         let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
-            "SELECT ag.mls_group_id
-             FROM accounts_groups ag
-             INNER JOIN group_information gi ON ag.mls_group_id = gi.mls_group_id
-             WHERE ag.account_pubkey = ?
-               AND ag.dm_peer_pubkey IS NULL
-               AND gi.group_type = 'direct_message'
-               AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)",
+            "SELECT mls_group_id
+             FROM accounts_groups
+             WHERE dm_peer_pubkey IS NULL
+               AND (user_confirmation IS NULL OR user_confirmation = 1)",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
         Ok(rows
@@ -671,26 +672,24 @@ impl AccountGroup {
             .collect())
     }
 
-    /// Updates the dm_peer_pubkey for a specific account-group record.
+    /// Updates the dm_peer_pubkey for a specific group record.
     ///
     /// Used by the startup backfill to populate the column for existing DM groups.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn update_dm_peer_pubkey(
-        account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         dm_peer_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             "UPDATE accounts_groups
              SET dm_peer_pubkey = ?, updated_at = ?
-             WHERE account_pubkey = ? AND mls_group_id = ? AND dm_peer_pubkey IS NULL",
+             WHERE mls_group_id = ? AND dm_peer_pubkey IS NULL",
         )
         .bind(dm_peer_pubkey.to_hex())
         .bind(Utc::now().timestamp_millis())
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
-        .execute(&database.pool)
+        .execute(pool)
         .await?;
 
         Ok(())
@@ -703,1593 +702,380 @@ impl AccountGroup {
         mls_group_id: &GroupId,
         welcomer_pubkey: Option<&PublicKey>,
         dm_peer_pubkey: Option<&PublicKey>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let now_ms = Utc::now().timestamp_millis();
 
-        let row = sqlx::query_as::<_, Self>(
-            "INSERT INTO accounts_groups (account_pubkey, mls_group_id, user_confirmation, welcomer_pubkey, dm_peer_pubkey, created_at, updated_at)
-             VALUES (?, ?, NULL, ?, ?, ?, ?)
+        let row = sqlx::query_as::<_, LocalAccountGroupRow>(
+            "INSERT INTO accounts_groups (mls_group_id, user_confirmation, welcomer_pubkey, dm_peer_pubkey, created_at, updated_at)
+             VALUES (?, NULL, ?, ?, ?, ?)
              RETURNING *",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(welcomer_pubkey.map(|pk| pk.to_hex()))
         .bind(dm_peer_pubkey.map(|pk| pk.to_hex()))
         .bind(now_ms)
         .bind(now_ms)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(row)
+        row.into_account_group(*account_pubkey)
+    }
+    /// Deletes all accounts_groups rows for the given group in this per-account DB.
+    #[perf_instrument("db::accounts_groups")]
+    pub(crate) async fn delete_for_group(
+        mls_group_id: &GroupId,
+        pool: &SqlitePool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM accounts_groups WHERE mls_group_id = ?")
+            .bind(mls_group_id.as_slice())
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns whether an accounts_groups row exists for the given group in this per-account DB.
+    #[perf_instrument("db::accounts_groups")]
+    pub(crate) async fn exists_for_group(
+        mls_group_id: &GroupId,
+        pool: &SqlitePool,
+    ) -> Result<bool, sqlx::Error> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM accounts_groups WHERE mls_group_id = ?)",
+        )
+        .bind(mls_group_id.as_slice())
+        .fetch_one(pool)
+        .await?;
+        Ok(exists)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
     use super::*;
-    use crate::whitenoise::group_information::{GroupInformation, GroupType};
-    use crate::whitenoise::test_utils::create_mock_whitenoise;
 
-    #[tokio::test]
-    async fn test_find_by_account_and_group_not_found() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[1; 32]);
-
-        let result = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
+    async fn test_pool() -> (SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let pool = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("test.db").display()
+        ))
         .await
         .unwrap();
 
+        sqlx::query(
+            "CREATE TABLE accounts_groups (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id         BLOB NOT NULL UNIQUE,
+                user_confirmation    INTEGER DEFAULT NULL
+                    CHECK (user_confirmation IS NULL OR user_confirmation IN (0, 1)),
+                welcomer_pubkey      TEXT,
+                last_read_message_id TEXT,
+                pin_order            INTEGER DEFAULT NULL,
+                dm_peer_pubkey       TEXT DEFAULT NULL,
+                archived_at          INTEGER DEFAULT NULL,
+                removed_at           INTEGER DEFAULT NULL,
+                self_removed         INTEGER NOT NULL DEFAULT 0,
+                muted_until          INTEGER DEFAULT NULL,
+                chat_cleared_at      INTEGER DEFAULT NULL,
+                created_at           INTEGER NOT NULL,
+                updated_at           INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        (pool, dir)
+    }
+
+    fn test_pubkey() -> PublicKey {
+        PublicKey::parse(&"ab".repeat(32)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_find_by_account_and_group_not_found() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
+        let group_id = GroupId::from_slice(&[1; 32]);
+
+        let result = AccountGroup::find_by_account_and_group(&pubkey, &group_id, &pool)
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn test_find_or_create_creates_new() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
         let group_id = GroupId::from_slice(&[2; 32]);
 
-        let (account_group, was_created) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let (ag, was_created) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
+            .await
+            .unwrap();
 
         assert!(was_created);
-        assert_eq!(account_group.account_pubkey, account.pubkey);
-        assert_eq!(account_group.mls_group_id, group_id);
-        assert!(account_group.user_confirmation.is_none()); // Should be pending
-        assert!(account_group.id.is_some());
+        assert_eq!(ag.account_pubkey, pubkey);
+        assert_eq!(ag.mls_group_id, group_id);
+        assert!(ag.user_confirmation.is_none());
+        assert!(ag.id.is_some());
     }
 
     #[tokio::test]
     async fn test_find_or_create_finds_existing() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
         let group_id = GroupId::from_slice(&[3; 32]);
 
-        // First create
-        let (original, was_created) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        assert!(was_created);
+        let (first, _) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
+            .await
+            .unwrap();
 
-        // Second call should find existing
-        let (found, was_created) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let (second, was_created) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
+            .await
+            .unwrap();
 
         assert!(!was_created);
-        assert_eq!(found.id, original.id);
+        assert_eq!(first.id, second.id);
     }
 
     #[tokio::test]
-    async fn test_update_user_confirmation_accept() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+    async fn test_update_user_confirmation() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
         let group_id = GroupId::from_slice(&[4; 32]);
 
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(account_group.user_confirmation.is_none());
-
-        let updated = account_group
-            .update_user_confirmation(true, &whitenoise.shared.database)
+        let (ag, _) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
             .await
             .unwrap();
+        assert!(ag.user_confirmation.is_none());
 
+        let updated = ag.update_user_confirmation(true, &pool).await.unwrap();
         assert_eq!(updated.user_confirmation, Some(true));
-        assert_eq!(updated.id, account_group.id);
     }
 
     #[tokio::test]
-    async fn test_update_user_confirmation_decline() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+    async fn test_save_upsert() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
         let group_id = GroupId::from_slice(&[5; 32]);
 
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let ag = AccountGroup {
+            id: None,
+            account_pubkey: pubkey,
+            mls_group_id: group_id,
+            user_confirmation: Some(true),
+            welcomer_pubkey: None,
+            last_read_message_id: None,
+            pin_order: Some(10),
+            dm_peer_pubkey: None,
+            archived_at: None,
+            removed_at: None,
+            self_removed: false,
+            muted_until: None,
+            chat_cleared_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
 
-        let updated = account_group
-            .update_user_confirmation(false, &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        assert_eq!(updated.user_confirmation, Some(false));
+        let saved = ag.save(&pool).await.unwrap();
+        assert!(saved.id.is_some());
+        assert_eq!(saved.pin_order, Some(10));
+        assert_eq!(saved.user_confirmation, Some(true));
     }
 
     #[tokio::test]
-    async fn test_find_visible_for_account() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id1 = GroupId::from_slice(&[8; 32]); // Will be pending
-        let group_id2 = GroupId::from_slice(&[9; 32]); // Will be accepted
-        let group_id3 = GroupId::from_slice(&[10; 32]); // Will be declined
+    async fn test_find_visible_and_pending() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
 
-        let (_ag1, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id1,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let (ag2, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id2,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let (ag3, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id3,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // ag1 stays pending (NULL)
-        ag2.update_user_confirmation(true, &whitenoise.shared.database)
-            .await
-            .unwrap();
-        ag3.update_user_confirmation(false, &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        let visible =
-            AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.shared.database)
+        // Create 3 groups: pending, accepted, declined
+        let (pending, _) =
+            AccountGroup::find_or_create(&pubkey, &GroupId::from_slice(&[10; 32]), None, &pool)
                 .await
                 .unwrap();
 
-        // Should only include pending and accepted, not declined
-        assert_eq!(visible.len(), 2);
-        let ids: Vec<_> = visible.iter().map(|ag| ag.mls_group_id.clone()).collect();
-        assert!(ids.contains(&group_id1)); // pending
-        assert!(ids.contains(&group_id2)); // accepted
-        assert!(!ids.contains(&group_id3)); // declined - should NOT be visible
-    }
-
-    #[tokio::test]
-    async fn test_find_pending_for_account() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id1 = GroupId::from_slice(&[11; 32]); // Will be pending
-        let group_id2 = GroupId::from_slice(&[12; 32]); // Will be accepted
-
-        let (_, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id1,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let (ag2, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id2,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        ag2.update_user_confirmation(true, &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        let pending =
-            AccountGroup::find_pending_for_account(&account.pubkey, &whitenoise.shared.database)
+        let (accepted, _) =
+            AccountGroup::find_or_create(&pubkey, &GroupId::from_slice(&[11; 32]), None, &pool)
                 .await
                 .unwrap();
-
-        assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].mls_group_id, group_id1);
-    }
-
-    #[tokio::test]
-    async fn test_different_accounts_same_group() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account1 = whitenoise.create_identity().await.unwrap();
-        let account2 = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[14; 32]);
-
-        let (ag1, created1) = AccountGroup::find_or_create(
-            &account1.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let (ag2, created2) = AccountGroup::find_or_create(
-            &account2.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(created1);
-        assert!(created2);
-        assert_ne!(ag1.id, ag2.id);
-        assert_eq!(ag1.mls_group_id, ag2.mls_group_id);
-        assert_ne!(ag1.account_pubkey, ag2.account_pubkey);
-    }
-
-    #[tokio::test]
-    async fn test_find_by_group_empty() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let group_id = GroupId::from_slice(&[15; 32]);
-
-        let result = AccountGroup::find_by_group(&group_id, &whitenoise.shared.database)
+        accepted
+            .update_user_confirmation(true, &pool)
             .await
             .unwrap();
 
-        assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_find_by_group_single_account() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[16; 32]);
-
-        let (created_ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let result = AccountGroup::find_by_group(&group_id, &whitenoise.shared.database)
+        let (declined, _) =
+            AccountGroup::find_or_create(&pubkey, &GroupId::from_slice(&[12; 32]), None, &pool)
+                .await
+                .unwrap();
+        declined
+            .update_user_confirmation(false, &pool)
             .await
             .unwrap();
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, created_ag.id);
-        assert_eq!(result[0].account_pubkey, account.pubkey);
-        assert_eq!(result[0].mls_group_id, group_id);
+        let visible = AccountGroup::find_visible_for_account(&pubkey, &pool)
+            .await
+            .unwrap();
+        assert_eq!(visible.len(), 2); // pending + accepted
+
+        let pendings = AccountGroup::find_pending_for_account(&pubkey, &pool)
+            .await
+            .unwrap();
+        assert_eq!(pendings.len(), 1);
+        assert_eq!(pendings[0].mls_group_id, pending.mls_group_id);
     }
 
     #[tokio::test]
-    async fn test_find_by_group_multiple_accounts() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account1 = whitenoise.create_identity().await.unwrap();
-        let account2 = whitenoise.create_identity().await.unwrap();
-        let account3 = whitenoise.create_identity().await.unwrap();
-        let target_group = GroupId::from_slice(&[17; 32]);
-        let other_group = GroupId::from_slice(&[18; 32]);
+    async fn test_update_last_read_if_newer() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
+        let group_id = GroupId::from_slice(&[20; 32]);
 
-        // Add accounts 1 and 2 to the target group
-        AccountGroup::find_or_create(
-            &account1.pubkey,
-            &target_group,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        AccountGroup::find_or_create(
-            &account2.pubkey,
-            &target_group,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Add account 3 to a different group (should not be returned)
-        AccountGroup::find_or_create(
-            &account3.pubkey,
-            &other_group,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let result = AccountGroup::find_by_group(&target_group, &whitenoise.shared.database)
+        let (ag, _) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
             .await
             .unwrap();
 
-        assert_eq!(result.len(), 2);
+        let msg_id = EventId::from_hex(&"aa".repeat(32)).unwrap();
 
-        let pubkeys: Vec<_> = result.iter().map(|ag| ag.account_pubkey).collect();
-        assert!(pubkeys.contains(&account1.pubkey));
-        assert!(pubkeys.contains(&account2.pubkey));
-        assert!(!pubkeys.contains(&account3.pubkey)); // Should NOT be included
+        // First read: no current marker (pass 0)
+        let updated = ag
+            .update_last_read_if_newer(&msg_id, 1000, 0, &pool)
+            .await
+            .unwrap();
+        assert!(updated.is_some());
+        assert_eq!(updated.unwrap().last_read_message_id, Some(msg_id));
 
-        // All returned should have the target group_id
-        for ag in &result {
-            assert_eq!(ag.mls_group_id, target_group);
-        }
+        // Re-read fresh row
+        let ag = AccountGroup::find_by_account_and_group(&pubkey, &group_id, &pool)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Older message: should NOT update
+        let older_id = EventId::from_hex(&"bb".repeat(32)).unwrap();
+        let not_updated = ag
+            .update_last_read_if_newer(&older_id, 500, 1000, &pool)
+            .await
+            .unwrap();
+        assert!(not_updated.is_none());
+
+        // Newer message: should update
+        let newer_id = EventId::from_hex(&"cc".repeat(32)).unwrap();
+        let updated = ag
+            .update_last_read_if_newer(&newer_id, 2000, 1000, &pool)
+            .await
+            .unwrap();
+        assert!(updated.is_some());
+        assert_eq!(updated.unwrap().last_read_message_id, Some(newer_id));
     }
 
     #[tokio::test]
-    async fn test_save_creates_new_record() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let welcomer = whitenoise.create_identity().await.unwrap();
+    async fn test_dm_peer_pubkey_operations() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
+        let peer = PublicKey::parse(&"cd".repeat(32)).unwrap();
         let group_id = GroupId::from_slice(&[30; 32]);
 
-        let ag = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: None,
-            welcomer_pubkey: Some(welcomer.pubkey),
-            last_read_message_id: None,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
+        // Create with dm_peer_pubkey
+        let (ag, _) = AccountGroup::find_or_create(&pubkey, &group_id, Some(&peer), &pool)
+            .await
+            .unwrap();
+        assert_eq!(ag.dm_peer_pubkey, Some(peer));
 
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
+        // find_dm_group_id_by_peer
+        let found = AccountGroup::find_dm_group_id_by_peer(&peer, &pool)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(group_id.clone()));
 
-        let saved = ag.save(&whitenoise.shared.database).await.unwrap();
-
-        assert!(saved.id.is_some());
-        assert_eq!(saved.account_pubkey, account.pubkey);
-        assert_eq!(saved.mls_group_id, group_id);
-        assert!(saved.user_confirmation.is_none());
-        assert_eq!(saved.welcomer_pubkey, Some(welcomer.pubkey));
-        assert!(saved.pin_order.is_none());
+        // find_dm_peers_for_account
+        let peers = AccountGroup::find_dm_peers_for_account(&pool)
+            .await
+            .unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].0, group_id);
+        assert_eq!(peers[0].1, peer);
     }
 
     #[tokio::test]
-    async fn test_save_updates_existing_record() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let welcomer = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[31; 32]);
-
-        // Create initial record with welcomer
-        let ag = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: Some(true),
-            welcomer_pubkey: Some(welcomer.pubkey),
-            last_read_message_id: None,
-            pin_order: Some(100),
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
-
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        let original = ag.save(&whitenoise.shared.database).await.unwrap();
-        assert_eq!(original.welcomer_pubkey, Some(welcomer.pubkey));
-        assert_eq!(original.user_confirmation, Some(true));
-        assert_eq!(original.pin_order, Some(100));
-
-        // Save with None values - should overwrite existing values
-        let update = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: None,
-            welcomer_pubkey: None,
-            last_read_message_id: None,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
-
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        let saved = update.save(&whitenoise.shared.database).await.unwrap();
-
-        assert_eq!(saved.id, original.id);
-        assert!(saved.user_confirmation.is_none());
-        assert!(saved.welcomer_pubkey.is_none());
-        assert!(saved.pin_order.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_save_does_not_overwrite_archived_at() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[32; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Archive the group
-        let archived = ag
-            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(archived.is_archived());
-
-        // Re-save via save() — this simulates giftwrap processing
-        let resaved = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: Some(true),
-            welcomer_pubkey: None,
-            last_read_message_id: None,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
-
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        resaved.save(&whitenoise.shared.database).await.unwrap();
-
-        // Fetch and verify archived_at survived the save()
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert!(
-            found.is_archived(),
-            "save() must not overwrite archived_at — giftwrap processing would silently unarchive chats"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_update_last_read_if_newer_sets_when_null() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[40; 32]);
-
-        // Setup group_information (FK constraint)
-        GroupInformation::find_or_create_by_mls_group_id(
-            &group_id,
-            Some(GroupType::Group),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let message_id = EventId::all_zeros();
-        let message_time = Utc::now();
-
-        // Create the message
-        AggregatedMessage::create_for_test(
-            message_id,
-            group_id.clone(),
-            account.pubkey,
-            message_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(account_group.last_read_message_id.is_none());
-
-        // Should update when last_read_message_id is NULL
-        let updated = account_group
-            .update_last_read_if_newer(
-                &message_id,
-                message_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
-
-        assert!(updated.is_some());
-        assert_eq!(updated.unwrap().last_read_message_id, Some(message_id));
-    }
-
-    #[tokio::test]
-    async fn test_update_last_read_if_newer_advances_forward() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[41; 32]);
-
-        GroupInformation::find_or_create_by_mls_group_id(
-            &group_id,
-            Some(GroupType::Group),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let now = Utc::now();
-        let older_time = now - chrono::Duration::seconds(10);
-        let newer_time = now;
-
-        let older_msg_id = EventId::from_hex(&format!("{:0>64}", "1")).unwrap();
-        let newer_msg_id = EventId::from_hex(&format!("{:0>64}", "2")).unwrap();
-
-        AggregatedMessage::create_for_test(
-            older_msg_id,
-            group_id.clone(),
-            account.pubkey,
-            older_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        AggregatedMessage::create_for_test(
-            newer_msg_id,
-            group_id.clone(),
-            account.pubkey,
-            newer_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Set to older message first
-        let updated = account_group
-            .update_last_read_if_newer(
-                &older_msg_id,
-                older_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(updated.last_read_message_id, Some(older_msg_id));
-
-        // Should advance to newer message
-        let updated = updated
-            .update_last_read_if_newer(
-                &newer_msg_id,
-                newer_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
-
-        assert!(updated.is_some());
-        assert_eq!(updated.unwrap().last_read_message_id, Some(newer_msg_id));
-    }
-
-    #[tokio::test]
-    async fn test_update_last_read_if_newer_rejects_older() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[42; 32]);
-
-        GroupInformation::find_or_create_by_mls_group_id(
-            &group_id,
-            Some(GroupType::Group),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let now = Utc::now();
-        let older_time = now - chrono::Duration::seconds(10);
-        let newer_time = now;
-
-        let older_msg_id = EventId::from_hex(&format!("{:0>64}", "aaa")).unwrap();
-        let newer_msg_id = EventId::from_hex(&format!("{:0>64}", "bbb")).unwrap();
-
-        AggregatedMessage::create_for_test(
-            older_msg_id,
-            group_id.clone(),
-            account.pubkey,
-            older_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        AggregatedMessage::create_for_test(
-            newer_msg_id,
-            group_id.clone(),
-            account.pubkey,
-            newer_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Set to newer message first
-        let updated = account_group
-            .update_last_read_if_newer(
-                &newer_msg_id,
-                newer_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(updated.last_read_message_id, Some(newer_msg_id));
-
-        // Should reject older message (returns None)
-        let result = updated
-            .update_last_read_if_newer(
-                &older_msg_id,
-                older_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
-
-        // Verify the marker didn't change
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        assert_eq!(found.last_read_message_id, Some(newer_msg_id));
-    }
-
-    #[tokio::test]
-    async fn test_last_read_persists_through_find() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[43; 32]);
-
-        GroupInformation::find_or_create_by_mls_group_id(
-            &group_id,
-            Some(GroupType::Group),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let message_id = EventId::from_hex(&format!("{:0>64}", "abc")).unwrap();
-        let message_time = Utc::now();
-
-        AggregatedMessage::create_for_test(
-            message_id,
-            group_id.clone(),
-            account.pubkey,
-            message_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        account_group
-            .update_last_read_if_newer(
-                &message_id,
-                message_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
-
-        // Fetch again and verify persistence
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(found.last_read_message_id, Some(message_id));
-    }
-
-    #[tokio::test]
-    async fn test_update_pin_order_sets_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[60; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(account_group.pin_order.is_none());
-
-        let updated = account_group
-            .update_pin_order(Some(42), &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        assert_eq!(updated.pin_order, Some(42));
-    }
-
-    #[tokio::test]
-    async fn test_update_pin_order_clears_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[61; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Set pin order first
-        let pinned = account_group
-            .update_pin_order(Some(100), &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert_eq!(pinned.pin_order, Some(100));
-
-        // Clear pin order
-        let unpinned = pinned
-            .update_pin_order(None, &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        assert!(unpinned.pin_order.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_update_pin_order_persists() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[62; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        account_group
-            .update_pin_order(Some(77), &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        // Fetch again and verify persistence
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(found.pin_order, Some(77));
-    }
-
-    #[tokio::test]
-    async fn test_update_archived_at_sets_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[63; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(account_group.archived_at.is_none());
-
-        let now = Utc::now();
-        let updated = account_group
-            .update_archived_at(Some(now), &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        assert!(updated.archived_at.is_some());
-        assert!(updated.is_archived());
-    }
-
-    #[tokio::test]
-    async fn test_update_archived_at_clears_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[64; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Set archived
-        let archived = account_group
-            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(archived.is_archived());
-
-        // Clear archived
-        let unarchived = archived
-            .update_archived_at(None, &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(unarchived.archived_at.is_none());
-        assert!(!unarchived.is_archived());
-    }
-
-    #[tokio::test]
-    async fn test_update_archived_at_persists() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[65; 32]);
-
-        let (account_group, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        account_group
-            .update_archived_at(Some(Utc::now()), &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        // Fetch again and verify persistence
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert!(found.is_archived());
-    }
-
-    #[tokio::test]
-    async fn test_find_dm_groups_missing_peer_returns_dm_without_peer() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[70; 32]);
-
-        // Create group_information with DirectMessage type
-        GroupInformation::create_for_group(
-            &whitenoise,
-            &group_id,
-            Some(GroupType::DirectMessage),
-            "",
-        )
-        .await
-        .unwrap();
-
-        // Create account_group WITHOUT dm_peer_pubkey (simulates pre-migration state)
+    async fn test_find_groups_missing_peer() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
+
+        // Group with peer
         AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
+            &pubkey,
+            &GroupId::from_slice(&[40; 32]),
+            Some(&PublicKey::parse(&"ee".repeat(32)).unwrap()),
+            &pool,
         )
         .await
         .unwrap();
 
-        let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        // Group without peer
+        AccountGroup::find_or_create(&pubkey, &GroupId::from_slice(&[41; 32]), None, &pool)
+            .await
+            .unwrap();
 
+        let missing = AccountGroup::find_groups_missing_peer(&pool).await.unwrap();
         assert_eq!(missing.len(), 1);
-        assert_eq!(missing[0], group_id);
+        assert_eq!(missing[0], GroupId::from_slice(&[41; 32]));
     }
 
     #[tokio::test]
-    async fn test_find_dm_groups_missing_peer_excludes_groups_with_peer() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let peer = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[71; 32]);
+    async fn test_clear_expired_mutes() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
+        let group_id = GroupId::from_slice(&[50; 32]);
 
-        // Create group_information with DirectMessage type
-        GroupInformation::create_for_group(
-            &whitenoise,
-            &group_id,
-            Some(GroupType::DirectMessage),
-            "",
-        )
-        .await
-        .unwrap();
-
-        // Create account_group WITH dm_peer_pubkey (already populated)
-        AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            Some(&peer.pubkey),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
-                .await
-                .unwrap();
-
-        assert!(missing.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_find_dm_groups_missing_peer_excludes_regular_groups() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[72; 32]);
-
-        // Create group_information with Group type (not DM)
-        GroupInformation::create_for_group(
-            &whitenoise,
-            &group_id,
-            Some(GroupType::Group),
-            "Team Chat",
-        )
-        .await
-        .unwrap();
-
-        // Create account_group without dm_peer_pubkey
-        AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let missing =
-            AccountGroup::find_dm_groups_missing_peer(&account.pubkey, &whitenoise.shared.database)
-                .await
-                .unwrap();
-
-        // Should not include regular groups even if dm_peer_pubkey is NULL
-        assert!(missing.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_update_dm_peer_pubkey_sets_peer() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let peer = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[73; 32]);
-
-        // Create account_group without dm_peer_pubkey
-        AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Update the dm_peer_pubkey
-        AccountGroup::update_dm_peer_pubkey(
-            &account.pubkey,
-            &group_id,
-            &peer.pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Verify it was set
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(found.dm_peer_pubkey, Some(peer.pubkey));
-    }
-
-    #[tokio::test]
-    async fn test_update_dm_peer_pubkey_does_not_overwrite_existing() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let original_peer = whitenoise.create_identity().await.unwrap();
-        let new_peer = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[74; 32]);
-
-        // Create account_group WITH dm_peer_pubkey already set
-        AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            Some(&original_peer.pubkey),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Try to update with a different peer
-        AccountGroup::update_dm_peer_pubkey(
-            &account.pubkey,
-            &group_id,
-            &new_peer.pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Verify original peer is preserved (WHERE clause includes dm_peer_pubkey IS NULL)
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(found.dm_peer_pubkey, Some(original_peer.pubkey));
-    }
-
-    #[tokio::test]
-    async fn test_save_does_not_overwrite_removed_at() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[83; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Mark as removed
-        let removed = ag
-            .mark_removed_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("first mark_removed_atomic must update the row");
-        assert!(removed.removed_at.is_some());
-
-        // Re-save via save() with removed_at = None — simulates giftwrap re-processing
-        let resaved = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: Some(true),
-            welcomer_pubkey: None,
-            last_read_message_id: None,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
-
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        resaved.save(&whitenoise.shared.database).await.unwrap();
-
-        // Fetch and verify removed_at survived
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert!(
-            found.removed_at.is_some(),
-            "save() must not overwrite removed_at — giftwrap re-processing would silently un-remove chats"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_mark_left_atomic_sets_removed_at_and_self_removed() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[90; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        assert!(ag.removed_at.is_none());
-        assert!(!ag.self_removed);
-
-        let left = ag
-            .mark_left_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("first mark_left_atomic must update the row");
-
-        assert!(left.removed_at.is_some(), "removed_at must be set");
-        assert!(left.self_removed, "self_removed must be true");
-        assert!(left.is_removed());
-    }
-
-    #[tokio::test]
-    async fn test_mark_left_atomic_idempotent() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[91; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let first = ag
-            .mark_left_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("first call must succeed");
-
-        // Second call must be a no-op
-        let second = first
-            .mark_left_atomic(&whitenoise.shared.database)
+        let (ag, _) = AccountGroup::find_or_create(&pubkey, &group_id, None, &pool)
             .await
             .unwrap();
-        assert!(second.is_none(), "second mark_left_atomic must return None");
+
+        // Set an already-expired mute
+        let past = Utc::now() - chrono::Duration::hours(1);
+        ag.update_muted_until(Some(past), &pool).await.unwrap();
+
+        let cleared = AccountGroup::clear_expired_mutes(&pubkey, &pool)
+            .await
+            .unwrap();
+        assert_eq!(cleared.len(), 1);
+        assert!(cleared[0].muted_until.is_none());
     }
 
     #[tokio::test]
-    async fn test_mark_removed_atomic_noop_when_already_left() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[92; 32]);
+    async fn test_mark_left_and_removed() {
+        let (pool, _dir) = test_pool().await;
+        let pubkey = test_pubkey();
 
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // User leaves voluntarily
-        let left = ag
-            .mark_left_atomic(&whitenoise.shared.database)
+        // Test mark_left_atomic
+        let group_id1 = GroupId::from_slice(&[60; 32]);
+        let (ag, _) = AccountGroup::find_or_create(&pubkey, &group_id1, None, &pool)
             .await
-            .unwrap()
-            .expect("mark_left_atomic must succeed");
+            .unwrap();
+        let left = ag.mark_left_atomic(&pool).await.unwrap();
+        assert!(left.is_some());
+        let left = left.unwrap();
+        assert!(left.removed_at.is_some());
         assert!(left.self_removed);
 
-        // Later commit arrives — mark_removed_atomic must be a no-op
-        let removed = left
-            .mark_removed_atomic(&whitenoise.shared.database)
+        // Idempotent
+        let again = left.mark_left_atomic(&pool).await.unwrap();
+        assert!(again.is_none());
+
+        // Test mark_removed_atomic
+        let group_id2 = GroupId::from_slice(&[61; 32]);
+        let (ag2, _) = AccountGroup::find_or_create(&pubkey, &group_id2, None, &pool)
             .await
             .unwrap();
-        assert!(
-            removed.is_none(),
-            "mark_removed_atomic must no-op when mark_left_atomic already ran"
-        );
-
-        // Verify self_removed is still true (not overwritten)
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        assert!(
-            found.self_removed,
-            "self_removed must survive mark_removed_atomic no-op"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_mark_left_atomic_noop_when_already_removed() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[93; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Admin kicks user first
-        let removed = ag
-            .mark_removed_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("mark_removed_atomic must succeed");
+        let removed = ag2.mark_removed_atomic(&pool).await.unwrap();
+        assert!(removed.is_some());
+        let removed = removed.unwrap();
+        assert!(removed.removed_at.is_some());
         assert!(!removed.self_removed);
-
-        // User tries to leave — must be a no-op
-        let left = removed
-            .mark_left_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(
-            left.is_none(),
-            "mark_left_atomic must no-op when mark_removed_atomic already ran"
-        );
-
-        // Verify self_removed is still false
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        assert!(
-            !found.self_removed,
-            "self_removed must remain false after admin kick"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_save_does_not_overwrite_self_removed() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[94; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // User leaves voluntarily
-        let left = ag
-            .mark_left_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("mark_left_atomic must succeed");
-        assert!(left.self_removed);
-
-        // Re-save via save() — simulates giftwrap re-processing
-        let resaved = AccountGroup {
-            id: None,
-            account_pubkey: account.pubkey,
-            mls_group_id: group_id.clone(),
-            user_confirmation: Some(true),
-            welcomer_pubkey: None,
-            last_read_message_id: None,
-            pin_order: None,
-            dm_peer_pubkey: None,
-            archived_at: None,
-            removed_at: None,
-            self_removed: false,
-            muted_until: None,
-            chat_cleared_at: None,
-
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        resaved.save(&whitenoise.shared.database).await.unwrap();
-
-        // Fetch and verify self_removed survived
-        let found = AccountGroup::find_by_account_and_group(
-            &account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        assert!(found.self_removed, "save() must not overwrite self_removed");
-        assert!(
-            found.removed_at.is_some(),
-            "save() must not overwrite removed_at either"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_mark_removed_atomic_preserves_declined_user_confirmation() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[84; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Decline the invite first
-        let declined = ag
-            .update_user_confirmation(false, &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert_eq!(declined.user_confirmation, Some(false));
-
-        // Admin removes the user — user_confirmation must stay Some(false)
-        let removed = declined
-            .mark_removed_atomic(&whitenoise.shared.database)
-            .await
-            .unwrap()
-            .expect("mark_removed_atomic must update the row");
-
-        assert!(removed.removed_at.is_some());
-        assert_eq!(
-            removed.user_confirmation,
-            Some(false),
-            "mark_removed_atomic must not overwrite a declined user_confirmation"
-        );
-        // A declined+removed group stays hidden
-        assert!(!removed.is_visible());
-    }
-
-    #[tokio::test]
-    async fn test_update_chat_cleared_at_sets_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[90; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(ag.chat_cleared_at.is_none());
-
-        let now = Utc::now();
-        let updated = ag
-            .update_chat_cleared_at(Some(now), &whitenoise.shared.database)
-            .await
-            .unwrap();
-
-        assert!(updated.chat_cleared_at.is_some());
-    }
-
-    #[tokio::test]
-    async fn test_update_chat_cleared_at_clears_value() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[91; 32]);
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let cleared = ag
-            .update_chat_cleared_at(Some(Utc::now()), &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(cleared.chat_cleared_at.is_some());
-
-        let uncleared = cleared
-            .update_chat_cleared_at(None, &whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(uncleared.chat_cleared_at.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_reset_last_read_message_id() {
-        use crate::whitenoise::aggregated_message::AggregatedMessage;
-        use crate::whitenoise::group_information::{GroupInformation, GroupType};
-
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
-        let group_id = GroupId::from_slice(&[94; 32]);
-
-        GroupInformation::find_or_create_by_mls_group_id(
-            &group_id,
-            Some(GroupType::Group),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let message_id = EventId::from_hex(&format!("{:0>64}", "ccc")).unwrap();
-        let message_time = Utc::now();
-
-        AggregatedMessage::create_for_test(
-            message_id,
-            group_id.clone(),
-            account.pubkey,
-            message_time,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        let (ag, _) = AccountGroup::find_or_create(
-            &account.pubkey,
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        // Set the read marker first
-        let with_marker = ag
-            .update_last_read_if_newer(
-                &message_id,
-                message_time.timestamp_millis(),
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(with_marker.last_read_message_id, Some(message_id));
-
-        // Reset
-        let reset = with_marker
-            .reset_last_read_message_id(&whitenoise.shared.database)
-            .await
-            .unwrap();
-        assert!(reset.last_read_message_id.is_none());
     }
 }

--- a/src/whitenoise/database/accounts_groups.rs
+++ b/src/whitenoise/database/accounts_groups.rs
@@ -545,19 +545,28 @@ impl AccountGroup {
         }
     }
 
-    /// Atomically updates last_read_message_id only if the new message is newer.
+    /// Atomically updates last_read_message_id only if the new message is
+    /// newer than the current marker.
     ///
-    /// Returns `Some(updated)` if the update was applied, `None` if skipped
-    /// because the new message is not newer than the current read marker.
+    /// Uses optimistic concurrency (CAS): the UPDATE includes a
+    /// `last_read_message_id IS ?expected` guard so concurrent writers cannot
+    /// regress the marker. Returns `Some(updated)` on success, `None` if the
+    /// new message is not newer than the current marker.
+    ///
+    /// `expected_marker_id` must be the current `last_read_message_id` value
+    /// (or `None` if there is no marker). If another writer changed it between
+    /// the caller's read and this write, 0 rows are updated — the caller
+    /// should re-read and retry.
     ///
     /// `current_marker_created_at_ms` is the `created_at` timestamp of the
-    /// current `last_read_message_id` (looked up from `aggregated_messages` in
-    /// the shared DB by the caller). Pass `0` if there is no current marker.
+    /// current marker (from `aggregated_messages`). Pass `0` if there is no
+    /// current marker.
     #[perf_instrument("db::accounts_groups")]
     pub(crate) async fn update_last_read_if_newer(
         &self,
         message_id: &EventId,
         message_created_at_ms: i64,
+        expected_marker_id: Option<&EventId>,
         current_marker_created_at_ms: i64,
         pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
@@ -568,6 +577,7 @@ impl AccountGroup {
             "UPDATE accounts_groups
              SET last_read_message_id = ?, updated_at = ?
              WHERE id = ?
+               AND last_read_message_id IS ?
                AND (
                  last_read_message_id IS NULL
                  OR ? > ?
@@ -577,6 +587,7 @@ impl AccountGroup {
         .bind(message_id.to_hex())
         .bind(now_ms)
         .bind(id)
+        .bind(expected_marker_id.map(|eid| eid.to_hex()))
         .bind(message_created_at_ms)
         .bind(current_marker_created_at_ms)
         .fetch_optional(pool)
@@ -941,9 +952,9 @@ mod tests {
 
         let msg_id = EventId::from_hex(&"aa".repeat(32)).unwrap();
 
-        // First read: no current marker (pass 0)
+        // First read: no current marker (expected=None, ts=0)
         let updated = ag
-            .update_last_read_if_newer(&msg_id, 1000, 0, &pool)
+            .update_last_read_if_newer(&msg_id, 1000, None, 0, &pool)
             .await
             .unwrap();
         assert!(updated.is_some());
@@ -955,22 +966,30 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // Older message: should NOT update
+        // Older message: should NOT update (CAS expected=msg_id matches)
         let older_id = EventId::from_hex(&"bb".repeat(32)).unwrap();
         let not_updated = ag
-            .update_last_read_if_newer(&older_id, 500, 1000, &pool)
+            .update_last_read_if_newer(&older_id, 500, Some(&msg_id), 1000, &pool)
             .await
             .unwrap();
         assert!(not_updated.is_none());
 
-        // Newer message: should update
+        // Newer message: should update (CAS expected=msg_id matches)
         let newer_id = EventId::from_hex(&"cc".repeat(32)).unwrap();
         let updated = ag
-            .update_last_read_if_newer(&newer_id, 2000, 1000, &pool)
+            .update_last_read_if_newer(&newer_id, 2000, Some(&msg_id), 1000, &pool)
             .await
             .unwrap();
         assert!(updated.is_some());
         assert_eq!(updated.unwrap().last_read_message_id, Some(newer_id));
+
+        // CAS miss: expected=msg_id but current is now newer_id → 0 rows
+        let newest_id = EventId::from_hex(&"dd".repeat(32)).unwrap();
+        let cas_miss = ag
+            .update_last_read_if_newer(&newest_id, 3000, Some(&msg_id), 1000, &pool)
+            .await
+            .unwrap();
+        assert!(cas_miss.is_none(), "CAS must reject stale expected marker");
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -647,41 +647,48 @@ impl AggregatedMessage {
         pubkey: &PublicKey,
         query: &str,
         limit: u32,
+        visible_group_ids: &[Vec<u8>],
         database: &Database,
     ) -> Result<Vec<SearchResult>> {
+        if visible_group_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let limit_val = i64::from(limit.min(200));
         let like_pattern = super::content_search::query_to_like_pattern(query);
+        let pubkey_hex = pubkey.to_hex();
 
-        let rows: Vec<AggregatedMessageRow> = sqlx::query_as(
-            "WITH ranked AS (
-               SELECT am.*,
-                      mds.status AS delivery_status,
-                      (ROW_NUMBER() OVER (
-                         PARTITION BY am.mls_group_id
-                         ORDER BY am.created_at DESC, am.message_id DESC
-                      )) - 1 AS position
-               FROM aggregated_messages am
-               JOIN accounts_groups ag
-                 ON ag.mls_group_id = am.mls_group_id
-               LEFT JOIN message_delivery_status mds
-                 ON am.message_id = mds.message_id AND am.mls_group_id = mds.mls_group_id
-                    AND mds.account_pubkey = ?1
-               WHERE am.kind = 9
-                 AND ag.account_pubkey = ?1
-                 AND (ag.user_confirmation IS NULL OR ag.user_confirmation = 1)
-                 AND (mds.status IS NULL OR mds.status != '\"Retried\"')
-             )
-             SELECT * FROM ranked
-             WHERE deletion_event_id IS NULL
-               AND content_normalized LIKE ?2
-             ORDER BY created_at DESC, message_id DESC
-             LIMIT ?3",
-        )
-        .bind(pubkey.to_hex())
-        .bind(&like_pattern)
-        .bind(limit_val)
-        .fetch_all(&database.pool)
-        .await?;
+        let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+            "WITH ranked AS ( \
+             SELECT am.*, \
+             mds.status AS delivery_status, \
+             (ROW_NUMBER() OVER ( \
+             PARTITION BY am.mls_group_id \
+             ORDER BY am.created_at DESC, am.message_id DESC \
+             )) - 1 AS position \
+             FROM aggregated_messages am \
+             LEFT JOIN message_delivery_status mds \
+             ON am.message_id = mds.message_id \
+             AND am.mls_group_id = mds.mls_group_id \
+             AND mds.account_pubkey = ",
+        );
+        qb.push_bind(&pubkey_hex);
+        qb.push(" WHERE am.kind = 9 AND am.mls_group_id IN (");
+        let mut sep = qb.separated(", ");
+        for gid in visible_group_ids {
+            sep.push_bind(gid.clone());
+        }
+        sep.push_unseparated(
+            ") AND (mds.status IS NULL OR mds.status != '\"Retried\"') \
+             ) SELECT * FROM ranked \
+             WHERE deletion_event_id IS NULL \
+             AND content_normalized LIKE ",
+        );
+        qb.push_bind(like_pattern);
+        qb.push(" ORDER BY created_at DESC, message_id DESC LIMIT ");
+        qb.push_bind(limit_val);
+
+        let rows: Vec<AggregatedMessageRow> = qb.build_query_as().fetch_all(&database.pool).await?;
 
         Self::rows_to_search_results(rows, query)
     }
@@ -1235,6 +1242,25 @@ impl AggregatedMessage {
                 .await?;
 
         Ok(row.map(AggregatedMessageRow::into_aggregated_message))
+    }
+
+    /// Returns the `created_at` timestamp (in milliseconds) for a specific
+    /// message in a group, or `None` if no such message exists.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn created_at_ms_for_message(
+        message_id: &EventId,
+        mls_group_id: &GroupId,
+        database: &Database,
+    ) -> Result<Option<i64>> {
+        let ts: Option<i64> = sqlx::query_scalar(
+            "SELECT created_at FROM aggregated_messages \
+             WHERE message_id = ? AND mls_group_id = ?",
+        )
+        .bind(message_id.to_hex())
+        .bind(mls_group_id.as_slice())
+        .fetch_optional(&database.pool)
+        .await?;
+        Ok(ts)
     }
 
     /// Count unread messages for a group given its read marker message ID.
@@ -4952,7 +4978,8 @@ mod tests {
                 created_at: now,
                 updated_at: now,
             };
-            ag.save(&whitenoise.shared.database).await.unwrap();
+            let session = whitenoise.require_session(&pubkey).unwrap();
+            ag.save(&session.account_db.inner.pool).await.unwrap();
         }
 
         let author = Keys::generate().public_key();
@@ -4985,11 +5012,27 @@ mod tests {
             .await
             .unwrap();
 
-        // Cross-group search for "marmot"
-        let results =
-            AggregatedMessage::search_messages(&pubkey, "marmot", 50, &whitenoise.shared.database)
+        // Resolve visible group IDs from per-account DB (accepted + pending)
+        let session = whitenoise.require_session(&pubkey).unwrap();
+        let visible =
+            AccountGroup::find_visible_for_account(&pubkey, &session.account_db.inner.pool)
                 .await
                 .unwrap();
+        let visible_group_ids: Vec<Vec<u8>> = visible
+            .iter()
+            .map(|ag| ag.mls_group_id.as_slice().to_vec())
+            .collect();
+
+        // Cross-group search for "marmot"
+        let results = AggregatedMessage::search_messages(
+            &pubkey,
+            "marmot",
+            50,
+            &visible_group_ids,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
 
         // Should find 3 results (groups A and B), NOT the declined group
         assert_eq!(
@@ -5038,10 +5081,15 @@ mod tests {
         assert_eq!(group_b_result.position, 0);
 
         // Empty query returns all non-declined messages
-        let all_results =
-            AggregatedMessage::search_messages(&pubkey, "", 50, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let all_results = AggregatedMessage::search_messages(
+            &pubkey,
+            "",
+            50,
+            &visible_group_ids,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             all_results.len(),
             3,
@@ -5049,10 +5097,15 @@ mod tests {
         );
 
         // Limit is respected
-        let limited =
-            AggregatedMessage::search_messages(&pubkey, "marmot", 1, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let limited = AggregatedMessage::search_messages(
+            &pubkey,
+            "marmot",
+            1,
+            &visible_group_ids,
+            &whitenoise.shared.database,
+        )
+        .await
+        .unwrap();
         assert_eq!(limited.len(), 1, "limit should cap results");
 
         // No match returns empty
@@ -5060,6 +5113,7 @@ mod tests {
             &pubkey,
             "nonexistent",
             50,
+            &visible_group_ids,
             &whitenoise.shared.database,
         )
         .await

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -643,6 +643,9 @@ impl AggregatedMessage {
     /// O(sum of all group sizes) rather than O(single_group_size). The covering
     /// index from migration 0043 still drives each per-partition scan, but users
     /// with many large groups will pay proportionally more.
+    ///
+    /// Group IDs are chunked to stay within SQLite's bind-parameter limit
+    /// (default 999). Results are merged, re-sorted, and truncated to `limit`.
     pub async fn search_messages(
         pubkey: &PublicKey,
         query: &str,
@@ -655,6 +658,48 @@ impl AggregatedMessage {
         }
 
         let limit_val = i64::from(limit.min(200));
+
+        // Each chunk query uses ~3 fixed binds (pubkey, like_pattern, limit)
+        // plus one per group ID. Stay well under SQLite's 999-parameter limit.
+        const CHUNK_SIZE: usize = 900;
+
+        if visible_group_ids.len() <= CHUNK_SIZE {
+            return Self::search_messages_chunk(
+                pubkey,
+                query,
+                limit_val,
+                visible_group_ids,
+                database,
+            )
+            .await;
+        }
+
+        let mut all_results: Vec<SearchResult> = Vec::new();
+        for chunk in visible_group_ids.chunks(CHUNK_SIZE) {
+            let mut chunk_results =
+                Self::search_messages_chunk(pubkey, query, limit_val, chunk, database).await?;
+            all_results.append(&mut chunk_results);
+        }
+
+        // Re-sort by (created_at DESC, message_id DESC) and truncate.
+        all_results.sort_by(|a, b| {
+            b.message
+                .created_at
+                .cmp(&a.message.created_at)
+                .then_with(|| b.message.id.cmp(&a.message.id))
+        });
+        all_results.truncate(limit_val as usize);
+        Ok(all_results)
+    }
+
+    /// Inner helper: runs a single search query for a chunk of group IDs.
+    async fn search_messages_chunk(
+        pubkey: &PublicKey,
+        query: &str,
+        limit_val: i64,
+        group_ids: &[Vec<u8>],
+        database: &Database,
+    ) -> Result<Vec<SearchResult>> {
         let like_pattern = super::content_search::query_to_like_pattern(query);
         let pubkey_hex = pubkey.to_hex();
 
@@ -675,7 +720,7 @@ impl AggregatedMessage {
         qb.push_bind(&pubkey_hex);
         qb.push(" WHERE am.kind = 9 AND am.mls_group_id IN (");
         let mut sep = qb.separated(", ");
-        for gid in visible_group_ids {
+        for gid in group_ids {
             sep.push_bind(gid.clone());
         }
         sep.push_unseparated(

--- a/src/whitenoise/database/group_information.rs
+++ b/src/whitenoise/database/group_information.rs
@@ -184,6 +184,24 @@ impl GroupInformation {
 
         Ok(group_information)
     }
+
+    /// Returns whether the given group is a DM (direct_message) in the shared DB.
+    #[perf_instrument("db::group_information")]
+    pub(crate) async fn is_dm(
+        mls_group_id: &GroupId,
+        database: &Database,
+    ) -> Result<bool, WhitenoiseError> {
+        let is_dm: bool = sqlx::query_scalar(
+            "SELECT EXISTS(\
+                 SELECT 1 FROM group_information \
+                 WHERE mls_group_id = ? AND group_type = 'direct_message'\
+             )",
+        )
+        .bind(mls_group_id.as_slice())
+        .fetch_one(&database.pool)
+        .await?;
+        Ok(is_dm)
+    }
 }
 
 #[cfg(test)]

--- a/src/whitenoise/database/group_push_tokens.rs
+++ b/src/whitenoise/database/group_push_tokens.rs
@@ -5,54 +5,55 @@ use std::collections::BTreeMap;
 use chrono::Utc;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::{PublicKey, RelayUrl};
+use sqlx::SqlitePool;
 
-use super::{Database, utils::parse_timestamp};
 use crate::perf_instrument;
 use crate::whitenoise::push_notifications::GroupPushToken;
 
-impl<'r, R> sqlx::FromRow<'r, R> for GroupPushToken
-where
-    R: sqlx::Row,
-    &'r str: sqlx::ColumnIndex<R>,
-    String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Option<String>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-{
-    fn from_row(row: &'r R) -> Result<Self, sqlx::Error> {
-        let account_pubkey_str: String = row.try_get("account_pubkey")?;
-        let account_pubkey =
-            PublicKey::parse(&account_pubkey_str).map_err(|error| sqlx::Error::ColumnDecode {
-                index: "account_pubkey".to_string(),
-                source: Box::new(error),
-            })?;
+/// Row carrier for `group_push_tokens` in the per-account DB.
+///
+/// The `account_pubkey` column no longer exists in the table; the caller
+/// supplies it separately and attaches it to the returned
+/// [`GroupPushToken`].
+#[derive(sqlx::FromRow)]
+struct LocalGroupPushTokenRow {
+    mls_group_id: Vec<u8>,
+    member_pubkey: String,
+    leaf_index: i64,
+    server_pubkey: String,
+    relay_hint: Option<String>,
+    encrypted_token: String,
+    created_at: i64,
+    updated_at: i64,
+}
 
-        let mls_group_id_bytes: Vec<u8> = row.try_get("mls_group_id")?;
-        let mls_group_id = GroupId::from_slice(&mls_group_id_bytes);
+impl LocalGroupPushTokenRow {
+    fn into_group_push_token(
+        self,
+        account_pubkey: PublicKey,
+    ) -> Result<GroupPushToken, sqlx::Error> {
+        let mls_group_id = GroupId::from_slice(&self.mls_group_id);
 
-        let member_pubkey_str: String = row.try_get("member_pubkey")?;
         let member_pubkey =
-            PublicKey::parse(&member_pubkey_str).map_err(|error| sqlx::Error::ColumnDecode {
+            PublicKey::parse(&self.member_pubkey).map_err(|error| sqlx::Error::ColumnDecode {
                 index: "member_pubkey".to_string(),
                 source: Box::new(error),
             })?;
 
-        let leaf_index_int: i64 = row.try_get("leaf_index")?;
         let leaf_index =
-            u32::try_from(leaf_index_int).map_err(|error| sqlx::Error::ColumnDecode {
+            u32::try_from(self.leaf_index).map_err(|error| sqlx::Error::ColumnDecode {
                 index: "leaf_index".to_string(),
                 source: Box::new(error),
             })?;
 
-        let server_pubkey_str: String = row.try_get("server_pubkey")?;
         let server_pubkey =
-            PublicKey::parse(&server_pubkey_str).map_err(|error| sqlx::Error::ColumnDecode {
+            PublicKey::parse(&self.server_pubkey).map_err(|error| sqlx::Error::ColumnDecode {
                 index: "server_pubkey".to_string(),
                 source: Box::new(error),
             })?;
 
-        let relay_hint_str: Option<String> = row.try_get("relay_hint")?;
-        let relay_hint = relay_hint_str
+        let relay_hint = self
+            .relay_hint
             .map(|value| {
                 RelayUrl::parse(&value).map_err(|error| sqlx::Error::ColumnDecode {
                     index: "relay_hint".to_string(),
@@ -61,22 +62,31 @@ where
             })
             .transpose()?;
 
-        let encrypted_token: String = row.try_get("encrypted_token")?;
-        let created_at = parse_timestamp(row, "created_at")?;
-        let updated_at = parse_timestamp(row, "updated_at")?;
+        let created_at = parse_timestamp_millis(self.created_at)?;
+        let updated_at = parse_timestamp_millis(self.updated_at)?;
 
-        Ok(Self {
+        Ok(GroupPushToken {
             account_pubkey,
             mls_group_id,
             member_pubkey,
             leaf_index,
             server_pubkey,
             relay_hint,
-            encrypted_token,
+            encrypted_token: self.encrypted_token,
             created_at,
             updated_at,
         })
     }
+}
+
+fn parse_timestamp_millis(millis: i64) -> Result<chrono::DateTime<chrono::Utc>, sqlx::Error> {
+    chrono::DateTime::from_timestamp_millis(millis).ok_or_else(|| sqlx::Error::ColumnDecode {
+        index: "timestamp".to_string(),
+        source: Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid timestamp millis: {millis}"),
+        )),
+    })
 }
 
 impl GroupPushToken {
@@ -89,13 +99,12 @@ impl GroupPushToken {
         server_pubkey: &PublicKey,
         relay_hint: Option<&RelayUrl>,
         encrypted_token: &str,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let now = Utc::now().timestamp_millis();
 
-        let token = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalGroupPushTokenRow>(
             "INSERT INTO group_push_tokens (
-                 account_pubkey,
                  mls_group_id,
                  member_pubkey,
                  leaf_index,
@@ -105,16 +114,16 @@ impl GroupPushToken {
                  created_at,
                  updated_at
              )
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(account_pubkey, mls_group_id, leaf_index) DO UPDATE SET
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(mls_group_id, leaf_index) DO UPDATE SET
                  member_pubkey = excluded.member_pubkey,
                  server_pubkey = excluded.server_pubkey,
                  relay_hint = excluded.relay_hint,
                  encrypted_token = excluded.encrypted_token,
                  updated_at = excluded.updated_at
-             RETURNING *",
+             RETURNING mls_group_id, member_pubkey, leaf_index, server_pubkey,
+                       relay_hint, encrypted_token, created_at, updated_at",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(member_pubkey.to_hex())
         .bind(i64::from(leaf_index))
@@ -123,47 +132,56 @@ impl GroupPushToken {
         .bind(encrypted_token)
         .bind(now)
         .bind(now)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(token)
+        row.into_group_push_token(*account_pubkey)
     }
 
     #[perf_instrument("db::group_push_tokens")]
     pub(crate) async fn delete(
-        account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         leaf_index: u32,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             "DELETE FROM group_push_tokens
-             WHERE account_pubkey = ? AND mls_group_id = ? AND leaf_index = ?",
+             WHERE mls_group_id = ? AND leaf_index = ?",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(i64::from(leaf_index))
-        .execute(&database.pool)
+        .execute(pool)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     #[perf_instrument("db::group_push_tokens")]
+    pub(crate) async fn delete_by_group(
+        mls_group_id: &GroupId,
+        pool: &SqlitePool,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query("DELETE FROM group_push_tokens WHERE mls_group_id = ?")
+            .bind(mls_group_id.as_slice())
+            .execute(pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    #[perf_instrument("db::group_push_tokens")]
     pub(crate) async fn delete_by_member_pubkey(
-        account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         member_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             "DELETE FROM group_push_tokens
-             WHERE account_pubkey = ? AND mls_group_id = ? AND member_pubkey = ?",
+             WHERE mls_group_id = ? AND member_pubkey = ?",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(member_pubkey.to_hex())
-        .execute(&database.pool)
+        .execute(pool)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -173,35 +191,34 @@ impl GroupPushToken {
     pub(crate) async fn find_by_account_and_group(
         account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Vec<Self>, sqlx::Error> {
-        let tokens = sqlx::query_as::<_, Self>(
-            "SELECT *
+        let rows = sqlx::query_as::<_, LocalGroupPushTokenRow>(
+            "SELECT mls_group_id, member_pubkey, leaf_index, server_pubkey,
+                    relay_hint, encrypted_token, created_at, updated_at
              FROM group_push_tokens
-             WHERE account_pubkey = ? AND mls_group_id = ?
+             WHERE mls_group_id = ?
              ORDER BY leaf_index ASC",
         )
-        .bind(account_pubkey.to_hex())
         .bind(mls_group_id.as_slice())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
-        Ok(tokens)
+        rows.into_iter()
+            .map(|r| r.into_group_push_token(*account_pubkey))
+            .collect()
     }
 
     #[perf_instrument("db::group_push_tokens")]
     pub(crate) async fn group_ids_for_account(
-        account_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Vec<GroupId>, sqlx::Error> {
         let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
             "SELECT DISTINCT mls_group_id
              FROM group_push_tokens
-             WHERE account_pubkey = ?
              ORDER BY mls_group_id ASC",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&database.pool)
+        .fetch_all(pool)
         .await?;
 
         Ok(rows
@@ -212,13 +229,12 @@ impl GroupPushToken {
 
     #[perf_instrument("db::group_push_tokens")]
     pub(crate) async fn upsert_active_token_list_response(
-        account_pubkey: &PublicKey,
         mls_group_id: &GroupId,
         active_leaf_map: &BTreeMap<u32, PublicKey>,
         tokens: Vec<mdk_core::mip05::LeafTokenTag>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<(), sqlx::Error> {
-        let mut tx = database.pool.begin().await?;
+        let mut tx = pool.begin().await?;
         let now = Utc::now().timestamp_millis();
 
         for token in tokens {
@@ -228,7 +244,6 @@ impl GroupPushToken {
 
             sqlx::query(
                 "INSERT INTO group_push_tokens (
-                     account_pubkey,
                      mls_group_id,
                      member_pubkey,
                      leaf_index,
@@ -238,15 +253,14 @@ impl GroupPushToken {
                      created_at,
                      updated_at
                  )
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 ON CONFLICT(account_pubkey, mls_group_id, leaf_index) DO UPDATE SET
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(mls_group_id, leaf_index) DO UPDATE SET
                      member_pubkey = excluded.member_pubkey,
                      server_pubkey = excluded.server_pubkey,
                      relay_hint = excluded.relay_hint,
                      encrypted_token = excluded.encrypted_token,
                      updated_at = excluded.updated_at",
             )
-            .bind(account_pubkey.to_hex())
             .bind(mls_group_id.as_slice())
             .bind(member_pubkey.to_hex())
             .bind(i64::from(token.leaf_index))
@@ -271,18 +285,51 @@ impl GroupPushToken {
 mod tests {
     use chrono::DateTime;
     use nostr_sdk::{Keys, RelayUrl};
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
 
     use super::*;
-    use crate::whitenoise::test_utils::create_mock_whitenoise;
 
     fn make_group_id(seed: u8) -> GroupId {
         GroupId::from_slice(&[seed; 32])
     }
 
+    async fn setup() -> (SqlitePool, PublicKey, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let pool = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("account.db").display()
+        ))
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "CREATE TABLE group_push_tokens (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id    BLOB NOT NULL,
+                member_pubkey   TEXT NOT NULL,
+                leaf_index      INTEGER NOT NULL CHECK (leaf_index >= 0),
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                encrypted_token TEXT NOT NULL CHECK (
+                    length(trim(encrypted_token, ' ' || char(9) || char(10) || char(13))) > 0
+                ),
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                UNIQUE(mls_group_id, leaf_index)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let pubkey = Keys::generate().public_key();
+        (pool, pubkey, dir)
+    }
+
     #[tokio::test]
     async fn test_group_push_tokens_insert_replace_delete() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let mls_group_id = make_group_id(1);
         let first_server = Keys::generate().public_key();
         let second_server = Keys::generate().public_key();
@@ -290,14 +337,14 @@ mod tests {
         let relay_hint = RelayUrl::parse("wss://server.example.com/").unwrap();
 
         let created = GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             7,
             &first_server,
             Some(&relay_hint),
             "ciphertext-one",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -306,14 +353,14 @@ mod tests {
         assert_eq!(created.encrypted_token, "ciphertext-one");
 
         let replaced = GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             7,
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -323,76 +370,61 @@ mod tests {
         assert_eq!(replaced.encrypted_token, "ciphertext-two");
         assert!(replaced.updated_at >= created.updated_at);
 
-        let stored = GroupPushToken::find_by_account_and_group(
-            &account.pubkey,
-            &mls_group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let stored =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &mls_group_id, &pool)
+                .await
+                .unwrap();
         assert_eq!(stored, vec![replaced.clone()]);
 
-        let deleted = GroupPushToken::delete(
-            &account.pubkey,
-            &mls_group_id,
-            7,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let deleted = GroupPushToken::delete(&mls_group_id, 7, &pool)
+            .await
+            .unwrap();
         assert!(deleted);
 
-        let stored_after_delete = GroupPushToken::find_by_account_and_group(
-            &account.pubkey,
-            &mls_group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let stored_after_delete =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &mls_group_id, &pool)
+                .await
+                .unwrap();
         assert!(stored_after_delete.is_empty());
     }
 
     #[tokio::test]
     async fn test_group_push_tokens_upsert_allows_multiple_leaves_for_same_member() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let mls_group_id = make_group_id(9);
         let member_pubkey = Keys::generate().public_key();
         let first_server = Keys::generate().public_key();
         let second_server = Keys::generate().public_key();
 
         GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             3,
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
         let second_leaf = GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             7,
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
 
-        let stored = GroupPushToken::find_by_account_and_group(
-            &account.pubkey,
-            &mls_group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let stored =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &mls_group_id, &pool)
+                .await
+                .unwrap();
         assert_eq!(stored.len(), 2);
         assert_eq!(second_leaf.leaf_index, 7);
         assert_eq!(second_leaf.server_pubkey, second_server);
@@ -402,160 +434,117 @@ mod tests {
 
     #[tokio::test]
     async fn test_group_push_tokens_delete_by_member_pubkey_removes_all_leaves() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let mls_group_id = make_group_id(10);
         let member_pubkey = Keys::generate().public_key();
         let first_server = Keys::generate().public_key();
         let second_server = Keys::generate().public_key();
 
         GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             3,
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
         GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             7,
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
 
-        let deleted = GroupPushToken::delete_by_member_pubkey(
-            &account.pubkey,
-            &mls_group_id,
-            &member_pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let deleted = GroupPushToken::delete_by_member_pubkey(&mls_group_id, &member_pubkey, &pool)
+            .await
+            .unwrap();
         assert!(deleted);
 
-        let stored = GroupPushToken::find_by_account_and_group(
-            &account.pubkey,
-            &mls_group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let stored =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &mls_group_id, &pool)
+                .await
+                .unwrap();
         assert!(stored.is_empty());
     }
 
     #[tokio::test]
-    async fn test_group_push_tokens_are_scoped_by_account_and_group() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account_one = whitenoise.create_identity().await.unwrap();
-        let account_two = whitenoise.create_identity().await.unwrap();
+    async fn test_group_push_tokens_scoped_by_group() {
+        let (pool, account_pubkey, _dir) = setup().await;
         let group_one = make_group_id(11);
         let group_two = make_group_id(22);
         let first_member = Keys::generate().public_key();
         let second_member = Keys::generate().public_key();
-        let third_member = Keys::generate().public_key();
         let server_pubkey = Keys::generate().public_key();
 
         GroupPushToken::upsert(
-            &account_one.pubkey,
+            &account_pubkey,
             &group_one,
             &first_member,
             1,
             &server_pubkey,
             None,
-            "a1g1l1",
-            &whitenoise.shared.database,
+            "g1l1",
+            &pool,
         )
         .await
         .unwrap();
         GroupPushToken::upsert(
-            &account_one.pubkey,
+            &account_pubkey,
             &group_two,
             &second_member,
             2,
             &server_pubkey,
             None,
-            "a1g2l2",
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        GroupPushToken::upsert(
-            &account_two.pubkey,
-            &group_one,
-            &third_member,
-            3,
-            &server_pubkey,
-            None,
-            "a2g1l3",
-            &whitenoise.shared.database,
+            "g2l2",
+            &pool,
         )
         .await
         .unwrap();
 
-        let account_one_group_one = GroupPushToken::find_by_account_and_group(
-            &account_one.pubkey,
-            &group_one,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let account_one_group_two = GroupPushToken::find_by_account_and_group(
-            &account_one.pubkey,
-            &group_two,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let account_two_group_one = GroupPushToken::find_by_account_and_group(
-            &account_two.pubkey,
-            &group_one,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let account_one_groups =
-            GroupPushToken::group_ids_for_account(&account_one.pubkey, &whitenoise.shared.database)
+        let group_one_tokens =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &group_one, &pool)
                 .await
                 .unwrap();
+        let group_two_tokens =
+            GroupPushToken::find_by_account_and_group(&account_pubkey, &group_two, &pool)
+                .await
+                .unwrap();
+        let all_groups = GroupPushToken::group_ids_for_account(&pool).await.unwrap();
 
-        assert_eq!(account_one_group_one.len(), 1);
-        assert_eq!(account_one_group_one[0].encrypted_token, "a1g1l1");
-        assert_eq!(account_one_group_two.len(), 1);
-        assert_eq!(account_one_group_two[0].encrypted_token, "a1g2l2");
-        assert_eq!(account_two_group_one.len(), 1);
-        assert_eq!(account_two_group_one[0].encrypted_token, "a2g1l3");
-        assert_eq!(account_one_groups, vec![group_one, group_two]);
+        assert_eq!(group_one_tokens.len(), 1);
+        assert_eq!(group_one_tokens[0].encrypted_token, "g1l1");
+        assert_eq!(group_two_tokens.len(), 1);
+        assert_eq!(group_two_tokens[0].encrypted_token, "g2l2");
+        assert_eq!(all_groups, vec![group_one, group_two]);
     }
 
     #[tokio::test]
     async fn test_group_push_tokens_upsert_preserves_created_at() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let mls_group_id = make_group_id(33);
         let first_server = Keys::generate().public_key();
         let second_server = Keys::generate().public_key();
         let member_pubkey = Keys::generate().public_key();
 
         GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             4,
             &first_server,
             None,
             "ciphertext-one",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -564,27 +553,26 @@ mod tests {
         sqlx::query(
             "UPDATE group_push_tokens
              SET created_at = ?
-             WHERE account_pubkey = ? AND mls_group_id = ? AND leaf_index = ?",
+             WHERE mls_group_id = ? AND leaf_index = ?",
         )
         .bind(created_at_ms)
-        .bind(account.pubkey.to_hex())
         .bind(mls_group_id.as_slice())
         .bind(4_i64)
-        .execute(&whitenoise.shared.database.pool)
+        .execute(&pool)
         .await
         .unwrap();
 
         let expected_created_at = DateTime::from_timestamp_millis(created_at_ms).unwrap();
 
         let updated = GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             4,
             &second_server,
             None,
             "ciphertext-two",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -596,22 +584,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_group_push_tokens_upsert_rejects_whitespace_only_encrypted_token() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let mls_group_id = make_group_id(44);
         let server_pubkey = Keys::generate().public_key();
-
         let member_pubkey = Keys::generate().public_key();
 
         let error = GroupPushToken::upsert(
-            &account.pubkey,
+            &account_pubkey,
             &mls_group_id,
             &member_pubkey,
             1,
             &server_pubkey,
             None,
             " \n\t\r ",
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap_err();

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -88,7 +88,13 @@ impl Database {
     /// Open or create the SQLite file at `db_path` and run the unified
     /// migrator in shared-only mode (`account = None`).
     ///
-    /// **Unsafe for the shared DB once the unified timeline contains local
+    /// **Not safe for per-account DB files.** In shared-only mode the pool
+    /// passed here receives global migrations — including drop migrations
+    /// (e.g. m0037) that destroy tables which local migrations created.
+    /// Use `open_without_migrations` + `AccountDatabase::run_account_migrations`
+    /// for account DBs instead.
+    ///
+    /// **Not safe for the shared DB once the unified timeline contains local
     /// migrations** (Phase 18c+): in shared-only mode the migrator skips
     /// locals but advances past their version numbers, so any global drop
     /// migration sitting after a local will fire before the local has run
@@ -96,10 +102,9 @@ impl Database {
     /// `MIGRATOR.run_all` instead when there are accounts to migrate; the
     /// latter walks every per-account DB in lockstep with shared.
     ///
-    /// Safe to use for: per-account DB files (no globals advance against the
-    /// per-account pool because globals run against shared); fresh installs
-    /// where shared has no data yet (drops are no-ops on empty tables); test
-    /// helpers that want a one-shot fully-migrated DB.
+    /// Safe to use for: fresh installs where shared has no data yet (drops
+    /// are no-ops on empty tables); test helpers that want a one-shot
+    /// fully-migrated shared-shape DB.
     pub async fn new(db_path: PathBuf) -> Result<Self, DatabaseError> {
         let db = Self::open_without_migrations(db_path).await?;
         rust_migrations::MIGRATOR.run(&db.pool, None).await?;
@@ -282,28 +287,35 @@ impl Database {
     /// every account has set a `chat_cleared_at` value.
     ///
     /// Returns the number of rows deleted.
+    /// Delete aggregated messages older than the given threshold.
+    ///
+    /// `min_cleared_at` is the minimum `chat_cleared_at` across all accounts
+    /// that have this group, but only if **every** account has set a
+    /// `chat_cleared_at` value (i.e. all accounts have cleared). If any
+    /// account has `chat_cleared_at = NULL`, pass `None` and no cleanup
+    /// occurs.
     pub(crate) async fn try_cleanup_cleared_messages(
         &self,
         mls_group_id: &mdk_core::prelude::GroupId,
+        min_cleared_at: Option<i64>,
     ) -> Result<u64, DatabaseError> {
-        retry_on_lock(|| self.try_cleanup_cleared_messages_inner(mls_group_id)).await
+        let Some(threshold) = min_cleared_at else {
+            return Ok(0);
+        };
+        retry_on_lock(|| self.try_cleanup_cleared_messages_inner(mls_group_id, threshold)).await
     }
 
     async fn try_cleanup_cleared_messages_inner(
         &self,
         mls_group_id: &mdk_core::prelude::GroupId,
+        threshold: i64,
     ) -> Result<u64, DatabaseError> {
         let result = sqlx::query(
             "DELETE FROM aggregated_messages
-             WHERE mls_group_id = ?
-               AND created_at <= (
-                 SELECT MIN(chat_cleared_at) FROM accounts_groups
-                 WHERE mls_group_id = ?
-                 HAVING COUNT(*) = COUNT(chat_cleared_at)
-               )",
+             WHERE mls_group_id = ? AND created_at <= ?",
         )
         .bind(mls_group_id.as_slice())
-        .bind(mls_group_id.as_slice())
+        .bind(threshold)
         .execute(&self.pool)
         .await?;
 
@@ -319,77 +331,33 @@ impl Database {
     /// account's per-account DB file and are dropped with that file at full
     /// account deletion.
     ///
-    /// Returns `true` if shared group data was also deleted (i.e., this was the
-    /// last account).
-    pub(crate) async fn delete_chat_data(
+    /// All per-account data (accounts_groups, drafts, group_push_tokens,
+    /// media_references) has been moved to per-account DBs; the caller
+    /// deletes those. This method only handles shared data cleanup when
+    /// `is_last_account` is true.
+    pub(crate) async fn delete_shared_group_data(
         &self,
-        account_pubkey: &nostr_sdk::prelude::PublicKey,
         mls_group_id: &mdk_core::prelude::GroupId,
-    ) -> Result<bool, DatabaseError> {
-        retry_on_lock(|| self.delete_chat_data_inner(account_pubkey, mls_group_id)).await
+        is_last_account: bool,
+    ) -> Result<(), DatabaseError> {
+        if is_last_account {
+            retry_on_lock(|| self.delete_shared_group_data_inner(mls_group_id)).await
+        } else {
+            Ok(())
+        }
     }
 
-    async fn delete_chat_data_inner(
+    async fn delete_shared_group_data_inner(
         &self,
-        account_pubkey: &nostr_sdk::prelude::PublicKey,
         mls_group_id: &mdk_core::prelude::GroupId,
-    ) -> Result<bool, DatabaseError> {
-        let mut txn = self.pool.begin().await?;
-        let pubkey_hex = account_pubkey.to_hex();
+    ) -> Result<(), DatabaseError> {
+        // group_information cascades to aggregated_messages via FK
+        sqlx::query("DELETE FROM group_information WHERE mls_group_id = ?")
+            .bind(mls_group_id.as_slice())
+            .execute(&self.pool)
+            .await?;
 
-        // 1. Delete per-account data
-        sqlx::query(
-            "DELETE FROM accounts_groups
-             WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(&pubkey_hex)
-        .bind(mls_group_id.as_slice())
-        .execute(&mut *txn)
-        .await?;
-
-        // Drafts moved to per-account DB in Phase 18c — the account-DB file
-        // is removed when the account is fully deleted, so no cleanup here.
-
-        sqlx::query(
-            "DELETE FROM group_push_tokens
-             WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(&pubkey_hex)
-        .bind(mls_group_id.as_slice())
-        .execute(&mut *txn)
-        .await?;
-
-        // media_references now live in the per-account DB; the caller
-        // (delete_chat) deletes them there.
-
-        // 2. Check if any other accounts still reference this group
-        let (remaining,): (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM accounts_groups WHERE mls_group_id = ?")
-                .bind(mls_group_id.as_slice())
-                .fetch_one(&mut *txn)
-                .await?;
-
-        let last_account = remaining == 0;
-
-        if last_account {
-            // 3. Delete shared data (group_information cascades to
-            //    aggregated_messages via FK; per-account drafts live in
-            //    each account's per-account DB and are removed with that
-            //    file when an account is fully deleted)
-            sqlx::query("DELETE FROM group_information WHERE mls_group_id = ?")
-                .bind(mls_group_id.as_slice())
-                .execute(&mut *txn)
-                .await?;
-
-            sqlx::query("DELETE FROM group_push_tokens WHERE mls_group_id = ?")
-                .bind(mls_group_id.as_slice())
-                .execute(&mut *txn)
-                .await?;
-        }
-
-        txn.commit().await?;
-
-        Ok(last_account)
+        Ok(())
     }
 }
 
@@ -888,56 +856,6 @@ mod tests {
         .unwrap();
     }
 
-    /// Sets up an account (user + account rows) so FK constraints are satisfied.
-    async fn setup_account(db: &Database, pubkey_hex: &str) {
-        sqlx::query("INSERT INTO users (pubkey, metadata) VALUES (?, '{}')")
-            .bind(pubkey_hex)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        let (user_id,): (i64,) = sqlx::query_as("SELECT id FROM users WHERE pubkey = ?")
-            .bind(pubkey_hex)
-            .fetch_one(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO accounts (pubkey, user_id, last_synced_at) VALUES (?, ?, NULL)")
-            .bind(pubkey_hex)
-            .bind(user_id)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-    }
-
-    /// Creates an accounts_groups row.
-    async fn setup_account_group(
-        db: &Database,
-        pubkey_hex: &str,
-        group_id: &mdk_core::prelude::GroupId,
-    ) -> i64 {
-        let now = chrono::Utc::now().timestamp_millis();
-        sqlx::query(
-            "INSERT INTO accounts_groups
-             (account_pubkey, mls_group_id, user_confirmation, created_at, updated_at)
-             VALUES (?, ?, 1, ?, ?)",
-        )
-        .bind(pubkey_hex)
-        .bind(group_id.as_slice())
-        .bind(now)
-        .bind(now)
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        let (id,): (i64,) = sqlx::query_as(
-            "SELECT id FROM accounts_groups WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(pubkey_hex)
-        .bind(group_id.as_slice())
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
-        id
-    }
-
     /// Inserts a minimal aggregated_messages row.
     async fn setup_message(
         db: &Database,
@@ -976,34 +894,18 @@ mod tests {
     async fn test_try_cleanup_cleared_messages_deletes_when_all_accounts_cleared() {
         let (db, _temp) = create_test_db().await;
         let group_id = mdk_core::prelude::GroupId::from_slice(&[1; 32]);
-        let pk1 = "aa".repeat(32);
-        let pk2 = "bb".repeat(32);
 
         setup_group(&db, &group_id).await;
-        setup_account(&db, &pk1).await;
-        setup_account(&db, &pk2).await;
-        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
-        let ag2_id = setup_account_group(&db, &pk2, &group_id).await;
 
         // Insert messages at times 100 and 200
         setup_message(&db, &group_id, &format!("{:0>64}", "1"), 100).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "2"), 200).await;
 
-        // Both accounts clear at 150 -- should delete only the message at 100
-        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
-            .bind(150_i64)
-            .bind(ag1_id)
-            .execute(&db.pool)
+        // Both accounts cleared at 150 — should delete only the message at 100
+        let deleted = db
+            .try_cleanup_cleared_messages(&group_id, Some(150))
             .await
             .unwrap();
-        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
-            .bind(150_i64)
-            .bind(ag2_id)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-
-        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
         assert_eq!(deleted, 1, "only the message at t=100 should be deleted");
         assert_eq!(message_count(&db, &group_id).await, 1);
     }
@@ -1012,36 +914,20 @@ mod tests {
     async fn test_try_cleanup_cleared_messages_respects_min() {
         let (db, _temp) = create_test_db().await;
         let group_id = mdk_core::prelude::GroupId::from_slice(&[2; 32]);
-        let pk1 = "cc".repeat(32);
-        let pk2 = "dd".repeat(32);
 
         setup_group(&db, &group_id).await;
-        setup_account(&db, &pk1).await;
-        setup_account(&db, &pk2).await;
-        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
-        let ag2_id = setup_account_group(&db, &pk2, &group_id).await;
 
         // Messages at 100, 200, 300
         setup_message(&db, &group_id, &format!("{:0>64}", "a"), 100).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "b"), 200).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "c"), 300).await;
 
-        // Account 1 clears at 250, account 2 clears at 150
-        // MIN = 150, so only message at 100 should be deleted
-        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
-            .bind(250_i64)
-            .bind(ag1_id)
-            .execute(&db.pool)
+        // Account 1 cleared at 250, account 2 cleared at 150.
+        // Caller resolves MIN = 150, so only message at 100 should be deleted.
+        let deleted = db
+            .try_cleanup_cleared_messages(&group_id, Some(150))
             .await
             .unwrap();
-        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
-            .bind(150_i64)
-            .bind(ag2_id)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-
-        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
         assert_eq!(deleted, 1);
         assert_eq!(message_count(&db, &group_id).await, 2);
     }
@@ -1050,26 +936,15 @@ mod tests {
     async fn test_try_cleanup_cleared_messages_noop_when_not_all_cleared() {
         let (db, _temp) = create_test_db().await;
         let group_id = mdk_core::prelude::GroupId::from_slice(&[3; 32]);
-        let pk1 = "ee".repeat(32);
-        let pk2 = "ff".repeat(32);
 
         setup_group(&db, &group_id).await;
-        setup_account(&db, &pk1).await;
-        setup_account(&db, &pk2).await;
-        let ag1_id = setup_account_group(&db, &pk1, &group_id).await;
-        setup_account_group(&db, &pk2, &group_id).await;
-
         setup_message(&db, &group_id, &format!("{:0>64}", "d"), 100).await;
 
-        // Only account 1 clears -- account 2 still has chat_cleared_at = NULL
-        sqlx::query("UPDATE accounts_groups SET chat_cleared_at = ? WHERE id = ?")
-            .bind(200_i64)
-            .bind(ag1_id)
-            .execute(&db.pool)
+        // Not all accounts cleared — caller passes None
+        let deleted = db
+            .try_cleanup_cleared_messages(&group_id, None)
             .await
             .unwrap();
-
-        let deleted = db.try_cleanup_cleared_messages(&group_id).await.unwrap();
         assert_eq!(
             deleted, 0,
             "must not delete when some accounts have not cleared"
@@ -1078,21 +953,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_delete_chat_data_sole_account() {
+    async fn test_delete_shared_group_data_last_account() {
         let (db, _temp) = create_test_db().await;
         let group_id = mdk_core::prelude::GroupId::from_slice(&[4; 32]);
-        let pk1 = "11".repeat(32);
 
         setup_group(&db, &group_id).await;
-        setup_account(&db, &pk1).await;
-        setup_account_group(&db, &pk1, &group_id).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "e"), 100).await;
 
-        let pubkey = nostr_sdk::prelude::PublicKey::parse(&pk1).unwrap();
-        let was_last = db.delete_chat_data(&pubkey, &group_id).await.unwrap();
-        assert!(was_last, "sole account should return true");
+        // Delete shared data as last account
+        db.delete_shared_group_data(&group_id, true).await.unwrap();
 
-        // Verify everything is gone
+        // Verify group_information is gone
         let (gi_count,): (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
                 .bind(group_id.as_slice())
@@ -1101,62 +972,20 @@ mod tests {
                 .unwrap();
         assert_eq!(gi_count, 0);
 
-        let (ag_count,): (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM accounts_groups WHERE mls_group_id = ?")
-                .bind(group_id.as_slice())
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
-        assert_eq!(ag_count, 0);
-
         // Messages cascade from group_information delete
         assert_eq!(message_count(&db, &group_id).await, 0);
     }
 
     #[tokio::test]
-    async fn test_delete_chat_data_multi_account() {
+    async fn test_delete_shared_group_data_not_last_account() {
         let (db, _temp) = create_test_db().await;
         let group_id = mdk_core::prelude::GroupId::from_slice(&[5; 32]);
-        let pk1 = "33".repeat(32);
-        let pk2 = "44".repeat(32);
 
         setup_group(&db, &group_id).await;
-        setup_account(&db, &pk1).await;
-        setup_account(&db, &pk2).await;
-        setup_account_group(&db, &pk1, &group_id).await;
-        setup_account_group(&db, &pk2, &group_id).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "f"), 100).await;
 
-        let pubkey1 = nostr_sdk::prelude::PublicKey::parse(&pk1).unwrap();
-        let pubkey2 = nostr_sdk::prelude::PublicKey::parse(&pk2).unwrap();
-
-        // Account 1 deletes -- shared data should remain
-        let was_last = db.delete_chat_data(&pubkey1, &group_id).await.unwrap();
-        assert!(!was_last, "first account should return false");
-
-        // A's row gone
-        let (ag1_count,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM accounts_groups
-             WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(&pk1)
-        .bind(group_id.as_slice())
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
-        assert_eq!(ag1_count, 0, "A's account_group must be deleted");
-
-        // B's row intact
-        let (ag2_count,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM accounts_groups
-             WHERE account_pubkey = ? AND mls_group_id = ?",
-        )
-        .bind(&pk2)
-        .bind(group_id.as_slice())
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
-        assert_eq!(ag2_count, 1, "B's account_group must still exist");
+        // Delete shared data as non-last account -- should be a no-op
+        db.delete_shared_group_data(&group_id, false).await.unwrap();
 
         // Shared data preserved
         let (gi_count,): (i64,) =
@@ -1168,9 +997,8 @@ mod tests {
         assert_eq!(gi_count, 1);
         assert_eq!(message_count(&db, &group_id).await, 1);
 
-        // Account 2 deletes -- everything should be gone
-        let was_last = db.delete_chat_data(&pubkey2, &group_id).await.unwrap();
-        assert!(was_last, "last account should return true");
+        // Now delete as last account -- everything should be gone
+        db.delete_shared_group_data(&group_id, true).await.unwrap();
 
         let (gi_count,): (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")

--- a/src/whitenoise/database/push_registrations.rs
+++ b/src/whitenoise/database/push_registrations.rs
@@ -95,7 +95,7 @@ impl PushRegistration {
             "SELECT platform, raw_token, server_pubkey, relay_hint,
                     created_at, updated_at, last_shared_at
              FROM push_registrations
-             LIMIT 1",
+             WHERE id = 1",
         )
         .fetch_optional(pool)
         .await?;

--- a/src/whitenoise/database/push_registrations.rs
+++ b/src/whitenoise/database/push_registrations.rs
@@ -4,49 +4,46 @@ use std::str::FromStr;
 
 use chrono::Utc;
 use nostr_sdk::{PublicKey, RelayUrl};
+use sqlx::SqlitePool;
 
-use super::{
-    Database,
-    utils::{parse_optional_timestamp, parse_timestamp},
-};
 use crate::perf_instrument;
 use crate::whitenoise::push_notifications::{PushPlatform, PushRegistration};
 
-impl<'r, R> sqlx::FromRow<'r, R> for PushRegistration
-where
-    R: sqlx::Row,
-    &'r str: sqlx::ColumnIndex<R>,
-    String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Option<String>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-    Option<i64>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
-{
-    fn from_row(row: &'r R) -> std::result::Result<Self, sqlx::Error> {
-        let account_pubkey_str: String = row.try_get("account_pubkey")?;
-        let account_pubkey =
-            PublicKey::parse(&account_pubkey_str).map_err(|error| sqlx::Error::ColumnDecode {
-                index: "account_pubkey".to_string(),
-                source: Box::new(error),
-            })?;
+/// Row carrier for `push_registrations` in the per-account DB.
+///
+/// The `account_pubkey` column no longer exists in the table; the caller
+/// supplies it separately and attaches it to the returned
+/// [`PushRegistration`].
+#[derive(sqlx::FromRow)]
+struct LocalPushRegRow {
+    platform: String,
+    raw_token: String,
+    server_pubkey: String,
+    relay_hint: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+    last_shared_at: Option<i64>,
+}
 
-        let platform_str: String = row.try_get("platform")?;
+impl LocalPushRegRow {
+    fn into_push_registration(
+        self,
+        account_pubkey: PublicKey,
+    ) -> Result<PushRegistration, sqlx::Error> {
         let platform =
-            PushPlatform::from_str(&platform_str).map_err(|error| sqlx::Error::ColumnDecode {
+            PushPlatform::from_str(&self.platform).map_err(|error| sqlx::Error::ColumnDecode {
                 index: "platform".to_string(),
                 source: Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
             })?;
 
-        let raw_token: String = row.try_get("raw_token")?;
-
-        let server_pubkey_str: String = row.try_get("server_pubkey")?;
         let server_pubkey =
-            PublicKey::parse(&server_pubkey_str).map_err(|error| sqlx::Error::ColumnDecode {
+            PublicKey::parse(&self.server_pubkey).map_err(|error| sqlx::Error::ColumnDecode {
                 index: "server_pubkey".to_string(),
                 source: Box::new(error),
             })?;
 
-        let relay_hint_str: Option<String> = row.try_get("relay_hint")?;
-        let relay_hint = relay_hint_str
+        let relay_hint = self
+            .relay_hint
             .map(|value| {
                 RelayUrl::parse(&value).map_err(|error| sqlx::Error::ColumnDecode {
                     index: "relay_hint".to_string(),
@@ -55,14 +52,17 @@ where
             })
             .transpose()?;
 
-        let created_at = parse_timestamp(row, "created_at")?;
-        let updated_at = parse_timestamp(row, "updated_at")?;
-        let last_shared_at = parse_optional_timestamp(row, "last_shared_at")?;
+        let created_at = parse_timestamp_millis(self.created_at)?;
+        let updated_at = parse_timestamp_millis(self.updated_at)?;
+        let last_shared_at = self
+            .last_shared_at
+            .map(parse_timestamp_millis)
+            .transpose()?;
 
-        Ok(Self {
+        Ok(PushRegistration {
             account_pubkey,
             platform,
-            raw_token,
+            raw_token: self.raw_token,
             server_pubkey,
             relay_hint,
             created_at,
@@ -72,24 +72,44 @@ where
     }
 }
 
+fn parse_timestamp_millis(millis: i64) -> Result<chrono::DateTime<chrono::Utc>, sqlx::Error> {
+    chrono::DateTime::from_timestamp_millis(millis).ok_or_else(|| sqlx::Error::ColumnDecode {
+        index: "timestamp".to_string(),
+        source: Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid timestamp millis: {millis}"),
+        )),
+    })
+}
+
 impl PushRegistration {
+    /// Return the push registration for this account, if one exists.
+    ///
+    /// The per-account DB contains at most one row (no WHERE needed).
     #[perf_instrument("db::push_registrations")]
-    pub(crate) async fn find_by_account_pubkey(
+    pub(crate) async fn find(
         account_pubkey: &PublicKey,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Option<Self>, sqlx::Error> {
-        let registration = sqlx::query_as::<_, Self>(
-            "SELECT *
+        let row = sqlx::query_as::<_, LocalPushRegRow>(
+            "SELECT platform, raw_token, server_pubkey, relay_hint,
+                    created_at, updated_at, last_shared_at
              FROM push_registrations
-             WHERE account_pubkey = ?",
+             LIMIT 1",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_optional(&database.pool)
+        .fetch_optional(pool)
         .await?;
 
-        Ok(registration)
+        match row {
+            Some(r) => Ok(Some(r.into_push_registration(*account_pubkey)?)),
+            None => Ok(None),
+        }
     }
 
+    /// Create or replace the push registration for this account.
+    ///
+    /// Uses `ON CONFLICT(id)` with a fixed sentinel id (1) to ensure at most
+    /// one row per account DB.
     #[perf_instrument("db::push_registrations")]
     pub(crate) async fn upsert(
         account_pubkey: &PublicKey,
@@ -97,13 +117,13 @@ impl PushRegistration {
         raw_token: &str,
         server_pubkey: &PublicKey,
         relay_hint: Option<&RelayUrl>,
-        database: &Database,
+        pool: &SqlitePool,
     ) -> Result<Self, sqlx::Error> {
         let now = Utc::now().timestamp_millis();
 
-        let registration = sqlx::query_as::<_, Self>(
+        let row = sqlx::query_as::<_, LocalPushRegRow>(
             "INSERT INTO push_registrations (
-                 account_pubkey,
+                 id,
                  platform,
                  raw_token,
                  server_pubkey,
@@ -112,8 +132,8 @@ impl PushRegistration {
                  updated_at,
                  last_shared_at
              )
-             VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
-             ON CONFLICT(account_pubkey) DO UPDATE SET
+             VALUES (1, ?, ?, ?, ?, ?, ?, NULL)
+             ON CONFLICT(id) DO UPDATE SET
                  platform = excluded.platform,
                  raw_token = excluded.raw_token,
                  server_pubkey = excluded.server_pubkey,
@@ -134,33 +154,27 @@ impl PushRegistration {
                      THEN push_registrations.updated_at
                      ELSE excluded.updated_at
                  END
-             RETURNING *",
+             RETURNING platform, raw_token, server_pubkey, relay_hint,
+                       created_at, updated_at, last_shared_at",
         )
-        .bind(account_pubkey.to_hex())
         .bind(platform.as_str())
         .bind(raw_token)
         .bind(server_pubkey.to_hex())
         .bind(relay_hint.map(super::utils::normalize_relay_url))
         .bind(now)
         .bind(now)
-        .fetch_one(&database.pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(registration)
+        row.into_push_registration(*account_pubkey)
     }
 
+    /// Delete the push registration for this account.
     #[perf_instrument("db::push_registrations")]
-    pub(crate) async fn delete_by_account_pubkey(
-        account_pubkey: &PublicKey,
-        database: &Database,
-    ) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query(
-            "DELETE FROM push_registrations
-             WHERE account_pubkey = ?",
-        )
-        .bind(account_pubkey.to_hex())
-        .execute(&database.pool)
-        .await?;
+    pub(crate) async fn delete(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query("DELETE FROM push_registrations")
+            .execute(pool)
+            .await?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -170,25 +184,56 @@ impl PushRegistration {
 mod tests {
     use chrono::{DateTime, Utc};
     use nostr_sdk::{Keys, RelayUrl};
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
 
     use super::*;
-    use crate::whitenoise::test_utils::create_mock_whitenoise;
+
+    async fn setup() -> (SqlitePool, PublicKey, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let pool = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("account.db").display()
+        ))
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+                raw_token       TEXT NOT NULL CHECK (
+                    length(trim(raw_token, ' ' || char(9) || char(10) || char(13))) > 0
+                ),
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                last_shared_at  INTEGER
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let pubkey = Keys::generate().public_key();
+        (pool, pubkey, dir)
+    }
 
     #[tokio::test]
     async fn test_push_registration_upsert_and_replace() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let first_server = Keys::generate().public_key();
         let second_server = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://relay.push.example.com/").unwrap();
 
         let created = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-a",
             &first_server,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -201,12 +246,12 @@ mod tests {
         assert!(created.last_shared_at.is_none());
 
         let replaced = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Fcm,
             "token-b",
             &second_server,
             None,
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -217,118 +262,83 @@ mod tests {
         assert_eq!(replaced.created_at, created.created_at);
         assert!(replaced.updated_at >= created.updated_at);
 
-        let stored =
-            PushRegistration::find_by_account_pubkey(&account.pubkey, &whitenoise.shared.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let stored = PushRegistration::find(&account_pubkey, &pool)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(stored, replaced);
     }
 
     #[tokio::test]
-    async fn test_push_registration_delete_and_account_scoping() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account_one = whitenoise.create_identity().await.unwrap();
-        let account_two = whitenoise.create_identity().await.unwrap();
+    async fn test_push_registration_delete() {
+        let (pool, account_pubkey, _dir) = setup().await;
         let server_pubkey = Keys::generate().public_key();
 
         PushRegistration::upsert(
-            &account_one.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-one",
             &server_pubkey,
             None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        PushRegistration::upsert(
-            &account_two.pubkey,
-            PushPlatform::Fcm,
-            "token-two",
-            &server_pubkey,
-            None,
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
 
-        let deleted = PushRegistration::delete_by_account_pubkey(
-            &account_one.pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let deleted = PushRegistration::delete(&pool).await.unwrap();
         assert!(deleted);
 
-        let account_one_registration = PushRegistration::find_by_account_pubkey(
-            &account_one.pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-        let account_two_registration = PushRegistration::find_by_account_pubkey(
-            &account_two.pubkey,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
-
-        assert!(account_one_registration.is_none());
-        assert_eq!(account_two_registration.unwrap().raw_token, "token-two");
+        let registration = PushRegistration::find(&account_pubkey, &pool)
+            .await
+            .unwrap();
+        assert!(registration.is_none());
     }
 
     #[tokio::test]
     async fn test_push_registration_upsert_preserves_or_clears_last_shared_at() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let server_pubkey = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://relay.push.example.com").unwrap();
 
         PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
 
         let shared_at_ms = Utc::now().timestamp_millis();
-        sqlx::query(
-            "UPDATE push_registrations
-             SET last_shared_at = ?
-             WHERE account_pubkey = ?",
-        )
-        .bind(shared_at_ms)
-        .bind(account.pubkey.to_hex())
-        .execute(&whitenoise.shared.database.pool)
-        .await
-        .unwrap();
+        sqlx::query("UPDATE push_registrations SET last_shared_at = ?")
+            .bind(shared_at_ms)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let expected_shared_at = DateTime::from_timestamp_millis(shared_at_ms).unwrap();
 
         let no_op = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
         assert_eq!(no_op.last_shared_at, Some(expected_shared_at));
 
         let changed = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-b",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -337,55 +347,49 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_registration_upsert_preserves_or_advances_updated_at() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let server_pubkey = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://relay.push.example.com").unwrap();
 
         PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
 
         let updated_at_ms = Utc::now().timestamp_millis() - 60_000;
-        sqlx::query(
-            "UPDATE push_registrations
-             SET updated_at = ?
-             WHERE account_pubkey = ?",
-        )
-        .bind(updated_at_ms)
-        .bind(account.pubkey.to_hex())
-        .execute(&whitenoise.shared.database.pool)
-        .await
-        .unwrap();
+        sqlx::query("UPDATE push_registrations SET updated_at = ?")
+            .bind(updated_at_ms)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let expected_updated_at = DateTime::from_timestamp_millis(updated_at_ms).unwrap();
 
         let no_op = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-a",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
         assert_eq!(no_op.updated_at, expected_updated_at);
 
         let changed = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "token-b",
             &server_pubkey,
             Some(&relay_hint),
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap();
@@ -394,21 +398,100 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_registration_upsert_rejects_whitespace_only_token_at_db_level() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
-        let account = whitenoise.create_identity().await.unwrap();
+        let (pool, account_pubkey, _dir) = setup().await;
         let server_pubkey = Keys::generate().public_key();
 
         let error = PushRegistration::upsert(
-            &account.pubkey,
+            &account_pubkey,
             PushPlatform::Apns,
             "   ",
             &server_pubkey,
             None,
-            &whitenoise.shared.database,
+            &pool,
         )
         .await
         .unwrap_err();
 
         assert!(matches!(error, sqlx::Error::Database(_)));
+    }
+
+    /// Two separate account DBs must be fully isolated: upserting or
+    /// deleting in one must not affect the other.
+    #[tokio::test]
+    async fn test_two_account_dbs_are_isolated() {
+        let dir = TempDir::new().unwrap();
+
+        // Account A
+        let pool_a = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("account_a.db").display()
+        ))
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+                raw_token       TEXT NOT NULL,
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                last_shared_at  INTEGER
+            )",
+        )
+        .execute(&pool_a)
+        .await
+        .unwrap();
+
+        // Account B
+        let pool_b = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("account_b.db").display()
+        ))
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+                raw_token       TEXT NOT NULL,
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                last_shared_at  INTEGER
+            )",
+        )
+        .execute(&pool_b)
+        .await
+        .unwrap();
+
+        let pk_a = Keys::generate().public_key();
+        let pk_b = Keys::generate().public_key();
+        let server = Keys::generate().public_key();
+
+        // Upsert into both
+        PushRegistration::upsert(&pk_a, PushPlatform::Apns, "tok-a", &server, None, &pool_a)
+            .await
+            .unwrap();
+        PushRegistration::upsert(&pk_b, PushPlatform::Fcm, "tok-b", &server, None, &pool_b)
+            .await
+            .unwrap();
+
+        // Delete from A
+        PushRegistration::delete(&pool_a).await.unwrap();
+
+        // B is unaffected
+        let b_reg = PushRegistration::find(&pk_b, &pool_b).await.unwrap();
+        assert!(
+            b_reg.is_some(),
+            "account B registration must survive A's delete"
+        );
+        assert_eq!(b_reg.unwrap().raw_token, "tok-b");
+
+        // A is gone
+        let a_reg = PushRegistration::find(&pk_a, &pool_a).await.unwrap();
+        assert!(a_reg.is_none(), "account A registration must be deleted");
     }
 }

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -97,3 +97,71 @@ CREATE INDEX IF NOT EXISTS idx_media_refs_group_hash
 
 CREATE INDEX IF NOT EXISTS idx_media_refs_hash
     ON media_references(encrypted_file_hash);
+
+CREATE TABLE IF NOT EXISTS push_registrations (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+    raw_token       TEXT NOT NULL CHECK (
+        length(trim(raw_token, ' ' || char(9) || char(10) || char(13))) > 0
+    ),
+    server_pubkey   TEXT NOT NULL,
+    relay_hint      TEXT,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    last_shared_at  INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_registrations_server_pubkey
+    ON push_registrations(server_pubkey);
+
+CREATE TABLE IF NOT EXISTS group_push_tokens (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id    BLOB NOT NULL,
+    member_pubkey   TEXT NOT NULL,
+    leaf_index      INTEGER NOT NULL CHECK (leaf_index >= 0),
+    server_pubkey   TEXT NOT NULL,
+    relay_hint      TEXT,
+    encrypted_token TEXT NOT NULL CHECK (
+        length(trim(encrypted_token, ' ' || char(9) || char(10) || char(13))) > 0
+    ),
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    UNIQUE(mls_group_id, leaf_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_push_tokens_group
+    ON group_push_tokens(mls_group_id);
+
+CREATE INDEX IF NOT EXISTS idx_group_push_tokens_group_member
+    ON group_push_tokens(mls_group_id, member_pubkey);
+
+CREATE INDEX IF NOT EXISTS idx_group_push_tokens_server
+    ON group_push_tokens(server_pubkey);
+
+CREATE TABLE IF NOT EXISTS accounts_groups (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id         BLOB NOT NULL UNIQUE,
+    user_confirmation    INTEGER DEFAULT NULL
+        CHECK (user_confirmation IS NULL OR user_confirmation IN (0, 1)),
+    welcomer_pubkey      TEXT,
+    last_read_message_id TEXT
+        CHECK (last_read_message_id IS NULL OR
+               (length(last_read_message_id) = 64
+                AND last_read_message_id NOT GLOB '*[^0-9a-fA-F]*')),
+    pin_order            INTEGER DEFAULT NULL,
+    dm_peer_pubkey       TEXT DEFAULT NULL,
+    archived_at          INTEGER DEFAULT NULL,
+    removed_at           INTEGER DEFAULT NULL,
+    self_removed         INTEGER NOT NULL DEFAULT 0,
+    muted_until          INTEGER DEFAULT NULL,
+    chat_cleared_at      INTEGER DEFAULT NULL,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_groups_group
+    ON accounts_groups(mls_group_id);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_groups_dm_peer
+    ON accounts_groups(dm_peer_pubkey)
+    WHERE dm_peer_pubkey IS NOT NULL;

--- a/src/whitenoise/database/rust_migrations/m0032_move_push_registrations.rs
+++ b/src/whitenoise/database/rust_migrations/m0032_move_push_registrations.rs
@@ -1,0 +1,294 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `push_registrations` table
+/// during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedPushRegRow {
+    platform: String,
+    raw_token: String,
+    server_pubkey: String,
+    relay_hint: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+    last_shared_at: Option<i64>,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        32
+    }
+
+    fn description(&self) -> &'static str {
+        "Move push_registrations into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: no account_pubkey column (the file is the scope).
+        // The UNIQUE index on account_pubkey is unnecessary — one DB = one
+        // account, and there is only one row.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS push_registrations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+                raw_token       TEXT NOT NULL CHECK (
+                    length(trim(raw_token, ' ' || char(9) || char(10) || char(13))) > 0
+                ),
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                last_shared_at  INTEGER
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_push_registrations_server_pubkey
+                ON push_registrations(server_pubkey)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='push_registrations')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0032",
+                account = account_pubkey,
+                "shared.push_registrations is missing; skipping local copy. \
+                 Expected only on fresh installs or when v33 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        // Read rows from shared via the global_db pool, then insert into the
+        // per-account transaction. Can't use cross-DB SQL because the local
+        // migration runs against the per-account pool.
+        let rows: Vec<SharedPushRegRow> = sqlx::query_as(
+            "SELECT platform, raw_token, server_pubkey, relay_hint,
+                    created_at, updated_at, last_shared_at
+             FROM push_registrations
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        for r in &rows {
+            sqlx::query(
+                "INSERT OR IGNORE INTO push_registrations
+                    (platform, raw_token, server_pubkey, relay_hint,
+                     created_at, updated_at, last_shared_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&r.platform)
+            .bind(&r.raw_token)
+            .bind(&r.server_pubkey)
+            .bind(&r.relay_hint)
+            .bind(r.created_at)
+            .bind(r.updated_at)
+            .bind(r.last_shared_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if !rows.is_empty() {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0032",
+                account = account_pubkey,
+                "Copied {} push_registrations row(s) to per-account DB",
+                rows.len()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_global(global: &SqlitePool, account_pubkey: &str) {
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey  TEXT NOT NULL,
+                platform        TEXT NOT NULL CHECK (platform IN ('apns', 'fcm')),
+                raw_token       TEXT NOT NULL,
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                last_shared_at  INTEGER,
+                UNIQUE(account_pubkey)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO push_registrations
+                (account_pubkey, platform, raw_token, server_pubkey, relay_hint,
+                 created_at, updated_at, last_shared_at)
+             VALUES (?, 'apns', 'token-abc', 'serverpub1', 'wss://relay.example.com',
+                     1000, 2000, 3000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        // Row for a different account — should NOT be copied.
+        sqlx::query(
+            "INSERT INTO push_registrations
+                (account_pubkey, platform, raw_token, server_pubkey,
+                 created_at, updated_at)
+             VALUES ('other_account', 'fcm', 'token-xyz', 'serverpub2', 4000, 5000)",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_account_rows_to_local() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        seed_global(&global, &pubkey).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM push_registrations")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let has_col: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('push_registrations') \
+             WHERE name = 'account_pubkey'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(has_col, 0, "account_pubkey column should not exist");
+
+        let (platform, raw_token, server_pubkey): (String, String, String) =
+            sqlx::query_as("SELECT platform, raw_token, server_pubkey FROM push_registrations")
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(platform, "apns");
+        assert_eq!(raw_token, "token-abc");
+        assert_eq!(server_pubkey, "serverpub1");
+    }
+
+    #[tokio::test]
+    async fn migration_creates_table_when_no_shared_rows() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "cd".repeat(32);
+
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                raw_token TEXT NOT NULL,
+                server_pubkey TEXT NOT NULL,
+                relay_hint TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_shared_at INTEGER,
+                UNIQUE(account_pubkey)
+            )",
+        )
+        .execute(&global)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='push_registrations')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM push_registrations")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='push_registrations')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0033_drop_shared_push_registrations.rs
+++ b/src/whitenoise/database/rust_migrations/m0033_drop_shared_push_registrations.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        33
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared push_registrations (moved to per-account DB at v32)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS push_registrations")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE push_registrations (
+                id INTEGER PRIMARY KEY,
+                platform TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='push_registrations')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0034_move_group_push_tokens.rs
+++ b/src/whitenoise/database/rust_migrations/m0034_move_group_push_tokens.rs
@@ -1,0 +1,328 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `group_push_tokens` table
+/// during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedGroupPushTokenRow {
+    mls_group_id: Vec<u8>,
+    member_pubkey: String,
+    leaf_index: i64,
+    server_pubkey: String,
+    relay_hint: Option<String>,
+    encrypted_token: String,
+    created_at: i64,
+    updated_at: i64,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        34
+    }
+
+    fn description(&self) -> &'static str {
+        "Move group_push_tokens into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: no account_pubkey column (the file is the scope).
+        // UNIQUE index changes from (account_pubkey, mls_group_id, leaf_index)
+        // to (mls_group_id, leaf_index).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS group_push_tokens (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id    BLOB NOT NULL,
+                member_pubkey   TEXT NOT NULL,
+                leaf_index      INTEGER NOT NULL CHECK (leaf_index >= 0),
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                encrypted_token TEXT NOT NULL CHECK (
+                    length(trim(encrypted_token, ' ' || char(9) || char(10) || char(13))) > 0
+                ),
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_group_push_tokens_group_leaf
+                ON group_push_tokens(mls_group_id, leaf_index)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_group_push_tokens_group
+                ON group_push_tokens(mls_group_id)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_group_push_tokens_group_member
+                ON group_push_tokens(mls_group_id, member_pubkey)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_group_push_tokens_server
+                ON group_push_tokens(server_pubkey)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='group_push_tokens')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0034",
+                account = account_pubkey,
+                "shared.group_push_tokens is missing; skipping local copy. \
+                 Expected only on fresh installs or when v35 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        let rows: Vec<SharedGroupPushTokenRow> = sqlx::query_as(
+            "SELECT mls_group_id, member_pubkey, leaf_index, server_pubkey,
+                    relay_hint, encrypted_token, created_at, updated_at
+             FROM group_push_tokens
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        for r in &rows {
+            sqlx::query(
+                "INSERT OR IGNORE INTO group_push_tokens
+                    (mls_group_id, member_pubkey, leaf_index, server_pubkey,
+                     relay_hint, encrypted_token, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&r.mls_group_id)
+            .bind(&r.member_pubkey)
+            .bind(r.leaf_index)
+            .bind(&r.server_pubkey)
+            .bind(&r.relay_hint)
+            .bind(&r.encrypted_token)
+            .bind(r.created_at)
+            .bind(r.updated_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if !rows.is_empty() {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0034",
+                account = account_pubkey,
+                "Copied {} group_push_tokens row(s) to per-account DB",
+                rows.len()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_global(global: &SqlitePool, account_pubkey: &str) {
+        sqlx::query(
+            "CREATE TABLE group_push_tokens (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey  TEXT NOT NULL,
+                mls_group_id    BLOB NOT NULL,
+                member_pubkey   TEXT NOT NULL,
+                leaf_index      INTEGER NOT NULL CHECK (leaf_index >= 0),
+                server_pubkey   TEXT NOT NULL,
+                relay_hint      TEXT,
+                encrypted_token TEXT NOT NULL,
+                created_at      INTEGER NOT NULL,
+                updated_at      INTEGER NOT NULL,
+                UNIQUE(account_pubkey, mls_group_id, leaf_index)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO group_push_tokens
+                (account_pubkey, mls_group_id, member_pubkey, leaf_index,
+                 server_pubkey, relay_hint, encrypted_token, created_at, updated_at)
+             VALUES (?, X'01020304', 'member1', 3, 'serverpub1',
+                     'wss://relay.example.com', 'cipher-abc', 1000, 2000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO group_push_tokens
+                (account_pubkey, mls_group_id, member_pubkey, leaf_index,
+                 server_pubkey, encrypted_token, created_at, updated_at)
+             VALUES (?, X'01020304', 'member2', 7, 'serverpub2',
+                     'cipher-def', 3000, 4000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        // Row for a different account — should NOT be copied.
+        sqlx::query(
+            "INSERT INTO group_push_tokens
+                (account_pubkey, mls_group_id, member_pubkey, leaf_index,
+                 server_pubkey, encrypted_token, created_at, updated_at)
+             VALUES ('other_account', X'05060708', 'member3', 1, 'serverpub3',
+                     'cipher-ghi', 5000, 6000)",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_account_rows_to_local() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        seed_global(&global, &pubkey).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM group_push_tokens")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+
+        let has_col: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('group_push_tokens') \
+             WHERE name = 'account_pubkey'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(has_col, 0, "account_pubkey column should not exist");
+
+        let (encrypted_token,): (String,) =
+            sqlx::query_as("SELECT encrypted_token FROM group_push_tokens WHERE leaf_index = 3")
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(encrypted_token, "cipher-abc");
+    }
+
+    #[tokio::test]
+    async fn migration_creates_table_when_no_shared_rows() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "cd".repeat(32);
+
+        sqlx::query(
+            "CREATE TABLE group_push_tokens (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                member_pubkey TEXT NOT NULL,
+                leaf_index INTEGER NOT NULL,
+                server_pubkey TEXT NOT NULL,
+                relay_hint TEXT,
+                encrypted_token TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                UNIQUE(account_pubkey, mls_group_id, leaf_index)
+            )",
+        )
+        .execute(&global)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='group_push_tokens')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM group_push_tokens")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='group_push_tokens')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0035_drop_shared_group_push_tokens.rs
+++ b/src/whitenoise/database/rust_migrations/m0035_drop_shared_group_push_tokens.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        35
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared group_push_tokens (moved to per-account DB at v34)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS group_push_tokens")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE group_push_tokens (
+                id INTEGER PRIMARY KEY,
+                mls_group_id BLOB NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='group_push_tokens')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0036_move_accounts_groups.rs
+++ b/src/whitenoise/database/rust_migrations/m0036_move_accounts_groups.rs
@@ -1,0 +1,351 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `accounts_groups` table
+/// during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedAccountGroupRow {
+    mls_group_id: Vec<u8>,
+    user_confirmation: Option<i64>,
+    welcomer_pubkey: Option<String>,
+    last_read_message_id: Option<String>,
+    pin_order: Option<i64>,
+    dm_peer_pubkey: Option<String>,
+    archived_at: Option<i64>,
+    removed_at: Option<i64>,
+    self_removed: i64,
+    muted_until: Option<i64>,
+    chat_cleared_at: Option<i64>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        36
+    }
+
+    fn description(&self) -> &'static str {
+        "Move accounts_groups into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: no account_pubkey column (the file is the scope).
+        // UNIQUE index changes from (account_pubkey, mls_group_id) to just
+        // (mls_group_id). FK to accounts(pubkey) is dropped (cross-DB FK).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS accounts_groups (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id         BLOB NOT NULL UNIQUE,
+                user_confirmation    INTEGER DEFAULT NULL
+                    CHECK (user_confirmation IS NULL OR user_confirmation IN (0, 1)),
+                welcomer_pubkey      TEXT,
+                last_read_message_id TEXT
+                    CHECK (last_read_message_id IS NULL OR
+                           (length(last_read_message_id) = 64
+                            AND last_read_message_id NOT GLOB '*[^0-9a-fA-F]*')),
+                pin_order            INTEGER DEFAULT NULL,
+                dm_peer_pubkey       TEXT DEFAULT NULL,
+                archived_at          INTEGER DEFAULT NULL,
+                removed_at           INTEGER DEFAULT NULL,
+                self_removed         INTEGER NOT NULL DEFAULT 0,
+                muted_until          INTEGER DEFAULT NULL,
+                chat_cleared_at      INTEGER DEFAULT NULL,
+                created_at           INTEGER NOT NULL,
+                updated_at           INTEGER NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_accounts_groups_group
+                ON accounts_groups(mls_group_id)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_accounts_groups_dm_peer
+                ON accounts_groups(dm_peer_pubkey)
+                WHERE dm_peer_pubkey IS NOT NULL",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='accounts_groups')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0036",
+                account = account_pubkey,
+                "shared.accounts_groups is missing; skipping local copy. \
+                 Expected only on fresh installs or when v37 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        let rows: Vec<SharedAccountGroupRow> = sqlx::query_as(
+            "SELECT mls_group_id, user_confirmation, welcomer_pubkey,
+                    last_read_message_id, pin_order, dm_peer_pubkey,
+                    archived_at, removed_at, self_removed, muted_until,
+                    chat_cleared_at, created_at, updated_at
+             FROM accounts_groups
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        for r in &rows {
+            sqlx::query(
+                "INSERT OR IGNORE INTO accounts_groups
+                    (mls_group_id, user_confirmation, welcomer_pubkey,
+                     last_read_message_id, pin_order, dm_peer_pubkey,
+                     archived_at, removed_at, self_removed, muted_until,
+                     chat_cleared_at, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&r.mls_group_id)
+            .bind(r.user_confirmation)
+            .bind(&r.welcomer_pubkey)
+            .bind(&r.last_read_message_id)
+            .bind(r.pin_order)
+            .bind(&r.dm_peer_pubkey)
+            .bind(r.archived_at)
+            .bind(r.removed_at)
+            .bind(r.self_removed)
+            .bind(r.muted_until)
+            .bind(r.chat_cleared_at)
+            .bind(r.created_at)
+            .bind(r.updated_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if !rows.is_empty() {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0036",
+                account = account_pubkey,
+                "Copied {} accounts_groups row(s) to per-account DB",
+                rows.len()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_global(global: &SqlitePool, account_pubkey: &str) {
+        sqlx::query(
+            "CREATE TABLE accounts_groups (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey       TEXT NOT NULL,
+                mls_group_id         BLOB NOT NULL,
+                user_confirmation    INTEGER DEFAULT NULL,
+                welcomer_pubkey      TEXT,
+                last_read_message_id TEXT,
+                pin_order            INTEGER DEFAULT NULL,
+                dm_peer_pubkey       TEXT DEFAULT NULL,
+                archived_at          INTEGER DEFAULT NULL,
+                removed_at           INTEGER DEFAULT NULL,
+                self_removed         INTEGER NOT NULL DEFAULT 0,
+                muted_until          INTEGER DEFAULT NULL,
+                chat_cleared_at      INTEGER DEFAULT NULL,
+                created_at           INTEGER NOT NULL,
+                updated_at           INTEGER NOT NULL,
+                UNIQUE(account_pubkey, mls_group_id)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO accounts_groups
+                (account_pubkey, mls_group_id, user_confirmation, welcomer_pubkey,
+                 dm_peer_pubkey, created_at, updated_at)
+             VALUES (?, X'01020304', 1, 'welcomer1', 'peer1', 1000, 2000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO accounts_groups
+                (account_pubkey, mls_group_id, user_confirmation, pin_order,
+                 created_at, updated_at)
+             VALUES (?, X'05060708', 0, 42, 3000, 4000)",
+        )
+        .bind(account_pubkey)
+        .execute(global)
+        .await
+        .unwrap();
+
+        // Row for a different account — should NOT be copied.
+        sqlx::query(
+            "INSERT INTO accounts_groups
+                (account_pubkey, mls_group_id, created_at, updated_at)
+             VALUES ('other_account', X'09101112', 5000, 6000)",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_account_rows_to_local() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        seed_global(&global, &pubkey).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts_groups")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+
+        let has_col: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('accounts_groups') \
+             WHERE name = 'account_pubkey'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(has_col, 0, "account_pubkey column should not exist");
+
+        let (confirmation,): (Option<i64>,) = sqlx::query_as(
+            "SELECT user_confirmation FROM accounts_groups WHERE mls_group_id = X'01020304'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(confirmation, Some(1));
+
+        let (pin,): (Option<i64>,) = sqlx::query_as(
+            "SELECT pin_order FROM accounts_groups WHERE mls_group_id = X'05060708'",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert_eq!(pin, Some(42));
+    }
+
+    #[tokio::test]
+    async fn migration_creates_table_when_no_shared_rows() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "cd".repeat(32);
+
+        sqlx::query(
+            "CREATE TABLE accounts_groups (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                user_confirmation INTEGER DEFAULT NULL,
+                welcomer_pubkey TEXT,
+                last_read_message_id TEXT,
+                pin_order INTEGER DEFAULT NULL,
+                dm_peer_pubkey TEXT DEFAULT NULL,
+                archived_at INTEGER DEFAULT NULL,
+                removed_at INTEGER DEFAULT NULL,
+                self_removed INTEGER NOT NULL DEFAULT 0,
+                muted_until INTEGER DEFAULT NULL,
+                chat_cleared_at INTEGER DEFAULT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                UNIQUE(account_pubkey, mls_group_id)
+            )",
+        )
+        .execute(&global)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='accounts_groups')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts_groups")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='accounts_groups')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0037_drop_shared_accounts_groups.rs
+++ b/src/whitenoise/database/rust_migrations/m0037_drop_shared_accounts_groups.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        37
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared accounts_groups table (data moved to per-account DBs in v36)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS accounts_groups")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE accounts_groups (
+                id INTEGER PRIMARY KEY,
+                account_pubkey TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='accounts_groups')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -69,6 +69,8 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0027_drop_shared_account_follows::Migration),
         Box::new(m0028_purge_account_processed_events::Migration),
         Box::new(m0030_drop_shared_media_references::Migration),
+        // Note: version 31 is occupied by m0012_bootstrap (BOOTSTRAP_VERSION = 31).
+        // No m0031 file exists because the bootstrap migration claims that slot.
         Box::new(m0033_drop_shared_push_registrations::Migration),
         Box::new(m0035_drop_shared_group_push_tokens::Migration),
         Box::new(m0037_drop_shared_accounts_groups::Migration),

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -36,6 +36,12 @@ mod m0027_drop_shared_account_follows;
 mod m0028_purge_account_processed_events;
 mod m0029_move_media_references;
 mod m0030_drop_shared_media_references;
+mod m0032_move_push_registrations;
+mod m0033_drop_shared_push_registrations;
+mod m0034_move_group_push_tokens;
+mod m0035_drop_shared_group_push_tokens;
+mod m0036_move_accounts_groups;
+mod m0037_drop_shared_accounts_groups;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -63,6 +69,9 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0027_drop_shared_account_follows::Migration),
         Box::new(m0028_purge_account_processed_events::Migration),
         Box::new(m0030_drop_shared_media_references::Migration),
+        Box::new(m0033_drop_shared_push_registrations::Migration),
+        Box::new(m0035_drop_shared_group_push_tokens::Migration),
+        Box::new(m0037_drop_shared_accounts_groups::Migration),
     ]
 }
 
@@ -77,6 +86,9 @@ pub fn all_local_migrations() -> Vec<Box<dyn LocalMigration>> {
         Box::new(m0021_move_processed_events::Migration),
         Box::new(m0022_move_account_follows::Migration),
         Box::new(m0029_move_media_references::Migration),
+        Box::new(m0032_move_push_registrations::Migration),
+        Box::new(m0034_move_group_push_tokens::Migration),
+        Box::new(m0036_move_accounts_groups::Migration),
     ]
 }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -186,7 +186,7 @@ impl Whitenoise {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        account_group.save(&self.shared.database).await?;
+        account_group.save(&session.account_db.inner.pool).await?;
         tracing::debug!(target: "whitenoise::event_processor::process_welcome", "New AccountGroup created and saved");
 
         // Now accept the welcome to finalize MLS membership
@@ -755,10 +755,11 @@ mod tests {
         assert!(!groups.is_empty(), "Member should have at least one group");
 
         let group_id = &groups[0].mls_group_id;
+        let session = whitenoise.require_session(&member_account.pubkey).unwrap();
         let account_group = AccountGroup::find_by_account_and_group(
             &member_account.pubkey,
             group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
@@ -875,10 +876,11 @@ mod tests {
         .await;
 
         // Verify AccountGroup still exists and is pending
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let account_group = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
@@ -1111,10 +1113,11 @@ mod tests {
         .await;
 
         // AccountGroup must still exist
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let ag = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -114,7 +114,7 @@ impl Whitenoise {
             let has_account_group = AccountGroup::find_by_account_and_group(
                 &account.pubkey,
                 group_id,
-                &self.shared.database,
+                &session.account_db.inner.pool,
             )
             .await?
             .is_some();
@@ -1599,10 +1599,16 @@ mod tests {
             .await
             .unwrap();
 
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -1672,10 +1678,16 @@ mod tests {
             .await
             .unwrap();
 
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -1720,6 +1732,12 @@ mod tests {
         let admin_leaf_index = admin_mdk.own_leaf_index(&group_id).unwrap();
         let token_tag = make_token_tag(4);
 
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &member_account.pubkey,
             &group_id,
@@ -1728,7 +1746,7 @@ mod tests {
             &token_tag.server_pubkey,
             Some(&token_tag.relay_hint),
             &token_tag.encrypted_token.to_base64(),
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -1744,7 +1762,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -1896,6 +1914,12 @@ mod tests {
             .expect("removed member leaf should exist before removal");
         let stale_token = make_token_tag(8);
 
+        let member_two_pool = &whitenoise
+            .require_session(&member_two.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &member_two.pubkey,
             &group_id,
@@ -1904,7 +1928,7 @@ mod tests {
             &stale_token.server_pubkey,
             Some(&stale_token.relay_hint),
             &stale_token.encrypted_token.to_base64(),
-            &whitenoise.shared.database,
+            member_two_pool,
         )
         .await
         .unwrap();
@@ -1927,7 +1951,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_two.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_two_pool,
         )
         .await
         .unwrap();

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -461,10 +461,11 @@ impl Whitenoise {
     #[allow(deprecated)]
     #[perf_instrument("groups")]
     pub async fn leave_group(&self, account: &Account, group_id: &GroupId) -> Result<()> {
+        let session = self.require_session(&account.pubkey)?;
         let account_group = AccountGroup::find_by_account_and_group(
             &account.pubkey,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?
         .ok_or(WhitenoiseError::GroupNotFound)?;
@@ -686,10 +687,11 @@ mod tests {
         }
 
         // Verify AccountGroup was created and auto-accepted for the creator
+        let session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let account_group = AccountGroup::find_by_account_and_group(
             &creator_account.pubkey,
             &group.mls_group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
@@ -1359,10 +1361,10 @@ mod tests {
             .unwrap();
 
         // Delete the auto-created AccountGroup so tests can recreate with desired state
-        sqlx::query("DELETE FROM accounts_groups WHERE account_pubkey = ? AND mls_group_id = ?")
-            .bind(account.pubkey.to_hex())
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        sqlx::query("DELETE FROM accounts_groups WHERE mls_group_id = ?")
             .bind(group.mls_group_id.as_slice())
-            .execute(&whitenoise.shared.database.pool)
+            .execute(&session.account_db.inner.pool)
             .await
             .unwrap();
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -230,7 +230,7 @@ impl Whitenoise {
         // Best-effort read of `accounts.pubkey`. Fresh installs (no table yet)
         // return an empty list; that's fine — there's nothing to migrate.
         let mut pubkeys: HashSet<String> = accounts::Account::all_pubkeys_hex(shared)
-            .await
+            .await?
             .into_iter()
             .collect();
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -229,20 +229,10 @@ impl Whitenoise {
 
         // Best-effort read of `accounts.pubkey`. Fresh installs (no table yet)
         // return an empty list; that's fine — there's nothing to migrate.
-        let mut pubkeys: HashSet<String> =
-            match sqlx::query_scalar::<_, String>("SELECT pubkey FROM accounts")
-                .fetch_all(&shared.pool)
-                .await
-            {
-                Ok(rows) => rows.into_iter().collect(),
-                Err(e) => {
-                    tracing::debug!(
-                        target: "whitenoise::new",
-                        "No accounts table yet (fresh install or pre-bridge): {e}"
-                    );
-                    HashSet::new()
-                }
-            };
+        let mut pubkeys: HashSet<String> = accounts::Account::all_pubkeys_hex(shared)
+            .await
+            .into_iter()
+            .collect();
 
         // Also include any per-account DB files on disk that aren't in
         // `shared.accounts` — orphan files still deserve their own migration
@@ -1897,9 +1887,9 @@ mod tests {
             .unwrap();
         }
 
-        /// Create the minimal user + account + accounts_groups rows for a
-        /// raw pubkey so that `chat_cleared_at_ms` (and similar methods) can
-        /// find the account-group association.
+        /// Create the minimal user + account + session + accounts_groups rows
+        /// for a raw pubkey so that `chat_cleared_at_ms` (and similar methods)
+        /// can find the account-group association.
         async fn setup_account_group(
             pubkey: &nostr_sdk::PublicKey,
             group_id: &GroupId,
@@ -1923,7 +1913,7 @@ mod tests {
                 .fetch_one(&whitenoise.shared.database.pool)
                 .await
                 .unwrap();
-            // account row (FK target for accounts_groups)
+            // account row
             sqlx::query(
                 "INSERT OR IGNORE INTO accounts \
                  (pubkey, user_id, account_type, created_at, updated_at) \
@@ -1936,12 +1926,29 @@ mod tests {
             .execute(&whitenoise.shared.database.pool)
             .await
             .unwrap();
-            // accounts_groups row
+            // Create and register a session so require_session() works
+            if whitenoise.account_manager.get_session(pubkey).is_none() {
+                let mdk = whitenoise.create_mdk_for_account(*pubkey).unwrap();
+                let session = std::sync::Arc::new(
+                    session::AccountSession::new(
+                        *pubkey,
+                        mdk,
+                        whitenoise.shared.clone(),
+                        std::sync::Weak::new(),
+                        None,
+                    )
+                    .await
+                    .unwrap(),
+                );
+                whitenoise.account_manager.insert_session(session);
+            }
+            // accounts_groups row (per-account DB)
+            let session = whitenoise.require_session(pubkey).unwrap();
             accounts_groups::AccountGroup::find_or_create(
                 pubkey,
                 group_id,
                 None,
-                &whitenoise.shared.database,
+                &session.account_db.inner.pool,
             )
             .await
             .unwrap();

--- a/src/whitenoise/notification_streaming/mod.rs
+++ b/src/whitenoise/notification_streaming/mod.rs
@@ -231,10 +231,14 @@ impl Whitenoise {
         account_pubkey: &PublicKey,
         group_id: &GroupId,
     ) -> Option<&'static str> {
+        let session = match self.account_manager.get_session(account_pubkey) {
+            Some(s) => s,
+            None => return Some("no_session"),
+        };
         match AccountGroup::find_by_account_and_group(
             account_pubkey,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         {
@@ -601,6 +605,7 @@ mod tests {
         account_pubkey: &PublicKey,
         group_id: &GroupId,
     ) -> AccountGroup {
+        let session = whitenoise.require_session(account_pubkey).unwrap();
         let ag = AccountGroup {
             id: None,
             account_pubkey: *account_pubkey,
@@ -619,7 +624,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.shared.database).await.unwrap()
+        ag.save(&session.account_db.inner.pool).await.unwrap()
     }
 
     #[tokio::test]
@@ -651,7 +656,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.shared.database).await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        ag.save(&session.account_db.inner.pool).await.unwrap();
 
         whitenoise
             .emit_new_message_notification(
@@ -698,7 +704,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.shared.database).await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        ag.save(&session.account_db.inner.pool).await.unwrap();
 
         whitenoise
             .emit_new_message_notification(
@@ -771,7 +778,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.shared.database).await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        ag.save(&session.account_db.inner.pool).await.unwrap();
 
         whitenoise
             .emit_group_invite_notification(&account, &group_id, "Invite Group", welcomer)
@@ -812,7 +820,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        ag.save(&whitenoise.shared.database).await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        ag.save(&session.account_db.inner.pool).await.unwrap();
 
         assert_eq!(
             whitenoise
@@ -865,9 +874,10 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        let saved = ag.save(&whitenoise.shared.database).await.unwrap();
+        let session = whitenoise.require_session(account_pubkey).unwrap();
+        let saved = ag.save(&session.account_db.inner.pool).await.unwrap();
         saved
-            .update_muted_until(Some(muted_until), &whitenoise.shared.database)
+            .update_muted_until(Some(muted_until), &session.account_db.inner.pool)
             .await
             .unwrap();
     }

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -24,6 +24,7 @@ use mdk_core::prelude::{GroupId, MDK, group_types::GroupState};
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::{EventId, Kind, PublicKey, RelayUrl};
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
 
 use crate::whitenoise::{
     Whitenoise, WhitenoiseConfig,
@@ -181,11 +182,10 @@ pub(crate) fn is_push_group_message_kind(kind: Kind) -> bool {
 async fn group_push_token_tags_for_response_with(
     account_pubkey: &PublicKey,
     group_id: &GroupId,
-    database: &Database,
+    pool: &SqlitePool,
     mdk: &MDK<MdkSqliteStorage>,
 ) -> Result<Vec<LeafTokenTag>> {
-    let tokens =
-        GroupPushToken::find_by_account_and_group(account_pubkey, group_id, database).await?;
+    let tokens = GroupPushToken::find_by_account_and_group(account_pubkey, group_id, pool).await?;
     let active_leaf_map = mdk.group_leaf_map(group_id)?;
 
     let mut response_tokens = Vec::with_capacity(tokens.len());
@@ -273,14 +273,14 @@ pub(crate) async fn publish_push_group_message_with(
 #[perf_instrument("push_notifications")]
 pub(crate) async fn respond_to_token_request_with(
     mdk: &MDK<MdkSqliteStorage>,
-    database: &Database,
+    pool: &SqlitePool,
     relay_control: &RelayControlPlane,
     account_pubkey: &PublicKey,
     group_id: &GroupId,
     request_event_id: EventId,
 ) -> Result<()> {
     let token_tags =
-        group_push_token_tags_for_response_with(account_pubkey, group_id, database, mdk).await?;
+        group_push_token_tags_for_response_with(account_pubkey, group_id, pool, mdk).await?;
 
     if token_tags.is_empty() {
         return Ok(());
@@ -562,6 +562,7 @@ async fn publish_notification_batches_best_effort(
 pub(crate) async fn publish_notification_requests_after_delivery_with(
     config: &WhitenoiseConfig,
     database: &Database,
+    account_pool: &SqlitePool,
     relay_control: &RelayControlPlane,
     event_tracker: &Arc<dyn EventTracker>,
     ephemeral: &EphemeralPlane,
@@ -580,7 +581,7 @@ pub(crate) async fn publish_notification_requests_after_delivery_with(
             )
         })?;
     let cached_tokens =
-        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, database).await?;
+        GroupPushToken::find_by_account_and_group(&account_pubkey, group_id, account_pool).await?;
     let recipient_tokens = prepare_notification_recipient_tokens(
         &account_pubkey,
         &cached_tokens,
@@ -638,10 +639,8 @@ impl Whitenoise {
     )]
     #[perf_instrument("push_notifications")]
     pub async fn push_registration(&self, account: &Account) -> Result<Option<PushRegistration>> {
-        Ok(
-            PushRegistration::find_by_account_pubkey(&account.pubkey, &self.shared.database)
-                .await?,
-        )
+        let session = self.require_session(&account.pubkey)?;
+        Ok(PushRegistration::find(&account.pubkey, &session.account_db.inner.pool).await?)
     }
 
     /// Creates or replaces the locally stored push registration for `account`.
@@ -686,12 +685,8 @@ impl Whitenoise {
         // Validate the session and notification preference BEFORE persisting
         // the upsert. If the session lookup fails, we don't want a stale
         // push_registrations row to outlive the missing session.
-        let notifications_enabled = self
-            .require_session(&account.pubkey)?
-            .repos
-            .settings
-            .notifications_enabled()
-            .await?;
+        let session = self.require_session(&account.pubkey)?;
+        let notifications_enabled = session.repos.settings.notifications_enabled().await?;
 
         let registration = PushRegistration::upsert(
             &account.pubkey,
@@ -699,7 +694,7 @@ impl Whitenoise {
             raw_token,
             server_pubkey,
             relay_hint,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?;
 
@@ -739,7 +734,8 @@ impl Whitenoise {
     )]
     #[perf_instrument("push_notifications")]
     pub async fn clear_push_registration(&self, account: &Account) -> Result<()> {
-        PushRegistration::delete_by_account_pubkey(&account.pubkey, &self.shared.database).await?;
+        let session = self.require_session(&account.pubkey)?;
+        PushRegistration::delete(&session.account_db.inner.pool).await?;
 
         if let Err(error) = self
             .remove_local_push_token_from_joined_groups(account)
@@ -843,11 +839,11 @@ impl Whitenoise {
                     return Ok(true);
                 }
 
+                let session = self.require_session(&account.pubkey)?;
                 GroupPushToken::delete(
-                    &account.pubkey,
                     &message.mls_group_id,
                     leaf_index,
-                    &self.shared.database,
+                    &session.account_db.inner.pool,
                 )
                 .await?;
             }
@@ -1036,10 +1032,11 @@ impl Whitenoise {
             }
         };
 
-        let database = Arc::clone(&self.shared.database);
         let relay_control = Arc::clone(&self.shared.relay_control);
         let pending = Arc::clone(&self.shared.pending_push_token_responses);
         let config = self.config().clone();
+        let account_db_path =
+            crate::whitenoise::session::account_db_path(&config.data_dir, &account.pubkey);
         #[cfg(not(test))]
         let delay_ms = ::rand::rng().random_range(1_000..=3_000);
         #[cfg(test)]
@@ -1072,9 +1069,28 @@ impl Whitenoise {
                 }
             };
 
+            let account_db = match crate::whitenoise::database::account_db::AccountDatabase::new(
+                account.pubkey,
+                account_db_path.clone(),
+            )
+            .await
+            {
+                Ok(db) => db,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "whitenoise::push_notifications",
+                        account = %account.pubkey.to_hex(),
+                        error = %error,
+                        "Failed to open account DB for delayed MIP-05 token-list response"
+                    );
+                    drop(permit);
+                    return;
+                }
+            };
+
             if let Err(error) = respond_to_token_request_with(
                 &mdk,
-                &database,
+                &account_db.inner.pool,
                 &relay_control,
                 &account.pubkey,
                 &group_id,
@@ -1110,10 +1126,14 @@ impl Whitenoise {
         if group_state != GroupState::Active {
             return false;
         }
+        let session = match self.account_manager.get_session(&account.pubkey) {
+            Some(s) => s,
+            None => return false,
+        };
         match AccountGroup::find_by_account_and_group(
             &account.pubkey,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         {
@@ -1282,6 +1302,7 @@ impl Whitenoise {
             ));
         };
 
+        let session = self.require_session(&account.pubkey)?;
         GroupPushToken::upsert(
             &account.pubkey,
             mls_group_id,
@@ -1290,7 +1311,7 @@ impl Whitenoise {
             &token.server_pubkey,
             Some(&token.relay_hint),
             &token.encrypted_token.to_base64(),
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?;
 
@@ -1306,13 +1327,13 @@ impl Whitenoise {
         response: mdk_core::mip05::TokenListResponse,
     ) -> Result<()> {
         let active_leaf_map = mdk.group_leaf_map(mls_group_id)?;
+        let session = self.require_session(&account.pubkey)?;
 
         GroupPushToken::upsert_active_token_list_response(
-            &account.pubkey,
             mls_group_id,
             &active_leaf_map,
             response.tokens,
-            &self.shared.database,
+            &session.account_db.inner.pool,
         )
         .await?;
 
@@ -1328,6 +1349,7 @@ impl Whitenoise {
         token_tag: Option<&TokenTag>,
     ) -> Result<()> {
         let leaf_index = mdk.own_leaf_index(group_id)?;
+        let session = self.require_session(&account.pubkey)?;
 
         match token_tag {
             Some(token_tag) => {
@@ -1339,18 +1361,13 @@ impl Whitenoise {
                     &token_tag.server_pubkey,
                     Some(&token_tag.relay_hint),
                     &token_tag.encrypted_token.to_base64(),
-                    &self.shared.database,
+                    &session.account_db.inner.pool,
                 )
                 .await?;
             }
             None => {
-                GroupPushToken::delete(
-                    &account.pubkey,
-                    group_id,
-                    leaf_index,
-                    &self.shared.database,
-                )
-                .await?;
+                GroupPushToken::delete(group_id, leaf_index, &session.account_db.inner.pool)
+                    .await?;
             }
         }
 
@@ -1487,10 +1504,12 @@ mod tests {
         group_id: &GroupId,
     ) -> Result<()> {
         let ephemeral = whitenoise.shared.relay_control.ephemeral();
+        let session = whitenoise.require_session(&account.pubkey)?;
 
         publish_notification_requests_after_delivery_with(
             whitenoise.config(),
             &whitenoise.shared.database,
+            &session.account_db.inner.pool,
             &whitenoise.shared.relay_control,
             &whitenoise.shared.event_tracker,
             &ephemeral,
@@ -1788,6 +1807,12 @@ mod tests {
         let member_two_pubkey = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
 
+        let account_pool = &whitenoise
+            .require_session(&account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let first_token = GroupPushToken::upsert(
             &account.pubkey,
             &group_id,
@@ -1796,7 +1821,7 @@ mod tests {
             &server_pubkey,
             Some(&relay_hint),
             "ciphertext-one",
-            &whitenoise.shared.database,
+            account_pool,
         )
         .await
         .unwrap();
@@ -1808,7 +1833,7 @@ mod tests {
             &server_pubkey,
             Some(&relay_hint),
             "ciphertext-two",
-            &whitenoise.shared.database,
+            account_pool,
         )
         .await
         .unwrap();
@@ -2010,7 +2035,12 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &whitenoise
+                .require_session(&admin_account.pubkey)
+                .unwrap()
+                .account_db
+                .inner
+                .pool,
         )
         .await
         .unwrap();
@@ -2074,6 +2104,12 @@ mod tests {
         )
         .unwrap();
 
+        let admin_pool = &whitenoise
+            .require_session(&admin_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &admin_account.pubkey,
             &group_id,
@@ -2082,7 +2118,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &sender_token,
-            &whitenoise.shared.database,
+            admin_pool,
         )
         .await
         .unwrap();
@@ -2094,7 +2130,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &recipient_token.to_base64(),
-            &whitenoise.shared.database,
+            admin_pool,
         )
         .await
         .unwrap();
@@ -2200,6 +2236,12 @@ mod tests {
         )
         .unwrap();
 
+        let admin_pool = &whitenoise
+            .require_session(&admin_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &admin_account.pubkey,
             &group_id,
@@ -2208,7 +2250,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &sender_token,
-            &whitenoise.shared.database,
+            admin_pool,
         )
         .await
         .unwrap();
@@ -2220,7 +2262,7 @@ mod tests {
             &server_account.pubkey,
             Some(&server_relay_urls[0]),
             &recipient_token.to_base64(),
-            &whitenoise.shared.database,
+            admin_pool,
         )
         .await
         .unwrap();
@@ -2361,6 +2403,12 @@ mod tests {
         let unreachable_server_pubkey = Keys::generate().public_key();
         let unreachable_relay = RelayUrl::parse("ws://127.0.0.1:1").unwrap();
 
+        let creator_pool = &whitenoise
+            .require_session(&creator.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &creator.pubkey,
             &group_id,
@@ -2369,7 +2417,7 @@ mod tests {
             &unreachable_server_pubkey,
             Some(&unreachable_relay),
             &encrypted_fcm_token_base64(&unreachable_server_pubkey, "bad-recipient-device"),
-            &whitenoise.shared.database,
+            creator_pool,
         )
         .await
         .unwrap();
@@ -2378,6 +2426,7 @@ mod tests {
         publish_notification_requests_after_delivery_with(
             whitenoise.config(),
             &whitenoise.shared.database,
+            creator_pool,
             &whitenoise.shared.relay_control,
             &whitenoise.shared.event_tracker,
             &ephemeral,
@@ -2571,7 +2620,12 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &admin_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &whitenoise
+                .require_session(&admin_account.pubkey)
+                .unwrap()
+                .account_db
+                .inner
+                .pool,
         )
         .await
         .unwrap();
@@ -2661,6 +2715,12 @@ mod tests {
         let server_pubkey = Keys::generate().public_key();
         let relay_hint = RelayUrl::parse("wss://push.example.com").unwrap();
 
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         GroupPushToken::upsert(
             &member_account.pubkey,
             &group_id,
@@ -2669,7 +2729,7 @@ mod tests {
             &server_pubkey,
             Some(&relay_hint),
             "ciphertext-one",
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -2685,7 +2745,7 @@ mod tests {
         let stored = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -2729,7 +2789,12 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            &whitenoise
+                .require_session(&member_account.pubkey)
+                .unwrap()
+                .account_db
+                .inner
+                .pool,
         )
         .await
         .unwrap();
@@ -2772,13 +2837,16 @@ mod tests {
             .await
             .unwrap();
 
-        let cached_before_disable = GroupPushToken::find_by_account_and_group(
-            &admin_account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let admin_pool = &whitenoise
+            .require_session(&admin_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
+        let cached_before_disable =
+            GroupPushToken::find_by_account_and_group(&admin_account.pubkey, &group_id, admin_pool)
+                .await
+                .unwrap();
         assert!(
             cached_before_disable
                 .iter()
@@ -2813,13 +2881,10 @@ mod tests {
         tokio::time::resume();
         assert!(!settings.notifications_enabled);
 
-        let cached_after_disable = GroupPushToken::find_by_account_and_group(
-            &admin_account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let cached_after_disable =
+            GroupPushToken::find_by_account_and_group(&admin_account.pubkey, &group_id, admin_pool)
+                .await
+                .unwrap();
         assert!(
             cached_after_disable
                 .iter()
@@ -2928,13 +2993,16 @@ mod tests {
             .unwrap()
             .own_leaf_index(&group_id)
             .unwrap();
-        let cached_after_share = GroupPushToken::find_by_account_and_group(
-            &admin_account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let admin_pool = &whitenoise
+            .require_session(&admin_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
+        let cached_after_share =
+            GroupPushToken::find_by_account_and_group(&admin_account.pubkey, &group_id, admin_pool)
+                .await
+                .unwrap();
         assert!(
             cached_after_share
                 .iter()
@@ -2959,13 +3027,10 @@ mod tests {
             wait_for_published_event_count(&whitenoise, &admin_account, after_share_count).await;
         assert!(after_removal_count > after_share_count);
 
-        let cached_after_removal = GroupPushToken::find_by_account_and_group(
-            &admin_account.pubkey,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let cached_after_removal =
+            GroupPushToken::find_by_account_and_group(&admin_account.pubkey, &group_id, admin_pool)
+                .await
+                .unwrap();
         assert!(
             cached_after_removal
                 .iter()
@@ -3120,10 +3185,16 @@ mod tests {
         .await;
 
         // Before acceptance: no token cached for the member.
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let cached_before = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -3149,7 +3220,7 @@ mod tests {
         let cached_after = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -3205,10 +3276,16 @@ mod tests {
             .unwrap();
 
         // The accepted group should have the member's token cached.
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let accepted_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &accepted_group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -3223,7 +3300,7 @@ mod tests {
         let pending_tokens = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &pending_group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -3275,7 +3352,12 @@ mod tests {
         let cached_tokens = GroupPushToken::find_by_account_and_group(
             &creator.pubkey,
             &group.mls_group_id,
-            &whitenoise.shared.database,
+            &whitenoise
+                .require_session(&creator.pubkey)
+                .unwrap()
+                .account_db
+                .inner
+                .pool,
         )
         .await
         .unwrap();
@@ -3326,10 +3408,16 @@ mod tests {
             .await
             .unwrap();
 
+        let member_pool = &whitenoise
+            .require_session(&member_account.pubkey)
+            .unwrap()
+            .account_db
+            .inner
+            .pool;
         let cached_before = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();
@@ -3350,7 +3438,7 @@ mod tests {
         let cached_after = GroupPushToken::find_by_account_and_group(
             &member_account.pubkey,
             &group_id,
-            &whitenoise.shared.database,
+            member_pool,
         )
         .await
         .unwrap();

--- a/src/whitenoise/scheduled_tasks/tasks/mute_expiry_cleanup.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/mute_expiry_cleanup.rs
@@ -32,9 +32,18 @@ impl Task for MuteExpiryCleanup {
 
     #[perf_instrument("scheduled::mute_expiry_cleanup")]
     async fn execute(&self, whitenoise: std::sync::Arc<Whitenoise>) -> Result<(), WhitenoiseError> {
-        let cleared = AccountGroup::clear_expired_mutes(&whitenoise.shared.database).await?;
+        let mut all_cleared = Vec::new();
 
-        if cleared.is_empty() {
+        for session in whitenoise.account_manager.sessions_iter() {
+            let cleared = AccountGroup::clear_expired_mutes(
+                &session.account_pubkey,
+                &session.account_db.inner.pool,
+            )
+            .await?;
+            all_cleared.extend(cleared);
+        }
+
+        if all_cleared.is_empty() {
             tracing::debug!(
                 target: "whitenoise::scheduler::mute_expiry_cleanup",
                 "No expired mutes to clear"
@@ -45,11 +54,11 @@ impl Task for MuteExpiryCleanup {
         tracing::info!(
             target: "whitenoise::scheduler::mute_expiry_cleanup",
             "Cleared {} expired mute(s)",
-            cleared.len()
+            all_cleared.len()
         );
 
         // Emit ChatMuteChanged for each cleared mute so the UI updates.
-        for ag in &cleared {
+        for ag in &all_cleared {
             match Account::find_by_pubkey(&ag.account_pubkey, &whitenoise.shared.database).await {
                 Ok(account) => {
                     whitenoise

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -166,7 +166,7 @@ impl<'a> ChatListOps<'a> {
         let account_group = AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
-            &self.session.shared.database,
+            &self.session.account_db.inner.pool,
         )
         .await?;
         let Some(membership) = account_group else {
@@ -217,13 +217,11 @@ impl<'a> ChatListOps<'a> {
                 .collect::<HashMap<_, _>>()
         };
 
-        let dm_other_users: HashMap<GroupId, PublicKey> = AccountGroup::find_dm_peers_for_account(
-            &self.session.account_pubkey,
-            &self.session.shared.database,
-        )
-        .await?
-        .into_iter()
-        .collect();
+        let dm_other_users: HashMap<GroupId, PublicKey> =
+            AccountGroup::find_dm_peers_for_account(&self.session.account_db.inner.pool)
+                .await?
+                .into_iter()
+                .collect();
 
         let last_message_map: HashMap<GroupId, ChatMessageSummary> =
             AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.shared.database)

--- a/src/whitenoise/session/groups/mod.rs
+++ b/src/whitenoise/session/groups/mod.rs
@@ -72,7 +72,7 @@ impl<'a> GroupOps<'a> {
 
         let visible_account_groups = AccountGroup::find_visible_for_account(
             &self.session.account_pubkey,
-            &self.session.shared.database,
+            &self.session.account_db.inner.pool,
         )
         .await?;
 
@@ -433,7 +433,7 @@ impl<'a> GroupOps<'a> {
         let account_group = AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
-            database,
+            &self.session.account_db.inner.pool,
         )
         .await?
         .ok_or(WhitenoiseError::GroupNotFound)?;
@@ -663,11 +663,11 @@ impl<'a> GroupOps<'a> {
             &self.session.account_pubkey,
             &group.mls_group_id,
             dm_peer,
-            &self.session.shared.database,
+            &self.session.account_db.inner.pool,
         )
         .await?;
         account_group
-            .update_user_confirmation(true, &self.session.shared.database)
+            .update_user_confirmation(true, &self.session.account_db.inner.pool)
             .await?;
 
         // Best-effort: share the creator's push token into the new group.

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -368,7 +368,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         // Delete draft (best-effort).
         if let Err(e) = self.session.repos.drafts.delete(self.group_id).await {
             tracing::warn!(
-                target: "whitenoise::membership",
+                target: "whitenoise::session::membership",
                 "Failed to delete draft during clear_chat: {e}"
             );
         }
@@ -378,7 +378,7 @@ impl<'a> MembershipOpsForGroup<'a> {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(
-                    target: "whitenoise::membership",
+                    target: "whitenoise::session::membership",
                     "resolve_min_cleared_at failed; skipping cleanup: {e}"
                 );
                 None
@@ -390,7 +390,7 @@ impl<'a> MembershipOpsForGroup<'a> {
             .await
         {
             tracing::warn!(
-                target: "whitenoise::membership",
+                target: "whitenoise::session::membership",
                 "Failed to cleanup cleared messages: {e}"
             );
         }
@@ -398,7 +398,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         // Delete MDK message state (best-effort).
         if let Err(e) = self.session.mdk.delete_messages_for_group(self.group_id) {
             tracing::warn!(
-                target: "whitenoise::membership",
+                target: "whitenoise::session::membership",
                 "Failed to delete MDK messages during clear_chat: {e}"
             );
         }

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -62,47 +62,95 @@ impl<'a> MembershipOps<'a> {
 
     /// Mark a message as read for this account.
     ///
-    /// Looks up the message to find its group, then atomically advances the
-    /// read marker only if the new message is newer than the current one.
+    /// Looks up the message to find its group, then advances the read marker
+    /// only if the new message is newer than the current one. Uses CAS
+    /// (compare-and-swap on `last_read_message_id`) to handle concurrent
+    /// writers without cross-DB subqueries.
     pub async fn mark_message_read(&self, message_id: &EventId) -> Result<AccountGroup> {
         let message = AggregatedMessage::find_by_message_id(message_id, self.db())
             .await?
             .ok_or(WhitenoiseError::MessageNotFound)?;
 
-        let account_group = AccountGroup::find_by_account_and_group(
+        let message_created_at_ms = message.created_at.timestamp_millis();
+
+        // CAS retry loop: re-read the marker if another writer changed it
+        // between our read and our UPDATE (max 3 attempts).
+        for _ in 0..3 {
+            let account_group = AccountGroup::find_by_account_and_group(
+                self.pubkey(),
+                &message.mls_group_id,
+                self.pool(),
+            )
+            .await?
+            .ok_or(WhitenoiseError::GroupNotFound)?;
+
+            // Phase 18e: switch to account pool once aggregated_messages moves.
+            let current_marker_ts = match &account_group.last_read_message_id {
+                Some(marker_id) => AggregatedMessage::created_at_ms_for_message(
+                    marker_id,
+                    &message.mls_group_id,
+                    self.db(),
+                )
+                .await?
+                .unwrap_or(0),
+                None => 0,
+            };
+
+            match account_group
+                .update_last_read_if_newer(
+                    message_id,
+                    message_created_at_ms,
+                    account_group.last_read_message_id.as_ref(),
+                    current_marker_ts,
+                    self.pool(),
+                )
+                .await?
+            {
+                Some(updated) => return Ok(updated),
+                None => {
+                    // Either the message isn't newer (expected skip) or the
+                    // CAS guard failed (concurrent writer). Re-read to
+                    // distinguish: if the marker is now >= our message, the
+                    // skip was correct and we're done.
+                    let refreshed = AccountGroup::find_by_account_and_group(
+                        self.pubkey(),
+                        &message.mls_group_id,
+                        self.pool(),
+                    )
+                    .await?
+                    .ok_or(WhitenoiseError::GroupNotFound)?;
+
+                    let refreshed_ts = match &refreshed.last_read_message_id {
+                        Some(mid) => AggregatedMessage::created_at_ms_for_message(
+                            mid,
+                            &message.mls_group_id,
+                            self.db(),
+                        )
+                        .await?
+                        .unwrap_or(0),
+                        None => 0,
+                    };
+                    if refreshed_ts >= message_created_at_ms {
+                        // Another writer advanced past our message — done.
+                        return Ok(refreshed);
+                    }
+                    // CAS miss: marker changed but is still behind our
+                    // message. Retry with the fresh state.
+                    continue;
+                }
+            }
+        }
+
+        // Exhausted retries — return current state. This is benign: the
+        // marker will be corrected on the next mark_message_read call.
+        let current = AccountGroup::find_by_account_and_group(
             self.pubkey(),
             &message.mls_group_id,
             self.pool(),
         )
         .await?
         .ok_or(WhitenoiseError::GroupNotFound)?;
-
-        let message_created_at_ms = message.created_at.timestamp_millis();
-        // Phase 18e: switch to account pool once aggregated_messages moves.
-        let current_marker_ts = match &account_group.last_read_message_id {
-            Some(marker_id) => AggregatedMessage::created_at_ms_for_message(
-                marker_id,
-                &message.mls_group_id,
-                self.db(),
-            )
-            .await?
-            .unwrap_or(0),
-            None => 0,
-        };
-        if let Some(updated) = account_group
-            .update_last_read_if_newer(
-                message_id,
-                message_created_at_ms,
-                current_marker_ts,
-                self.pool(),
-            )
-            .await?
-        {
-            return Ok(updated);
-        }
-
-        // Update was skipped (message not newer), return current state.
-        Ok(account_group)
+        Ok(current)
     }
 
     /// Return the group ID of the latest DM group with `peer_pubkey`, if any.

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -78,6 +78,7 @@ impl<'a> MembershipOps<'a> {
         .ok_or(WhitenoiseError::GroupNotFound)?;
 
         let message_created_at_ms = message.created_at.timestamp_millis();
+        // Phase 18e: switch to account pool once aggregated_messages moves.
         let current_marker_ts = match &account_group.last_read_message_id {
             Some(marker_id) => AggregatedMessage::created_at_ms_for_message(
                 marker_id,

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -10,8 +10,10 @@ use std::sync::Arc;
 use chrono::Utc;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::{EventId, PublicKey};
+use sqlx::SqlitePool;
 
 use super::AccountSession;
+use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::{AccountGroup, MuteDuration};
 use crate::whitenoise::aggregated_message::AggregatedMessage;
 use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
@@ -44,14 +46,18 @@ impl<'a> MembershipOps<'a> {
         &self.session.shared.database
     }
 
+    fn pool(&self) -> &SqlitePool {
+        &self.session.account_db.inner.pool
+    }
+
     /// Return all visible (pending + accepted) account-group memberships.
     pub async fn visible_groups(&self) -> Result<Vec<AccountGroup>> {
-        Ok(AccountGroup::find_visible_for_account(self.pubkey(), self.db()).await?)
+        Ok(AccountGroup::find_visible_for_account(self.pubkey(), self.pool()).await?)
     }
 
     /// Return all pending (awaiting user confirmation) account-group memberships.
     pub async fn pending_groups(&self) -> Result<Vec<AccountGroup>> {
-        Ok(AccountGroup::find_pending_for_account(self.pubkey(), self.db()).await?)
+        Ok(AccountGroup::find_pending_for_account(self.pubkey(), self.pool()).await?)
     }
 
     /// Mark a message as read for this account.
@@ -66,14 +72,29 @@ impl<'a> MembershipOps<'a> {
         let account_group = AccountGroup::find_by_account_and_group(
             self.pubkey(),
             &message.mls_group_id,
-            self.db(),
+            self.pool(),
         )
         .await?
         .ok_or(WhitenoiseError::GroupNotFound)?;
 
         let message_created_at_ms = message.created_at.timestamp_millis();
+        let current_marker_ts = match &account_group.last_read_message_id {
+            Some(marker_id) => AggregatedMessage::created_at_ms_for_message(
+                marker_id,
+                &message.mls_group_id,
+                self.db(),
+            )
+            .await?
+            .unwrap_or(0),
+            None => 0,
+        };
         if let Some(updated) = account_group
-            .update_last_read_if_newer(message_id, message_created_at_ms, self.db())
+            .update_last_read_if_newer(
+                message_id,
+                message_created_at_ms,
+                current_marker_ts,
+                self.pool(),
+            )
             .await?
         {
             return Ok(updated);
@@ -85,7 +106,7 @@ impl<'a> MembershipOps<'a> {
 
     /// Return the group ID of the latest DM group with `peer_pubkey`, if any.
     pub async fn dm_group_with_peer(&self, peer_pubkey: &PublicKey) -> Result<Option<GroupId>> {
-        Ok(AccountGroup::find_dm_group_id_by_peer(self.pubkey(), peer_pubkey, self.db()).await?)
+        Ok(AccountGroup::find_dm_group_id_by_peer(peer_pubkey, self.pool()).await?)
     }
 }
 
@@ -106,9 +127,13 @@ impl<'a> MembershipOpsForGroup<'a> {
         &self.session.shared.database
     }
 
+    fn pool(&self) -> &SqlitePool {
+        &self.session.account_db.inner.pool
+    }
+
     /// Load the account-group row, returning `GroupNotFound` if absent.
     async fn require_account_group(&self) -> Result<AccountGroup> {
-        AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+        AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.pool())
             .await?
             .ok_or(WhitenoiseError::GroupNotFound)
     }
@@ -133,7 +158,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         dm_peer_pubkey: Option<&PublicKey>,
     ) -> Result<(AccountGroup, bool)> {
         Ok(
-            AccountGroup::find_or_create(self.pubkey(), self.group_id, dm_peer_pubkey, self.db())
+            AccountGroup::find_or_create(self.pubkey(), self.group_id, dm_peer_pubkey, self.pool())
                 .await?,
         )
     }
@@ -141,7 +166,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     /// Return the last-read message ID for this account in this group.
     pub async fn last_read_message_id(&self) -> Result<Option<EventId>> {
         let account_group =
-            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.pool())
                 .await?;
         Ok(account_group.and_then(|ag| ag.last_read_message_id))
     }
@@ -156,7 +181,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     pub async fn accept(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
         Ok(account_group
-            .update_user_confirmation(true, self.db())
+            .update_user_confirmation(true, self.pool())
             .await?)
     }
 
@@ -168,7 +193,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     pub async fn decline(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
         Ok(account_group
-            .update_user_confirmation(false, self.db())
+            .update_user_confirmation(false, self.pool())
             .await?)
     }
 
@@ -179,7 +204,9 @@ impl<'a> MembershipOpsForGroup<'a> {
     /// `None` = unpin, `Some(n)` = pin at order n (lower values first).
     pub async fn set_pin_order(&self, pin_order: Option<i64>) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
-        Ok(account_group.update_pin_order(pin_order, self.db()).await?)
+        Ok(account_group
+            .update_pin_order(pin_order, self.pool())
+            .await?)
     }
 
     // ── Archive ───────────────────────────────────────────────────
@@ -191,7 +218,7 @@ impl<'a> MembershipOpsForGroup<'a> {
             return Ok(account_group);
         }
         let updated = account_group
-            .update_archived_at(Some(Utc::now()), self.db())
+            .update_archived_at(Some(Utc::now()), self.pool())
             .await?;
         self.emit_chat_list_update(ChatListUpdateTrigger::ChatArchiveChanged)
             .await;
@@ -204,7 +231,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         if !account_group.is_archived() {
             return Ok(account_group);
         }
-        let updated = account_group.update_archived_at(None, self.db()).await?;
+        let updated = account_group.update_archived_at(None, self.pool()).await?;
         self.emit_chat_list_update(ChatListUpdateTrigger::ChatArchiveChanged)
             .await;
         Ok(updated)
@@ -226,7 +253,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         }
         let account_group = self.require_account_group().await?;
         let updated = account_group
-            .update_muted_until(Some(until), self.db())
+            .update_muted_until(Some(until), self.pool())
             .await?;
         self.emit_chat_list_update(ChatListUpdateTrigger::ChatMuteChanged)
             .await;
@@ -237,7 +264,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     /// mute already expired.
     pub async fn unmute(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
-        let updated = account_group.update_muted_until(None, self.db()).await?;
+        let updated = account_group.update_muted_until(None, self.pool()).await?;
         self.emit_chat_list_update(ChatListUpdateTrigger::ChatMuteChanged)
             .await;
         Ok(updated)
@@ -251,7 +278,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     /// changes.
     pub(crate) async fn mark_as_left(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
-        let Some(updated) = account_group.mark_left_atomic(self.db()).await? else {
+        let Some(updated) = account_group.mark_left_atomic(self.pool()).await? else {
             // Already departed — reload current state.
             return self.require_account_group().await;
         };
@@ -266,7 +293,7 @@ impl<'a> MembershipOpsForGroup<'a> {
     /// the row changes.
     pub(crate) async fn mark_as_removed(&self) -> Result<AccountGroup> {
         let account_group = self.require_account_group().await?;
-        let Some(updated) = account_group.mark_removed_atomic(self.db()).await? else {
+        let Some(updated) = account_group.mark_removed_atomic(self.pool()).await? else {
             // Another task won the atomic update — reload persisted state.
             return self.require_account_group().await;
         };
@@ -286,7 +313,7 @@ impl<'a> MembershipOpsForGroup<'a> {
         let account_group = self.require_account_group().await?;
 
         account_group
-            .clear_chat_state(Utc::now(), self.db())
+            .clear_chat_state(Utc::now(), self.pool())
             .await?;
 
         // Delete draft (best-effort).
@@ -298,7 +325,21 @@ impl<'a> MembershipOpsForGroup<'a> {
         }
 
         // Cleanup aggregated messages that all accounts have cleared (best-effort).
-        if let Err(e) = self.db().try_cleanup_cleared_messages(self.group_id).await {
+        let min_cleared_at = match self.resolve_min_cleared_at().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::membership",
+                    "resolve_min_cleared_at failed; skipping cleanup: {e}"
+                );
+                None
+            }
+        };
+        if let Err(e) = self
+            .db()
+            .try_cleanup_cleared_messages(self.group_id, min_cleared_at)
+            .await
+        {
             tracing::warn!(
                 target: "whitenoise::membership",
                 "Failed to cleanup cleared messages: {e}"
@@ -317,5 +358,55 @@ impl<'a> MembershipOpsForGroup<'a> {
             .await;
 
         Ok(())
+    }
+
+    /// Compute the minimum `chat_cleared_at` across all accounts for this
+    /// group, returning `Ok(Some(millis))` only when **every** account has a
+    /// non-null value. Returns `Ok(None)` if any account has not cleared or
+    /// if not all accounts have active sessions (conservative — avoids
+    /// premature message deletion). Returns `Err` on real DB failures so
+    /// the caller can log the concrete error.
+    async fn resolve_min_cleared_at(&self) -> Result<Option<i64>> {
+        let wn = self
+            .session
+            .whitenoise
+            .upgrade()
+            .ok_or(WhitenoiseError::Initialization)?;
+        let total_accounts = Account::count(&wn.shared.database).await?;
+        let mut sessions_checked: i64 = 0;
+        let mut min: Option<i64> = None;
+        for session in wn.account_manager.sessions_iter() {
+            sessions_checked += 1;
+            match AccountGroup::chat_cleared_at_ms(
+                &session.account_pubkey,
+                self.group_id,
+                &session.account_db.inner.pool,
+            )
+            .await
+            {
+                Ok(Some(ms)) => {
+                    min = Some(min.map_or(ms, |prev: i64| prev.min(ms)));
+                }
+                Ok(None) => return Ok(None),
+                Err(WhitenoiseError::GroupNotFound) => {
+                    // This session doesn't have this group — skip it.
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        // If not all accounts have active sessions, we can't be sure every
+        // account has cleared — return None to prevent premature deletion.
+        if sessions_checked < total_accounts {
+            tracing::warn!(
+                target: "whitenoise::session::membership",
+                checked = sessions_checked,
+                total = total_accounts,
+                "Not all accounts have active sessions; \
+                 skipping cleared-message cleanup"
+            );
+            return Ok(None);
+        }
+        Ok(min)
     }
 }

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -41,7 +41,20 @@ impl<'a> MessageOps<'a> {
     /// Search messages across all groups.
     pub async fn search(&self, query: &str, limit: Option<u32>) -> Result<Vec<SearchResult>> {
         let limit_val = limit.unwrap_or(50);
-        Ok(AggregatedMessage::search_messages(self.pubkey(), query, limit_val, self.db()).await?)
+        let pool = &self.session.account_db.inner.pool;
+        let visible = AccountGroup::find_visible_for_account(self.pubkey(), pool).await?;
+        let visible_group_ids: Vec<Vec<u8>> = visible
+            .iter()
+            .map(|ag| ag.mls_group_id.as_slice().to_vec())
+            .collect();
+        Ok(AggregatedMessage::search_messages(
+            self.pubkey(),
+            query,
+            limit_val,
+            &visible_group_ids,
+            self.db(),
+        )
+        .await?)
     }
 
     fn pubkey(&self) -> &PublicKey {
@@ -66,6 +79,10 @@ impl<'a> MessageOpsForGroup<'a> {
 
     fn db(&self) -> &Arc<Database> {
         &self.session.shared.database
+    }
+
+    fn pool(&self) -> &sqlx::SqlitePool {
+        &self.session.account_db.inner.pool
     }
 
     fn emit(&self, trigger: UpdateTrigger, message: ChatMessage) {
@@ -97,7 +114,7 @@ impl<'a> MessageOpsForGroup<'a> {
         limit: Option<u32>,
     ) -> Result<Vec<ChatMessage>> {
         let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.db()).await?;
+            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.pool()).await?;
 
         AggregatedMessage::find_messages_by_group_paginated(
             self.group_id,
@@ -124,7 +141,7 @@ impl<'a> MessageOpsForGroup<'a> {
         minimum: Option<u32>,
     ) -> Result<Vec<ChatMessage>> {
         let account_group =
-            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.db())
+            AccountGroup::find_by_account_and_group(self.pubkey(), self.group_id, self.pool())
                 .await?
                 .ok_or(WhitenoiseError::GroupNotFound)?;
 
@@ -152,7 +169,7 @@ impl<'a> MessageOpsForGroup<'a> {
     /// Search messages by content within this group.
     pub async fn search(&self, query: &str, limit: Option<u32>) -> Result<Vec<SearchResult>> {
         let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.db()).await?;
+            AccountGroup::chat_cleared_at_ms(self.pubkey(), self.group_id, self.pool()).await?;
 
         Ok(AggregatedMessage::search_messages_in_group(
             self.group_id,
@@ -304,6 +321,7 @@ impl<'a> MessageOpsForGroup<'a> {
         let ephemeral = self.session.ephemeral.clone_inner();
         let account_pubkey = *self.pubkey();
         let shared = self.session.shared.clone();
+        let account_db = self.session.account_db.clone();
         let group_id = self.group_id.clone();
         let event_id_str = event_id.to_string();
         let tags = mdk_message.tags.clone();
@@ -328,6 +346,7 @@ impl<'a> MessageOpsForGroup<'a> {
                 if let Err(e) = publish_notification_requests_after_delivery_with(
                     &shared.config,
                     &shared.database,
+                    &account_db.inner.pool,
                     &shared.relay_control,
                     &shared.event_tracker,
                     &ephemeral,

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -293,7 +293,7 @@ impl AccountSession {
         self.pending_push_token_responses.insert(key, ());
 
         let mdk = Arc::clone(&self.mdk);
-        let database = Arc::clone(&self.shared.database);
+        let account_db = Arc::clone(&self.account_db);
         let pending = Arc::clone(&self.pending_push_token_responses);
         let relay_control = Arc::clone(self.group_handle.relay_control());
         let account_pubkey = self.account_pubkey;
@@ -316,7 +316,7 @@ impl AccountSession {
 
             if let Err(error) = respond_to_token_request_with(
                 &mdk,
-                &database,
+                &account_db.inner.pool,
                 &relay_control,
                 &account_pubkey,
                 &group_id,

--- a/src/whitenoise/session/mute_list.rs
+++ b/src/whitenoise/session/mute_list.rs
@@ -346,9 +346,8 @@ impl<'a> MuteListOps<'a> {
     /// target user, if one exists.
     async fn emit_block_changed(&self, target_pubkey: &PublicKey) {
         match AccountGroup::find_dm_group_id_by_peer(
-            &self.session.account_pubkey,
             target_pubkey,
-            self.db(),
+            &self.session.account_db.inner.pool,
         )
         .await
         {

--- a/src/whitenoise/session/push.rs
+++ b/src/whitenoise/session/push.rs
@@ -505,7 +505,7 @@ impl<'a> PushOps<'a> {
         match AccountGroup::find_by_account_and_group(
             &self.session.account_pubkey,
             group_id,
-            &self.session.shared.database,
+            &self.session.account_db.inner.pool,
         )
         .await
         {
@@ -613,7 +613,7 @@ impl<'a> PushOps<'a> {
     ) -> Result<()> {
         respond_to_token_request_with(
             &self.session.mdk,
-            &self.session.shared.database,
+            &self.session.account_db.inner.pool,
             self.session.group_handle.relay_control(),
             &self.session.account_pubkey,
             group_id,

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -51,9 +51,13 @@ impl Whitenoise {
 
         // 2. Fetch the most-recent `limit` messages using the paginated query so the initial
         //    snapshot honours the same page size the Flutter side will use for further loads.
-        let cleared_at_ms =
-            AccountGroup::chat_cleared_at_ms(account_pubkey, group_id, &self.shared.database)
-                .await?;
+        let session = self.require_session(account_pubkey)?;
+        let cleared_at_ms = AccountGroup::chat_cleared_at_ms(
+            account_pubkey,
+            group_id,
+            &session.account_db.inner.pool,
+        )
+        .await?;
 
         let fetched_messages =
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(

--- a/src/whitenoise/user_search/graph.rs
+++ b/src/whitenoise/user_search/graph.rs
@@ -56,20 +56,33 @@ pub(super) async fn get_group_co_member_pubkeys(
         }
     };
 
-    let groups =
-        match AccountGroup::find_visible_for_account(&account.pubkey, &whitenoise.shared.database)
-            .await
-        {
-            Ok(g) => g,
-            Err(e) => {
-                tracing::debug!(
-                    target: "whitenoise::user_search::graph",
-                    "Could not fetch account groups: {}",
-                    e
-                );
-                return HashSet::new();
-            }
-        };
+    let session = match whitenoise.session(&account.pubkey) {
+        Some(s) => s,
+        None => {
+            tracing::debug!(
+                target: "whitenoise::user_search::graph",
+                "No session found for account {}",
+                account.pubkey.to_hex()
+            );
+            return HashSet::new();
+        }
+    };
+    let groups = match AccountGroup::find_visible_for_account(
+        &account.pubkey,
+        &session.account_db.inner.pool,
+    )
+    .await
+    {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::debug!(
+                target: "whitenoise::user_search::graph",
+                "Could not fetch account groups: {}",
+                e
+            );
+            return HashSet::new();
+        }
+    };
 
     let mut co_members = HashSet::new();
 
@@ -1173,11 +1186,12 @@ mod tests {
 
         // Insert a pending group (user_confirmation = None)
         let group_id = mdk_core::prelude::GroupId::from_slice(&[1, 2, 3]);
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         AccountGroup::find_or_create(
             &account.pubkey,
             &group_id,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
@@ -1194,15 +1208,16 @@ mod tests {
 
         // Insert and decline a group
         let group_id = mdk_core::prelude::GroupId::from_slice(&[4, 5, 6]);
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let (ag, _) = AccountGroup::find_or_create(
             &account.pubkey,
             &group_id,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
-        ag.update_user_confirmation(false, &whitenoise.shared.database)
+        ag.update_user_confirmation(false, &session.account_db.inner.pool)
             .await
             .unwrap();
 
@@ -1219,15 +1234,16 @@ mod tests {
         // Insert and accept a group — group_members() will fail because
         // mock whitenoise has no MLS infrastructure, exercising the error branch
         let group_id = mdk_core::prelude::GroupId::from_slice(&[7, 8, 9]);
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         let (ag, _) = AccountGroup::find_or_create(
             &account.pubkey,
             &group_id,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner.pool,
         )
         .await
         .unwrap();
-        ag.update_user_confirmation(true, &whitenoise.shared.database)
+        ag.update_user_confirmation(true, &session.account_db.inner.pool)
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- **Moves `accounts_groups`, `push_registrations`, and `group_push_tokens`** from the shared SQLite database to per-account database files (Phase 18d of the session/projection rearchitecture)
- Adds six new Rust migrations (m0032–m0037): three to copy data into per-account DBs, three to drop the shared-side tables
- Fixes `AccountDatabase::new` to use `open_without_migrations` instead of `Database::new`, preventing global drop migrations from destroying account-local tables on reopen
- Replaces raw SQL in domain/session layers with proper `database/` helper functions (`delete_for_group`, `exists_for_group`, `is_dm`, `created_at_ms_for_message`)
- Adds conservative session-count checks in `delete_chat` and `clear_chat` to avoid deleting shared data when inactive accounts may still reference it
- Upgrades `resolve_min_cleared_at` from `Option<i64>` to `Result<Option<i64>>` so DB errors propagate with concrete types instead of collapsing into `None`
- Adds CAS (compare-and-swap) guard on `update_last_read_if_newer` to prevent read-marker regression from concurrent writers after the cross-DB split
- Chunks `search_messages` IN-list to stay within SQLite's bind-parameter limit
- Adds regression tests for account DB table survival across reopens and push registration isolation between account DBs

## Test plan

- [x] `just precommit-quick` passes (fmt, docs, clippy, dead_code, tests)
- [ ] `just precommit` with Docker (integration tests)