### PR TITLE
Phase 18e: move message projection tables to per-account DBs

### DIFF
--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -2605,6 +2605,58 @@ mod tests {
         );
     }
 
+    /// Regression: post-phase-18e, `clear_chat` must drop this account's old
+    /// `aggregated_messages` rows immediately. The pre-18e logic gated cleanup
+    /// on a min-across-accounts `chat_cleared_at`, which after the per-account
+    /// split silently turned the cleanup into a no-op whenever any other
+    /// account in the group hadn't cleared its (totally separate) DB.
+    #[tokio::test]
+    async fn test_clear_chat_deletes_per_account_aggregated_messages() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let group_id = GroupId::from_slice(&[145; 32]);
+        let session = whitenoise.session(&account.pubkey).unwrap();
+
+        whitenoise
+            .get_or_create_account_group(&account, &group_id, None)
+            .await
+            .unwrap();
+
+        // Seed two old messages directly in this account's per-account DB.
+        let old = Utc::now() - chrono::Duration::seconds(10);
+        for tag in &["e1", "e2"] {
+            let id = EventId::from_hex(&format!("{:0>64}", tag)).unwrap();
+            AggregatedMessage::create_for_test(
+                id,
+                group_id.clone(),
+                account.pubkey,
+                old,
+                &session.account_db.inner,
+            )
+            .await
+            .unwrap();
+        }
+        let before = AggregatedMessage::count_by_group(&group_id, &session.account_db.inner)
+            .await
+            .unwrap();
+        assert_eq!(before, 2);
+
+        session
+            .membership()
+            .for_group(&group_id)
+            .clear_chat()
+            .await
+            .unwrap();
+
+        let after = AggregatedMessage::count_by_group(&group_id, &session.account_db.inner)
+            .await
+            .unwrap();
+        assert_eq!(
+            after, 0,
+            "clear_chat must drop this account's seeded messages even when no other account has cleared"
+        );
+    }
+
     #[tokio::test]
     async fn test_clear_chat_idempotent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -651,8 +651,10 @@ impl Whitenoise {
         // 4. Delete per-account accounts_groups row
         AccountGroup::delete_for_group(group_id, &session.account_db.inner.pool).await?;
 
-        // 4-pre-shared: Delete per-account aggregated_messages for this group
-        // (message_delivery_status cascades via intra-DB FK).
+        // Delete per-account aggregated_messages for this group. Order doesn't
+        // matter relative to the steps below: there's no FK between
+        // accounts_groups and aggregated_messages, and message_delivery_status
+        // cascades via the intra-DB FK on aggregated_messages.
         crate::whitenoise::aggregated_message::AggregatedMessage::delete_by_group(
             group_id,
             &session.account_db.inner,

--- a/src/whitenoise/accounts_groups.rs
+++ b/src/whitenoise/accounts_groups.rs
@@ -651,6 +651,14 @@ impl Whitenoise {
         // 4. Delete per-account accounts_groups row
         AccountGroup::delete_for_group(group_id, &session.account_db.inner.pool).await?;
 
+        // 4-pre-shared: Delete per-account aggregated_messages for this group
+        // (message_delivery_status cascades via intra-DB FK).
+        crate::whitenoise::aggregated_message::AggregatedMessage::delete_by_group(
+            group_id,
+            &session.account_db.inner,
+        )
+        .await?;
+
         // 4a. Check if any other account still has this group.
         // We can only inspect active sessions, not every persisted account.
         // If inactive accounts exist, conservatively keep shared data — the
@@ -1307,12 +1315,13 @@ mod tests {
         let older_msg_id = EventId::from_hex(&format!("{:0>64}", "aaa")).unwrap();
         let newer_msg_id = EventId::from_hex(&format!("{:0>64}", "bbb")).unwrap();
 
+        let session = whitenoise.session(&account.pubkey).unwrap();
         AggregatedMessage::create_for_test(
             older_msg_id,
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1322,7 +1331,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1369,12 +1378,13 @@ mod tests {
         let older_msg_id = EventId::from_hex(&format!("{:0>64}", "ccc")).unwrap();
         let newer_msg_id = EventId::from_hex(&format!("{:0>64}", "ddd")).unwrap();
 
+        let session = whitenoise.session(&account.pubkey).unwrap();
         AggregatedMessage::create_for_test(
             older_msg_id,
             group_id.clone(),
             account.pubkey,
             older_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1384,7 +1394,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             newer_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1430,12 +1440,13 @@ mod tests {
         let first_msg_id = EventId::from_hex(&format!("{:0>64}", "eee")).unwrap();
         let second_msg_id = EventId::from_hex(&format!("{:0>64}", "fff")).unwrap();
 
+        let session = whitenoise.session(&account.pubkey).unwrap();
         AggregatedMessage::create_for_test(
             first_msg_id,
             group_id.clone(),
             account.pubkey,
             same_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1445,7 +1456,7 @@ mod tests {
             group_id.clone(),
             account.pubkey,
             same_time,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -2550,12 +2561,13 @@ mod tests {
 
         // Create a message and mark it as read
         let msg_id = EventId::from_hex(&format!("{:0>64}", "aab")).unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         AggregatedMessage::create_for_test(
             msg_id,
             group_id.clone(),
             account.pubkey,
             Utc::now(),
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -326,7 +326,7 @@ impl Whitenoise {
 
         let last_message_summary = AggregatedMessage::find_last_by_group_ids(
             std::slice::from_ref(group_id),
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         .into_iter()
@@ -367,7 +367,7 @@ impl Whitenoise {
         let unread_count = AggregatedMessage::count_unread_for_group(
             group_id,
             account_group.last_read_message_id.as_ref(),
-            &self.shared.database,
+            &session.account_db.inner,
             cleared_ms,
         )
         .await?;
@@ -918,11 +918,12 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         AggregatedMessage::insert_message(
             &msg1,
             &group1.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -946,7 +947,7 @@ mod tests {
             &msg2,
             &group2.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1111,11 +1112,12 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         AggregatedMessage::insert_message(
             &msg,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1178,11 +1180,12 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         AggregatedMessage::insert_message(
             &msg,
             &group1.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1272,11 +1275,12 @@ mod tests {
             media_attachments: vec![],
             delivery_status: None,
         };
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         AggregatedMessage::insert_message(
             &msg,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1553,6 +1557,7 @@ mod tests {
 
         // Add messages with identical timestamps to all groups
         let same_timestamp = Timestamp::from(5000);
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         for group in &groups {
             let msg = ChatMessage {
                 id: format!("{:0>64}", hex::encode(group.mls_group_id.as_slice())),
@@ -1573,7 +1578,7 @@ mod tests {
                 &msg,
                 &group.mls_group_id,
                 &creator.pubkey,
-                &whitenoise.shared.database,
+                &session.account_db.inner,
             )
             .await
             .unwrap();

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -1702,19 +1702,7 @@ mod tests {
     use nostr_sdk::Keys;
 
     use super::*;
-    use crate::whitenoise::group_information::{GroupInformation, GroupType};
     use crate::whitenoise::test_utils::create_mock_whitenoise;
-
-    async fn setup_group(group_id: &GroupId, database: &Database) {
-        // Create group_information record (required for foreign key constraint)
-        GroupInformation::find_or_create_by_mls_group_id(
-            group_id,
-            Some(GroupType::Group),
-            database,
-        )
-        .await
-        .unwrap();
-    }
 
     fn create_test_chat_message(seed: u8, author: PublicKey) -> ChatMessage {
         // Create a valid 64-character hex string by repeating a pattern
@@ -1740,9 +1728,12 @@ mod tests {
     #[tokio::test]
     async fn test_count_by_group_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+        let count = AggregatedMessage::count_by_group(&group_id, db)
             .await
             .unwrap();
         assert_eq!(count, 0);
@@ -1751,66 +1742,59 @@ mod tests {
     #[tokio::test]
     async fn test_get_all_event_ids_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        let ids =
-            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let ids = AggregatedMessage::get_all_event_ids_by_group(&group_id, db)
+            .await
+            .unwrap();
         assert!(ids.is_empty());
     }
 
     #[tokio::test]
     async fn test_find_messages_by_group_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[1; 32]);
-        let author = Keys::generate().public_key();
 
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert!(messages.is_empty());
     }
 
     #[tokio::test]
     async fn test_insert_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[1; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(1, author);
 
         // Insert message
-        let result = AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await;
+        let result =
+            AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db).await;
         assert!(result.is_ok());
 
         // Verify it was inserted
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+        let count = AggregatedMessage::count_by_group(&group_id, db)
             .await
             .unwrap();
         assert_eq!(count, 1);
 
         // Verify we can retrieve it
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, message.id);
         assert_eq!(messages[0].content, message.content);
@@ -1819,8 +1803,10 @@ mod tests {
     #[tokio::test]
     async fn test_insert_multiple_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[2; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -1829,38 +1815,28 @@ mod tests {
         for i in 1..=3 {
             let message = create_test_chat_message(i, author);
             message_ids.push(message.id.clone());
-            AggregatedMessage::insert_message(
-                &message,
-                &group_id,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
         }
 
         // Verify count
-        let count = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+        let count = AggregatedMessage::count_by_group(&group_id, db)
             .await
             .unwrap();
         assert_eq!(count, 3);
 
         // Verify we can retrieve all messages
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 3);
 
         // Verify event IDs
-        let event_ids =
-            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let event_ids = AggregatedMessage::get_all_event_ids_by_group(&group_id, db)
+            .await
+            .unwrap();
         assert_eq!(event_ids.len(), 3);
         for id in &message_ids {
             assert!(event_ids.contains(id));
@@ -1870,54 +1846,41 @@ mod tests {
     #[tokio::test]
     async fn test_mark_deleted_does_not_decrease_count() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[3; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message
         let message = create_test_chat_message(10, author);
-        AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
-        let count_before =
-            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let count_before = AggregatedMessage::count_by_group(&group_id, db)
+            .await
+            .unwrap();
         assert_eq!(count_before, 1);
 
         // Mark as deleted - need a valid 64-char hex ID
         let deletion_event_id = format!("{:0>64}", "abc123");
-        AggregatedMessage::mark_deleted(
-            &message.id,
-            &group_id,
-            &deletion_event_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&message.id, &group_id, &deletion_event_id, db)
+            .await
+            .unwrap();
 
         // Count should remain the same - mark_deleted doesn't remove the row
-        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+        let count_after = AggregatedMessage::count_by_group(&group_id, db)
             .await
             .unwrap();
         assert_eq!(count_after, 1);
 
         // But the message should have deletion_event_id set
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_deleted);
     }
@@ -1925,124 +1888,96 @@ mod tests {
     #[tokio::test]
     async fn test_delete_by_group_removes_all_events() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[4; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert multiple messages
         let message1 = create_test_chat_message(20, author);
-        AggregatedMessage::insert_message(
-            &message1,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message1, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         let message2 = create_test_chat_message(21, author);
-        AggregatedMessage::insert_message(
-            &message2,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message2, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         let message3 = create_test_chat_message(22, author);
-        AggregatedMessage::insert_message(
-            &message3,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message3, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Verify count before deletion
-        let count_before =
-            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let count_before = AggregatedMessage::count_by_group(&group_id, db)
+            .await
+            .unwrap();
         assert_eq!(count_before, 3);
 
         // Delete all events for the group
-        AggregatedMessage::delete_by_group(&group_id, &whitenoise.shared.database)
+        AggregatedMessage::delete_by_group(&group_id, db)
             .await
             .unwrap();
 
         // Count should now be zero
-        let count_after = AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
+        let count_after = AggregatedMessage::count_by_group(&group_id, db)
             .await
             .unwrap();
         assert_eq!(count_after, 0);
 
         // No messages should be found
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert!(messages.is_empty());
 
         // No event IDs should be found
-        let event_ids =
-            AggregatedMessage::get_all_event_ids_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let event_ids = AggregatedMessage::get_all_event_ids_by_group(&group_id, db)
+            .await
+            .unwrap();
         assert!(event_ids.is_empty());
     }
 
     #[tokio::test]
     async fn test_delete_by_group_is_group_specific() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id_1 = GroupId::from_slice(&[5; 32]);
         let group_id_2 = GroupId::from_slice(&[6; 32]);
-        setup_group(&group_id_1, &whitenoise.shared.database).await;
-        setup_group(&group_id_2, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert message in group 1
         let message1 = create_test_chat_message(30, author);
-        AggregatedMessage::insert_message(
-            &message1,
-            &group_id_1,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message1, &group_id_1, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Insert message in group 2
         let message2 = create_test_chat_message(31, author);
-        AggregatedMessage::insert_message(
-            &message2,
-            &group_id_2,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message2, &group_id_2, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Delete group 1
-        AggregatedMessage::delete_by_group(&group_id_1, &whitenoise.shared.database)
+        AggregatedMessage::delete_by_group(&group_id_1, db)
             .await
             .unwrap();
 
         // Group 1 should be empty
-        let count_1 = AggregatedMessage::count_by_group(&group_id_1, &whitenoise.shared.database)
+        let count_1 = AggregatedMessage::count_by_group(&group_id_1, db)
             .await
             .unwrap();
         assert_eq!(count_1, 0);
 
         // Group 2 should still have its message
-        let count_2 = AggregatedMessage::count_by_group(&group_id_2, &whitenoise.shared.database)
+        let count_2 = AggregatedMessage::count_by_group(&group_id_2, db)
             .await
             .unwrap();
         assert_eq!(count_2, 1);
@@ -2051,21 +1986,18 @@ mod tests {
     #[tokio::test]
     async fn test_update_reactions() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[7; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message with empty reactions
         let message = create_test_chat_message(40, author);
-        AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Update with reactions
         let mut reactions = ReactionSummary::default();
@@ -2078,24 +2010,15 @@ mod tests {
             },
         );
 
-        AggregatedMessage::update_reactions(
-            &message.id,
-            &group_id,
-            &reactions,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::update_reactions(&message.id, &group_id, &reactions, db)
+            .await
+            .unwrap();
 
         // Verify reactions were updated
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].reactions.by_emoji.len(), 1);
         assert!(messages[0].reactions.by_emoji.contains_key("👍"));
@@ -2104,8 +2027,11 @@ mod tests {
     #[tokio::test]
     async fn test_find_last_by_group_ids_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
-        let result = AggregatedMessage::find_last_by_group_ids(&[], &whitenoise.shared.database)
+        let result = AggregatedMessage::find_last_by_group_ids(&[], db)
             .await
             .unwrap();
         assert!(result.is_empty());
@@ -2114,6 +2040,9 @@ mod tests {
     #[tokio::test]
     async fn test_find_last_by_group_ids_comprehensive() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         // Setup groups with different scenarios
         let group_with_media = GroupId::from_slice(&[50; 32]);
@@ -2121,16 +2050,6 @@ mod tests {
         let group_with_deletion = GroupId::from_slice(&[52; 32]);
         let group_empty = GroupId::from_slice(&[53; 32]);
         let group_multiple_messages = GroupId::from_slice(&[54; 32]);
-
-        for group_id in [
-            &group_with_media,
-            &group_no_media,
-            &group_with_deletion,
-            &group_empty,
-            &group_multiple_messages,
-        ] {
-            setup_group(group_id, &whitenoise.shared.database).await;
-        }
 
         let author = Keys::generate().public_key();
 
@@ -2171,56 +2090,36 @@ mod tests {
                 created_at: chrono::Utc::now(),
             },
         ];
-        AggregatedMessage::insert_message(
-            &msg_with_media,
-            &group_with_media,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_with_media, &group_with_media, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Group 2: Message without media
         let mut msg_no_media = create_test_chat_message(51, author);
         msg_no_media.content = "Message without media".to_string();
-        AggregatedMessage::insert_message(
-            &msg_no_media,
-            &group_no_media,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_no_media, &group_no_media, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Group 3: Has deleted newest message, should return older one
         let mut msg_older = create_test_chat_message(52, author);
         msg_older.content = "Older non-deleted".to_string();
         msg_older.created_at = Timestamp::from(1000);
-        AggregatedMessage::insert_message(
-            &msg_older,
-            &group_with_deletion,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_older, &group_with_deletion, &account.pubkey, db)
+            .await
+            .unwrap();
 
         let mut msg_deleted = create_test_chat_message(53, author);
         msg_deleted.content = "Deleted message".to_string();
         msg_deleted.created_at = Timestamp::from(2000);
-        AggregatedMessage::insert_message(
-            &msg_deleted,
-            &group_with_deletion,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_deleted, &group_with_deletion, &account.pubkey, db)
+            .await
+            .unwrap();
         AggregatedMessage::mark_deleted(
             &msg_deleted.id,
             &group_with_deletion,
             &format!("{:0>64}", "del"),
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
@@ -2234,8 +2133,8 @@ mod tests {
         AggregatedMessage::insert_message(
             &msg_first,
             &group_multiple_messages,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
         )
         .await
         .unwrap();
@@ -2243,14 +2142,9 @@ mod tests {
         let mut msg_last = create_test_chat_message(55, author);
         msg_last.content = "Last message".to_string();
         msg_last.created_at = Timestamp::from(2000);
-        AggregatedMessage::insert_message(
-            &msg_last,
-            &group_multiple_messages,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_last, &group_multiple_messages, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Query all groups
         let result = AggregatedMessage::find_last_by_group_ids(
@@ -2261,7 +2155,7 @@ mod tests {
                 group_empty.clone(),
                 group_multiple_messages.clone(),
             ],
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
@@ -2299,22 +2193,19 @@ mod tests {
     #[tokio::test]
     async fn test_find_by_message_id_returns_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[70; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(70, author);
-        AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         let event_id = EventId::from_hex(&message.id).unwrap();
-        let found = AggregatedMessage::find_by_message_id(&event_id, &whitenoise.shared.database)
+        let found = AggregatedMessage::find_by_message_id(&event_id, db)
             .await
             .unwrap();
 
@@ -2327,9 +2218,12 @@ mod tests {
     #[tokio::test]
     async fn test_find_by_message_id_returns_none_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let fake_id = EventId::all_zeros();
 
-        let found = AggregatedMessage::find_by_message_id(&fake_id, &whitenoise.shared.database)
+        let found = AggregatedMessage::find_by_message_id(&fake_id, db)
             .await
             .unwrap();
 
@@ -2339,30 +2233,22 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_group_no_read_marker_returns_all() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[80; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         for i in 1..=3 {
             let msg = create_test_chat_message(80 + i, author);
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_id,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
         }
 
-        let count = AggregatedMessage::count_unread_for_group(
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-            None,
-        )
-        .await
-        .unwrap();
+        let count = AggregatedMessage::count_unread_for_group(&group_id, None, db, None)
+            .await
+            .unwrap();
 
         assert_eq!(count, 3);
     }
@@ -2370,35 +2256,28 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_group_with_read_marker() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[90; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let mut messages = Vec::new();
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(90 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_id,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
             messages.push(msg);
         }
 
         // Read marker at message 2 -> 3 unread (messages 3, 4, 5)
         let read_marker_id = EventId::from_hex(&messages[1].id).unwrap();
-        let count = AggregatedMessage::count_unread_for_group(
-            &group_id,
-            Some(&read_marker_id),
-            &whitenoise.shared.database,
-            None,
-        )
-        .await
-        .unwrap();
+        let count =
+            AggregatedMessage::count_unread_for_group(&group_id, Some(&read_marker_id), db, None)
+                .await
+                .unwrap();
 
         assert_eq!(count, 3);
     }
@@ -2406,37 +2285,29 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_group_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[100; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(100, author);
         let msg2 = create_test_chat_message(101, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &account.pubkey, db)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &account.pubkey, db)
             .await
             .unwrap();
 
         // Delete msg2
-        AggregatedMessage::mark_deleted(
-            &msg2.id,
-            &group_id,
-            &format!("{:0>64}", "del"),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &format!("{:0>64}", "del"), db)
+            .await
+            .unwrap();
 
-        let count = AggregatedMessage::count_unread_for_group(
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-            None,
-        )
-        .await
-        .unwrap();
+        let count = AggregatedMessage::count_unread_for_group(&group_id, None, db, None)
+            .await
+            .unwrap();
 
         assert_eq!(count, 1); // Only msg1 counted
     }
@@ -2444,8 +2315,11 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_groups_empty_input() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
-        let result = AggregatedMessage::count_unread_for_groups(&[], &whitenoise.shared.database)
+        let result = AggregatedMessage::count_unread_for_groups(&[], db)
             .await
             .unwrap();
 
@@ -2455,21 +2329,20 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_groups_no_markers() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         let group1 = GroupId::from_slice(&[110; 32]);
         let group2 = GroupId::from_slice(&[111; 32]);
         let group3 = GroupId::from_slice(&[112; 32]); // Empty group
-
-        for group_id in [&group1, &group2, &group3] {
-            setup_group(group_id, &whitenoise.shared.database).await;
-        }
 
         let author = Keys::generate().public_key();
 
         // Group 1: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(110 + i, author);
-            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(&msg, &group1, &account.pubkey, db)
                 .await
                 .unwrap();
         }
@@ -2477,7 +2350,7 @@ mod tests {
         // Group 2: 5 messages
         for i in 1..=5 {
             let msg = create_test_chat_message(120 + i, author);
-            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(&msg, &group2, &account.pubkey, db)
                 .await
                 .unwrap();
         }
@@ -2490,10 +2363,9 @@ mod tests {
             (group3.clone(), None, None),
         ];
 
-        let result =
-            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let result = AggregatedMessage::count_unread_for_groups(&input, db)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[&group1], 3);
@@ -2504,13 +2376,12 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_groups_with_markers() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         let group1 = GroupId::from_slice(&[130; 32]);
         let group2 = GroupId::from_slice(&[131; 32]);
-
-        for group_id in [&group1, &group2] {
-            setup_group(group_id, &whitenoise.shared.database).await;
-        }
 
         let author = Keys::generate().public_key();
 
@@ -2519,7 +2390,7 @@ mod tests {
         for i in 1..=5u8 {
             let mut msg = create_test_chat_message(130 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group1, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(&msg, &group1, &account.pubkey, db)
                 .await
                 .unwrap();
             group1_messages.push(msg);
@@ -2531,7 +2402,7 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(140 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(&msg, &group2, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(&msg, &group2, &account.pubkey, db)
                 .await
                 .unwrap();
             group2_messages.push(msg);
@@ -2543,10 +2414,9 @@ mod tests {
             (group2.clone(), Some(marker2), None),
         ];
 
-        let result =
-            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let result = AggregatedMessage::count_unread_for_groups(&input, db)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[&group1], 3); // Messages 3, 4, 5 unread
@@ -2556,14 +2426,13 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_groups_mixed_markers() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         let group_with_marker = GroupId::from_slice(&[150; 32]);
         let group_without_marker = GroupId::from_slice(&[151; 32]);
         let group_empty = GroupId::from_slice(&[152; 32]);
-
-        for group_id in [&group_with_marker, &group_without_marker, &group_empty] {
-            setup_group(group_id, &whitenoise.shared.database).await;
-        }
 
         let author = Keys::generate().public_key();
 
@@ -2572,14 +2441,9 @@ mod tests {
         for i in 1..=4u8 {
             let mut msg = create_test_chat_message(150 + i, author);
             msg.created_at = Timestamp::from(i as u64 * 1000);
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_with_marker,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_with_marker, &account.pubkey, db)
+                .await
+                .unwrap();
             messages.push(msg);
         }
         let marker = EventId::from_hex(&messages[1].id).unwrap();
@@ -2587,14 +2451,9 @@ mod tests {
         // Group without marker: 3 messages
         for i in 1..=3 {
             let msg = create_test_chat_message(160 + i, author);
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_without_marker,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_without_marker, &account.pubkey, db)
+                .await
+                .unwrap();
         }
 
         let input = vec![
@@ -2603,10 +2462,9 @@ mod tests {
             (group_empty.clone(), None, None),
         ];
 
-        let result =
-            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let result = AggregatedMessage::count_unread_for_groups(&input, db)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[&group_with_marker], 2); // Messages 3, 4 unread
@@ -2617,66 +2475,53 @@ mod tests {
     #[tokio::test]
     async fn test_update_delivery_status_and_find_by_id() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[200; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a message with Sending status
         let mut message = create_test_chat_message(200, author);
         message.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Verify initial Sending status via find_by_id
-        let found = AggregatedMessage::find_by_id(
-            &message.id,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
 
         // Update to Sent(3) — returned message should have the updated status
         let updated = AggregatedMessage::update_delivery_status(
             &message.id,
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Sent(3),
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
         assert_eq!(updated.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Verify via find_by_id as well
-        let found = AggregatedMessage::find_by_id(
-            &message.id,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(3)));
 
         // Update to Failed
         let updated = AggregatedMessage::update_delivery_status(
             &message.id,
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Failed("timeout".to_string()),
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
@@ -2689,91 +2534,68 @@ mod tests {
     #[tokio::test]
     async fn test_find_by_id_returns_none_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[201; 32]);
-        let author = Keys::generate().public_key();
 
-        let found = AggregatedMessage::find_by_id(
-            "nonexistent",
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let found = AggregatedMessage::find_by_id("nonexistent", &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
         assert!(found.is_none());
     }
 
     #[tokio::test]
     async fn test_insert_message_with_no_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[202; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let message = create_test_chat_message(202, author);
         // delivery_status is None (incoming message)
         assert!(message.delivery_status.is_none());
 
-        AggregatedMessage::insert_message(
-            &message,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
-        let found = AggregatedMessage::find_by_id(
-            &message.id,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let found = AggregatedMessage::find_by_id(&message.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(found.delivery_status, None);
     }
 
     #[tokio::test]
     async fn test_find_messages_by_group_preserves_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[203; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert incoming message (no delivery status)
         let msg_incoming = create_test_chat_message(203, author);
-        AggregatedMessage::insert_message(
-            &msg_incoming,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_incoming, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Insert outgoing message with Sent status
         let mut msg_outgoing = create_test_chat_message(204, author);
         msg_outgoing.delivery_status = Some(DeliveryStatus::Sent(2));
-        AggregatedMessage::insert_message(
-            &msg_outgoing,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_outgoing, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 2);
 
         let statuses: Vec<_> = messages.iter().map(|m| &m.delivery_status).collect();
@@ -2784,17 +2606,18 @@ mod tests {
     #[tokio::test]
     async fn test_update_delivery_status_returns_error_for_nonexistent_message() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[205; 32]);
-        let author = Keys::generate().public_key();
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         // Try to update delivery status for a message that doesn't exist
         let result = AggregatedMessage::update_delivery_status(
             &format!("{:0>64}", "ff"),
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Sent(1),
-            &whitenoise.shared.database,
+            db,
         )
         .await;
 
@@ -2813,54 +2636,37 @@ mod tests {
     #[tokio::test]
     async fn test_find_messages_by_group_excludes_retried() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[206; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
         // Insert a normal message
         let msg_normal = create_test_chat_message(206, author);
-        AggregatedMessage::insert_message(
-            &msg_normal,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_normal, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Insert a message with Retried status (simulating a retried failed message)
         let mut msg_retried = create_test_chat_message(207, author);
         msg_retried.delivery_status = Some(DeliveryStatus::Retried);
-        AggregatedMessage::insert_message(
-            &msg_retried,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_retried, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         // Insert a message with Failed status (should still be visible)
         let mut msg_failed = create_test_chat_message(208, author);
         msg_failed.delivery_status = Some(DeliveryStatus::Failed("error".to_string()));
-        AggregatedMessage::insert_message(
-            &msg_failed,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_failed, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
 
         // Only normal and failed messages should appear, not retried
         assert_eq!(messages.len(), 2);
@@ -2873,9 +2679,11 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_for_groups_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         let group_id = GroupId::from_slice(&[170; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(170, author);
@@ -2883,26 +2691,20 @@ mod tests {
         let msg3 = create_test_chat_message(172, author);
 
         for msg in [&msg1, &msg2, &msg3] {
-            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(msg, &group_id, &account.pubkey, db)
                 .await
                 .unwrap();
         }
 
         // Delete msg2
-        AggregatedMessage::mark_deleted(
-            &msg2.id,
-            &group_id,
-            &format!("{:0>64}", "del"),
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &format!("{:0>64}", "del"), db)
+            .await
+            .unwrap();
 
         let input = vec![(group_id.clone(), None, None)];
-        let result =
-            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let result = AggregatedMessage::count_unread_for_groups(&input, db)
+            .await
+            .unwrap();
 
         assert_eq!(result[&group_id], 2); // msg1 and msg3, excluding deleted msg2
     }
@@ -2910,66 +2712,59 @@ mod tests {
     #[tokio::test]
     async fn test_insert_delivery_status_and_has_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[180; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(180, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
             .await
             .unwrap();
 
         // Before inserting, has_delivery_status should return false
-        let has = AggregatedMessage::has_delivery_status(
-            &msg.id,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
         assert!(!has, "No delivery status should exist yet");
 
         // Insert delivery status
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Sending,
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
 
         // Now has_delivery_status should return true
-        let has = AggregatedMessage::has_delivery_status(
-            &msg.id,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let has = AggregatedMessage::has_delivery_status(&msg.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
         assert!(has, "Delivery status should exist after insert");
 
         // Verify it shows up in find_by_id
-        let found =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.shared.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sending));
     }
 
     #[tokio::test]
     async fn test_insert_delivery_status_upsert() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[181; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg = create_test_chat_message(181, author);
-        AggregatedMessage::insert_message(&msg, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
             .await
             .unwrap();
 
@@ -2977,9 +2772,9 @@ mod tests {
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Sending,
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
@@ -2988,74 +2783,67 @@ mod tests {
         AggregatedMessage::insert_delivery_status(
             &msg.id,
             &group_id,
-            &author,
+            &account.pubkey,
             &DeliveryStatus::Sent(2),
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
 
-        let found =
-            AggregatedMessage::find_by_id(&msg.id, &group_id, &author, &whitenoise.shared.database)
-                .await
-                .unwrap()
-                .unwrap();
+        let found = AggregatedMessage::find_by_id(&msg.id, &group_id, &account.pubkey, db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(found.delivery_status, Some(DeliveryStatus::Sent(2)));
     }
 
     #[tokio::test]
     async fn test_unmark_deleted_reverses_deletion() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[182; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(182, author);
         let msg2 = create_test_chat_message(183, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &account.pubkey, db)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &account.pubkey, db)
             .await
             .unwrap();
 
         let del_id = format!("{:0>64x}", 0xde1182u64);
 
         // Mark both as deleted by the same deletion event
-        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_id, &whitenoise.shared.database)
+        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_id, db)
             .await
             .unwrap();
-        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_id, &whitenoise.shared.database)
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_id, db)
             .await
             .unwrap();
 
         // Both should have is_deleted=true
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert!(
             messages.iter().all(|m| m.is_deleted),
             "All messages should be marked as deleted"
         );
 
         // Unmark — both should revert to not deleted
-        AggregatedMessage::unmark_deleted(&del_id, &group_id, &whitenoise.shared.database)
+        AggregatedMessage::unmark_deleted(&del_id, &group_id, db)
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         assert_eq!(messages.len(), 2, "Both messages should still be present");
         assert!(
             messages.iter().all(|m| !m.is_deleted),
@@ -3066,42 +2854,40 @@ mod tests {
     #[tokio::test]
     async fn test_unmark_deleted_only_affects_matching_deletion() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[184; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let msg1 = create_test_chat_message(184, author);
         let msg2 = create_test_chat_message(185, author);
-        AggregatedMessage::insert_message(&msg1, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg1, &group_id, &account.pubkey, db)
             .await
             .unwrap();
-        AggregatedMessage::insert_message(&msg2, &group_id, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg2, &group_id, &account.pubkey, db)
             .await
             .unwrap();
 
         let del_a = format!("{:0>64x}", 0xde1au64);
         let del_b = format!("{:0>64x}", 0xde1bu64);
 
-        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_a, &whitenoise.shared.database)
+        AggregatedMessage::mark_deleted(&msg1.id, &group_id, &del_a, db)
             .await
             .unwrap();
-        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_b, &whitenoise.shared.database)
+        AggregatedMessage::mark_deleted(&msg2.id, &group_id, &del_b, db)
             .await
             .unwrap();
 
         // Unmark only del_a — msg1 should revert to not-deleted, msg2 stays deleted
-        AggregatedMessage::unmark_deleted(&del_a, &group_id, &whitenoise.shared.database)
+        AggregatedMessage::unmark_deleted(&del_a, &group_id, db)
             .await
             .unwrap();
 
-        let messages = AggregatedMessage::find_messages_by_group(
-            &group_id,
-            &author,
-            None,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
         let not_deleted: Vec<_> = messages.iter().filter(|m| !m.is_deleted).collect();
         assert_eq!(not_deleted.len(), 1, "Only msg1 should be un-deleted");
         assert_eq!(not_deleted[0].id, msg1.id);
@@ -3110,8 +2896,10 @@ mod tests {
     #[tokio::test]
     async fn test_find_orphaned_reactions_excludes_deleted() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[186; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         // Use valid hex IDs (find_orphaned_reactions parses message_id as EventId)
@@ -3139,56 +2927,41 @@ mod tests {
         .bind(&empty_tokens)
         .bind(&empty_reactions)
         .bind(&empty_media)
-        .execute(&whitenoise.shared.database.pool)
+        .execute(&db.pool)
         .await
         .unwrap();
 
         // The reaction should appear as orphaned
-        let orphans = AggregatedMessage::find_orphaned_reactions(
-            &parent_id,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let orphans = AggregatedMessage::find_orphaned_reactions(&parent_id, &group_id, db)
+            .await
+            .unwrap();
         assert_eq!(orphans.len(), 1, "Non-deleted reaction should be found");
 
         // Now mark the reaction as deleted
         let del_id = format!("{:0>64x}", 0xde1186u64);
-        AggregatedMessage::mark_deleted(
-            &reaction_id,
-            &group_id,
-            &del_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&reaction_id, &group_id, &del_id, db)
+            .await
+            .unwrap();
 
         // Deleted reaction should NOT appear as orphaned
-        let orphans = AggregatedMessage::find_orphaned_reactions(
-            &parent_id,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let orphans = AggregatedMessage::find_orphaned_reactions(&parent_id, &group_id, db)
+            .await
+            .unwrap();
         assert_eq!(orphans.len(), 0, "Deleted reaction should be excluded");
     }
 
     #[tokio::test]
     async fn test_has_delivery_status_returns_false_for_nonexistent() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[188; 32]);
-        let author = Keys::generate().public_key();
 
-        let has = AggregatedMessage::has_delivery_status(
-            "nonexistent",
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let has =
+            AggregatedMessage::has_delivery_status("nonexistent", &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
         assert!(!has);
     }
 
@@ -3227,13 +3000,15 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_empty_group_returns_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[200; 32]);
-        let author = Keys::generate().public_key();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -3246,29 +3021,24 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_default_returns_up_to_50_newest() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[201; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
 
         // Insert 60 messages with ascending timestamps
         for i in 1u8..=60 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Default (no cursor) should return the 50 newest
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -3302,22 +3072,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_before_cursor_excludes_on_or_after() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[202; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_100_000;
 
         // Insert 5 messages: ts+1, ts+2, ts+3, ts+4, ts+5
         for i in 1u8..=5 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Cursor at ts+3 (seed 3): should return only messages with created_at < ts+3 → ts+1, ts+2.
@@ -3326,8 +3091,8 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(cursor_ts),
                 before_message_id: Some(cursor_id.clone()),
@@ -3351,27 +3116,22 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_limit_is_respected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[203; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_200_000;
 
         for i in 1u8..=10 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             Some(3),
             None,
@@ -3393,8 +3153,10 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_limit_capped_at_200() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[204; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_300_000;
@@ -3403,21 +3165,14 @@ mod tests {
         for i in 0u8..=209 {
             // Use two bytes for the seed to stay within u8 — spread across different IDs
             let id_seed = i;
-            insert_message_at(
-                id_seed,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(id_seed, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Requesting u32::MAX should be capped to 200
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             Some(u32::MAX),
             None,
@@ -3431,29 +3186,24 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_pages_are_contiguous_without_overlap_or_gap() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[205; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_400_000;
 
         // Insert 10 messages with distinct timestamps
         for i in 1u8..=10 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Page 1: newest 5 (seeds 6–10)
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             Some(5),
             None,
@@ -3467,8 +3217,8 @@ mod tests {
         let cursor_id = page1[0].id.as_str();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(cursor_ts),
                 before_message_id: Some(cursor_id.to_string()),
@@ -3496,8 +3246,8 @@ mod tests {
         let cursor_id2 = page2[0].id.as_str();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(cursor_ts2),
                 before_message_id: Some(cursor_id2.to_string()),
@@ -3518,8 +3268,10 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_tied_timestamps_no_skip_or_duplicate_across_pages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[206; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -3529,32 +3281,18 @@ mod tests {
 
         // Seeds 1–6: all at `tie_ts` (identical created_at seconds)
         // Seeds 7–8: flanking timestamps to confirm ordering is correct
-        insert_message_at(
-            7,
-            author,
-            tie_ts - 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await; // earlier
+        insert_message_at(7, author, tie_ts - 1, &group_id, db).await; // earlier
         for i in 1u8..=6 {
-            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.shared.database).await;
+            insert_message_at(i, author, tie_ts, &group_id, db).await;
         }
-        insert_message_at(
-            8,
-            author,
-            tie_ts + 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await; // later
+        insert_message_at(8, author, tie_ts + 1, &group_id, db).await; // later
 
         // Total 8 messages. Page size 3 — three pages needed.
         // Page 1: newest 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             Some(3),
             None,
@@ -3568,8 +3306,8 @@ mod tests {
         let c1_id = page1[0].id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(c1_ts),
                 before_message_id: Some(c1_id.clone()),
@@ -3587,8 +3325,8 @@ mod tests {
         let c2_id = page2[0].id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(c2_ts),
                 before_message_id: Some(c2_id.clone()),
@@ -3610,8 +3348,8 @@ mod tests {
         let c3_id = page3[0].id.clone();
         let page4 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(c3_ts),
                 before_message_id: Some(c3_id.clone()),
@@ -3655,15 +3393,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_half_specified_cursor_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[207; 32]);
-        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_700_000_000u64);
 
         // before=Some, before_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(ts),
                 ..Default::default()
@@ -3681,8 +3421,8 @@ mod tests {
         // before=None, before_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before_message_id: Some(
                     "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
@@ -3703,15 +3443,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_invalid_before_message_id_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[208; 32]);
-        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_700_000_000u64);
 
         // Non-hex string → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some("not-valid-hex-at-all".to_string()),
@@ -3730,8 +3472,8 @@ mod tests {
         // Valid hex but wrong length (32 chars instead of 64) → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some("00000000000000000000000000000001".to_string()),
@@ -3753,22 +3495,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_after_cursor_returns_only_newer_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[220; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_000_000;
 
         // Insert 5 messages: ts+1 … ts+5
         for i in 1u8..=5 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Cursor at ts+2 (seed 2): should return only messages with created_at > ts+2 → ts+3, ts+4, ts+5.
@@ -3776,8 +3513,8 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 2u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3802,21 +3539,16 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_after_cursor_returns_oldest_first() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[221; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_100_000;
 
         for i in 1u8..=10 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Cursor at ts+3: should return ts+4 … ts+10 in ascending order
@@ -3824,8 +3556,8 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 3u8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3851,32 +3583,20 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_after_cursor_tied_timestamps() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[222; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let tie_ts: u64 = 1_710_200_000;
 
         // Insert one message before the tie, six at tie_ts, one after
-        insert_message_at(
-            7,
-            author,
-            tie_ts - 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await;
+        insert_message_at(7, author, tie_ts - 1, &group_id, db).await;
         for i in 1u8..=6 {
-            insert_message_at(i, author, tie_ts, &group_id, &whitenoise.shared.database).await;
+            insert_message_at(i, author, tie_ts, &group_id, db).await;
         }
-        insert_message_at(
-            8,
-            author,
-            tie_ts + 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await;
+        insert_message_at(8, author, tie_ts + 1, &group_id, db).await;
 
         // Use the earliest message (seed 7, ts-1) as the after cursor
         let cursor_ts = Timestamp::from(tie_ts - 1);
@@ -3885,8 +3605,8 @@ mod tests {
         // Page through with limit 3
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -3903,8 +3623,8 @@ mod tests {
         let c1_id = page1.last().unwrap().id.clone();
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(c1_ts),
                 after_message_id: Some(c1_id.clone()),
@@ -3921,8 +3641,8 @@ mod tests {
         let c2_id = page2.last().unwrap().id.clone();
         let page3 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(c2_ts),
                 after_message_id: Some(c2_id.clone()),
@@ -3964,15 +3684,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_both_before_and_after_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[223; 32]);
-        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_710_300_000u64);
         let id = "0000000000000000000000000000000000000000000000000000000000000001";
 
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(ts),
                 before_message_id: Some(id.to_string()),
@@ -3993,15 +3715,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_half_specified_after_cursor_is_rejected() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[224; 32]);
-        let author = Keys::generate().public_key();
         let ts = Timestamp::from(1_710_400_000u64);
 
         // after=Some, after_message_id=None → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(ts),
                 ..Default::default()
@@ -4019,8 +3743,8 @@ mod tests {
         // after=None, after_message_id=Some → InvalidCursor
         let err = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after_message_id: Some(
                     "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
@@ -4041,21 +3765,16 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_after_cursor_past_newest_returns_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[225; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_710_500_000;
 
         for i in 1u8..=3 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Cursor beyond all messages
@@ -4063,8 +3782,8 @@ mod tests {
         let cursor_id = format!("{:0>64}", format!("{:x}", 0xffu8));
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 after: Some(cursor_ts),
                 after_message_id: Some(cursor_id.clone()),
@@ -4088,40 +3807,27 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_group_isolation() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_a = GroupId::from_slice(&[210; 32]);
         let group_b = GroupId::from_slice(&[211; 32]);
-        setup_group(&group_a, &whitenoise.shared.database).await;
-        setup_group(&group_b, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_701_000_000;
 
         // 3 messages in group A, 2 messages in group B
         for i in 1u8..=3 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_a,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_a, db).await;
         }
         for i in 10u8..=11 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_b,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_b, db).await;
         }
 
         let results_a = AggregatedMessage::find_messages_by_group_paginated(
             &group_a,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4130,8 +3836,8 @@ mod tests {
         .unwrap();
         let results_b = AggregatedMessage::find_messages_by_group_paginated(
             &group_b,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4156,40 +3862,30 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_deleted_messages_are_included_as_tombstones() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[212; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_702_000_000;
 
         // Insert 3 messages: seeds 1, 2, 3
         for i in 1u8..=3 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Delete seed-2 message
         let msg2_id = format!("{:0>64}", format!("{:x}", 2u8));
         let deletion_id = format!("{:0>64x}", 0xde1212u64);
-        AggregatedMessage::mark_deleted(
-            &msg2_id,
-            &group_id,
-            &deletion_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&msg2_id, &group_id, &deletion_id, db)
+            .await
+            .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4220,44 +3916,34 @@ mod tests {
     #[tokio::test]
     async fn test_unread_minimum_deleted_messages_are_included_as_tombstones() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[214; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_702_000_000;
 
         // Insert 3 messages: seeds 1, 2, 3
         for i in 1u8..=3 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Delete seed-2 message
         let msg2_id = format!("{:0>64}", format!("{:x}", 2u8));
         let deletion_id = format!("{:0>64x}", 0xde1212u64);
-        AggregatedMessage::mark_deleted(
-            &msg2_id,
-            &group_id,
-            &deletion_id,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::mark_deleted(&msg2_id, &group_id, &deletion_id, db)
+            .await
+            .unwrap();
 
         // No read marker → all non-deleted messages are unread (cnt=2), minimum=3
         // LIMIT = MAX(2, 3) = 3, so all 3 rows (including the tombstone) are returned.
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
             &group_id,
-            &author,
+            &account.pubkey,
             None,
             3,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4284,21 +3970,16 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_non_kind9_messages_are_excluded() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[213; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_703_000_000;
 
         // Insert one kind-9 message via the normal helper
-        insert_message_at(
-            1,
-            author,
-            base_ts + 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await;
+        insert_message_at(1, author, base_ts + 1, &group_id, db).await;
 
         // Insert a kind-7 reaction row directly with raw SQL (insert_message always writes kind=9)
         let reaction_id = format!("{:0>64}", format!("{:x}", 200u8));
@@ -4320,14 +4001,14 @@ mod tests {
         .bind(&empty_tokens)
         .bind(&empty_reactions)
         .bind(&empty_media)
-        .execute(&whitenoise.shared.database.pool)
+        .execute(&db.pool)
         .await
         .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4354,22 +4035,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_uppercase_cursor_id_is_canonicalized() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[214; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_704_000_000;
 
         // Insert 5 messages
         for i in 1u8..=5 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Build cursor from seed 3 (ts+3) but pass the message ID in uppercase
@@ -4379,8 +4055,8 @@ mod tests {
         // Should not error — uppercase is valid hex and gets canonicalized internally
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(Timestamp::from(base_ts + 3)),
                 before_message_id: Some(uppercase_id.clone()),
@@ -4407,18 +4083,20 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_single_message_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[215; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let ts: u64 = 1_705_000_000;
 
-        let msg = insert_message_at(1, author, ts, &group_id, &whitenoise.shared.database).await;
+        let msg = insert_message_at(1, author, ts, &group_id, db).await;
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4435,8 +4113,8 @@ mod tests {
         // Cursor from the only message → next page is empty
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
                 before_message_id: Some(page1[0].id.clone()),
@@ -4458,27 +4136,22 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_exactly_default_limit_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[216; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_706_000_000;
 
         for i in 1u8..=50 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4494,8 +4167,8 @@ mod tests {
         // Cursor from the oldest (page1[0]) → no older messages exist
         let page2 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(page1[0].created_at),
                 before_message_id: Some(page1[0].id.clone()),
@@ -4517,22 +4190,17 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_limit_one_traverses_all_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[217; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_707_000_000;
         let total: u8 = 5;
 
         for i in 1u8..=total {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         let mut all_seen: Vec<String> = Vec::new();
@@ -4550,8 +4218,8 @@ mod tests {
 
             let page = AggregatedMessage::find_messages_by_group_paginated(
                 &group_id,
-                &author,
-                &whitenoise.shared.database,
+                &account.pubkey,
+                db,
                 &opts,
                 Some(1),
                 None,
@@ -4590,29 +4258,24 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_cursor_at_oldest_message_yields_empty() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[218; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_708_000_000;
 
         // Insert 3 messages; seed 1 is the oldest
         for i in 1u8..=3 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // Full first page
         let page1 = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4625,8 +4288,8 @@ mod tests {
         let oldest = &page1[0];
         let next_page = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions {
                 before: Some(oldest.created_at),
                 before_message_id: Some(oldest.id.clone()),
@@ -4650,21 +4313,16 @@ mod tests {
     #[tokio::test]
     async fn test_paginated_retried_messages_are_excluded() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[219; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_709_000_000;
 
         // Insert a normal message (seed 1) and a retried message (seed 2)
-        insert_message_at(
-            1,
-            author,
-            base_ts + 1,
-            &group_id,
-            &whitenoise.shared.database,
-        )
-        .await;
+        insert_message_at(1, author, base_ts + 1, &group_id, db).await;
 
         let retried_msg = ChatMessage {
             id: format!("{:0>64}", format!("{:x}", 2u8)),
@@ -4681,19 +4339,14 @@ mod tests {
             media_attachments: vec![],
             delivery_status: Some(DeliveryStatus::Retried),
         };
-        AggregatedMessage::insert_message(
-            &retried_msg,
-            &group_id,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&retried_msg, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
 
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             None,
@@ -4739,8 +4392,10 @@ mod tests {
     #[tokio::test]
     async fn test_search_messages_in_group() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[42; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
 
@@ -4758,7 +4413,7 @@ mod tests {
         ];
 
         for msg in &messages {
-            AggregatedMessage::insert_message(msg, &group_id, &author, &whitenoise.shared.database)
+            AggregatedMessage::insert_message(msg, &group_id, &account.pubkey, db)
                 .await
                 .unwrap();
         }
@@ -4766,10 +4421,10 @@ mod tests {
         // Basic single-word search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "hello",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4782,10 +4437,10 @@ mod tests {
         // Forward-order multi-word search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "big plans",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4801,10 +4456,10 @@ mod tests {
         // Substring matching ("big" matches "bigger")
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "big",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4814,10 +4469,10 @@ mod tests {
         // Case insensitive
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "MARMOT",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4828,10 +4483,10 @@ mod tests {
         // CJK search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "日本語",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4842,10 +4497,10 @@ mod tests {
         // Cyrillic search
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "привет",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4855,10 +4510,10 @@ mod tests {
         // Devanagari search (with combining marks)
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "नमस्ते",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4869,10 +4524,10 @@ mod tests {
         // No match
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "nonexistent",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4882,10 +4537,10 @@ mod tests {
         // Empty query matches all — positions are sequential newest-first
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4897,10 +4552,10 @@ mod tests {
         // Limit is respected
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "",
             2,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4913,8 +4568,10 @@ mod tests {
     #[tokio::test]
     async fn test_search_same_timestamp_deterministic_ordering() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[99; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let same_ts = Timestamp::from(1_700_000_000u64);
@@ -4944,23 +4601,18 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_id,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
         }
 
         // Search for all three: "same-ts" matches every message
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "same-ts",
             50,
-            &whitenoise.shared.database,
+            db,
             None,
         )
         .await
@@ -4989,15 +4641,13 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let pubkey = account.pubkey;
+        let session = whitenoise.session(&pubkey).unwrap();
+        let db = &session.account_db.inner;
 
         // Set up three groups with messages
         let group_a = GroupId::from_slice(&[10; 32]);
         let group_b = GroupId::from_slice(&[11; 32]);
         let group_declined = GroupId::from_slice(&[12; 32]);
-
-        for gid in [&group_a, &group_b, &group_declined] {
-            setup_group(gid, &whitenoise.shared.database).await;
-        }
 
         // Link account to groups: A = accepted, B = pending (null), C = declined
         let now = Utc::now();
@@ -5031,29 +4681,24 @@ mod tests {
 
         // Insert messages: "marmot" in all three groups
         let msg_a = create_test_chat_message_with_content(1, author, "marmot in group A");
-        AggregatedMessage::insert_message(&msg_a, &group_a, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg_a, &group_a, &author, db)
             .await
             .unwrap();
 
         let msg_b = create_test_chat_message_with_content(2, author, "marmot in group B");
-        AggregatedMessage::insert_message(&msg_b, &group_b, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg_b, &group_b, &author, db)
             .await
             .unwrap();
 
         let msg_declined =
             create_test_chat_message_with_content(3, author, "marmot in declined group");
-        AggregatedMessage::insert_message(
-            &msg_declined,
-            &group_declined,
-            &author,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        AggregatedMessage::insert_message(&msg_declined, &group_declined, &author, db)
+            .await
+            .unwrap();
 
         // Also add a second message in group A to verify per-group positions
         let msg_a2 = create_test_chat_message_with_content(4, author, "another marmot in group A");
-        AggregatedMessage::insert_message(&msg_a2, &group_a, &author, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg_a2, &group_a, &author, db)
             .await
             .unwrap();
 
@@ -5069,15 +4714,10 @@ mod tests {
             .collect();
 
         // Cross-group search for "marmot"
-        let results = AggregatedMessage::search_messages(
-            &pubkey,
-            "marmot",
-            50,
-            &visible_group_ids,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let results =
+            AggregatedMessage::search_messages(&pubkey, "marmot", 50, &visible_group_ids, db)
+                .await
+                .unwrap();
 
         // Should find 3 results (groups A and B), NOT the declined group
         assert_eq!(
@@ -5126,15 +4766,10 @@ mod tests {
         assert_eq!(group_b_result.position, 0);
 
         // Empty query returns all non-declined messages
-        let all_results = AggregatedMessage::search_messages(
-            &pubkey,
-            "",
-            50,
-            &visible_group_ids,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let all_results =
+            AggregatedMessage::search_messages(&pubkey, "", 50, &visible_group_ids, db)
+                .await
+                .unwrap();
         assert_eq!(
             all_results.len(),
             3,
@@ -5142,27 +4777,17 @@ mod tests {
         );
 
         // Limit is respected
-        let limited = AggregatedMessage::search_messages(
-            &pubkey,
-            "marmot",
-            1,
-            &visible_group_ids,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let limited =
+            AggregatedMessage::search_messages(&pubkey, "marmot", 1, &visible_group_ids, db)
+                .await
+                .unwrap();
         assert_eq!(limited.len(), 1, "limit should cap results");
 
         // No match returns empty
-        let no_match = AggregatedMessage::search_messages(
-            &pubkey,
-            "nonexistent",
-            50,
-            &visible_group_ids,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        let no_match =
+            AggregatedMessage::search_messages(&pubkey, "nonexistent", 50, &visible_group_ids, db)
+                .await
+                .unwrap();
         assert!(no_match.is_empty(), "no match should return empty");
     }
 
@@ -5171,22 +4796,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_messages_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[240; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
 
         // Insert 5 messages at known timestamps (seconds)
         for i in 1u8..=5 {
-            insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
         }
 
         // cleared_at = message 3's timestamp in millis → messages 4, 5 survive
@@ -5195,9 +4815,9 @@ mod tests {
         // find_messages_by_group
         let messages = AggregatedMessage::find_messages_by_group(
             &group_id,
-            &author,
+            &account.pubkey,
             Some(cleared_at_ms),
-            &whitenoise.shared.database,
+            db,
         )
         .await
         .unwrap();
@@ -5208,8 +4828,8 @@ mod tests {
         // find_messages_by_group_paginated
         let messages = AggregatedMessage::find_messages_by_group_paginated(
             &group_id,
-            &author,
-            &whitenoise.shared.database,
+            &account.pubkey,
+            db,
             &PaginationOptions::default(),
             None,
             Some(cleared_at_ms),
@@ -5221,10 +4841,10 @@ mod tests {
         // find_messages_with_unread_minimum
         let messages = AggregatedMessage::find_messages_with_unread_minimum(
             &group_id,
-            &author,
+            &account.pubkey,
             None,
             50,
-            &whitenoise.shared.database,
+            db,
             Some(cleared_at_ms),
         )
         .await
@@ -5235,22 +4855,17 @@ mod tests {
     #[tokio::test]
     async fn test_count_unread_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[241; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
 
         let mut messages = Vec::new();
         for i in 1u8..=5 {
-            let msg = insert_message_at(
-                i,
-                author,
-                base_ts + u64::from(i),
-                &group_id,
-                &whitenoise.shared.database,
-            )
-            .await;
+            let msg = insert_message_at(i, author, base_ts + u64::from(i), &group_id, db).await;
             messages.push(msg);
         }
 
@@ -5258,14 +4873,10 @@ mod tests {
         let cleared_at_ms = (base_ts + 2) as i64 * 1000;
 
         // count_unread_for_group with no read marker: 3 visible messages
-        let count = AggregatedMessage::count_unread_for_group(
-            &group_id,
-            None,
-            &whitenoise.shared.database,
-            Some(cleared_at_ms),
-        )
-        .await
-        .unwrap();
+        let count =
+            AggregatedMessage::count_unread_for_group(&group_id, None, db, Some(cleared_at_ms))
+                .await
+                .unwrap();
         assert_eq!(count, 3);
 
         // count_unread_for_group with read marker at msg 3: messages 4, 5 unread
@@ -5273,7 +4884,7 @@ mod tests {
         let count = AggregatedMessage::count_unread_for_group(
             &group_id,
             Some(&marker),
-            &whitenoise.shared.database,
+            db,
             Some(cleared_at_ms),
         )
         .await
@@ -5282,18 +4893,19 @@ mod tests {
 
         // count_unread_for_groups batch API
         let input = vec![(group_id.clone(), None, Some(cleared_at_ms))];
-        let result =
-            AggregatedMessage::count_unread_for_groups(&input, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let result = AggregatedMessage::count_unread_for_groups(&input, db)
+            .await
+            .unwrap();
         assert_eq!(result[&group_id], 3);
     }
 
     #[tokio::test]
     async fn test_search_respects_chat_cleared_at() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[242; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let author = Keys::generate().public_key();
         let base_ts: u64 = 1_700_000_000;
@@ -5316,14 +4928,9 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            AggregatedMessage::insert_message(
-                &msg,
-                &group_id,
-                &author,
-                &whitenoise.shared.database,
-            )
-            .await
-            .unwrap();
+            AggregatedMessage::insert_message(&msg, &group_id, &account.pubkey, db)
+                .await
+                .unwrap();
         }
 
         // cleared_at = message 2's timestamp → messages 3, 4 visible
@@ -5331,10 +4938,10 @@ mod tests {
 
         let results = AggregatedMessage::search_messages_in_group(
             &group_id,
-            &author,
+            &account.pubkey,
             "hello",
             50,
-            &whitenoise.shared.database,
+            db,
             Some(cleared_at_ms),
         )
         .await
@@ -5355,8 +4962,10 @@ mod tests {
     #[tokio::test]
     async fn test_delivery_status_isolated_between_accounts() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
         let group_id = GroupId::from_slice(&[42; 32]);
-        setup_group(&group_id, &whitenoise.shared.database).await;
 
         let account_a = Keys::generate().public_key();
         let account_b = Keys::generate().public_key();
@@ -5364,20 +4973,15 @@ mod tests {
         // Account A sends a message with delivery status
         let mut msg = create_test_chat_message(1, account_a);
         msg.delivery_status = Some(DeliveryStatus::Sending);
-        AggregatedMessage::insert_message(&msg, &group_id, &account_a, &whitenoise.shared.database)
+        AggregatedMessage::insert_message(&msg, &group_id, &account_a, db)
             .await
             .unwrap();
 
         // Account A sees delivery status on their own message
-        let fetched_by_a = AggregatedMessage::find_by_id(
-            &msg.id,
-            &group_id,
-            &account_a,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .expect("message should exist");
+        let fetched_by_a = AggregatedMessage::find_by_id(&msg.id, &group_id, &account_a, db)
+            .await
+            .unwrap()
+            .expect("message should exist");
         assert_eq!(
             fetched_by_a.delivery_status,
             Some(DeliveryStatus::Sending),
@@ -5385,15 +4989,10 @@ mod tests {
         );
 
         // Account B queries the same message — must NOT see A's delivery status
-        let fetched_by_b = AggregatedMessage::find_by_id(
-            &msg.id,
-            &group_id,
-            &account_b,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap()
-        .expect("message should exist for any account");
+        let fetched_by_b = AggregatedMessage::find_by_id(&msg.id, &group_id, &account_b, db)
+            .await
+            .unwrap()
+            .expect("message should exist for any account");
         assert_eq!(
             fetched_by_b.delivery_status, None,
             "other account must not see sender's delivery status (issue #739)"

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -280,26 +280,22 @@ impl Database {
         Ok(())
     }
 
-    /// Deletes aggregated messages that all accounts have cleared.
+    /// Delete aggregated messages whose `created_at <= threshold`.
     ///
-    /// Only deletes messages whose `created_at` is at or before the minimum
-    /// `chat_cleared_at` across all accounts in the group, and only when
-    /// every account has set a `chat_cleared_at` value.
+    /// Intended for the per-account cleanup path: after `clear_chat` advances
+    /// this account's `chat_cleared_at`, the caller passes that timestamp here
+    /// to drop the now-invisible message rows from this account's per-account
+    /// DB. Cross-account coordination is irrelevant because each account owns
+    /// its own copy of `aggregated_messages` post-phase-18e.
     ///
-    /// Returns the number of rows deleted.
-    /// Delete aggregated messages older than the given threshold.
-    ///
-    /// `min_cleared_at` is the minimum `chat_cleared_at` across all accounts
-    /// that have this group, but only if **every** account has set a
-    /// `chat_cleared_at` value (i.e. all accounts have cleared). If any
-    /// account has `chat_cleared_at = NULL`, pass `None` and no cleanup
-    /// occurs.
+    /// Pass `None` to make the call a no-op. Returns the number of rows
+    /// deleted.
     pub(crate) async fn try_cleanup_cleared_messages(
         &self,
         mls_group_id: &mdk_core::prelude::GroupId,
-        min_cleared_at: Option<i64>,
+        cleared_at_ms: Option<i64>,
     ) -> Result<u64, DatabaseError> {
-        let Some(threshold) = min_cleared_at else {
+        let Some(threshold) = cleared_at_ms else {
             return Ok(0);
         };
         retry_on_lock(|| self.try_cleanup_cleared_messages_inner(mls_group_id, threshold)).await

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -322,19 +322,13 @@ impl Database {
         Ok(result.rows_affected())
     }
 
-    /// Delete all data for an account's association with a group.
-    ///
-    /// Removes the per-account row and data (accounts_groups, push tokens,
-    /// media files). If no other accounts reference this group after the deletion,
-    /// also removes shared data (group_information, which cascades to
-    /// aggregated_messages). Per-account drafts (Phase 18c) live in each
-    /// account's per-account DB file and are dropped with that file at full
-    /// account deletion.
+    /// Delete shared-DB data for a group when the last account leaves it.
     ///
     /// All per-account data (accounts_groups, drafts, group_push_tokens,
-    /// media_references) has been moved to per-account DBs; the caller
-    /// deletes those. This method only handles shared data cleanup when
-    /// `is_last_account` is true.
+    /// media_references, aggregated_messages, message_delivery_status) lives
+    /// in per-account DBs and is removed by the caller. This method only
+    /// removes the shared `group_information` row (and anything still
+    /// cascading off it inside the shared DB).
     pub(crate) async fn delete_shared_group_data(
         &self,
         mls_group_id: &mdk_core::prelude::GroupId,
@@ -351,7 +345,6 @@ impl Database {
         &self,
         mls_group_id: &mdk_core::prelude::GroupId,
     ) -> Result<(), DatabaseError> {
-        // group_information cascades to aggregated_messages via FK
         sqlx::query("DELETE FROM group_information WHERE mls_group_id = ?")
             .bind(mls_group_id.as_slice())
             .execute(&self.pool)
@@ -856,6 +849,35 @@ mod tests {
         .unwrap();
     }
 
+    /// Creates the per-account-shape `aggregated_messages` table on a generic
+    /// test DB. Phase 18e moved this table out of the shared schema, so tests
+    /// that exercise per-account-DB methods (`try_cleanup_cleared_messages`)
+    /// must materialise the table themselves.
+    async fn setup_aggregated_messages_table(db: &Database) {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS aggregated_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                author TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                kind INTEGER NOT NULL,
+                content TEXT NOT NULL DEFAULT '',
+                tags JSONB NOT NULL,
+                reply_to_id TEXT,
+                deletion_event_id TEXT,
+                content_tokens JSONB NOT NULL,
+                reactions JSONB NOT NULL,
+                media_attachments JSONB NOT NULL,
+                content_normalized TEXT NOT NULL DEFAULT '',
+                UNIQUE(message_id, mls_group_id)
+            )",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
     /// Inserts a minimal aggregated_messages row.
     async fn setup_message(
         db: &Database,
@@ -896,6 +918,7 @@ mod tests {
         let group_id = mdk_core::prelude::GroupId::from_slice(&[1; 32]);
 
         setup_group(&db, &group_id).await;
+        setup_aggregated_messages_table(&db).await;
 
         // Insert messages at times 100 and 200
         setup_message(&db, &group_id, &format!("{:0>64}", "1"), 100).await;
@@ -916,6 +939,7 @@ mod tests {
         let group_id = mdk_core::prelude::GroupId::from_slice(&[2; 32]);
 
         setup_group(&db, &group_id).await;
+        setup_aggregated_messages_table(&db).await;
 
         // Messages at 100, 200, 300
         setup_message(&db, &group_id, &format!("{:0>64}", "a"), 100).await;
@@ -938,6 +962,7 @@ mod tests {
         let group_id = mdk_core::prelude::GroupId::from_slice(&[3; 32]);
 
         setup_group(&db, &group_id).await;
+        setup_aggregated_messages_table(&db).await;
         setup_message(&db, &group_id, &format!("{:0>64}", "d"), 100).await;
 
         // Not all accounts cleared — caller passes None
@@ -958,12 +983,13 @@ mod tests {
         let group_id = mdk_core::prelude::GroupId::from_slice(&[4; 32]);
 
         setup_group(&db, &group_id).await;
-        setup_message(&db, &group_id, &format!("{:0>64}", "e"), 100).await;
 
-        // Delete shared data as last account
+        // Delete shared data as last account.
         db.delete_shared_group_data(&group_id, true).await.unwrap();
 
-        // Verify group_information is gone
+        // Verify group_information is gone. Per-account aggregated_messages
+        // cleanup is the caller's responsibility (delete_chat) post phase 18e —
+        // this method only owns the shared-DB row.
         let (gi_count,): (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
                 .bind(group_id.as_slice())
@@ -971,9 +997,6 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(gi_count, 0);
-
-        // Messages cascade from group_information delete
-        assert_eq!(message_count(&db, &group_id).await, 0);
     }
 
     #[tokio::test]
@@ -982,12 +1005,11 @@ mod tests {
         let group_id = mdk_core::prelude::GroupId::from_slice(&[5; 32]);
 
         setup_group(&db, &group_id).await;
-        setup_message(&db, &group_id, &format!("{:0>64}", "f"), 100).await;
 
         // Delete shared data as non-last account -- should be a no-op
         db.delete_shared_group_data(&group_id, false).await.unwrap();
 
-        // Shared data preserved
+        // Shared row preserved
         let (gi_count,): (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM group_information WHERE mls_group_id = ?")
                 .bind(group_id.as_slice())
@@ -995,9 +1017,8 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(gi_count, 1);
-        assert_eq!(message_count(&db, &group_id).await, 1);
 
-        // Now delete as last account -- everything should be gone
+        // Now delete as last account -- shared row should be gone
         db.delete_shared_group_data(&group_id, true).await.unwrap();
 
         let (gi_count,): (i64,) =
@@ -1007,6 +1028,5 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(gi_count, 0);
-        assert_eq!(message_count(&db, &group_id).await, 0);
     }
 }

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -165,3 +165,50 @@ CREATE INDEX IF NOT EXISTS idx_accounts_groups_group
 CREATE INDEX IF NOT EXISTS idx_accounts_groups_dm_peer
     ON accounts_groups(dm_peer_pubkey)
     WHERE dm_peer_pubkey IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS aggregated_messages (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id            TEXT NOT NULL
+        CHECK (length(message_id) = 64 AND message_id GLOB '[0-9a-fA-F]*'),
+    mls_group_id          BLOB NOT NULL,
+    author                TEXT NOT NULL
+        CHECK (length(author) = 64 AND author GLOB '[0-9a-fA-F]*'),
+    created_at            INTEGER NOT NULL,
+    kind                  INTEGER NOT NULL,
+    content               TEXT NOT NULL DEFAULT '',
+    tags                  JSONB NOT NULL,
+    reply_to_id           TEXT
+        CHECK (reply_to_id IS NULL OR
+               (length(reply_to_id) = 64 AND reply_to_id GLOB '[0-9a-fA-F]*')),
+    deletion_event_id     TEXT
+        CHECK (deletion_event_id IS NULL OR
+               (length(deletion_event_id) = 64 AND deletion_event_id GLOB '[0-9a-fA-F]*')),
+    content_tokens        JSONB NOT NULL,
+    reactions             JSONB NOT NULL,
+    media_attachments     JSONB NOT NULL,
+    content_normalized    TEXT NOT NULL DEFAULT '',
+    UNIQUE(message_id, mls_group_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_aggregated_messages_message_id
+    ON aggregated_messages(message_id);
+
+CREATE INDEX IF NOT EXISTS idx_aggregated_messages_group
+    ON aggregated_messages(mls_group_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_aggregated_messages_kind_group
+    ON aggregated_messages(kind, mls_group_id, created_at DESC, message_id DESC);
+
+CREATE TABLE IF NOT EXISTS message_delivery_status (
+    message_id      TEXT NOT NULL,
+    mls_group_id    BLOB NOT NULL,
+    account_pubkey  TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    PRIMARY KEY (message_id, mls_group_id, account_pubkey),
+    FOREIGN KEY (message_id, mls_group_id)
+        REFERENCES aggregated_messages(message_id, mls_group_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mds_group_account_status
+    ON message_delivery_status (mls_group_id, account_pubkey, status);

--- a/src/whitenoise/database/rust_migrations/m0001_bridge.rs
+++ b/src/whitenoise/database/rust_migrations/m0001_bridge.rs
@@ -331,17 +331,19 @@ mod tests {
             );
         }
 
-        // Verify m0011 actually ran (message_delivery_status has account_pubkey).
-        let has_account_pubkey: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM pragma_table_info('message_delivery_status') \
-             WHERE name = 'account_pubkey'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(
-            has_account_pubkey, 1,
-            "m0011 should have added account_pubkey to message_delivery_status"
+        // Verify m0011 actually executed (i.e. wasn't auto-stamped). Checking
+        // the table schema would be misleading: phase 18e (m0040/m0041) drops
+        // shared message_delivery_status entirely. Inspect the tracking row
+        // directly instead — its description distinguishes a real run from an
+        // auto-stamp marker.
+        let (m0011_desc,): (String,) =
+            sqlx::query_as("SELECT description FROM _rust_migrations WHERE version = 11")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            !m0011_desc.contains("Auto-stamped"),
+            "m0011 should have executed, not been auto-stamped; got: {m0011_desc}"
         );
     }
 

--- a/src/whitenoise/database/rust_migrations/m0038_move_aggregated_messages.rs
+++ b/src/whitenoise/database/rust_migrations/m0038_move_aggregated_messages.rs
@@ -1,0 +1,369 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `aggregated_messages` table
+/// during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedAggregatedMessageRow {
+    message_id: String,
+    mls_group_id: Vec<u8>,
+    author: String,
+    created_at: i64,
+    kind: i64,
+    content: String,
+    tags: String,
+    reply_to_id: Option<String>,
+    deletion_event_id: Option<String>,
+    content_tokens: String,
+    reactions: String,
+    media_attachments: String,
+    content_normalized: String,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        38
+    }
+
+    fn description(&self) -> &'static str {
+        "Move aggregated_messages into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: identical to shared but the cross-DB FK to
+        // group_information(mls_group_id) is dropped (group_information is
+        // shared, this table is account-scoped).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS aggregated_messages (
+                id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id            TEXT NOT NULL
+                    CHECK (length(message_id) = 64 AND message_id GLOB '[0-9a-fA-F]*'),
+                mls_group_id          BLOB NOT NULL,
+                author                TEXT NOT NULL
+                    CHECK (length(author) = 64 AND author GLOB '[0-9a-fA-F]*'),
+                created_at            INTEGER NOT NULL,
+                kind                  INTEGER NOT NULL,
+                content               TEXT NOT NULL DEFAULT '',
+                tags                  JSONB NOT NULL,
+                reply_to_id           TEXT
+                    CHECK (reply_to_id IS NULL OR
+                           (length(reply_to_id) = 64 AND reply_to_id GLOB '[0-9a-fA-F]*')),
+                deletion_event_id     TEXT
+                    CHECK (deletion_event_id IS NULL OR
+                           (length(deletion_event_id) = 64
+                            AND deletion_event_id GLOB '[0-9a-fA-F]*')),
+                content_tokens        JSONB NOT NULL,
+                reactions             JSONB NOT NULL,
+                media_attachments     JSONB NOT NULL,
+                content_normalized    TEXT NOT NULL DEFAULT '',
+                UNIQUE(message_id, mls_group_id)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_aggregated_messages_message_id
+                ON aggregated_messages(message_id)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_aggregated_messages_group
+                ON aggregated_messages(mls_group_id, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_aggregated_messages_kind_group
+                ON aggregated_messages(kind, mls_group_id, created_at DESC, message_id DESC)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='aggregated_messages')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0038",
+                account = account_pubkey,
+                "shared.aggregated_messages is missing; skipping local copy. \
+                 Expected only on fresh installs or when v41 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        // accounts_groups was moved to the per-account DB by v36, so the
+        // membership lookup now happens locally.
+        let group_ids: Vec<Vec<u8>> =
+            sqlx::query_scalar("SELECT mls_group_id FROM accounts_groups")
+                .fetch_all(&mut *tx)
+                .await?;
+
+        let mut copied = 0u64;
+        for group_id in &group_ids {
+            let rows: Vec<SharedAggregatedMessageRow> = sqlx::query_as(
+                "SELECT message_id, mls_group_id, author, created_at, kind, content,
+                        tags, reply_to_id, deletion_event_id, content_tokens, reactions,
+                        media_attachments, content_normalized
+                 FROM aggregated_messages
+                 WHERE mls_group_id = ?",
+            )
+            .bind(group_id)
+            .fetch_all(global_db)
+            .await?;
+
+            for r in &rows {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO aggregated_messages
+                        (message_id, mls_group_id, author, created_at, kind, content,
+                         tags, reply_to_id, deletion_event_id, content_tokens, reactions,
+                         media_attachments, content_normalized)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(&r.message_id)
+                .bind(&r.mls_group_id)
+                .bind(&r.author)
+                .bind(r.created_at)
+                .bind(r.kind)
+                .bind(&r.content)
+                .bind(&r.tags)
+                .bind(&r.reply_to_id)
+                .bind(&r.deletion_event_id)
+                .bind(&r.content_tokens)
+                .bind(&r.reactions)
+                .bind(&r.media_attachments)
+                .bind(&r.content_normalized)
+                .execute(&mut *tx)
+                .await?;
+            }
+            copied += rows.len() as u64;
+        }
+
+        if copied > 0 {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0038",
+                account = account_pubkey,
+                "Copied {copied} aggregated_messages row(s) across {} group(s) to per-account DB",
+                group_ids.len()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_local_accounts_groups(local: &SqlitePool, group_ids: &[&[u8]]) {
+        // Mirror the schema produced by m0036.
+        sqlx::query(
+            "CREATE TABLE accounts_groups (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                mls_group_id         BLOB NOT NULL UNIQUE,
+                user_confirmation    INTEGER DEFAULT NULL,
+                welcomer_pubkey      TEXT,
+                last_read_message_id TEXT,
+                pin_order            INTEGER DEFAULT NULL,
+                dm_peer_pubkey       TEXT DEFAULT NULL,
+                archived_at          INTEGER DEFAULT NULL,
+                removed_at           INTEGER DEFAULT NULL,
+                self_removed         INTEGER NOT NULL DEFAULT 0,
+                muted_until          INTEGER DEFAULT NULL,
+                chat_cleared_at      INTEGER DEFAULT NULL,
+                created_at           INTEGER NOT NULL,
+                updated_at           INTEGER NOT NULL
+            )",
+        )
+        .execute(local)
+        .await
+        .unwrap();
+
+        for gid in group_ids {
+            sqlx::query(
+                "INSERT INTO accounts_groups (mls_group_id, created_at, updated_at)
+                 VALUES (?, 0, 0)",
+            )
+            .bind(*gid)
+            .execute(local)
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn seed_shared(global: &SqlitePool) {
+        sqlx::query(
+            "CREATE TABLE aggregated_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                author TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                kind INTEGER NOT NULL,
+                content TEXT NOT NULL DEFAULT '',
+                tags JSONB NOT NULL,
+                reply_to_id TEXT,
+                deletion_event_id TEXT,
+                content_tokens JSONB NOT NULL,
+                reactions JSONB NOT NULL,
+                media_attachments JSONB NOT NULL,
+                content_normalized TEXT NOT NULL DEFAULT '',
+                UNIQUE(message_id, mls_group_id)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+
+        // Two messages in group A (which the account joins), one in group B
+        // (which the account does NOT join — must not be copied).
+        let ma = "a".repeat(64);
+        let mb = "b".repeat(64);
+        let mc = "c".repeat(64);
+        let author = "d".repeat(64);
+
+        for (msg, gid, ts) in [
+            (&ma, &[0x01, 0x02, 0x03, 0x04][..], 1000),
+            (&mb, &[0x01, 0x02, 0x03, 0x04][..], 2000),
+            (&mc, &[0x99, 0x88][..], 3000),
+        ] {
+            sqlx::query(
+                "INSERT INTO aggregated_messages
+                    (message_id, mls_group_id, author, created_at, kind, content,
+                     tags, content_tokens, reactions, media_attachments)
+                 VALUES (?, ?, ?, ?, 9, '', '[]', '[]', '{}', '[]')",
+            )
+            .bind(msg)
+            .bind(gid)
+            .bind(&author)
+            .bind(ts)
+            .execute(global)
+            .await
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn migration_copies_only_account_groups() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        seed_local_accounts_groups(&local, &[&[0x01, 0x02, 0x03, 0x04]]).await;
+        seed_shared(&global).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM aggregated_messages")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 2,
+            "only the two messages in the joined group are copied"
+        );
+
+        let (other_present,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM aggregated_messages WHERE mls_group_id = ?")
+                .bind(&[0x99u8, 0x88][..])
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(
+            other_present, 0,
+            "non-joined group's messages must not leak in"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_creates_table_with_no_groups() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "cd".repeat(32);
+        seed_local_accounts_groups(&local, &[]).await;
+        seed_shared(&global).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='aggregated_messages')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM aggregated_messages")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+        seed_local_accounts_groups(&local, &[&[0x01, 0x02]]).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='aggregated_messages')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0039_move_message_delivery_status.rs
+++ b/src/whitenoise/database/rust_migrations/m0039_move_message_delivery_status.rs
@@ -1,0 +1,309 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `message_delivery_status`
+/// table during migration. Not used outside this module.
+#[derive(sqlx::FromRow)]
+struct SharedDeliveryStatusRow {
+    message_id: String,
+    mls_group_id: Vec<u8>,
+    account_pubkey: String,
+    status: String,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        39
+    }
+
+    fn description(&self) -> &'static str {
+        "Move message_delivery_status into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema: column set unchanged from m0011 so that existing
+        // queries keep working without rewrites. The `account_pubkey` column
+        // becomes redundant (every row in this DB belongs to the same account)
+        // but is preserved as a no-op filter.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS message_delivery_status (
+                message_id      TEXT NOT NULL,
+                mls_group_id    BLOB NOT NULL,
+                account_pubkey  TEXT NOT NULL,
+                status          TEXT NOT NULL,
+                PRIMARY KEY (message_id, mls_group_id, account_pubkey),
+                FOREIGN KEY (message_id, mls_group_id)
+                    REFERENCES aggregated_messages(message_id, mls_group_id)
+                    ON DELETE CASCADE
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_mds_group_account_status
+                ON message_delivery_status (mls_group_id, account_pubkey, status)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='message_delivery_status')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0039",
+                account = account_pubkey,
+                "shared.message_delivery_status is missing; skipping local copy. \
+                 Expected only on fresh installs or when v40 already dropped \
+                 the table."
+            );
+            return Ok(());
+        }
+
+        let rows: Vec<SharedDeliveryStatusRow> = sqlx::query_as(
+            "SELECT message_id, mls_group_id, account_pubkey, status
+             FROM message_delivery_status
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        // The local FK on (message_id, mls_group_id) only fires when the
+        // referenced row exists, so we gate inserts on the presence of a
+        // matching aggregated_messages row that v38 just copied. Rows whose
+        // parent message wasn't copied (e.g. for groups this account isn't
+        // in) are silently skipped — they would never satisfy the FK.
+        let mut inserted = 0u64;
+        for r in &rows {
+            let parent_present: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM aggregated_messages
+                  WHERE message_id = ? AND mls_group_id = ?)",
+            )
+            .bind(&r.message_id)
+            .bind(&r.mls_group_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            if !parent_present {
+                continue;
+            }
+
+            sqlx::query(
+                "INSERT OR IGNORE INTO message_delivery_status
+                    (message_id, mls_group_id, account_pubkey, status)
+                 VALUES (?, ?, ?, ?)",
+            )
+            .bind(&r.message_id)
+            .bind(&r.mls_group_id)
+            .bind(&r.account_pubkey)
+            .bind(&r.status)
+            .execute(&mut *tx)
+            .await?;
+            inserted += 1;
+        }
+
+        if inserted > 0 {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0039",
+                account = account_pubkey,
+                "Copied {inserted} message_delivery_status row(s) to per-account DB"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_local_aggregated(local: &SqlitePool, message_ids: &[(&str, &[u8])]) {
+        // Mirror the schema produced by m0038 (no FK to group_information).
+        sqlx::query(
+            "CREATE TABLE aggregated_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                author TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                kind INTEGER NOT NULL,
+                content TEXT NOT NULL DEFAULT '',
+                tags JSONB NOT NULL,
+                reply_to_id TEXT,
+                deletion_event_id TEXT,
+                content_tokens JSONB NOT NULL,
+                reactions JSONB NOT NULL,
+                media_attachments JSONB NOT NULL,
+                content_normalized TEXT NOT NULL DEFAULT '',
+                UNIQUE(message_id, mls_group_id)
+            )",
+        )
+        .execute(local)
+        .await
+        .unwrap();
+        let author = "d".repeat(64);
+        for (msg, gid) in message_ids {
+            sqlx::query(
+                "INSERT INTO aggregated_messages
+                    (message_id, mls_group_id, author, created_at, kind, content,
+                     tags, content_tokens, reactions, media_attachments)
+                 VALUES (?, ?, ?, 0, 9, '', '[]', '[]', '{}', '[]')",
+            )
+            .bind(*msg)
+            .bind(*gid)
+            .bind(&author)
+            .execute(local)
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn seed_shared_mds(global: &SqlitePool) {
+        sqlx::query(
+            "CREATE TABLE message_delivery_status (
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                account_pubkey TEXT NOT NULL,
+                status TEXT NOT NULL,
+                PRIMARY KEY (message_id, mls_group_id, account_pubkey)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_only_this_account_with_parent_present() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        let other_pubkey = "ff".repeat(32);
+
+        seed_local_aggregated(
+            &local,
+            &[("1".repeat(64).as_str(), &[0x01, 0x02, 0x03, 0x04])],
+        )
+        .await;
+        seed_shared_mds(&global).await;
+
+        // Status for this account, parent present locally — copied.
+        sqlx::query(
+            "INSERT INTO message_delivery_status
+                (message_id, mls_group_id, account_pubkey, status)
+             VALUES (?, ?, ?, '\"Sent\"')",
+        )
+        .bind("1".repeat(64))
+        .bind(&[0x01u8, 0x02, 0x03, 0x04][..])
+        .bind(&pubkey)
+        .execute(&global)
+        .await
+        .unwrap();
+
+        // Status for this account but parent NOT present locally — skipped.
+        sqlx::query(
+            "INSERT INTO message_delivery_status
+                (message_id, mls_group_id, account_pubkey, status)
+             VALUES (?, ?, ?, '\"Sent\"')",
+        )
+        .bind("2".repeat(64))
+        .bind(&[0x05u8, 0x06][..])
+        .bind(&pubkey)
+        .execute(&global)
+        .await
+        .unwrap();
+
+        // Status for a different account — must not leak in.
+        sqlx::query(
+            "INSERT INTO message_delivery_status
+                (message_id, mls_group_id, account_pubkey, status)
+             VALUES (?, ?, ?, '\"Sent\"')",
+        )
+        .bind("1".repeat(64))
+        .bind(&[0x01u8, 0x02, 0x03, 0x04][..])
+        .bind(&other_pubkey)
+        .execute(&global)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM message_delivery_status")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "only this account's status with parent present is copied"
+        );
+
+        let (account,): (String,) =
+            sqlx::query_as("SELECT account_pubkey FROM message_delivery_status")
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(account, pubkey);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+        seed_local_aggregated(&local, &[]).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='message_delivery_status')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0040_drop_shared_message_delivery_status.rs
+++ b/src/whitenoise/database/rust_migrations/m0040_drop_shared_message_delivery_status.rs
@@ -1,0 +1,76 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        40
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared message_delivery_status table (data moved to per-account DBs in v39)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        // Drop before v41 removes aggregated_messages — message_delivery_status
+        // has an FK pointing at aggregated_messages and SQLite would refuse the
+        // parent drop while the child table still references it.
+        sqlx::query("DROP TABLE IF EXISTS message_delivery_status")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE message_delivery_status (
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL,
+                account_pubkey TEXT NOT NULL,
+                status TEXT NOT NULL,
+                PRIMARY KEY (message_id, mls_group_id, account_pubkey)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='message_delivery_status')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0041_drop_shared_aggregated_messages.rs
+++ b/src/whitenoise/database/rust_migrations/m0041_drop_shared_aggregated_messages.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        41
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared aggregated_messages table (data moved to per-account DBs in v38)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP TABLE IF EXISTS aggregated_messages")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE aggregated_messages (
+                id INTEGER PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                mls_group_id BLOB NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='aggregated_messages')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -42,6 +42,10 @@ mod m0034_move_group_push_tokens;
 mod m0035_drop_shared_group_push_tokens;
 mod m0036_move_accounts_groups;
 mod m0037_drop_shared_accounts_groups;
+mod m0038_move_aggregated_messages;
+mod m0039_move_message_delivery_status;
+mod m0040_drop_shared_message_delivery_status;
+mod m0041_drop_shared_aggregated_messages;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -74,6 +78,8 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0033_drop_shared_push_registrations::Migration),
         Box::new(m0035_drop_shared_group_push_tokens::Migration),
         Box::new(m0037_drop_shared_accounts_groups::Migration),
+        Box::new(m0040_drop_shared_message_delivery_status::Migration),
+        Box::new(m0041_drop_shared_aggregated_messages::Migration),
     ]
 }
 
@@ -91,6 +97,8 @@ pub fn all_local_migrations() -> Vec<Box<dyn LocalMigration>> {
         Box::new(m0032_move_push_registrations::Migration),
         Box::new(m0034_move_group_push_tokens::Migration),
         Box::new(m0036_move_accounts_groups::Migration),
+        Box::new(m0038_move_aggregated_messages::Migration),
+        Box::new(m0039_move_message_delivery_status::Migration),
     ]
 }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -255,7 +255,7 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<()> {
-        let last_message_id = self.get_last_message_id(group_id).await;
+        let last_message_id = self.get_last_message_id(account_pubkey, group_id).await;
 
         for (trigger, msg) in self
             .cache_deletion(account_pubkey, group_id, message)
@@ -486,10 +486,15 @@ impl Whitenoise {
     }
 
     /// Gets the ID of the last message in a group (if any).
-    async fn get_last_message_id(&self, group_id: &GroupId) -> Option<String> {
+    async fn get_last_message_id(
+        &self,
+        account_pubkey: &PublicKey,
+        group_id: &GroupId,
+    ) -> Option<String> {
+        let session = self.account_manager.get_session(account_pubkey)?;
         AggregatedMessage::find_last_by_group_ids(
             std::slice::from_ref(group_id),
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await
         .ok()
@@ -533,7 +538,7 @@ impl Whitenoise {
             &chat_message.id,
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
             && existing_message.delivery_status.is_some()
@@ -545,13 +550,13 @@ impl Whitenoise {
             &chat_message,
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
 
         // Apply orphaned reactions/deletions - modifies in-place and returns final state
         let final_message = self
-            .apply_orphaned_reactions_and_deletions(chat_message, group_id)
+            .apply_orphaned_reactions_and_deletions(account_pubkey, chat_message, group_id)
             .await?;
 
         tracing::debug!(
@@ -576,6 +581,10 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Option<ChatMessage>> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         // If this reaction already has a delivery status, it was sent by us and already
         // applied to the parent — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
@@ -583,7 +592,7 @@ impl Whitenoise {
             &message.id.to_string(),
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         {
@@ -596,7 +605,7 @@ impl Whitenoise {
             return Ok(None);
         }
 
-        AggregatedMessage::insert_reaction(message, group_id, &self.shared.database).await?;
+        AggregatedMessage::insert_reaction(message, group_id, &session.account_db.inner).await?;
 
         let result = self
             .apply_reaction_to_target(account_pubkey, message, group_id)
@@ -630,13 +639,17 @@ impl Whitenoise {
         reaction: &Message,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         let target_id = extract_reaction_target_id(&reaction.tags)?;
 
         let Some(mut target) = AggregatedMessage::find_by_id(
             &target_id,
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         else {
@@ -660,7 +673,7 @@ impl Whitenoise {
             &target.id,
             group_id,
             &target.reactions,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
 
@@ -678,6 +691,10 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<Vec<(UpdateTrigger, ChatMessage)>> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         // If this deletion already has a delivery status, it was sent by us and already
         // applied to targets — skip re-applying to avoid unnecessary DB writes and
         // duplicate UI emissions.
@@ -685,7 +702,7 @@ impl Whitenoise {
             &message.id.to_string(),
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         {
@@ -698,7 +715,7 @@ impl Whitenoise {
             return Ok(Vec::new());
         }
 
-        AggregatedMessage::insert_deletion(message, group_id, &self.shared.database).await?;
+        AggregatedMessage::insert_deletion(message, group_id, &session.account_db.inner).await?;
 
         let updates = self
             .apply_deletions_to_targets(account_pubkey, message, group_id)
@@ -745,9 +762,13 @@ impl Whitenoise {
         deletion_event_id: &EventId,
         group_id: &GroupId,
     ) -> Result<Option<(UpdateTrigger, ChatMessage)>> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         // Check if target is a reaction
         if let Some(reaction) =
-            AggregatedMessage::find_reaction_by_id(target_id, group_id, &self.shared.database)
+            AggregatedMessage::find_reaction_by_id(target_id, group_id, &session.account_db.inner)
                 .await?
         {
             let parent_update = self
@@ -757,7 +778,7 @@ impl Whitenoise {
                 target_id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.shared.database,
+                &session.account_db.inner,
             )
             .await?;
             return Ok(parent_update.map(|msg| (UpdateTrigger::ReactionRemoved, msg)));
@@ -768,7 +789,7 @@ impl Whitenoise {
             target_id,
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         {
@@ -777,7 +798,7 @@ impl Whitenoise {
                 target_id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.shared.database,
+                &session.account_db.inner,
             )
             .await?;
             return Ok(Some((UpdateTrigger::MessageDeleted, msg)));
@@ -788,7 +809,7 @@ impl Whitenoise {
             target_id,
             group_id,
             &deletion_event_id.to_string(),
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
         Ok(None)
@@ -801,6 +822,10 @@ impl Whitenoise {
         reaction: &AggregatedMessage,
         group_id: &GroupId,
     ) -> Result<Option<ChatMessage>> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         let Ok(parent_id) = extract_reaction_target_id(&reaction.tags) else {
             return Ok(None);
         };
@@ -809,7 +834,7 @@ impl Whitenoise {
             &parent_id,
             group_id,
             account_pubkey,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?
         else {
@@ -821,7 +846,7 @@ impl Whitenoise {
                 &parent_id,
                 group_id,
                 &parent.reactions,
-                &self.shared.database,
+                &session.account_db.inner,
             )
             .await?;
 
@@ -844,20 +869,25 @@ impl Whitenoise {
     /// This avoids re-fetching from the database after applying orphans.
     async fn apply_orphaned_reactions_and_deletions(
         &self,
+        account_pubkey: &PublicKey,
         mut message: ChatMessage,
         group_id: &GroupId,
     ) -> Result<ChatMessage> {
+        let session = self
+            .account_manager
+            .get_session(account_pubkey)
+            .ok_or(WhitenoiseError::AccountNotFound)?;
         let orphaned_reactions = AggregatedMessage::find_orphaned_reactions(
             &message.id,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
 
         let orphaned_deletions = AggregatedMessage::find_orphaned_deletions(
             &message.id,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
 
@@ -904,7 +934,7 @@ impl Whitenoise {
                 &message.id,
                 group_id,
                 &message.reactions,
-                &self.shared.database,
+                &session.account_db.inner,
             )
             .await?;
         }
@@ -916,7 +946,7 @@ impl Whitenoise {
                 &message.id,
                 group_id,
                 &deletion_event_id.to_string(),
-                &self.shared.database,
+                &session.account_db.inner,
             )
             .await?;
         }
@@ -1012,7 +1042,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1039,7 +1069,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1070,7 +1100,7 @@ mod tests {
             &message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1082,6 +1112,7 @@ mod tests {
     async fn test_cache_chat_message_preserves_existing_delivery_status() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let creator_account = whitenoise.create_identity().await.unwrap();
+        let creator_session = whitenoise.require_session(&creator_account.pubkey).unwrap();
         let members = setup_multiple_test_accounts(&whitenoise, 1).await;
         let member_pubkey = members[0].0.pubkey;
 
@@ -1131,7 +1162,7 @@ mod tests {
             &group.mls_group_id,
             &creator_account.pubkey,
             &DeliveryStatus::Sent(1),
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1147,7 +1178,7 @@ mod tests {
             &message_id.to_string(),
             &group.mls_group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1257,7 +1288,7 @@ mod tests {
         let orphaned_reactions = AggregatedMessage::find_orphaned_reactions(
             &future_message_id.to_string(),
             group_id,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1291,7 +1322,7 @@ mod tests {
             &future_message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1399,7 +1430,7 @@ mod tests {
             &future_message_id.to_string(),
             group_id,
             &creator_account.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1546,7 +1577,7 @@ mod tests {
             &group.mls_group_id,
             &creator_account.pubkey,
             None,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1626,7 +1657,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.shared.database,
+            &member_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1708,7 +1739,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.shared.database,
+            &member_session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1772,7 +1803,7 @@ mod tests {
             &group_id,
             &member_account.pubkey,
             None,
-            &whitenoise.shared.database,
+            &member_session.account_db.inner,
         )
         .await
         .unwrap();

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -177,7 +177,7 @@ impl Whitenoise {
                 let mdk_messages = mdk.get_messages(&group_info.mls_group_id, None)?;
 
                 if self
-                    .cache_needs_sync(&group_info.mls_group_id, &mdk_messages)
+                    .cache_needs_sync(&account.pubkey, &group_info.mls_group_id, &mdk_messages)
                     .await?
                 {
                     tracing::info!(
@@ -211,13 +211,19 @@ impl Whitenoise {
     }
 
     #[perf_instrument("messages")]
-    async fn cache_needs_sync(&self, group_id: &GroupId, mdk_messages: &[Message]) -> Result<bool> {
+    async fn cache_needs_sync(
+        &self,
+        account_pubkey: &PublicKey,
+        group_id: &GroupId,
+        mdk_messages: &[Message],
+    ) -> Result<bool> {
         if mdk_messages.is_empty() {
             return Ok(false);
         }
 
+        let session = self.require_session(account_pubkey)?;
         let cached_count =
-            AggregatedMessage::count_by_group(group_id, &self.shared.database).await?;
+            AggregatedMessage::count_by_group(group_id, &session.account_db.inner).await?;
 
         if mdk_messages.len() != cached_count {
             tracing::debug!(
@@ -247,8 +253,14 @@ impl Whitenoise {
             return Ok(());
         }
 
+        let session = self
+            .account_manager
+            .get_session(pubkey)
+            .ok_or_else(|| crate::whitenoise::error::WhitenoiseError::AccountNotFound)?;
+
         let cached_ids =
-            AggregatedMessage::get_all_event_ids_by_group(group_id, &self.shared.database).await?;
+            AggregatedMessage::get_all_event_ids_by_group(group_id, &session.account_db.inner)
+                .await?;
 
         let new_events: Vec<Message> = mdk_messages
             .into_iter()
@@ -273,10 +285,6 @@ impl Whitenoise {
             hex::encode(group_id.as_slice())
         );
 
-        let session = self
-            .account_manager
-            .get_session(pubkey)
-            .ok_or_else(|| crate::whitenoise::error::WhitenoiseError::AccountNotFound)?;
         let media_files = MediaFile::find_by_group(
             &session.account_db.inner.pool,
             &self.shared.database,
@@ -301,7 +309,7 @@ impl Whitenoise {
             new_events,
             processed_messages,
             group_id,
-            &self.shared.database,
+            &session.account_db.inner,
         )
         .await?;
 
@@ -582,10 +590,15 @@ mod tests {
     #[tokio::test]
     async fn test_cache_needs_sync_empty_mdk() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
         let group_id = GroupId::from_slice(&[1; 32]);
 
-        // Empty MDK messages should not need sync
-        let needs_sync = whitenoise.cache_needs_sync(&group_id, &[]).await.unwrap();
+        // Empty MDK messages should not need sync — short-circuits before
+        // touching the account DB, so the missing group is irrelevant.
+        let needs_sync = whitenoise
+            .cache_needs_sync(&account.pubkey, &group_id, &[])
+            .await
+            .unwrap();
         assert!(!needs_sync);
     }
 
@@ -666,8 +679,9 @@ mod tests {
         // But MDK also has kind 7/5 events (MLS protocol), so cache_needs_sync
         // compares total event count (MDK) vs cache count.
         // Cache only has kind 9 from proactive caching, sync fills in the rest.
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(
@@ -683,7 +697,7 @@ mod tests {
 
         // Cache should not need sync anymore
         let needs_sync = whitenoise
-            .cache_needs_sync(&group.mls_group_id, &mdk_messages)
+            .cache_needs_sync(&creator.pubkey, &group.mls_group_id, &mdk_messages)
             .await
             .unwrap();
         assert!(!needs_sync, "Cache should not need sync after syncing");
@@ -693,7 +707,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -733,8 +747,9 @@ mod tests {
             .unwrap();
 
         // Verify 2 messages already in cache (proactive caching)
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 2);
@@ -755,7 +770,7 @@ mod tests {
 
         // Verify 3 messages in cache
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 3);
@@ -765,7 +780,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -810,8 +825,9 @@ mod tests {
         }
 
         // Cache already has 5 messages from proactive caching
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -821,7 +837,7 @@ mod tests {
 
         // Cache should still have 5 messages
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -831,7 +847,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -850,7 +866,7 @@ mod tests {
         whitenoise.sync_message_cache_on_startup().await.unwrap();
 
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 5);
@@ -1019,8 +1035,9 @@ mod tests {
             .unwrap();
 
         // Verify kind 9 was cached
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 1, "kind 9 message should be cached");
@@ -1050,7 +1067,7 @@ mod tests {
 
         // Cache count should be 2 (kind 9 + kind 7)
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(
@@ -1063,7 +1080,7 @@ mod tests {
             &chat_result.message.id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1106,11 +1123,12 @@ mod tests {
         let event_id = result.message.id;
 
         // Verify status is Sending
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let msg = AggregatedMessage::find_by_id(
             &event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1207,12 +1225,13 @@ mod tests {
 
         // Manually mark the message as Failed (simulating exhausted retries).
         // Done after the sleep so background publish_with_retries doesn't overwrite it.
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         AggregatedMessage::update_delivery_status(
             &original_event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
             &DeliveryStatus::Failed("simulated failure".to_string()),
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1222,7 +1241,7 @@ mod tests {
             &original_event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1254,7 +1273,7 @@ mod tests {
             &original_event_id.to_string(),
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1272,7 +1291,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1343,11 +1362,12 @@ mod tests {
         let event_id = result.message.id.to_string();
 
         // Verify initial status is Sending
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let msg = AggregatedMessage::find_by_id(
             &event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1387,7 +1407,7 @@ mod tests {
                 &unreachable_relays,
                 &event_id,
                 &group.mls_group_id,
-                &whitenoise.shared.database,
+                &session.account_db.inner,
                 &whitenoise.shared.message_stream_manager,
             )
             .await;
@@ -1397,7 +1417,7 @@ mod tests {
             &event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1413,12 +1433,13 @@ mod tests {
     #[tokio::test]
     async fn test_cache_needs_sync_empty_messages() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
 
         let group_id = GroupId::from_slice(&[42u8; 32]);
         let empty_messages: Vec<Message> = vec![];
 
         let needs_sync = whitenoise
-            .cache_needs_sync(&group_id, &empty_messages)
+            .cache_needs_sync(&account.pubkey, &group_id, &empty_messages)
             .await
             .unwrap();
         assert!(!needs_sync, "Empty MDK messages should not need sync");
@@ -1460,7 +1481,7 @@ mod tests {
 
         // Cache is in sync — should return false
         let needs_sync = whitenoise
-            .cache_needs_sync(&group.mls_group_id, &mdk_messages)
+            .cache_needs_sync(&creator.pubkey, &group.mls_group_id, &mdk_messages)
             .await
             .unwrap();
         assert!(
@@ -1469,13 +1490,14 @@ mod tests {
         );
 
         // Delete the cache to simulate stale state
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
+        let creator_session = whitenoise.session(&creator.pubkey).unwrap();
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &creator_session.account_db.inner)
             .await
             .unwrap();
 
         // Now cache count (0) != MDK count (3) — should return true
         let needs_sync = whitenoise
-            .cache_needs_sync(&group.mls_group_id, &mdk_messages)
+            .cache_needs_sync(&creator.pubkey, &group.mls_group_id, &mdk_messages)
             .await
             .unwrap();
         assert!(needs_sync, "Cache should need sync after deletion");
@@ -1521,11 +1543,12 @@ mod tests {
         assert!(!mdk_messages.is_empty());
 
         // Clear the cache entirely
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
+        let session = whitenoise.session(&creator.pubkey).unwrap();
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &session.account_db.inner)
             .await
             .unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 0, "Cache should be empty after deletion");
@@ -1541,7 +1564,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1574,10 +1597,10 @@ mod tests {
             .await
             .unwrap();
 
-        let cached_count =
-            AggregatedMessage::count_by_group(&group_id, &whitenoise.shared.database)
-                .await
-                .unwrap();
+        let session = whitenoise.session(&creator.pubkey).unwrap();
+        let cached_count = AggregatedMessage::count_by_group(&group_id, &session.account_db.inner)
+            .await
+            .unwrap();
         assert_eq!(cached_count, 0);
     }
 
@@ -1616,18 +1639,19 @@ mod tests {
         }
 
         // Verify proactive cache has 4 messages
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 4);
 
         // Clear the cache to simulate a stale/corrupt state
-        AggregatedMessage::delete_by_group(&group.mls_group_id, &whitenoise.shared.database)
+        AggregatedMessage::delete_by_group(&group.mls_group_id, &session.account_db.inner)
             .await
             .unwrap();
         let cached_count =
-            AggregatedMessage::count_by_group(&group.mls_group_id, &whitenoise.shared.database)
+            AggregatedMessage::count_by_group(&group.mls_group_id, &session.account_db.inner)
                 .await
                 .unwrap();
         assert_eq!(cached_count, 0, "Cache should be empty");
@@ -1640,7 +1664,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1709,11 +1733,12 @@ mod tests {
         );
 
         // find_by_id should return the message but with is_deleted=true
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let target = AggregatedMessage::find_by_id(
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1725,7 +1750,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1741,7 +1766,7 @@ mod tests {
             &del_event_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1793,11 +1818,12 @@ mod tests {
             .unwrap();
 
         // Verify reaction was applied to parent
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let parent = AggregatedMessage::find_by_id(
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1819,7 +1845,7 @@ mod tests {
             &creator.pubkey,
             "+",
             &group.mls_group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -1829,7 +1855,7 @@ mod tests {
             &target_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -1886,11 +1912,12 @@ mod tests {
             .unwrap();
 
         // Verify message is marked as deleted
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let messages = AggregatedMessage::find_messages_by_group(
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -1909,7 +1936,7 @@ mod tests {
             &creator.pubkey,
             "",
             &group.mls_group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -1919,7 +1946,7 @@ mod tests {
             &group.mls_group_id,
             &creator.pubkey,
             None,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap();
@@ -2017,6 +2044,7 @@ mod tests {
         let del_event_id = del_result.message.id.to_string();
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &reaction_id]).unwrap()]);
         let stream_manager = MessageStreamManager::new();
+        let session = whitenoise.session(&creator.pubkey).unwrap();
 
         cascade_delivery_failure(
             5,
@@ -2025,7 +2053,7 @@ mod tests {
             &creator.pubkey,
             "",
             &group.mls_group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -2047,6 +2075,8 @@ mod tests {
     async fn test_cascade_kind9_is_noop() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[199; 32]);
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         let author = Keys::generate().public_key();
         let stream_manager = MessageStreamManager::new();
 
@@ -2058,7 +2088,7 @@ mod tests {
             &author,
             "",
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -2104,6 +2134,8 @@ mod tests {
     async fn test_cascade_reaction_failure_parent_not_found() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[200; 32]);
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         let author = Keys::generate().public_key();
         let stream_manager = MessageStreamManager::new();
 
@@ -2119,7 +2151,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -2131,6 +2163,8 @@ mod tests {
     async fn test_cascade_reaction_failure_missing_etag() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[201; 32]);
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         let author = Keys::generate().public_key();
         let stream_manager = MessageStreamManager::new();
 
@@ -2142,7 +2176,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -2208,11 +2242,12 @@ mod tests {
         assert!(del_result.is_ok(), "Deletion should succeed");
 
         // The second message should be marked deleted
+        let session = whitenoise.session(&creator.pubkey).unwrap();
         let msg = AggregatedMessage::find_by_id(
             &last_id,
             &group.mls_group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
         )
         .await
         .unwrap()
@@ -2225,13 +2260,15 @@ mod tests {
     async fn test_cascade_reaction_failure_handles_db_error() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[202; 32]);
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         let author = Keys::generate().public_key();
         let target_id = format!("{:0>64x}", 0xabc123u64);
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &target_id]).unwrap()]);
         let stream_manager = MessageStreamManager::new();
 
         // Close the pool to force DB errors on find_by_id
-        whitenoise.shared.database.pool.close().await;
+        session.account_db.inner.pool.close().await;
 
         cascade_delivery_failure(
             7,
@@ -2240,7 +2277,7 @@ mod tests {
             &author,
             "+",
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;
@@ -2253,12 +2290,14 @@ mod tests {
     async fn test_cascade_deletion_failure_handles_db_error() {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let group_id = GroupId::from_slice(&[203; 32]);
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
         let target_id = format!("{:0>64x}", 0xdef456u64);
         let tags = Tags::from_list(vec![Tag::parse(vec!["e", &target_id]).unwrap()]);
         let stream_manager = MessageStreamManager::new();
 
         // Close the pool to force DB errors on unmark_deleted
-        whitenoise.shared.database.pool.close().await;
+        session.account_db.inner.pool.close().await;
 
         cascade_delivery_failure(
             5,
@@ -2267,7 +2306,7 @@ mod tests {
             &Keys::generate().public_key(),
             "",
             &group_id,
-            &whitenoise.shared.database,
+            &session.account_db.inner,
             &stream_manager,
         )
         .await;

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1749,11 +1749,12 @@ mod tests {
                 delivery_status: None,
             };
 
+            let session = whitenoise.session(&test_pubkey).unwrap();
             aggregated_message::AggregatedMessage::insert_message(
                 &msg1,
                 &group_id,
                 &test_pubkey,
-                &whitenoise.shared.database,
+                &session.account_db.inner,
             )
             .await
             .unwrap();
@@ -1761,7 +1762,7 @@ mod tests {
                 &msg2,
                 &group_id,
                 &test_pubkey,
-                &whitenoise.shared.database,
+                &session.account_db.inner,
             )
             .await
             .unwrap();
@@ -1865,11 +1866,12 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
+            let session = whitenoise.session(&author).unwrap();
             aggregated_message::AggregatedMessage::insert_message(
                 &msg,
                 group_id,
                 &author,
-                &whitenoise.shared.database,
+                &session.account_db.inner,
             )
             .await
             .unwrap();
@@ -3427,6 +3429,7 @@ mod tests {
                 (&group_e, "5", "Message E", base_timestamp + 3600), // +1 hour
             ];
 
+            let session = whitenoise.session(&creator.pubkey).unwrap();
             for (group, id, content, timestamp) in messages {
                 let msg = message_aggregator::ChatMessage {
                     id: format!("{:0>64}", id),
@@ -3447,7 +3450,7 @@ mod tests {
                     &msg,
                     &group.mls_group_id,
                     &creator.pubkey,
-                    &whitenoise.shared.database,
+                    &session.account_db.inner,
                 )
                 .await
                 .unwrap();

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1843,10 +1843,13 @@ mod tests {
         // ── Helper ────────────────────────────────────────────────────────────
 
         /// Insert a `ChatMessage` with an explicit Unix-seconds timestamp and a
-        /// deterministic ID derived from `seed`.  Returns the inserted message.
+        /// deterministic ID derived from `seed`. Writes into `account_pubkey`'s
+        /// per-account DB; `author` is just the message author field and may
+        /// differ from the storing account. Returns the inserted message.
         async fn insert_msg_at(
             seed: u8,
             author: nostr_sdk::PublicKey,
+            account_pubkey: &nostr_sdk::PublicKey,
             unix_secs: u64,
             group_id: &GroupId,
             whitenoise: &Whitenoise,
@@ -1866,11 +1869,11 @@ mod tests {
                 media_attachments: vec![],
                 delivery_status: None,
             };
-            let session = whitenoise.session(&author).unwrap();
+            let session = whitenoise.session(account_pubkey).unwrap();
             aggregated_message::AggregatedMessage::insert_message(
                 &msg,
                 group_id,
-                &author,
+                account_pubkey,
                 &session.account_db.inner,
             )
             .await
@@ -1970,7 +1973,8 @@ mod tests {
 
             // Insert 10 messages with distinct timestamps (seeds 1–10)
             for i in 1u8..=10 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
+                    .await;
             }
 
             let subscription = whitenoise
@@ -2006,7 +2010,8 @@ mod tests {
             let base: u64 = 1_711_000_000;
 
             for i in 1u8..=5 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
+                    .await;
             }
 
             let subscription = whitenoise
@@ -2034,7 +2039,8 @@ mod tests {
 
             // Insert exactly 50 messages
             for i in 1u8..=50 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
+                    .await;
             }
 
             let subscription = whitenoise
@@ -2061,7 +2067,8 @@ mod tests {
             let base: u64 = 1_713_000_000;
 
             for i in 1u8..=60 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
+                    .await;
             }
 
             let subscription = whitenoise
@@ -2098,7 +2105,8 @@ mod tests {
 
             // Insert in reverse order to confirm sorting is not dependent on insertion order
             for i in (1u8..=5).rev() {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
+                    .await;
             }
 
             let subscription = whitenoise
@@ -2144,7 +2152,7 @@ mod tests {
             let author = nostr_sdk::Keys::generate().public_key();
             setup_account_group(&author, &group_id, &whitenoise).await;
 
-            insert_msg_at(1, author, 1_715_000_001, &group_id, &whitenoise).await;
+            insert_msg_at(1, author, &author, 1_715_000_001, &group_id, &whitenoise).await;
 
             // No updates are emitted — the drain must exit via the Empty arm immediately
             let subscription = whitenoise
@@ -2178,7 +2186,7 @@ mod tests {
             setup_account_group(&author, &group_id, &whitenoise).await;
 
             // Insert a message into the DB — this is the "stale" row
-            insert_msg_at(1, author, 1_716_000_001, &group_id, &whitenoise).await;
+            insert_msg_at(1, author, &author, 1_716_000_001, &group_id, &whitenoise).await;
 
             let subscription = whitenoise
                 .subscribe_to_group_messages(&author, &group_id, None)
@@ -2262,8 +2270,8 @@ mod tests {
             let author = nostr_sdk::Keys::generate().public_key();
             setup_account_group(&author, &group_id, &whitenoise).await;
 
-            insert_msg_at(1, author, 1_718_000_001, &group_id, &whitenoise).await;
-            insert_msg_at(2, author, 1_718_000_002, &group_id, &whitenoise).await;
+            insert_msg_at(1, author, &author, 1_718_000_001, &group_id, &whitenoise).await;
+            insert_msg_at(2, author, &author, 1_718_000_002, &group_id, &whitenoise).await;
 
             let mut subscription = whitenoise
                 .subscribe_to_group_messages(&author, &group_id, None)
@@ -2349,7 +2357,7 @@ mod tests {
             let author = nostr_sdk::Keys::generate().public_key();
             setup_account_group(&author, &group_id, &whitenoise).await;
 
-            insert_msg_at(1, author, 1_720_000_001, &group_id, &whitenoise).await;
+            insert_msg_at(1, author, &author, 1_720_000_001, &group_id, &whitenoise).await;
 
             // Two independent subscriptions
             let mut sub_a = whitenoise
@@ -2515,7 +2523,15 @@ mod tests {
             // History: 10 messages at t+1 … t+10 (oldest → newest)
             let base: u64 = 1_730_000_000;
             for i in 1u8..=10 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &account.pubkey,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             // ── Step 1: open chat ─────────────────────────────────────────────
@@ -2713,7 +2729,15 @@ mod tests {
             // Exactly 10 messages, page size 5 — two full pages, then nothing
             let base: u64 = 1_731_000_000;
             for i in 1u8..=10 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &account.pubkey,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             // Page 1 (initial snapshot): seeds 6–10
@@ -2778,7 +2802,15 @@ mod tests {
 
             let base: u64 = 1_732_000_000;
             for i in 1u8..=15 {
-                insert_msg_at(i, author, base + u64::from(i), &group_id, &whitenoise).await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &account.pubkey,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             // Subscribe (snapshot = seeds 11–15)
@@ -2883,11 +2915,11 @@ mod tests {
 
             // 8 messages: seeds 1–6 all at the same second (tie), seed 7 earlier, seed 8 later
             let tie_ts: u64 = 1_733_000_000;
-            insert_msg_at(7, author, tie_ts - 1, &group_id, &whitenoise).await;
+            insert_msg_at(7, author, &account.pubkey, tie_ts - 1, &group_id, &whitenoise).await;
             for i in 1u8..=6 {
-                insert_msg_at(i, author, tie_ts, &group_id, &whitenoise).await;
+                insert_msg_at(i, author, &account.pubkey, tie_ts, &group_id, &whitenoise).await;
             }
-            insert_msg_at(8, author, tie_ts + 1, &group_id, &whitenoise).await;
+            insert_msg_at(8, author, &account.pubkey, tie_ts + 1, &group_id, &whitenoise).await;
 
             // Subscribe with limit=3 → snapshot is the 3 newest
             let subscription = whitenoise

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1973,8 +1973,15 @@ mod tests {
 
             // Insert 10 messages with distinct timestamps (seeds 1–10)
             for i in 1u8..=10 {
-                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
-                    .await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &author,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             let subscription = whitenoise
@@ -2010,8 +2017,15 @@ mod tests {
             let base: u64 = 1_711_000_000;
 
             for i in 1u8..=5 {
-                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
-                    .await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &author,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             let subscription = whitenoise
@@ -2039,8 +2053,15 @@ mod tests {
 
             // Insert exactly 50 messages
             for i in 1u8..=50 {
-                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
-                    .await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &author,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             let subscription = whitenoise
@@ -2067,8 +2088,15 @@ mod tests {
             let base: u64 = 1_713_000_000;
 
             for i in 1u8..=60 {
-                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
-                    .await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &author,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             let subscription = whitenoise
@@ -2105,8 +2133,15 @@ mod tests {
 
             // Insert in reverse order to confirm sorting is not dependent on insertion order
             for i in (1u8..=5).rev() {
-                insert_msg_at(i, author, &author, base + u64::from(i), &group_id, &whitenoise)
-                    .await;
+                insert_msg_at(
+                    i,
+                    author,
+                    &author,
+                    base + u64::from(i),
+                    &group_id,
+                    &whitenoise,
+                )
+                .await;
             }
 
             let subscription = whitenoise
@@ -2915,11 +2950,27 @@ mod tests {
 
             // 8 messages: seeds 1–6 all at the same second (tie), seed 7 earlier, seed 8 later
             let tie_ts: u64 = 1_733_000_000;
-            insert_msg_at(7, author, &account.pubkey, tie_ts - 1, &group_id, &whitenoise).await;
+            insert_msg_at(
+                7,
+                author,
+                &account.pubkey,
+                tie_ts - 1,
+                &group_id,
+                &whitenoise,
+            )
+            .await;
             for i in 1u8..=6 {
                 insert_msg_at(i, author, &account.pubkey, tie_ts, &group_id, &whitenoise).await;
             }
-            insert_msg_at(8, author, &account.pubkey, tie_ts + 1, &group_id, &whitenoise).await;
+            insert_msg_at(
+                8,
+                author,
+                &account.pubkey,
+                tie_ts + 1,
+                &group_id,
+                &whitenoise,
+            )
+            .await;
 
             // Subscribe with limit=3 → snapshot is the 3 newest
             let subscription = whitenoise

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -1588,13 +1588,14 @@ mod tests {
         group_id: &GroupId,
         message_id: &EventId,
     ) {
+        let session = whitenoise.session(account_pubkey).unwrap();
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 let message = AggregatedMessage::find_by_id(
                     &message_id.to_string(),
                     group_id,
                     account_pubkey,
-                    &whitenoise.shared.database,
+                    &session.account_db.inner,
                 )
                 .await
                 .unwrap()
@@ -2436,11 +2437,12 @@ mod tests {
         .await
         .unwrap();
 
+        let creator_session = whitenoise.session(&creator.pubkey).unwrap();
         let cached_message = AggregatedMessage::find_by_id(
             &send_result.message.id.to_string(),
             &group_id,
             &creator.pubkey,
-            &whitenoise.shared.database,
+            &creator_session.account_db.inner,
         )
         .await
         .unwrap()

--- a/src/whitenoise/session/chat_list.rs
+++ b/src/whitenoise/session/chat_list.rs
@@ -224,7 +224,7 @@ impl<'a> ChatListOps<'a> {
                 .collect();
 
         let last_message_map: HashMap<GroupId, ChatMessageSummary> =
-            AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.shared.database)
+            AggregatedMessage::find_last_by_group_ids(&group_ids, &self.session.account_db.inner)
                 .await?
                 .into_iter()
                 .map(|s| (s.mls_group_id.clone(), s))
@@ -249,7 +249,7 @@ impl<'a> ChatListOps<'a> {
             .collect();
         let unread_counts = AggregatedMessage::count_unread_for_groups(
             &group_markers,
-            &self.session.shared.database,
+            &self.session.account_db.inner,
         )
         .await?;
 

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -5,8 +5,6 @@
 //! acceptance/decline, read markers, pinning, archiving, muting, departure
 //! tracking, DM peer lookup, and chat clearing.
 
-use std::sync::Arc;
-
 use chrono::Utc;
 use mdk_core::prelude::GroupId;
 use nostr_sdk::{EventId, PublicKey};
@@ -42,8 +40,8 @@ impl<'a> MembershipOps<'a> {
         &self.session.account_pubkey
     }
 
-    fn db(&self) -> &Arc<Database> {
-        &self.session.shared.database
+    fn db(&self) -> &Database {
+        &self.session.account_db.inner
     }
 
     fn pool(&self) -> &SqlitePool {
@@ -172,8 +170,8 @@ impl<'a> MembershipOpsForGroup<'a> {
         &self.session.account_pubkey
     }
 
-    fn db(&self) -> &Arc<Database> {
-        &self.session.shared.database
+    fn db(&self) -> &Database {
+        &self.session.account_db.inner
     }
 
     fn pool(&self) -> &SqlitePool {

--- a/src/whitenoise/session/membership.rs
+++ b/src/whitenoise/session/membership.rs
@@ -11,7 +11,6 @@ use nostr_sdk::{EventId, PublicKey};
 use sqlx::SqlitePool;
 
 use super::AccountSession;
-use crate::whitenoise::accounts::Account;
 use crate::whitenoise::accounts_groups::{AccountGroup, MuteDuration};
 use crate::whitenoise::aggregated_message::AggregatedMessage;
 use crate::whitenoise::chat_list_streaming::ChatListUpdateTrigger;
@@ -359,8 +358,9 @@ impl<'a> MembershipOpsForGroup<'a> {
     pub async fn clear_chat(&self) -> Result<()> {
         let account_group = self.require_account_group().await?;
 
+        let cleared_at = Utc::now();
         account_group
-            .clear_chat_state(Utc::now(), self.pool())
+            .clear_chat_state(cleared_at, self.pool())
             .await?;
 
         // Delete draft (best-effort).
@@ -371,20 +371,13 @@ impl<'a> MembershipOpsForGroup<'a> {
             );
         }
 
-        // Cleanup aggregated messages that all accounts have cleared (best-effort).
-        let min_cleared_at = match self.resolve_min_cleared_at().await {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::session::membership",
-                    "resolve_min_cleared_at failed; skipping cleanup: {e}"
-                );
-                None
-            }
-        };
+        // Delete this account's aggregated_messages older than the clear point
+        // (best-effort). Per-account DBs are independent post-18e: this clear
+        // only touches the current account's copy and is unaffected by what
+        // other accounts have or haven't cleared.
         if let Err(e) = self
             .db()
-            .try_cleanup_cleared_messages(self.group_id, min_cleared_at)
+            .try_cleanup_cleared_messages(self.group_id, Some(cleared_at.timestamp_millis()))
             .await
         {
             tracing::warn!(
@@ -405,55 +398,5 @@ impl<'a> MembershipOpsForGroup<'a> {
             .await;
 
         Ok(())
-    }
-
-    /// Compute the minimum `chat_cleared_at` across all accounts for this
-    /// group, returning `Ok(Some(millis))` only when **every** account has a
-    /// non-null value. Returns `Ok(None)` if any account has not cleared or
-    /// if not all accounts have active sessions (conservative — avoids
-    /// premature message deletion). Returns `Err` on real DB failures so
-    /// the caller can log the concrete error.
-    async fn resolve_min_cleared_at(&self) -> Result<Option<i64>> {
-        let wn = self
-            .session
-            .whitenoise
-            .upgrade()
-            .ok_or(WhitenoiseError::Initialization)?;
-        let total_accounts = Account::count(&wn.shared.database).await?;
-        let mut sessions_checked: i64 = 0;
-        let mut min: Option<i64> = None;
-        for session in wn.account_manager.sessions_iter() {
-            sessions_checked += 1;
-            match AccountGroup::chat_cleared_at_ms(
-                &session.account_pubkey,
-                self.group_id,
-                &session.account_db.inner.pool,
-            )
-            .await
-            {
-                Ok(Some(ms)) => {
-                    min = Some(min.map_or(ms, |prev: i64| prev.min(ms)));
-                }
-                Ok(None) => return Ok(None),
-                Err(WhitenoiseError::GroupNotFound) => {
-                    // This session doesn't have this group — skip it.
-                    continue;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-        // If not all accounts have active sessions, we can't be sure every
-        // account has cleared — return None to prevent premature deletion.
-        if sessions_checked < total_accounts {
-            tracing::warn!(
-                target: "whitenoise::session::membership",
-                checked = sessions_checked,
-                total = total_accounts,
-                "Not all accounts have active sessions; \
-                 skipping cleared-message cleanup"
-            );
-            return Ok(None);
-        }
-        Ok(min)
     }
 }

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use mdk_core::prelude::*;
 use nostr_sdk::prelude::*;
 
@@ -61,8 +59,8 @@ impl<'a> MessageOps<'a> {
         &self.session.account_pubkey
     }
 
-    fn db(&self) -> &Arc<Database> {
-        &self.session.shared.database
+    fn db(&self) -> &Database {
+        &self.session.account_db.inner
     }
 }
 
@@ -77,8 +75,8 @@ impl<'a> MessageOpsForGroup<'a> {
         &self.session.account_pubkey
     }
 
-    fn db(&self) -> &Arc<Database> {
-        &self.session.shared.database
+    fn db(&self) -> &Database {
+        &self.session.account_db.inner
     }
 
     fn pool(&self) -> &sqlx::SqlitePool {
@@ -336,7 +334,7 @@ impl<'a> MessageOpsForGroup<'a> {
                     &group_relays,
                     &event_id_str,
                     &group_id,
-                    &shared.database,
+                    &account_db.inner,
                     &shared.message_stream_manager,
                 )
                 .await
@@ -370,7 +368,7 @@ impl<'a> MessageOpsForGroup<'a> {
                     &author,
                     &content,
                     &group_id,
-                    &shared.database,
+                    &account_db.inner,
                     &shared.message_stream_manager,
                 )
                 .await;

--- a/src/whitenoise/streaming.rs
+++ b/src/whitenoise/streaming.rs
@@ -63,7 +63,7 @@ impl Whitenoise {
             aggregated_message::AggregatedMessage::find_messages_by_group_paginated(
                 group_id,
                 account_pubkey,
-                &self.shared.database,
+                &session.account_db.inner,
                 &PaginationOptions::default(),
                 limit,
                 cleared_at_ms,


### PR DESCRIPTION
![marmot](https://blossom.primal.net/549da501820077eb7db6f3d712bae71cfc9257520d4b42f5886d6f7067c3a1e2.png)

Closes the per-account split for the messenger schema. After 18a-d moved settings, drafts, key packages, processed events, follows, media references, push registrations, group push tokens, and accounts_groups out of the shared database, two tables were still shared: `aggregated_messages` and `message_delivery_status`. This PR moves both, so every per-account marmot now has its own burrow for chat history.

## What moves

| Table | Was | Now |
|---|---|---|
| `aggregated_messages` | shared | per-account |
| `message_delivery_status` | shared | per-account (FK to `aggregated_messages` stays intra-DB) |

The cross-DB FK from `aggregated_messages.mls_group_id` to `group_information.mls_group_id` is dropped: SQLite has no cross-database FK. `delete_chat` deletes per-account `aggregated_messages` rows explicitly because the cascade no longer reaches.

## Migration timeline

- **v38** (local): create per-account `aggregated_messages`, copy rows for groups in this account's `accounts_groups` (which v36 moved local).
- **v39** (local): create per-account `message_delivery_status`, copy rows where `account_pubkey` matches; gated on the parent message having been copied by v38 to satisfy the FK.
- **v40** (global): drop shared `message_delivery_status` (FK-dependent child must drop before parent).
- **v41** (global): drop shared `aggregated_messages`.

`fresh_account_schema.sql` gets both tables baked in for fresh installs.

## Chat-list joins

The plan called for converting single-SQL chat-list joins to application-level joins. 18d already removed the cross-DB JOIN in `search_messages` when `accounts_groups` moved, and `session/chat_list.rs::build_for` was already an in-Rust join across per-method DB calls. So this PR is a routing change: every `AggregatedMessage::*` call now points at `session.account_db.inner` instead of `session.shared.database`.

## Bug fix

`streaming.rs::subscribe_to_group_messages` was passing `shared.database` to `find_messages_by_group_paginated`; would have broken every initial message-stream snapshot the moment v41 dropped the shared table. Fixed.

## Test surface

- 9 new migration tests (m0038-m0041) cover the move/drop pairs and cross-account isolation in `message_delivery_status`.
- ~110 existing test sites updated across `messages.rs`, `chat_list.rs`, `accounts_groups.rs`, `mod.rs`, `push_notifications.rs`, `streaming.rs`, `database/aggregated_messages.rs`, and `event_handlers/handle_mls_message.rs` to use the per-account DB.
- `database/mod.rs` cascade tests had their now-obsolete cross-DB cascade assertions stripped; added `setup_aggregated_messages_table` so per-account-DB methods can still be tested against a generic `Database`.
- `m0001_bridge` upgrade test now verifies m0011 ran via the `_rust_migrations` description (the column it used to assert on lives in a table that v40 drops).

## Validation

`just precommit-quick`: fmt, docs, clippy, dead_code all green. Tests: 944/945 pass; the one failure is `handle_contact_list::test_handle_contact_list_accounts_are_independent`, the same SQLite "database is locked" relay-discovery flake that pre-dates this branch. Passes when re-run alone, and 18e doesn't touch that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured message and delivery status data storage from shared to per-account databases for improved data isolation and account-level performance.

* **Database Migrations**
  * Added migrations v38–41 to safely migrate message and delivery status data to per-account storage and remove redundant shared tables.

* **Tests**
  * Updated test suite to align with per-account database structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->