### PR TITLE
[codex] Fix stale database keyring rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=575ae29d25d58494135058d9e46affec7174e79a#575ae29d25d58494135058d9e46affec7174e79a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
 dependencies = [
  "base64",
  "blurhash",
@@ -2719,12 +2719,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=575ae29d25d58494135058d9e46affec7174e79a#575ae29d25d58494135058d9e46affec7174e79a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=575ae29d25d58494135058d9e46affec7174e79a#575ae29d25d58494135058d9e46affec7174e79a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=575ae29d25d58494135058d9e46affec7174e79a#575ae29d25d58494135058d9e46affec7174e79a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
 dependencies = [
  "nostr",
  "openmls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "1"
-mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "575ae29d25d58494135058d9e46affec7174e79a", features = [
+mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "575ae29d25d58494135058d9e46affec7174e79a" }
-mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "575ae29d25d58494135058d9e46affec7174e79a" }
+mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507" }
+mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -842,7 +842,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_logout_removes_mdk_storage_and_key() {
-        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (mut whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let (account, keys) = create_test_account(&whitenoise).await;
         account.save(&whitenoise.database).await.unwrap();
         whitenoise.secrets_store.store_private_key(&keys).unwrap();
@@ -854,15 +854,17 @@ mod tests {
             .await
             .unwrap();
 
+        let keyring_service_id = whitenoise.keyring_service_id().to_string();
+        whitenoise.config.keyring_service_id = format!("  {keyring_service_id}  ");
         let db_key_id = Account::mdk_db_key_id(&account.pubkey);
-        keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+        keyring::get_or_create_db_key(&keyring_service_id, &db_key_id)
             .expect("Failed to create MDK database key");
 
         whitenoise.logout(&account.pubkey).await.unwrap();
 
         assert!(!mls_storage_dir.exists());
         assert!(
-            keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+            keyring::get_db_key(&keyring_service_id, &db_key_id)
                 .unwrap()
                 .is_none(),
             "Account logout should remove the account-scoped MDK database key"

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -847,17 +847,14 @@ mod tests {
         account.save(&whitenoise.database).await.unwrap();
         whitenoise.secrets_store.store_private_key(&keys).unwrap();
 
-        let mls_storage_dir = whitenoise
-            .config
-            .data_dir
-            .join("mls")
-            .join(account.pubkey.to_hex());
+        let mls_storage_dir =
+            Account::mdk_storage_path(&account.pubkey, &whitenoise.config.data_dir);
         tokio::fs::create_dir_all(&mls_storage_dir).await.unwrap();
         tokio::fs::write(mls_storage_dir.join("storage.sqlite"), b"test")
             .await
             .unwrap();
 
-        let db_key_id = format!("mdk.db.key.{}", account.pubkey.to_hex());
+        let db_key_id = Account::mdk_db_key_id(&account.pubkey);
         keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
             .expect("Failed to create MDK database key");
 

--- a/src/whitenoise/accounts/login.rs
+++ b/src/whitenoise/accounts/login.rs
@@ -265,6 +265,7 @@ impl Whitenoise {
 
         // Delete the account from the database
         account.delete(&self.database).await?;
+        self.delete_mdk_storage_for_account(pubkey).await?;
 
         // Sync discovery subscriptions with remaining accounts (tears down on last logout)
         if let Err(e) = self.sync_discovery_subscriptions().await {
@@ -324,6 +325,7 @@ impl Whitenoise {
 
 #[cfg(test)]
 mod tests {
+    use mdk_sqlite_storage::keyring;
     use nostr_sdk::prelude::*;
 
     use crate::RelayType;
@@ -835,6 +837,38 @@ mod tests {
         assert!(
             stored_keys_after.is_err(),
             "Key should be removed after logout"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_logout_removes_mdk_storage_and_key() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let (account, keys) = create_test_account(&whitenoise).await;
+        account.save(&whitenoise.database).await.unwrap();
+        whitenoise.secrets_store.store_private_key(&keys).unwrap();
+
+        let mls_storage_dir = whitenoise
+            .config
+            .data_dir
+            .join("mls")
+            .join(account.pubkey.to_hex());
+        tokio::fs::create_dir_all(&mls_storage_dir).await.unwrap();
+        tokio::fs::write(mls_storage_dir.join("storage.sqlite"), b"test")
+            .await
+            .unwrap();
+
+        let db_key_id = format!("mdk.db.key.{}", account.pubkey.to_hex());
+        keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+            .expect("Failed to create MDK database key");
+
+        whitenoise.logout(&account.pubkey).await.unwrap();
+
+        assert!(!mls_storage_dir.exists());
+        assert!(
+            keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                .unwrap()
+                .is_none(),
+            "Account logout should remove the account-scoped MDK database key"
         );
     }
 

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -9,7 +9,7 @@ use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{LazyLock, Mutex};
 use thiserror::Error;
@@ -556,8 +556,8 @@ impl Account {
         data_dir: &Path,
         keyring_service_id: &str,
     ) -> core::result::Result<MDK<MdkSqliteStorage>, AccountError> {
-        let mls_storage_dir = data_dir.join("mls").join(pubkey.to_hex());
-        let db_key_id = format!("mdk.db.key.{}", pubkey.to_hex());
+        let mls_storage_dir = Self::mdk_storage_path(&pubkey, data_dir);
+        let db_key_id = Self::mdk_db_key_id(&pubkey);
         let storage = {
             let _storage_init_guard = MDK_STORAGE_INIT_LOCK
                 .lock()
@@ -565,6 +565,14 @@ impl Account {
             MdkSqliteStorage::new(mls_storage_dir, keyring_service_id, &db_key_id)?
         };
         Ok(MDK::new(storage))
+    }
+
+    pub(crate) fn mdk_storage_path(pubkey: &PublicKey, data_dir: &Path) -> PathBuf {
+        data_dir.join("mls").join(pubkey.to_hex())
+    }
+
+    pub(crate) fn mdk_db_key_id(pubkey: &PublicKey) -> String {
+        format!("mdk.db.key.{}", pubkey.to_hex())
     }
 }
 

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -2,6 +2,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{ErrorKind, Read},
     path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
     time::{Duration, SystemTime},
 };
 
@@ -14,6 +15,7 @@ pub(super) const WHITENOISE_DB_KEY_ID: &str = "whitenoise.db.key.v1";
 
 const SQLITE_HEADER: &[u8; 16] = b"SQLite format 3\0";
 const MIGRATION_LOCK_STALE_SECS: u64 = 15 * 60;
+static APP_DB_KEY_ROTATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DatabaseFileState {
@@ -30,10 +32,16 @@ pub(super) async fn prepare_sqlcipher_database(
     assert_sqlcipher_available().await?;
 
     let mut state = database_file_state(db_path)?;
+    let has_recovery_sidecar = has_migration_recovery_sidecar(db_path);
     let config = match state {
         DatabaseFileState::Encrypted => existing_key(db_path, keyring_service_id, key_id)?,
-        DatabaseFileState::MissingOrEmpty | DatabaseFileState::Plaintext => {
+        DatabaseFileState::MissingOrEmpty | DatabaseFileState::Plaintext
+            if has_recovery_sidecar =>
+        {
             get_or_create_key(keyring_service_id, key_id)?
+        }
+        DatabaseFileState::MissingOrEmpty | DatabaseFileState::Plaintext => {
+            create_fresh_key(keyring_service_id, key_id)?
         }
     };
 
@@ -54,6 +62,15 @@ pub(super) fn cleanup_completed_migration(db_path: &Path) -> Result<(), Database
         remove_file_if_exists(&sidecar_path(db_path, ".plaintext.backup"))?;
     }
 
+    Ok(())
+}
+
+pub(super) fn delete_database_files(db_path: &Path) -> Result<(), DatabaseError> {
+    remove_file_if_exists(db_path)?;
+    remove_sqlite_sidecars(db_path)?;
+    remove_file_if_exists(&sidecar_path(db_path, ".encrypted.tmp"))?;
+    remove_file_if_exists(&sidecar_path(db_path, ".plaintext.backup"))?;
+    remove_file_if_exists(&sidecar_path(db_path, ".encryption.lock"))?;
     Ok(())
 }
 
@@ -304,6 +321,21 @@ fn get_or_create_key(
         .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))
 }
 
+fn create_fresh_key(
+    keyring_service_id: &str,
+    key_id: &str,
+) -> Result<EncryptionConfig, DatabaseError> {
+    let lock = APP_DB_KEY_ROTATION_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().map_err(|e| {
+        DatabaseError::EncryptionKey(format!("Failed to acquire app DB key rotation lock: {e}"))
+    })?;
+
+    keyring::delete_db_key(keyring_service_id, key_id)
+        .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))?;
+    keyring::get_or_create_db_key(keyring_service_id, key_id)
+        .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))
+}
+
 fn database_file_state(db_path: &Path) -> Result<DatabaseFileState, DatabaseError> {
     if !db_path.exists() {
         return Ok(DatabaseFileState::MissingOrEmpty);
@@ -364,6 +396,11 @@ fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     let mut path = db_path.as_os_str().to_owned();
     path.push(suffix);
     PathBuf::from(path)
+}
+
+fn has_migration_recovery_sidecar(db_path: &Path) -> bool {
+    sidecar_path(db_path, ".encrypted.tmp").exists()
+        || sidecar_path(db_path, ".plaintext.backup").exists()
 }
 
 // SQLite's ATTACH DATABASE does not accept bind parameters — only literal strings — so we

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -70,6 +70,8 @@ pub(super) fn delete_database_files(db_path: &Path) -> Result<(), DatabaseError>
     remove_sqlite_sidecars(db_path)?;
     remove_file_if_exists(&sidecar_path(db_path, ".encrypted.tmp"))?;
     remove_file_if_exists(&sidecar_path(db_path, ".plaintext.backup"))?;
+    // Usually removed by MigrationLock::drop; delete it here too so a full
+    // wipe clears crashed-migration residue.
     remove_file_if_exists(&sidecar_path(db_path, ".encryption.lock"))?;
     Ok(())
 }
@@ -325,11 +327,19 @@ fn create_fresh_key(
     keyring_service_id: &str,
     key_id: &str,
 ) -> Result<EncryptionConfig, DatabaseError> {
+    // This only protects the Whitenoise app database key lifecycle. Test and
+    // benchmark builds may override the key id for isolation, but those calls
+    // are still app database opens rather than a general key rotation API.
     let lock = APP_DB_KEY_ROTATION_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = lock.lock().map_err(|e| {
         DatabaseError::EncryptionKey(format!("Failed to acquire app DB key rotation lock: {e}"))
     })?;
 
+    tracing::debug!(
+        target: "whitenoise::database",
+        key_id,
+        "Rotating stale database keyring entry before fresh database setup"
+    );
     keyring::delete_db_key(keyring_service_id, key_id)
         .map_err(|e| DatabaseError::EncryptionKey(e.to_string()))?;
     keyring::get_or_create_db_key(keyring_service_id, key_id)

--- a/src/whitenoise/database/encryption.rs
+++ b/src/whitenoise/database/encryption.rs
@@ -472,3 +472,63 @@ impl Drop for MigrationLock {
         let _ = fs::remove_file(&self.path);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_database_file_state_treats_short_non_empty_file_as_encrypted() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("short.db");
+
+        fs::write(&db_path, "short").unwrap();
+
+        assert_eq!(
+            database_file_state(&db_path).unwrap(),
+            DatabaseFileState::Encrypted
+        );
+    }
+
+    #[test]
+    fn test_migration_lock_rejects_active_lock_file() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let lock_path = temp_dir.path().join("database.sqlite.encryption.lock");
+
+        File::create(&lock_path).unwrap();
+        let err = match MigrationLock::acquire(&lock_path) {
+            Ok(_) => panic!("Active migration lock should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, DatabaseError::EncryptionMigration(_)));
+        assert!(lock_path.exists());
+    }
+
+    #[test]
+    fn test_migration_lock_replaces_stale_lock_file() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let lock_path = temp_dir.path().join("database.sqlite.encryption.lock");
+
+        let stale_file = File::create(&lock_path).unwrap();
+        stale_file.set_modified(SystemTime::UNIX_EPOCH).unwrap();
+        drop(stale_file);
+
+        let lock = MigrationLock::acquire(&lock_path).unwrap();
+
+        assert!(lock_path.exists());
+        drop(lock);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn test_sql_string_literal_escapes_single_quotes() {
+        assert_eq!(sql_string_literal("plain"), "'plain'");
+        assert_eq!(
+            sql_string_literal("/tmp/white'noise.sqlite"),
+            "'/tmp/white''noise.sqlite'"
+        );
+    }
+}

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -460,7 +460,10 @@ mod tests {
         fs::{self, File},
         io::Read,
         path::{Path, PathBuf},
-        sync::atomic::{AtomicU64, Ordering},
+        sync::{
+            LazyLock,
+            atomic::{AtomicU64, Ordering},
+        },
     };
 
     use mdk_sqlite_storage::keyring;
@@ -469,6 +472,8 @@ mod tests {
     use crate::whitenoise::Whitenoise;
 
     const SQLITE_HEADER: &[u8; 16] = b"SQLite format 3\0";
+    static SQLCIPHER_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
 
     fn unique_service_id() -> String {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -523,6 +528,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encrypted_database_creation() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("encrypted.db");
@@ -548,6 +554,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_encrypted_database_replaces_stale_keyring_entry() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("encrypted-stale-key.db");
@@ -590,6 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encrypted_database_reopen_existing() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("encrypted-reopen.db");
@@ -617,6 +625,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encrypted_database_reopen_cleans_completed_migration_sidecars() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("encrypted-clean-sidecars.db");
@@ -643,6 +652,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_plaintext_database_migrates_to_encrypted_without_data_loss() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("migrate.db");
@@ -675,6 +685,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_plaintext_database_migration_replaces_stale_keyring_entry() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("migrate-stale-key.db");
@@ -729,6 +740,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_interrupted_migration_restores_plaintext_backup_when_database_missing() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("recover-backup.db");
@@ -782,6 +794,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_interrupted_migration_restores_valid_encrypted_temp_when_database_missing() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("recover-encrypted-temp.db");
@@ -812,6 +825,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_interrupted_migration_rejects_invalid_encrypted_temp_without_backup() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("recover-invalid-temp.db");
@@ -836,6 +850,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encrypted_database_requires_existing_key() {
+        let _sqlcipher_guard = SQLCIPHER_TEST_LOCK.lock().await;
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("missing-key.db");

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -616,6 +616,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_encrypted_database_reopen_cleans_completed_migration_sidecars() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("encrypted-clean-sidecars.db");
+        let service_id = unique_service_id();
+        let temp_path = PathBuf::from(format!("{}.encrypted.tmp", db_path.display()));
+        let backup_path = PathBuf::from(format!("{}.plaintext.backup", db_path.display()));
+
+        let db = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to create encrypted database");
+        drop(db);
+        fs::write(&temp_path, "completed migration temp").unwrap();
+        fs::write(&backup_path, "completed migration backup").unwrap();
+
+        let reopened = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to reopen encrypted database");
+        drop(reopened);
+
+        assert!(db_path.exists());
+        assert!(!temp_path.exists());
+        assert!(!backup_path.exists());
+    }
+
+    #[tokio::test]
     async fn test_plaintext_database_migrates_to_encrypted_without_data_loss() {
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
@@ -752,6 +778,60 @@ mod tests {
         );
         assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
         assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_interrupted_migration_restores_valid_encrypted_temp_when_database_missing() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("recover-encrypted-temp.db");
+        let temp_path = PathBuf::from(format!("{}.encrypted.tmp", db_path.display()));
+        let service_id = unique_service_id();
+        let pubkey = "cd".repeat(32);
+
+        let db = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to create encrypted database");
+        setup_account(&db, &pubkey).await;
+        drop(db);
+        fs::rename(&db_path, &temp_path).expect("Failed to move encrypted database to temp");
+
+        let recovered = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect("Failed to recover encrypted temp database");
+        let account_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&recovered.pool)
+            .await
+            .expect("Failed to count recovered accounts");
+
+        assert_eq!(account_count.0, 1);
+        assert!(db_path.exists());
+        assert!(!temp_path.exists());
+        assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_interrupted_migration_rejects_invalid_encrypted_temp_without_backup() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("recover-invalid-temp.db");
+        let temp_path = PathBuf::from(format!("{}.encrypted.tmp", db_path.display()));
+        let service_id = unique_service_id();
+
+        keyring::get_or_create_db_key(&service_id, encryption::WHITENOISE_DB_KEY_ID)
+            .expect("Failed to create database key");
+        fs::write(&temp_path, "not a valid encrypted database").unwrap();
+
+        let err = Database::new_encrypted(db_path.clone(), &service_id)
+            .await
+            .expect_err("Invalid encrypted temp without backup should fail recovery");
+
+        assert!(matches!(
+            err,
+            DatabaseError::Sqlx(_) | DatabaseError::EncryptionMigration(_)
+        ));
+        assert!(!db_path.exists());
+        assert!(temp_path.exists());
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/mod.rs
+++ b/src/whitenoise/database/mod.rs
@@ -39,6 +39,8 @@ pub mod utils;
 
 pub static MIGRATOR: LazyLock<Migrator> = LazyLock::new(|| sqlx::migrate!("./db_migrations"));
 
+pub(crate) const WHITENOISE_DB_KEY_ID: &str = encryption::WHITENOISE_DB_KEY_ID;
+
 const DB_ACQUIRE_TIMEOUT_SECS: u64 = 5;
 const DB_MAX_CONNECTIONS: u32 = 10;
 const DB_BUSY_TIMEOUT_MS: u32 = 5000;
@@ -220,6 +222,11 @@ impl Database {
     pub async fn migrate_up(&self) -> Result<(), DatabaseError> {
         MIGRATOR.run(&self.pool).await?;
         Ok(())
+    }
+
+    pub async fn close_and_delete_files(&self) -> Result<(), DatabaseError> {
+        self.pool.close().await;
+        encryption::delete_database_files(&self.path)
     }
 
     /// Deletes all data from all tables while preserving the schema
@@ -540,6 +547,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_missing_encrypted_database_replaces_stale_keyring_entry() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("encrypted-stale-key.db");
+        let service_id = unique_service_id();
+        let key_id = "test.whitenoise.stale-missing-db";
+
+        let stale_config = keyring::get_or_create_db_key(&service_id, key_id)
+            .expect("Failed to create stale database key");
+        let stale_key = *stale_config.key();
+
+        assert!(!db_path.exists());
+
+        let db = Database::new_encrypted_with_key_id(db_path.clone(), &service_id, key_id)
+            .await
+            .expect("Failed to create encrypted database");
+        drop(db);
+
+        let current_config = keyring::get_db_key(&service_id, key_id)
+            .expect("Failed to read current database key")
+            .expect("Database key should exist after creation");
+
+        assert_ne!(
+            current_config.key(),
+            &stale_key,
+            "Fresh encrypted database creation should replace stale keyring entries"
+        );
+        assert!(
+            encryption::validate_encrypted_database(&db_path, &current_config)
+                .await
+                .is_ok(),
+            "Current keyring key should decrypt the fresh database"
+        );
+        assert!(
+            encryption::validate_encrypted_database(&db_path, &EncryptionConfig::new(stale_key),)
+                .await
+                .is_err(),
+            "Stale key should not decrypt the fresh database"
+        );
+    }
+
+    #[tokio::test]
     async fn test_encrypted_database_reopen_existing() {
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
@@ -599,12 +648,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_plaintext_database_migration_replaces_stale_keyring_entry() {
+        Whitenoise::initialize_mock_keyring_store();
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("migrate-stale-key.db");
+        let service_id = unique_service_id();
+        let key_id = "test.whitenoise.stale-plaintext-db";
+        let pubkey = "bc".repeat(32);
+
+        let plaintext = Database::new(db_path.clone())
+            .await
+            .expect("Failed to create plaintext database");
+        setup_account(&plaintext, &pubkey).await;
+        drop(plaintext);
+
+        let stale_config = keyring::get_or_create_db_key(&service_id, key_id)
+            .expect("Failed to create stale database key");
+        let stale_key = *stale_config.key();
+
+        assert!(encryption::is_plaintext_sqlite_database(&db_path).unwrap());
+
+        let encrypted = Database::new_encrypted_with_key_id(db_path.clone(), &service_id, key_id)
+            .await
+            .expect("Failed to migrate plaintext database");
+
+        let account_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&encrypted.pool)
+            .await
+            .expect("Failed to count migrated accounts");
+
+        let current_config = keyring::get_db_key(&service_id, key_id)
+            .expect("Failed to read current database key")
+            .expect("Database key should exist after migration");
+
+        assert_eq!(account_count.0, 1);
+        assert_ne!(
+            current_config.key(),
+            &stale_key,
+            "Plaintext encryption migration should replace stale keyring entries"
+        );
+        assert!(
+            encryption::validate_encrypted_database(&db_path, &current_config)
+                .await
+                .is_ok(),
+            "Current keyring key should decrypt the migrated database"
+        );
+        assert!(
+            encryption::validate_encrypted_database(&db_path, &EncryptionConfig::new(stale_key),)
+                .await
+                .is_err(),
+            "Stale key should not decrypt the migrated database"
+        );
+    }
+
+    #[tokio::test]
     async fn test_interrupted_migration_restores_plaintext_backup_when_database_missing() {
         Whitenoise::initialize_mock_keyring_store();
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let db_path = temp_dir.path().join("recover-backup.db");
         let backup_path = PathBuf::from(format!("{}.plaintext.backup", db_path.display()));
         let service_id = unique_service_id();
+        let key_id = "test.whitenoise.recovery-preserves-key";
         let pubkey = "cc".repeat(32);
 
         let plaintext = Database::new(db_path.clone())
@@ -622,7 +726,11 @@ mod tests {
         assert!(!db_path.exists());
         assert_eq!(read_db_header(&backup_path), *SQLITE_HEADER);
 
-        let encrypted = Database::new_encrypted(db_path.clone(), &service_id)
+        let original_config = keyring::get_or_create_db_key(&service_id, key_id)
+            .expect("Failed to create original database key");
+        let original_key = *original_config.key();
+
+        let encrypted = Database::new_encrypted_with_key_id(db_path.clone(), &service_id, key_id)
             .await
             .expect("Failed to recover and migrate plaintext backup");
 
@@ -634,6 +742,14 @@ mod tests {
         assert_eq!(account_count.0, 1);
         assert!(db_path.exists());
         assert!(!backup_path.exists());
+        let current_config = keyring::get_db_key(&service_id, key_id)
+            .expect("Failed to read current database key")
+            .expect("Database key should exist after recovery");
+        assert_eq!(
+            current_config.key(),
+            &original_key,
+            "Interrupted migration recovery should preserve the existing keyring entry"
+        );
         assert_ne!(read_db_header(&db_path), *SQLITE_HEADER);
         assert!(encryption::is_sqlcipher_database(&db_path).unwrap());
     }

--- a/src/whitenoise/groups/media.rs
+++ b/src/whitenoise/groups/media.rs
@@ -418,7 +418,7 @@ impl Whitenoise {
         let decrypted_data = Self::download_and_decrypt_chat_media_blob(
             &account.pubkey,
             &self.config.data_dir,
-            &self.config.keyring_service_id,
+            self.keyring_service_id(),
             group_id,
             &media_file,
             original_file_hash,

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -154,6 +154,10 @@ pub struct WhitenoiseConfig {
 }
 
 impl WhitenoiseConfig {
+    fn normalize_keyring_service_id(&mut self) {
+        self.keyring_service_id = self.keyring_service_id.trim().to_string();
+    }
+
     pub fn new(data_dir: &Path, logs_dir: &Path, keyring_service_id: &str) -> Self {
         let env_suffix = if cfg!(debug_assertions) {
             "dev"
@@ -214,6 +218,7 @@ impl WhitenoiseConfig {
 
 pub struct Whitenoise {
     pub config: WhitenoiseConfig,
+    keyring_service_id: String,
     database: Arc<Database>,
     event_tracker: std::sync::Arc<dyn event_tracker::EventTracker>,
     content_parser: crate::nostr_manager::parser::ContentParser,
@@ -286,6 +291,7 @@ impl std::fmt::Debug for Whitenoise {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Whitenoise")
             .field("config", &self.config)
+            .field("keyring_service_id", &self.keyring_service_id)
             .field("database", &"<REDACTED>")
             .field("event_tracker", &"<REDACTED>")
             .field("content_parser", &"<REDACTED>")
@@ -313,10 +319,12 @@ impl std::fmt::Debug for Whitenoise {
 
 impl Whitenoise {
     fn from_components(
-        config: WhitenoiseConfig,
+        mut config: WhitenoiseConfig,
         database: Arc<Database>,
         components: WhitenoiseComponents,
     ) -> Self {
+        config.normalize_keyring_service_id();
+        let keyring_service_id = config.keyring_service_id.clone();
         let mut session_salt = [0u8; 16];
         ::rand::rng().fill_bytes(&mut session_salt);
         let relay_control = Arc::new(RelayControlPlane::new(
@@ -328,6 +336,7 @@ impl Whitenoise {
 
         Self {
             config,
+            keyring_service_id,
             database,
             event_tracker: components.event_tracker,
             content_parser: crate::nostr_manager::parser::ContentParser::new(),
@@ -634,11 +643,7 @@ impl Whitenoise {
         &self,
         pubkey: PublicKey,
     ) -> core::result::Result<MDK<MdkSqliteStorage>, AccountError> {
-        Account::create_mdk(
-            pubkey,
-            &self.config.data_dir,
-            &self.config.keyring_service_id,
-        )
+        Account::create_mdk(pubkey, &self.config.data_dir, self.keyring_service_id())
     }
 
     /// Initializes the Whitenoise application with the provided configuration.
@@ -651,16 +656,17 @@ impl Whitenoise {
     ///
     /// * `config` - A [`WhitenoiseConfig`] struct specifying the data and log directories.
     #[perf_instrument("whitenoise")]
-    pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<()> {
+    pub async fn initialize_whitenoise(mut config: WhitenoiseConfig) -> Result<()> {
         init_timing::start();
 
         // Validate keyring_service_id is not empty or whitespace
-        let keyring_service_id = config.keyring_service_id.trim().to_string();
-        if keyring_service_id.is_empty() {
+        config.normalize_keyring_service_id();
+        if config.keyring_service_id.is_empty() {
             return Err(WhitenoiseError::Configuration(
                 "keyring_service_id cannot be empty or whitespace".to_string(),
             ));
         }
+        let keyring_service_id = config.keyring_service_id.clone();
 
         // Ensure keyring-core has a credential store before any MDK or
         // SecretsStore operations attempt to create or read keyring entries.
@@ -961,8 +967,7 @@ impl Whitenoise {
         let accounts = Account::all(&self.database).await?;
         let database_key_id = self.database_key_id().to_string();
         let close_result = self.database.close_and_delete_files().await;
-        let key_delete_result =
-            keyring::delete_db_key(&self.config.keyring_service_id, &database_key_id);
+        let key_delete_result = keyring::delete_db_key(self.keyring_service_id(), &database_key_id);
 
         match (close_result, key_delete_result) {
             (Ok(()), Ok(())) => {}
@@ -1128,8 +1133,12 @@ impl Whitenoise {
 
     fn delete_mdk_database_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<()> {
         let db_key_id = Account::mdk_db_key_id(pubkey);
-        keyring::delete_db_key(&self.config.keyring_service_id, &db_key_id)?;
+        keyring::delete_db_key(self.keyring_service_id(), &db_key_id)?;
         Ok(())
+    }
+
+    pub(crate) fn keyring_service_id(&self) -> &str {
+        &self.keyring_service_id
     }
 
     fn database_key_id(&self) -> &str {
@@ -2149,6 +2158,26 @@ mod tests {
                     .unwrap()
                     .is_none(),
                 "App wipe should attempt key deletion even when database file deletion fails"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_delete_all_data_uses_normalized_keyring_service_id_for_key_delete() {
+            let (mut whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let keyring_service_id = whitenoise.keyring_service_id().to_string();
+            let database_key_id = whitenoise.database_key_id().to_string();
+
+            whitenoise.config.keyring_service_id = format!("  {keyring_service_id}  ");
+            keyring::get_or_create_db_key(&keyring_service_id, &database_key_id)
+                .expect("Failed to create app database key");
+
+            whitenoise.delete_all_data().await.unwrap();
+
+            assert!(
+                keyring::get_db_key(&keyring_service_id, &database_key_id)
+                    .unwrap()
+                    .is_none(),
+                "App wipe should use the normalized keyring service id for key deletion"
             );
         }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -996,7 +996,7 @@ impl Whitenoise {
     }
 
     async fn delete_mdk_storage_for_account(&self, pubkey: &PublicKey) -> Result<()> {
-        let mls_storage_path = self.config.data_dir.join("mls").join(pubkey.to_hex());
+        let mls_storage_path = Account::mdk_storage_path(pubkey, &self.config.data_dir);
         match tokio::fs::metadata(&mls_storage_path).await {
             Ok(metadata) if metadata.is_dir() => {
                 tokio::fs::remove_dir_all(mls_storage_path).await?;
@@ -1004,27 +1004,52 @@ impl Whitenoise {
             Ok(_) => {
                 tokio::fs::remove_file(mls_storage_path).await?;
             }
-            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) if e.kind() == ErrorKind::NotADirectory => {
+                tracing::warn!(
+                    target: "whitenoise::accounts",
+                    account_pubkey = %pubkey,
+                    path = ?mls_storage_path,
+                    "Unable to remove MDK storage because a path component is not a directory"
+                );
+            }
             Err(e) => return Err(e.into()),
         }
         self.delete_mdk_database_key_for_pubkey(pubkey)
     }
 
     fn delete_mdk_database_keys_for_accounts(&self, accounts: &[Account]) -> Result<()> {
+        let mut first_error = None;
+
         for account in accounts {
-            self.delete_mdk_database_key_for_pubkey(&account.pubkey)?;
+            if let Err(e) = self.delete_mdk_database_key_for_pubkey(&account.pubkey) {
+                tracing::warn!(
+                    target: "whitenoise::delete_all_data",
+                    account_pubkey = %account.pubkey,
+                    "Failed to delete MDK database key: {e}"
+                );
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
         }
 
-        Ok(())
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     fn delete_mdk_database_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<()> {
-        let db_key_id = format!("mdk.db.key.{}", pubkey.to_hex());
+        let db_key_id = Account::mdk_db_key_id(pubkey);
         keyring::delete_db_key(&self.config.keyring_service_id, &db_key_id)?;
         Ok(())
     }
 
     fn database_key_id(&self) -> &str {
+        // The database_key_id override field only exists in test,
+        // integration-test, and benchmark builds; production always uses the
+        // stable app database key id.
         #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
         {
             self.config
@@ -1091,6 +1116,10 @@ impl Whitenoise {
     #[cfg(feature = "integration-tests")]
     #[perf_instrument("whitenoise")]
     pub async fn wipe_database(&self) -> Result<()> {
+        // Integration scenarios use this row-level reset while keeping the
+        // same Whitenoise instance, pool, and database key alive. Full app
+        // wipes must use delete_all_data so database files and keyring entries
+        // are removed together.
         self.database.delete_all_data().await?;
         Ok(())
     }
@@ -2011,7 +2040,7 @@ mod tests {
             let (account, _keys) = create_test_account(&whitenoise).await;
             account.save(&whitenoise.database).await.unwrap();
 
-            let db_key_id = format!("mdk.db.key.{}", account.pubkey.to_hex());
+            let db_key_id = Account::mdk_db_key_id(&account.pubkey);
             keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
                 .expect("Failed to create MDK database key");
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -2105,12 +2105,15 @@ mod tests {
         async fn test_delete_all_data_removes_app_database_key_when_file_delete_fails() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
             let database_path = whitenoise.database.path.clone();
+            let lock_path = database_path.with_file_name(format!(
+                "{}.encryption.lock",
+                database_path.file_name().unwrap().to_string_lossy()
+            ));
             let database_key_id = whitenoise.database_key_id().to_string();
 
             keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
                 .expect("Failed to create app database key");
-            std::fs::remove_file(&database_path).unwrap();
-            std::fs::create_dir(&database_path).unwrap();
+            std::fs::create_dir(&lock_path).unwrap();
 
             let result = whitenoise.delete_all_data().await;
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -76,7 +77,7 @@ pub mod utils;
 pub mod zapstore;
 
 use mdk_core::prelude::MDK;
-use mdk_sqlite_storage::MdkSqliteStorage;
+use mdk_sqlite_storage::{MdkSqliteStorage, keyring};
 
 use crate::init_tracing;
 use crate::perf_instrument;
@@ -955,8 +956,11 @@ impl Whitenoise {
         // Tear down all relay-control subscriptions
         self.relay_control.shutdown_all().await;
 
-        // Remove database (accounts and media) data
-        self.database.delete_all_data().await?;
+        // Remove database files and key material.
+        let accounts = Account::all(&self.database).await?;
+        let database_key_id = self.database_key_id().to_string();
+        self.database.close_and_delete_files().await?;
+        keyring::delete_db_key(&self.config.keyring_service_id, &database_key_id)?;
 
         // Remove storage artifacts (media cache, etc.)
         self.storage.wipe_all().await?;
@@ -973,6 +977,7 @@ impl Whitenoise {
         }
         // Always recreate the empty MLS directory
         tokio::fs::create_dir_all(&mls_dir).await?;
+        self.delete_mdk_database_keys_for_accounts(&accounts)?;
 
         // Remove logs
         if self.config.logs_dir.exists() {
@@ -988,6 +993,50 @@ impl Whitenoise {
         }
 
         Ok(())
+    }
+
+    async fn delete_mdk_storage_for_account(&self, pubkey: &PublicKey) -> Result<()> {
+        let mls_storage_path = self.config.data_dir.join("mls").join(pubkey.to_hex());
+        match tokio::fs::metadata(&mls_storage_path).await {
+            Ok(metadata) if metadata.is_dir() => {
+                tokio::fs::remove_dir_all(mls_storage_path).await?;
+            }
+            Ok(_) => {
+                tokio::fs::remove_file(mls_storage_path).await?;
+            }
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) => {}
+            Err(e) => return Err(e.into()),
+        }
+        self.delete_mdk_database_key_for_pubkey(pubkey)
+    }
+
+    fn delete_mdk_database_keys_for_accounts(&self, accounts: &[Account]) -> Result<()> {
+        for account in accounts {
+            self.delete_mdk_database_key_for_pubkey(&account.pubkey)?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_mdk_database_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<()> {
+        let db_key_id = format!("mdk.db.key.{}", pubkey.to_hex());
+        keyring::delete_db_key(&self.config.keyring_service_id, &db_key_id)?;
+        Ok(())
+    }
+
+    fn database_key_id(&self) -> &str {
+        #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
+        {
+            self.config
+                .database_key_id
+                .as_deref()
+                .unwrap_or(WHITENOISE_DB_KEY_ID)
+        }
+
+        #[cfg(not(any(test, feature = "integration-tests", feature = "benchmark-tests")))]
+        {
+            WHITENOISE_DB_KEY_ID
+        }
     }
 
     /// Gracefully shuts down all scheduled tasks.
@@ -1899,6 +1948,8 @@ mod tests {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
             // Create test files in the whitenoise directories
+            let database_path = whitenoise.database.path.clone();
+            let database_key_id = whitenoise.database_key_id().to_string();
             let test_data_file = whitenoise.config.data_dir.join("test_data.txt");
             let test_log_file = whitenoise.config.logs_dir.join("test_log.txt");
             tokio::fs::write(&test_data_file, "test data")
@@ -1922,13 +1973,26 @@ mod tests {
                 .filter_map(|e| e.ok())
                 .collect();
             assert_eq!(cache_entries.len(), 1);
+            keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
+                .expect("Failed to create app database key");
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
+                    .unwrap()
+                    .is_some()
+            );
 
             // Delete all data
             let result = whitenoise.delete_all_data().await;
             assert!(result.is_ok());
 
             // Verify cleanup
-            assert!(Account::all(&whitenoise.database).await.unwrap().is_empty());
+            assert!(!database_path.exists());
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
+                    .unwrap()
+                    .is_none(),
+                "App wipe should remove the app database key"
+            );
             assert!(!test_log_file.exists());
 
             // Media cache directory should be removed
@@ -1939,6 +2003,32 @@ mod tests {
             let mls_dir = whitenoise.config.data_dir.join("mls");
             assert!(mls_dir.exists());
             assert!(mls_dir.is_dir());
+        }
+
+        #[tokio::test]
+        async fn test_delete_all_data_removes_mdk_database_keys() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let (account, _keys) = create_test_account(&whitenoise).await;
+            account.save(&whitenoise.database).await.unwrap();
+
+            let db_key_id = format!("mdk.db.key.{}", account.pubkey.to_hex());
+            keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                .expect("Failed to create MDK database key");
+
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                    .unwrap()
+                    .is_some()
+            );
+
+            whitenoise.delete_all_data().await.unwrap();
+
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                    .unwrap()
+                    .is_none(),
+                "App wipe should remove account-scoped MDK database keys"
+            );
         }
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1988,6 +1988,17 @@ mod tests {
             );
         }
 
+        #[test]
+        fn test_keyring_service_id_normalization_trims_whitespace() {
+            let data_dir = std::path::Path::new("/test/data");
+            let logs_dir = std::path::Path::new("/test/logs");
+            let mut config = WhitenoiseConfig::new(data_dir, logs_dir, "  com.test.app  ");
+
+            config.normalize_keyring_service_id();
+
+            assert_eq!(config.keyring_service_id, "com.test.app");
+        }
+
         #[tokio::test]
         async fn test_initialize_whitenoise_rejects_empty_keyring_service_id() {
             use tempfile::TempDir;

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -959,14 +959,29 @@ impl Whitenoise {
         // Remove database files and key material.
         let accounts = Account::all(&self.database).await?;
         let database_key_id = self.database_key_id().to_string();
-        self.database.close_and_delete_files().await?;
-        keyring::delete_db_key(&self.config.keyring_service_id, &database_key_id)?;
+        let close_result = self.database.close_and_delete_files().await;
+        let key_delete_result =
+            keyring::delete_db_key(&self.config.keyring_service_id, &database_key_id);
+
+        match (close_result, key_delete_result) {
+            (Ok(()), Ok(())) => {}
+            (Err(e), Ok(())) => return Err(e.into()),
+            (Ok(()), Err(e)) => return Err(e.into()),
+            (Err(close_error), Err(key_error)) => {
+                return Err(WhitenoiseError::Internal(format!(
+                    "Failed to delete database files ({close_error}) and app database key ({key_error})"
+                )));
+            }
+        }
 
         // Remove storage artifacts (media cache, etc.)
         self.storage.wipe_all().await?;
 
         // Remove MLS related data
         let mls_dir = self.config.data_dir.join("mls");
+        let orphaned_mdk_database_key_pubkeys = self
+            .collect_orphaned_mdk_storage_pubkeys(&accounts, &mls_dir)
+            .await?;
         if mls_dir.exists() {
             tracing::debug!(
                 target: "whitenoise::delete_all_data",
@@ -978,6 +993,7 @@ impl Whitenoise {
         // Always recreate the empty MLS directory
         tokio::fs::create_dir_all(&mls_dir).await?;
         self.delete_mdk_database_keys_for_accounts(&accounts)?;
+        self.delete_mdk_database_keys_for_pubkeys(&orphaned_mdk_database_key_pubkeys)?;
 
         // Remove logs
         if self.config.logs_dir.exists() {
@@ -1019,13 +1035,21 @@ impl Whitenoise {
     }
 
     fn delete_mdk_database_keys_for_accounts(&self, accounts: &[Account]) -> Result<()> {
+        let pubkeys = accounts
+            .iter()
+            .map(|account| account.pubkey)
+            .collect::<Vec<_>>();
+        self.delete_mdk_database_keys_for_pubkeys(&pubkeys)
+    }
+
+    fn delete_mdk_database_keys_for_pubkeys(&self, pubkeys: &[PublicKey]) -> Result<()> {
         let mut first_error = None;
 
-        for account in accounts {
-            if let Err(e) = self.delete_mdk_database_key_for_pubkey(&account.pubkey) {
+        for pubkey in pubkeys {
+            if let Err(e) = self.delete_mdk_database_key_for_pubkey(pubkey) {
                 tracing::warn!(
                     target: "whitenoise::delete_all_data",
-                    account_pubkey = %account.pubkey,
+                    account_pubkey = %pubkey,
                     "Failed to delete MDK database key: {e}"
                 );
                 if first_error.is_none() {
@@ -1038,6 +1062,48 @@ impl Whitenoise {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    async fn collect_orphaned_mdk_storage_pubkeys(
+        &self,
+        accounts: &[Account],
+        mls_dir: &Path,
+    ) -> Result<Vec<PublicKey>> {
+        let mut pubkeys = Vec::new();
+        let mut entries = match tokio::fs::read_dir(mls_dir).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(pubkeys),
+            Err(e) => return Err(e.into()),
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                tracing::warn!(
+                    target: "whitenoise::delete_all_data",
+                    path = ?entry.path(),
+                    "Skipping MLS storage entry with non-UTF-8 filename"
+                );
+                continue;
+            };
+
+            let Ok(pubkey) = file_name.parse::<PublicKey>() else {
+                tracing::debug!(
+                    target: "whitenoise::delete_all_data",
+                    path = ?entry.path(),
+                    "Skipping non-account MLS storage entry while collecting MDK database keys"
+                );
+                continue;
+            };
+
+            if !accounts.iter().any(|account| account.pubkey == pubkey)
+                && !pubkeys.contains(&pubkey)
+            {
+                pubkeys.push(pubkey);
+            }
+        }
+
+        Ok(pubkeys)
     }
 
     fn delete_mdk_database_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<()> {
@@ -2034,6 +2100,29 @@ mod tests {
             assert!(mls_dir.is_dir());
         }
 
+        #[cfg(unix)]
+        #[tokio::test]
+        async fn test_delete_all_data_removes_app_database_key_when_file_delete_fails() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let database_path = whitenoise.database.path.clone();
+            let database_key_id = whitenoise.database_key_id().to_string();
+
+            keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
+                .expect("Failed to create app database key");
+            std::fs::remove_file(&database_path).unwrap();
+            std::fs::create_dir(&database_path).unwrap();
+
+            let result = whitenoise.delete_all_data().await;
+
+            assert!(result.is_err());
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &database_key_id)
+                    .unwrap()
+                    .is_none(),
+                "App wipe should attempt key deletion even when database file deletion fails"
+            );
+        }
+
         #[tokio::test]
         async fn test_delete_all_data_removes_mdk_database_keys() {
             let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
@@ -2058,6 +2147,37 @@ mod tests {
                     .is_none(),
                 "App wipe should remove account-scoped MDK database keys"
             );
+        }
+
+        #[tokio::test]
+        async fn test_delete_all_data_removes_orphaned_mdk_database_keys_from_storage_dirs() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let orphan_pubkey = create_test_keys().public_key();
+            let orphan_storage_dir =
+                Account::mdk_storage_path(&orphan_pubkey, &whitenoise.config.data_dir);
+            let db_key_id = Account::mdk_db_key_id(&orphan_pubkey);
+
+            tokio::fs::create_dir_all(&orphan_storage_dir)
+                .await
+                .unwrap();
+            keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                .expect("Failed to create orphaned MDK database key");
+
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                    .unwrap()
+                    .is_some()
+            );
+
+            whitenoise.delete_all_data().await.unwrap();
+
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                    .unwrap()
+                    .is_none(),
+                "App wipe should remove orphaned MDK database keys discovered from storage dirs"
+            );
+            assert!(!orphan_storage_dir.exists());
         }
     }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -1026,7 +1027,7 @@ impl Whitenoise {
                     target: "whitenoise::accounts",
                     account_pubkey = %pubkey,
                     path = ?mls_storage_path,
-                    "Unable to remove MDK storage because a path component is not a directory"
+                    reason = "path component is not a directory",
                 );
             }
             Err(e) => return Err(e.into()),
@@ -1043,14 +1044,24 @@ impl Whitenoise {
     }
 
     fn delete_mdk_database_keys_for_pubkeys(&self, pubkeys: &[PublicKey]) -> Result<()> {
+        Self::delete_mdk_database_keys(pubkeys, |pubkey| {
+            self.delete_mdk_database_key_for_pubkey(pubkey)
+        })
+    }
+
+    fn delete_mdk_database_keys<F>(pubkeys: &[PublicKey], mut delete: F) -> Result<()>
+    where
+        F: FnMut(&PublicKey) -> Result<()>,
+    {
         let mut first_error = None;
 
         for pubkey in pubkeys {
-            if let Err(e) = self.delete_mdk_database_key_for_pubkey(pubkey) {
+            if let Err(e) = delete(pubkey) {
                 tracing::warn!(
                     target: "whitenoise::delete_all_data",
                     account_pubkey = %pubkey,
-                    "Failed to delete MDK database key: {e}"
+                    error = %e,
+                    reason = "failed to delete MDK database key",
                 );
                 if first_error.is_none() {
                     first_error = Some(e);
@@ -1062,6 +1073,28 @@ impl Whitenoise {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    fn mdk_storage_pubkey_from_entry_name(file_name: &OsStr, path: &Path) -> Option<PublicKey> {
+        let Some(file_name) = file_name.to_str() else {
+            tracing::warn!(
+                target: "whitenoise::delete_all_data",
+                path = ?path,
+                reason = "non-UTF-8 MLS storage filename",
+            );
+            return None;
+        };
+
+        let Ok(pubkey) = file_name.parse::<PublicKey>() else {
+            tracing::debug!(
+                target: "whitenoise::delete_all_data",
+                path = ?path,
+                reason = "non-account MLS storage entry",
+            );
+            return None;
+        };
+
+        Some(pubkey)
     }
 
     async fn collect_orphaned_mdk_storage_pubkeys(
@@ -1078,21 +1111,8 @@ impl Whitenoise {
 
         while let Some(entry) = entries.next_entry().await? {
             let file_name = entry.file_name();
-            let Some(file_name) = file_name.to_str() else {
-                tracing::warn!(
-                    target: "whitenoise::delete_all_data",
-                    path = ?entry.path(),
-                    "Skipping MLS storage entry with non-UTF-8 filename"
-                );
-                continue;
-            };
-
-            let Ok(pubkey) = file_name.parse::<PublicKey>() else {
-                tracing::debug!(
-                    target: "whitenoise::delete_all_data",
-                    path = ?entry.path(),
-                    "Skipping non-account MLS storage entry while collecting MDK database keys"
-                );
+            let Some(pubkey) = Self::mdk_storage_pubkey_from_entry_name(&file_name, &entry.path())
+            else {
                 continue;
             };
 
@@ -1710,6 +1730,12 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use keyring_core::api::CredentialStoreApi;
@@ -2177,10 +2203,146 @@ mod tests {
             assert!(
                 keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
                     .unwrap()
-                    .is_none(),
-                "App wipe should remove orphaned MDK database keys discovered from storage dirs"
+                    .is_none()
             );
             assert!(!orphan_storage_dir.exists());
+        }
+
+        #[tokio::test]
+        async fn test_collect_orphaned_mdk_storage_pubkeys_handles_missing_and_invalid_entries() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let account_pubkey = create_test_keys().public_key();
+            let orphan_pubkey = create_test_keys().public_key();
+            let mls_dir = whitenoise.config.data_dir.join("scan_mls");
+            let missing_dir = whitenoise.config.data_dir.join("missing_mls");
+            let not_a_dir = whitenoise.config.data_dir.join("mls-file");
+            let accounts = vec![
+                Account::new_external(&whitenoise, account_pubkey)
+                    .await
+                    .unwrap(),
+            ];
+
+            let missing = whitenoise
+                .collect_orphaned_mdk_storage_pubkeys(&accounts, &missing_dir)
+                .await
+                .unwrap();
+            assert!(missing.is_empty());
+
+            tokio::fs::write(&not_a_dir, "not a directory")
+                .await
+                .unwrap();
+            assert!(
+                whitenoise
+                    .collect_orphaned_mdk_storage_pubkeys(&accounts, &not_a_dir)
+                    .await
+                    .is_err()
+            );
+
+            tokio::fs::create_dir_all(mls_dir.join(account_pubkey.to_string()))
+                .await
+                .unwrap();
+            tokio::fs::create_dir_all(mls_dir.join(orphan_pubkey.to_string()))
+                .await
+                .unwrap();
+            tokio::fs::write(mls_dir.join("not-a-pubkey"), "ignored")
+                .await
+                .unwrap();
+
+            let found = whitenoise
+                .collect_orphaned_mdk_storage_pubkeys(&accounts, &mls_dir)
+                .await
+                .unwrap();
+
+            assert_eq!(found, vec![orphan_pubkey]);
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn test_mdk_storage_pubkey_from_entry_name_skips_non_utf8_and_invalid_names() {
+            let orphan_pubkey = create_test_keys().public_key();
+            let non_utf8_name = OsString::from_vec(vec![0xff, b'm', b'd', b'k']);
+
+            assert_eq!(
+                Whitenoise::mdk_storage_pubkey_from_entry_name(
+                    non_utf8_name.as_os_str(),
+                    Path::new("non-utf8")
+                ),
+                None
+            );
+            assert_eq!(
+                Whitenoise::mdk_storage_pubkey_from_entry_name(
+                    OsStr::new("not-a-pubkey"),
+                    Path::new("invalid")
+                ),
+                None
+            );
+            assert_eq!(
+                Whitenoise::mdk_storage_pubkey_from_entry_name(
+                    OsStr::new(&orphan_pubkey.to_string()),
+                    Path::new("valid")
+                ),
+                Some(orphan_pubkey)
+            );
+        }
+
+        #[tokio::test]
+        async fn test_delete_mdk_storage_for_account_treats_not_a_directory_as_cleanup_complete() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let pubkey = create_test_keys().public_key();
+            let mls_dir = whitenoise.config.data_dir.join("mls");
+            let db_key_id = Account::mdk_db_key_id(&pubkey);
+
+            let _ = tokio::fs::remove_dir_all(&mls_dir).await;
+            tokio::fs::write(&mls_dir, "not a directory").await.unwrap();
+            keyring::get_or_create_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                .expect("Failed to create MDK database key");
+
+            whitenoise
+                .delete_mdk_storage_for_account(&pubkey)
+                .await
+                .unwrap();
+
+            assert!(
+                keyring::get_db_key(&whitenoise.config.keyring_service_id, &db_key_id)
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[cfg(unix)]
+        #[tokio::test]
+        async fn test_delete_mdk_storage_for_account_propagates_unexpected_metadata_errors() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+            let pubkey = create_test_keys().public_key();
+            let mls_dir = whitenoise.config.data_dir.join("mls");
+
+            tokio::fs::create_dir_all(&mls_dir).await.unwrap();
+            std::fs::set_permissions(&mls_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+            let result = whitenoise.delete_mdk_storage_for_account(&pubkey).await;
+
+            std::fs::set_permissions(&mls_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_delete_mdk_database_keys_continues_after_delete_error() {
+            let first_pubkey = create_test_keys().public_key();
+            let second_pubkey = create_test_keys().public_key();
+            let pubkeys = vec![first_pubkey, second_pubkey];
+            let mut attempted_pubkeys = Vec::new();
+
+            let result = Whitenoise::delete_mdk_database_keys(&pubkeys, |pubkey| {
+                attempted_pubkeys.push(*pubkey);
+                if *pubkey == first_pubkey {
+                    return Err(WhitenoiseError::Internal("delete failed".to_string()));
+                }
+
+                Ok(())
+            });
+
+            assert!(result.is_err());
+            assert_eq!(attempted_pubkeys, pubkeys);
         }
     }
 

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -170,6 +170,7 @@ const PUSH_GROUP_MESSAGE_KINDS: [u16; 3] = [
 #[derive(Clone)]
 struct PendingTokenResponseContext {
     config: WhitenoiseConfig,
+    keyring_service_id: String,
     database: Arc<Database>,
     pending_push_token_responses: Arc<dashmap::DashMap<(PublicKey, GroupId, EventId), ()>>,
     relay_control: Arc<RelayControlPlane>,
@@ -215,7 +216,7 @@ impl PendingTokenResponseContext {
         let mdk = Account::create_mdk(
             account.pubkey,
             &self.config.data_dir,
-            &self.config.keyring_service_id,
+            &self.keyring_service_id,
         )?;
         respond_to_token_request_with(
             &mdk,
@@ -1021,6 +1022,7 @@ impl Whitenoise {
 
         let context = PendingTokenResponseContext {
             config: self.config.clone(),
+            keyring_service_id: self.keyring_service_id().to_string(),
             database: Arc::clone(&self.database),
             pending_push_token_responses: Arc::clone(&self.pending_push_token_responses),
             relay_control: Arc::clone(&self.relay_control),


### PR DESCRIPTION
## Summary

- Rotate stale Whitenoise app database keyring entries when creating a fresh encrypted database or encrypting a plaintext database.
- Preserve existing keyring entries during interrupted migration recovery sidecar handling.
- Delete app and per-account MDK database keyring entries during app wipe, and delete per-account MDK storage/keyring entries on logout.
- Pin MDK to merged master commit `634085a919ffac725323f7085291d945979af507`, which includes marmot-protocol/mdk#275 for fresh per-account MLS database key rotation.

## Root Cause

If a database file was removed while its keyring entry remained, fresh database creation could reuse stale SQLCipher key material. That was wrong for a fresh app install/wipe and could also affect account-scoped MDK storage when MLS database files were removed independently.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `just precommit-quick`

Fixes #798.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout removes per-account storage and clears associated encryption keys.
  * Global data deletion now closes databases, deletes underlying files, and removes app and orphaned per-account keys.
  * Safer encryption/migration recovery with serialized key rotation and improved file cleanup to avoid stale-key issues.

* **Chores**
  * Aligned core/storage dependency versions for consistency.

* **Tests**
  * Added/updated tests verifying keyring cleanup and migration recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->