### PR TITLE
Fix Android keyring migration build and update MDK rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,8 +2676,8 @@ dependencies = [
 
 [[package]]
 name = "mdk-core"
-version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
+version = "0.8.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=c1ee17ec4c811f28d5c1ffdbd9284121dda214ab#c1ee17ec4c811f28d5c1ffdbd9284121dda214ab"
 dependencies = [
  "base64",
  "blurhash",
@@ -2704,13 +2704,13 @@ dependencies = [
 
 [[package]]
 name = "mdk-macros"
-version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
+version = "0.8.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=c1ee17ec4c811f28d5c1ffdbd9284121dda214ab#c1ee17ec4c811f28d5c1ffdbd9284121dda214ab"
 
 [[package]]
 name = "mdk-sqlite-storage"
-version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
+version = "0.8.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=c1ee17ec4c811f28d5c1ffdbd9284121dda214ab#c1ee17ec4c811f28d5c1ffdbd9284121dda214ab"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -2731,8 +2731,8 @@ dependencies = [
 
 [[package]]
 name = "mdk-storage-traits"
-version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
+version = "0.8.0"
+source = "git+https://github.com/marmot-protocol/mdk?rev=c1ee17ec4c811f28d5c1ffdbd9284121dda214ab#c1ee17ec4c811f28d5c1ffdbd9284121dda214ab"
 dependencies = [
  "nostr",
  "openmls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
+source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
 dependencies = [
  "base64",
  "blurhash",
@@ -2705,13 +2705,14 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
+source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
+source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
 dependencies = [
+ "base64",
  "getrandom 0.4.2",
  "hex",
  "keyring-core",
@@ -2731,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8#8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8"
+source = "git+https://github.com/marmot-protocol/mdk?rev=639fb66c2c0c19d48b3169e54bd3cc75c3926179#639fb66c2c0c19d48b3169e54bd3cc75c3926179"
 dependencies = [
  "nostr",
  "openmls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "1"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "8d479fa05bdb5cbb0eaf0a86f3bfc6ee2f1789b8" }
+mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179" }
+mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "1"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179", features = [
+mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "c1ee17ec4c811f28d5c1ffdbd9284121dda214ab", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179" }
-mdk-storage-traits = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "639fb66c2c0c19d48b3169e54bd3cc75c3926179" }
+mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "c1ee17ec4c811f28d5c1ffdbd9284121dda214ab" }
+mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "c1ee17ec4c811f28d5c1ffdbd9284121dda214ab" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [
@@ -42,8 +42,8 @@ nostr-sdk = { version = "0.44", features = [
 once_cell = "1"
 
 # LOCAL MDK FOR DEVELOPMENT
-# mdk-core = { version = "0.7.1", path="../mdk/crates/mdk-core" }
-# mdk-sqlite-storage = { version = "0.7.1", path="../mdk/crates/mdk-sqlite-storage" }
+# mdk-core = { version = "0.8.0", path="../mdk/crates/mdk-core" }
+# mdk-sqlite-storage = { version = "0.8.0", path="../mdk/crates/mdk-sqlite-storage" }
 
 # LOCAL RUST_NOSTR FOR DEVELOPMENT
 # nostr-blossom = { version = "0.43", path="../rust-nostr/rfs/nostr-blossom" }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1574,6 +1574,17 @@ mod tests {
     use super::*;
     use database::aggregated_messages::PaginationOptions;
 
+    struct CustomLegacyStoreCreationError;
+
+    impl From<CustomLegacyStoreCreationError> for keyring_core::Error {
+        fn from(_: CustomLegacyStoreCreationError) -> Self {
+            keyring_core::Error::Invalid(
+                "legacy Android".to_string(),
+                "custom missing NDK context".to_string(),
+            )
+        }
+    }
+
     #[test]
     fn keyring_store_init_retries_after_failed_attempt() {
         let init = KeyringStoreInit::new();
@@ -1704,6 +1715,34 @@ mod tests {
                 "legacy Android".to_string(),
                 "missing NDK context".to_string(),
             )),
+            "legacy Android",
+        );
+
+        assert_eq!(
+            store
+                .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+                .unwrap()
+                .get_secret()
+                .unwrap(),
+            b"primary-db-key"
+        );
+    }
+
+    #[test]
+    fn legacy_migration_keyring_store_falls_back_to_primary_when_custom_legacy_error_converts() {
+        let primary = keyring_core::mock::Store::new().unwrap();
+        primary
+            .build("com.whitenoise.app", "whitenoise.db.key.v1", None)
+            .unwrap()
+            .set_secret(b"primary-db-key")
+            .unwrap();
+
+        let store = Whitenoise::create_legacy_migration_keyring_store::<
+            keyring_core::mock::Store,
+            CustomLegacyStoreCreationError,
+        >(
+            primary,
+            Err(CustomLegacyStoreCreationError),
             "legacy Android",
         );
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -569,14 +569,16 @@ impl Whitenoise {
             not(feature = "benchmark-tests")
         )
     ))]
-    fn create_legacy_migration_keyring_store<S>(
+    fn create_legacy_migration_keyring_store<S, E>(
         primary: Arc<keyring_core::CredentialStore>,
-        legacy: keyring_core::Result<Arc<S>>,
+        legacy: core::result::Result<Arc<S>, E>,
         legacy_store_name: &str,
     ) -> Arc<keyring_core::CredentialStore>
     where
         S: keyring_core::api::CredentialStoreApi + Send + Sync + 'static,
+        E: Into<keyring_core::Error>,
     {
+        let legacy = legacy.map_err(Into::into);
         match Self::create_keyring_store(legacy, legacy_store_name) {
             Ok(legacy) => keyring_store::LegacyMigrationCredentialStore::new(primary, legacy),
             Err(err) => {
@@ -1693,7 +1695,10 @@ mod tests {
             .set_secret(b"primary-db-key")
             .unwrap();
 
-        let store = Whitenoise::create_legacy_migration_keyring_store::<keyring_core::mock::Store>(
+        let store = Whitenoise::create_legacy_migration_keyring_store::<
+            keyring_core::mock::Store,
+            keyring_core::Error,
+        >(
             primary,
             Err(keyring_core::Error::Invalid(
                 "legacy Android".to_string(),


### PR DESCRIPTION
## Summary
- Generalize the legacy migration keyring helper to accept any error convertible to `keyring_core::Error`
- Map the Android legacy store creation error through that conversion path
- Bump `mdk-core`, `mdk-sqlite-storage`, and `mdk-storage-traits` to the latest `master` rev and refresh `Cargo.lock`

## Testing
- `just precommit-quick` passed
- `cargo check --locked --lib` passed
- `cargo check --locked --target aarch64-linux-android --lib` passed with local NDK/OpenSSL paths

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to v0.8.0 and aligned development overrides.
* **Bug Fixes**
  * Improved legacy migration handling so fallback to the primary key store consistently occurs even when legacy store creation fails with custom error types; tests updated to cover this.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->