### PR TITLE
fix: update chat_media_upload integration tests for MIP-04 v2

### DIFF
--- a/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
@@ -204,10 +204,15 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
         // instance (same shared DB). The sender's upload already created a
         // media_blobs row with a real file_path, and the receiver's save hits
         // ON CONFLICT which preserves the existing non-empty path. In production,
-        // sender and receiver are on different devices so this doesn't happen.
-        // We just log the value rather than asserting emptiness.
+        // sender and receiver are on different devices so this would be empty.
+        // Either way, the receiver must reuse the existing blob row.
+        assert_eq!(
+            receiver_media.file_path, media_file.file_path,
+            "Receiver should reuse sender's media_blobs row, not create a new one"
+        );
+
         tracing::info!(
-            "✓ Receiver's MediaFile file_path: {:?} (may inherit sender's cached path in test env)",
+            "✓ Receiver's MediaFile file_path: {:?} (reuses sender's media_blobs row)",
             receiver_media.file_path
         );
 
@@ -236,6 +241,13 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
             "chat_media should not have nostr_key (uses MDK encryption)"
         );
 
+        // Verify nonce was preserved from imeta 'n' field (MIP-04 v2 contract)
+        assert_eq!(
+            receiver_media.nonce.as_deref(),
+            Some(nonce_hex.as_str()),
+            "Receiver should preserve the nonce from imeta 'n' field"
+        );
+
         tracing::info!(
             "✓ Media reference successfully created on receiver's database with both hashes"
         );
@@ -247,7 +259,7 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
             "  • encrypted_file_hash: {} (from Blossom URL)",
             hex::encode(&receiver_media.encrypted_file_hash)
         );
-        tracing::info!("  • file_path: empty (not downloaded)");
+        tracing::info!("  • file_path: {:?}", receiver_media.file_path);
         tracing::info!("  • media_type: {}", receiver_media.media_type);
 
         Ok(())

--- a/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/receive_message_with_media.rs
@@ -200,13 +200,16 @@ impl TestCase for ReceiveMessageWithMediaTestCase {
             hex::encode(&receiver_media.encrypted_file_hash)
         );
 
-        // Verify file_path is empty (not downloaded yet)
-        assert!(
-            receiver_media.file_path.to_str().unwrap_or("").is_empty(),
-            "Receiver's MediaFile should have empty file_path (not downloaded yet)"
+        // In integration tests, sender and receiver share the same Whitenoise
+        // instance (same shared DB). The sender's upload already created a
+        // media_blobs row with a real file_path, and the receiver's save hits
+        // ON CONFLICT which preserves the existing non-empty path. In production,
+        // sender and receiver are on different devices so this doesn't happen.
+        // We just log the value rather than asserting emptiness.
+        tracing::info!(
+            "✓ Receiver's MediaFile file_path: {:?} (may inherit sender's cached path in test env)",
+            receiver_media.file_path
         );
-
-        tracing::info!("✓ Receiver's MediaFile has empty file_path (not downloaded)");
 
         // Verify metadata was extracted correctly
         assert_eq!(

--- a/src/integration_tests/test_cases/chat_media_upload/send_message_with_media.rs
+++ b/src/integration_tests/test_cases/chat_media_upload/send_message_with_media.rs
@@ -21,13 +21,14 @@ impl SendMessageWithMediaTestCase {
     }
 
     /// Build imeta tag per MIP-04 spec
-    /// Format: `["imeta", "url <blossom_url>", "m <mime_type>", "filename <name>", "x <hash>", "v <version>"]`
-    /// Note: MIP-04 requires filename and version fields
+    /// Format: `["imeta", "url <blossom_url>", "m <mime_type>", "filename <name>", "x <hash>", "n <nonce>", "v <version>"]`
+    /// Note: MIP-04 requires url, m, filename, x, n, and v fields
     fn build_imeta_tag(
         &self,
         hash_hex: &str,
         blossom_url: &str,
         mime_type: &str,
+        nonce_hex: &str,
     ) -> Result<Tag, WhitenoiseError> {
         Tag::parse(vec![
             "imeta",
@@ -35,7 +36,8 @@ impl SendMessageWithMediaTestCase {
             &format!("m {}", mime_type),
             "filename image.jpg",
             &format!("x {}", hash_hex),
-            "v mip04-v1",
+            &format!("n {}", nonce_hex),
+            "v mip04-v2",
         ])
         .map_err(|e| WhitenoiseError::Internal(format!("Failed to create imeta tag: {}", e)))
     }
@@ -68,8 +70,16 @@ impl TestCase for SendMessageWithMediaTestCase {
             WhitenoiseError::Configuration("Uploaded media has no blossom URL".to_string())
         })?;
 
-        let imeta_tag =
-            self.build_imeta_tag(&media_hash_hex, blossom_url, &media_file.mime_type)?;
+        let nonce_hex = media_file.nonce.as_ref().ok_or_else(|| {
+            WhitenoiseError::Configuration("Chat media must have nonce for MIP-04 v2".to_string())
+        })?;
+
+        let imeta_tag = self.build_imeta_tag(
+            &media_hash_hex,
+            blossom_url,
+            &media_file.mime_type,
+            nonce_hex,
+        )?;
 
         // Send message with imeta tag
         let send_result = context


### PR DESCRIPTION
## Summary

- `send_message_with_media` was building imeta tags without the `n` (nonce) field required by MIP-04 v2, causing MDK to reject them as malformed and breaking media attachment linking
- `receive_message_with_media` asserted `file_path` must be empty, but in integration tests sender and receiver share the same shared DB so the receiver inherits the sender's cached path via `ON CONFLICT`
- Strengthened receiver assertions: verify `file_path` matches sender's blob row, verify nonce preserved from imeta `n` field (MIP-04 v2 end-to-end contract)

## Test plan

- [x] `just int-test chat-media-upload` passes 11/11
- [x] `just precommit-quick` passes

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/795">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->