### PR TITLE
[codex] Enforce deletion author checks

### DIFF
--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -1034,7 +1034,10 @@ impl AggregatedMessage {
         Ok(())
     }
 
-    /// Mark a message or reaction as deleted
+    /// Mark a message or reaction as deleted when its author matches `target_author`.
+    ///
+    /// The author predicate enforces deletion ownership. If the cached target's
+    /// author differs, this is a no-op.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn mark_deleted(
         message_id: &str,
@@ -1056,6 +1059,25 @@ impl AggregatedMessage {
         .await?;
 
         Ok(())
+    }
+
+    /// Return targets marked deleted by a specific deletion event.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn find_deleted_target_ids_by_deletion_event_id(
+        deletion_event_id: &str,
+        group_id: &GroupId,
+        database: &Database,
+    ) -> Result<Vec<String>> {
+        let target_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT message_id FROM aggregated_messages
+             WHERE deletion_event_id = ? AND mls_group_id = ? AND kind IN (7, 9)",
+        )
+        .bind(deletion_event_id)
+        .bind(group_id.as_slice())
+        .fetch_all(&database.pool)
+        .await?;
+
+        Ok(target_ids)
     }
 
     /// Reverse a deletion by clearing `deletion_event_id` for targets of a specific deletion.
@@ -1604,20 +1626,23 @@ impl AggregatedMessage {
             .collect())
     }
 
-    /// Find orphaned deletions targeting a specific message.
-    /// Returns deletions (kind 5) that reference the target `message_id`.
-    /// Callers must check `author` before applying — only deletions whose
-    /// author matches the target's author are valid.
+    /// Find authorized orphaned deletions targeting a specific message.
+    ///
+    /// An orphaned deletion is a cached kind-5 deletion whose target message had
+    /// not arrived yet. The `target_author` filter leaves cross-author deletion
+    /// events in the cache as audit records without replaying them.
     #[perf_instrument("db::aggregated_messages")]
     pub async fn find_orphaned_deletions(
         message_id: &str,
         group_id: &GroupId,
+        target_author: &PublicKey,
         database: &Database,
     ) -> Result<Vec<AggregatedMessage>> {
         let rows: Vec<AggregatedMessageRow> = sqlx::query_as(
             "SELECT * FROM aggregated_messages am
              WHERE am.kind = 5
                AND am.mls_group_id = ?
+               AND am.author = ?
                AND EXISTS (
                  SELECT 1 FROM json_each(am.tags) AS tag
                  WHERE json_extract(tag.value, '$[0]') = 'e'
@@ -1625,6 +1650,7 @@ impl AggregatedMessage {
                )",
         )
         .bind(group_id.as_slice())
+        .bind(target_author.to_hex())
         .bind(message_id)
         .fetch_all(&database.pool)
         .await
@@ -1956,6 +1982,52 @@ mod tests {
         assert_eq!(count_after, 1);
 
         // But the message should have deletion_event_id set
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].is_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_mark_deleted_requires_matching_author() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
+        let group_id = GroupId::from_slice(&[213; 32]);
+
+        let author = Keys::generate().public_key();
+        let other_author = Keys::generate().public_key();
+        let message = create_test_chat_message(213, author);
+        AggregatedMessage::insert_message(&message, &group_id, &account.pubkey, db)
+            .await
+            .unwrap();
+
+        let wrong_deletion_event_id = format!("{:0>64x}", 0xde1213u64);
+        AggregatedMessage::mark_deleted(
+            &message.id,
+            &group_id,
+            &wrong_deletion_event_id,
+            &other_author,
+            db,
+        )
+        .await
+        .unwrap();
+
+        let messages =
+            AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
+                .await
+                .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(!messages[0].is_deleted);
+
+        let deletion_event_id = format!("{:0>64x}", 0xde1214u64);
+        AggregatedMessage::mark_deleted(&message.id, &group_id, &deletion_event_id, &author, db)
+            .await
+            .unwrap();
+
         let messages =
             AggregatedMessage::find_messages_by_group(&group_id, &account.pubkey, None, db)
                 .await
@@ -3040,6 +3112,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(orphans.len(), 0, "Deleted reaction should be excluded");
+    }
+
+    #[tokio::test]
+    async fn test_find_orphaned_deletions_filters_author_mismatch() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.session(&account.pubkey).unwrap();
+        let db = &session.account_db.inner;
+        let group_id = GroupId::from_slice(&[187; 32]);
+
+        let target_author = Keys::generate().public_key();
+        let other_author = Keys::generate().public_key();
+        let parent_id = format!("{:0>64x}", 0xba187u64);
+        let authorized_deletion_id = format!("{:0>64x}", 0xde187u64);
+        let unauthorized_deletion_id = format!("{:0>64x}", 0xde188u64);
+        let tags_json = serde_json::to_string(&vec![vec!["e", &parent_id]]).unwrap();
+        let empty_tokens = serde_json::to_string(&Vec::<SerializableToken>::new()).unwrap();
+        let empty_reactions = serde_json::to_string(&ReactionSummary::default()).unwrap();
+        let empty_media = serde_json::to_string(&Vec::<MediaFile>::new()).unwrap();
+
+        for (deletion_id, author) in [
+            (&authorized_deletion_id, &target_author),
+            (&unauthorized_deletion_id, &other_author),
+        ] {
+            sqlx::query(
+                "INSERT INTO aggregated_messages
+                 (message_id, mls_group_id, author, created_at, kind, content, tags,
+                  content_tokens, reactions, media_attachments)
+                 VALUES (?, ?, ?, ?, 5, '', ?, ?, ?, ?)",
+            )
+            .bind(deletion_id)
+            .bind(group_id.as_slice())
+            .bind(author.to_hex())
+            .bind(1000i64)
+            .bind(&tags_json)
+            .bind(&empty_tokens)
+            .bind(&empty_reactions)
+            .bind(&empty_media)
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        }
+
+        let orphans =
+            AggregatedMessage::find_orphaned_deletions(&parent_id, &group_id, &target_author, db)
+                .await
+                .unwrap();
+
+        assert_eq!(orphans.len(), 1, "Only same-author deletion should replay");
+        assert_eq!(orphans[0].event_id.to_string(), authorized_deletion_id);
+        assert_eq!(orphans[0].author, target_author);
     }
 
     #[tokio::test]

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -255,29 +255,28 @@ impl Whitenoise {
         group_id: &GroupId,
         message: &Message,
     ) -> Result<()> {
+        // Capture the pre-deletion last message so authorized deletes can emit
+        // LastMessageDeleted after cache_deletion mutates the target row.
         let last_message_id = self.get_last_message_id(account_pubkey, group_id).await;
-
-        for (trigger, msg) in self
+        let updates = self
             .cache_deletion(account_pubkey, group_id, message)
-            .await?
-        {
+            .await?;
+        let deleted_last_message = last_message_id.as_ref().is_some_and(|last_message_id| {
+            updates.iter().any(|(trigger, msg)| {
+                matches!(trigger, UpdateTrigger::MessageDeleted) && &msg.id == last_message_id
+            })
+        });
+
+        for (trigger, msg) in updates {
             self.emit_message_update(group_id, trigger, msg);
         }
 
-        // Check if the deleted message was the last message.
-        // This check must happen AFTER get_last_message_id but the
-        // result is only valid for the FIRST handler (before cache_deletion
-        // modifies shared state). We emit for ALL subscribed accounts because
-        // subsequent handlers will see incorrect post-deletion state.
-        if let Some(last_message_id) = last_message_id {
-            let deleted_ids = extract_deletion_target_ids(&message.tags);
-            if deleted_ids.contains(&last_message_id) {
-                self.emit_chat_list_update_for_group(
-                    group_id,
-                    ChatListUpdateTrigger::LastMessageDeleted,
-                )
-                .await;
-            }
+        if deleted_last_message {
+            self.emit_chat_list_update_for_group(
+                group_id,
+                ChatListUpdateTrigger::LastMessageDeleted,
+            )
+            .await;
         }
 
         Ok(())
@@ -787,7 +786,7 @@ impl Whitenoise {
                     target: "whitenoise::cache",
                     deletion_author = %deletion_author.to_hex(),
                     target_author = %reaction.author.to_hex(),
-                    target_id = target_id,
+                    target_id = %target_id,
                     "Ignoring deletion whose author does not match reaction author"
                 );
                 return Ok(None);
@@ -821,7 +820,7 @@ impl Whitenoise {
                     target: "whitenoise::cache",
                     deletion_author = %deletion_author.to_hex(),
                     target_author = %msg.author.to_hex(),
-                    target_id = target_id,
+                    target_id = %target_id,
                     "Ignoring deletion whose author does not match message author"
                 );
                 return Ok(None);
@@ -915,6 +914,7 @@ impl Whitenoise {
         let orphaned_deletions = AggregatedMessage::find_orphaned_deletions(
             &message.id,
             group_id,
+            &message.author,
             &session.account_db.inner,
         )
         .await?;
@@ -967,30 +967,21 @@ impl Whitenoise {
             .await?;
         }
 
-        // Apply orphaned deletions, but only those whose author matches the
-        // target message author. Cross-author deletions never legitimately
-        // apply and would let a malicious peer wipe other members' content.
+        // Apply orphaned deletions through the same path used for live deletes.
+        // `find_orphaned_deletions` has already filtered to matching authors.
         for deletion in orphaned_deletions {
-            if deletion.author != message.author {
-                tracing::warn!(
-                    target: "whitenoise::cache",
-                    deletion_author = %deletion.author.to_hex(),
-                    target_author = %message.author.to_hex(),
-                    target_id = %message.id,
-                    "Ignoring orphaned deletion whose author does not match message author"
-                );
-                continue;
+            if let Some((UpdateTrigger::MessageDeleted, deleted_message)) = self
+                .apply_single_deletion(
+                    account_pubkey,
+                    &deletion.author,
+                    &message.id,
+                    &deletion.event_id,
+                    group_id,
+                )
+                .await?
+            {
+                message = deleted_message;
             }
-
-            message.is_deleted = true;
-            AggregatedMessage::mark_deleted(
-                &message.id,
-                group_id,
-                &deletion.event_id.to_string(),
-                &deletion.author,
-                &session.account_db.inner,
-            )
-            .await?;
         }
 
         Ok(message)
@@ -1149,6 +1140,234 @@ mod tests {
         .unwrap()
         .unwrap();
         assert!(cached_msg.is_deleted, "Message should be marked as deleted");
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_rejects_cross_author_deletion() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+
+        let mut message_inner = UnsignedEvent::new(
+            admin_account.pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "Protected admin message".to_string(),
+        );
+        message_inner.ensure_id();
+        let message_id = message_inner.id.unwrap();
+        let message_event = admin_mdk
+            .create_message(&group_id, message_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, message_event)
+            .await
+            .unwrap();
+
+        let member_mdk = whitenoise
+            .create_mdk_for_account(member_account.pubkey)
+            .unwrap();
+        let mut deletion_inner = UnsignedEvent::new(
+            member_account.pubkey,
+            Timestamp::now(),
+            Kind::EventDeletion,
+            vec![Tag::parse(vec!["e", &message_id.to_string()]).unwrap()],
+            String::new(),
+        );
+        deletion_inner.ensure_id();
+        let deletion_event = member_mdk
+            .create_message(&group_id, deletion_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, deletion_event)
+            .await
+            .unwrap();
+
+        let cached_msg = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            &group_id,
+            &admin_account.pubkey,
+            &admin_session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!cached_msg.is_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_rejects_cross_author_orphaned_deletion() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+        let mut message_inner = UnsignedEvent::new(
+            admin_account.pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "Late protected admin message".to_string(),
+        );
+        message_inner.ensure_id();
+        let future_message_id = message_inner.id.unwrap();
+        let member_mdk = whitenoise
+            .create_mdk_for_account(member_account.pubkey)
+            .unwrap();
+
+        let mut deletion_inner = UnsignedEvent::new(
+            member_account.pubkey,
+            Timestamp::now(),
+            Kind::EventDeletion,
+            vec![Tag::parse(vec!["e", &future_message_id.to_string()]).unwrap()],
+            String::new(),
+        );
+        deletion_inner.ensure_id();
+        let deletion_event = member_mdk
+            .create_message(&group_id, deletion_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, deletion_event)
+            .await
+            .unwrap();
+
+        let message_event = admin_mdk
+            .create_message(&group_id, message_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, message_event)
+            .await
+            .unwrap();
+
+        let cached_msg = AggregatedMessage::find_by_id(
+            &future_message_id.to_string(),
+            &group_id,
+            &admin_account.pubkey,
+            &admin_session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!cached_msg.is_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_rejects_cross_author_reaction_deletion() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+
+        let mut message_inner = UnsignedEvent::new(
+            admin_account.pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "Reaction parent".to_string(),
+        );
+        message_inner.ensure_id();
+        let message_id = message_inner.id.unwrap();
+        let message_event = admin_mdk
+            .create_message(&group_id, message_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, message_event)
+            .await
+            .unwrap();
+
+        let mut reaction_inner = UnsignedEvent::new(
+            admin_account.pubkey,
+            Timestamp::now(),
+            Kind::Reaction,
+            vec![Tag::parse(vec!["e", &message_id.to_string()]).unwrap()],
+            "+".to_string(),
+        );
+        reaction_inner.ensure_id();
+        let reaction_id = reaction_inner.id.unwrap();
+        let reaction_event = admin_mdk
+            .create_message(&group_id, reaction_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, reaction_event)
+            .await
+            .unwrap();
+
+        let member_mdk = whitenoise
+            .create_mdk_for_account(member_account.pubkey)
+            .unwrap();
+        let mut deletion_inner = UnsignedEvent::new(
+            member_account.pubkey,
+            Timestamp::now(),
+            Kind::EventDeletion,
+            vec![Tag::parse(vec!["e", &reaction_id.to_string()]).unwrap()],
+            String::new(),
+        );
+        deletion_inner.ensure_id();
+        let deletion_event = member_mdk
+            .create_message(&group_id, deletion_inner, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, deletion_event)
+            .await
+            .unwrap();
+
+        let cached_msg = AggregatedMessage::find_by_id(
+            &message_id.to_string(),
+            &group_id,
+            &admin_account.pubkey,
+            &admin_session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let total_reactions: usize = cached_msg
+            .reactions
+            .by_emoji
+            .values()
+            .map(|reaction| reaction.count)
+            .sum();
+        assert_eq!(total_reactions, 1);
+
+        let cached_reaction = AggregatedMessage::find_reaction_by_id(
+            &reaction_id.to_string(),
+            &group_id,
+            &admin_session.account_db.inner,
+        )
+        .await
+        .unwrap();
+        assert!(cached_reaction.is_some());
     }
 
     #[tokio::test]

--- a/src/whitenoise/messages.rs
+++ b/src/whitenoise/messages.rs
@@ -330,10 +330,30 @@ mod tests {
 
     use super::*;
     use crate::whitenoise::error::WhitenoiseError;
-    use crate::whitenoise::message_aggregator::DeliveryStatus;
+    use crate::whitenoise::message_aggregator::{
+        ChatMessage, DeliveryStatus, ReactionSummary, reaction_handler,
+    };
     use crate::whitenoise::message_streaming::{MessageStreamManager, UpdateTrigger};
     use crate::whitenoise::session::messages::cascade_delivery_failure;
     use crate::whitenoise::test_utils::*;
+
+    fn test_chat_message(seed: u64, author: PublicKey, content: &str) -> ChatMessage {
+        ChatMessage {
+            id: format!("{seed:0>64x}"),
+            author,
+            content: content.to_string(),
+            created_at: Timestamp::now(),
+            tags: Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: false,
+            content_tokens: vec![],
+            reactions: ReactionSummary::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+        }
+    }
 
     /// Test successful message sending with various scenarios:
     /// - Default tags (None)
@@ -1812,6 +1832,253 @@ mod tests {
         .await
         .unwrap();
         assert!(has_status, "Deletion event should have delivery status");
+    }
+
+    #[tokio::test]
+    async fn test_send_deletion_rejects_cross_author_message_target() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member]).await;
+
+        let group = whitenoise
+            .require_session(&creator.pubkey)
+            .unwrap()
+            .groups()
+            .create_group(
+                vec![member.pubkey],
+                create_nostr_group_config_data(vec![creator.pubkey]),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let creator_session = whitenoise.require_session(&creator.pubkey).unwrap();
+        let target = test_chat_message(0xca501, member.pubkey, "Member-owned message");
+        AggregatedMessage::insert_message(
+            &target,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &creator_session.account_db.inner,
+        )
+        .await
+        .unwrap();
+
+        let deletion_tags = Some(vec![Tag::parse(vec!["e", &target.id]).unwrap()]);
+        let result = creator_session
+            .messages()
+            .for_group(&group.mls_group_id)
+            .send(String::new(), 5, deletion_tags)
+            .await
+            .unwrap();
+
+        assert!(
+            !result.last_message_deleted,
+            "cross-author deletion must not report that it deleted the last message"
+        );
+
+        let cached = AggregatedMessage::find_by_id(
+            &target.id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &creator_session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(
+            !cached.is_deleted,
+            "cross-author deletion must not mark the target deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_deletion_rejects_cross_author_reaction_target() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member = members[0].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member]).await;
+
+        let group = whitenoise
+            .require_session(&creator.pubkey)
+            .unwrap()
+            .groups()
+            .create_group(
+                vec![member.pubkey],
+                create_nostr_group_config_data(vec![creator.pubkey]),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let creator_session = whitenoise.require_session(&creator.pubkey).unwrap();
+        let reaction_id = EventId::from_hex(&format!("{:0>64x}", 0xea501u64)).unwrap();
+        let mut parent = test_chat_message(0xca502, creator.pubkey, "Parent message");
+        reaction_handler::add_reaction_to_message(
+            &mut parent,
+            &member.pubkey,
+            "+",
+            Timestamp::now(),
+            reaction_id,
+        );
+        AggregatedMessage::insert_message(
+            &parent,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &creator_session.account_db.inner,
+        )
+        .await
+        .unwrap();
+
+        let reaction_tags = Tags::from_list(vec![Tag::parse(vec!["e", &parent.id]).unwrap()]);
+        let empty_tokens =
+            serde_json::to_string(&Vec::<crate::nostr_manager::parser::SerializableToken>::new())
+                .unwrap();
+        let empty_reactions = serde_json::to_string(&ReactionSummary::default()).unwrap();
+        let empty_media =
+            serde_json::to_string(&Vec::<crate::whitenoise::media_files::MediaFile>::new())
+                .unwrap();
+        sqlx::query(
+            "INSERT INTO aggregated_messages
+             (message_id, mls_group_id, author, created_at, kind, content, tags,
+              content_tokens, reactions, media_attachments)
+             VALUES (?, ?, ?, ?, 7, '+', ?, ?, ?, ?)",
+        )
+        .bind(reaction_id.to_string())
+        .bind(group.mls_group_id.as_slice())
+        .bind(member.pubkey.to_hex())
+        .bind(1000i64)
+        .bind(serde_json::to_string(&reaction_tags).unwrap())
+        .bind(&empty_tokens)
+        .bind(&empty_reactions)
+        .bind(&empty_media)
+        .execute(&creator_session.account_db.inner.pool)
+        .await
+        .unwrap();
+
+        let deletion_tags = Some(vec![
+            Tag::parse(vec!["e", &reaction_id.to_string()]).unwrap(),
+        ]);
+        let deletion_result = creator_session
+            .messages()
+            .for_group(&group.mls_group_id)
+            .send(String::new(), 5, deletion_tags)
+            .await
+            .unwrap();
+        assert!(
+            !deletion_result.last_message_deleted,
+            "cross-author reaction deletion must not report that it deleted the last message"
+        );
+
+        let parent_after_delete = AggregatedMessage::find_by_id(
+            &parent.id,
+            &group.mls_group_id,
+            &creator.pubkey,
+            &creator_session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let total_reactions: usize = parent_after_delete
+            .reactions
+            .by_emoji
+            .values()
+            .map(|reaction| reaction.count)
+            .sum();
+        assert_eq!(
+            total_reactions, 1,
+            "cross-author deletion must not remove another author's reaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cascade_deletion_failure_skips_unmarked_reaction_targets() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        let group_id = GroupId::from_slice(&[0xcb; 32]);
+        let reaction_author = Keys::generate().public_key();
+        let reaction_id = EventId::from_hex(&format!("{:0>64x}", 0xea502u64)).unwrap();
+
+        let mut parent = test_chat_message(0xca503, account.pubkey, "Parent message");
+        reaction_handler::add_reaction_to_message(
+            &mut parent,
+            &reaction_author,
+            "+",
+            Timestamp::now(),
+            reaction_id,
+        );
+        let original_reactions = parent.reactions.clone();
+        AggregatedMessage::insert_message(
+            &parent,
+            &group_id,
+            &account.pubkey,
+            &session.account_db.inner,
+        )
+        .await
+        .unwrap();
+
+        let reaction_tags = Tags::from_list(vec![Tag::parse(vec!["e", &parent.id]).unwrap()]);
+        let empty_tokens =
+            serde_json::to_string(&Vec::<crate::nostr_manager::parser::SerializableToken>::new())
+                .unwrap();
+        let empty_reactions = serde_json::to_string(&ReactionSummary::default()).unwrap();
+        let empty_media =
+            serde_json::to_string(&Vec::<crate::whitenoise::media_files::MediaFile>::new())
+                .unwrap();
+        sqlx::query(
+            "INSERT INTO aggregated_messages
+             (message_id, mls_group_id, author, created_at, kind, content, tags,
+              content_tokens, reactions, media_attachments)
+             VALUES (?, ?, ?, ?, 7, '+', ?, ?, ?, ?)",
+        )
+        .bind(reaction_id.to_string())
+        .bind(group_id.as_slice())
+        .bind(reaction_author.to_hex())
+        .bind(1000i64)
+        .bind(serde_json::to_string(&reaction_tags).unwrap())
+        .bind(&empty_tokens)
+        .bind(&empty_reactions)
+        .bind(&empty_media)
+        .execute(&session.account_db.inner.pool)
+        .await
+        .unwrap();
+
+        let deletion_event_id = format!("{:0>64x}", 0xde502u64);
+        let deletion_tags = Tags::from_list(vec![
+            Tag::parse(vec!["e", &reaction_id.to_string()]).unwrap(),
+        ]);
+        let stream_manager = MessageStreamManager::new();
+
+        cascade_delivery_failure(
+            5,
+            &deletion_event_id,
+            &deletion_tags,
+            &account.pubkey,
+            "",
+            &group_id,
+            &session.account_db.inner,
+            &stream_manager,
+        )
+        .await;
+
+        let parent_after_cascade = AggregatedMessage::find_by_id(
+            &parent.id,
+            &group_id,
+            &account.pubkey,
+            &session.account_db.inner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            parent_after_cascade.reactions, original_reactions,
+            "rollback should not restore a reaction target that this deletion never marked"
+        );
     }
 
     /// Test cascade_delivery_failure for kind 7 (reaction) removes reaction from parent.

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -4058,11 +4058,22 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Tear down subscriptions to simulate the welcome-processing
-            // cascade failure (group exists in MDK but not in group plane)
             let session = whitenoise
                 .session(&creator_account.pubkey)
                 .expect("session should exist");
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    if session.group_handle.group_count().await == 1 {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("background group-plane refresh should settle");
+
+            // Tear down subscriptions to simulate the welcome-processing
+            // cascade failure (group exists in MDK but not in group plane)
             session.deactivate_subscriptions().await;
 
             // Re-activate inbox only (without groups) to isolate the test

--- a/src/whitenoise/session/messages.rs
+++ b/src/whitenoise/session/messages.rs
@@ -479,11 +479,23 @@ impl<'a> MessageOpsForGroup<'a> {
 
         let deletion_id = mdk_message.id.to_string();
         let target_ids = extract_deletion_target_ids(&mdk_message.tags);
+        let mut deleted_last_message = false;
 
         for target_id in &target_ids {
             if let Some(reaction) =
                 AggregatedMessage::find_reaction_by_id(target_id, self.group_id, self.db()).await?
             {
+                if reaction.author != mdk_message.pubkey {
+                    tracing::warn!(
+                        target: "whitenoise::session::messages",
+                        deletion_author = %mdk_message.pubkey.to_hex(),
+                        target_author = %reaction.author.to_hex(),
+                        target_id = %target_id,
+                        "Ignoring outgoing deletion whose author does not match reaction author"
+                    );
+                    continue;
+                }
+
                 if let Ok(parent_id) = extract_reaction_target_id(&reaction.tags)
                     && let Some(mut parent) = AggregatedMessage::find_by_id(
                         &parent_id,
@@ -514,25 +526,39 @@ impl<'a> MessageOpsForGroup<'a> {
                 continue;
             }
 
-            AggregatedMessage::mark_deleted(
-                target_id,
-                self.group_id,
-                &deletion_id,
-                self.pubkey(),
-                self.db(),
-            )
-            .await?;
-
             if let Some(mut msg) =
                 AggregatedMessage::find_by_id(target_id, self.group_id, self.pubkey(), self.db())
                     .await?
             {
+                if msg.author != mdk_message.pubkey {
+                    tracing::warn!(
+                        target: "whitenoise::session::messages",
+                        deletion_author = %mdk_message.pubkey.to_hex(),
+                        target_author = %msg.author.to_hex(),
+                        target_id = %target_id,
+                        "Ignoring outgoing deletion whose author does not match message author"
+                    );
+                    continue;
+                }
+
+                AggregatedMessage::mark_deleted(
+                    target_id,
+                    self.group_id,
+                    &deletion_id,
+                    self.pubkey(),
+                    self.db(),
+                )
+                .await?;
+
                 msg.is_deleted = true;
+                deleted_last_message |= last_message_id
+                    .as_ref()
+                    .is_some_and(|last_message_id| last_message_id == target_id);
                 self.emit(UpdateTrigger::MessageDeleted, msg);
             }
         }
 
-        Ok(last_message_id.is_some_and(|id| target_ids.contains(&id)))
+        Ok(deleted_last_message)
     }
 }
 
@@ -586,10 +612,7 @@ pub(crate) async fn cascade_delivery_failure(
             )
             .await
         }
-        5 => {
-            cascade_deletion_failure(event_id, tags, author, group_id, database, stream_manager)
-                .await
-        }
+        5 => cascade_deletion_failure(event_id, author, group_id, database, stream_manager).await,
         _ => {}
     }
 }
@@ -653,12 +676,19 @@ async fn cascade_reaction_failure(
 
 async fn cascade_deletion_failure(
     event_id: &str,
-    tags: &Tags,
     author: &PublicKey,
     group_id: &GroupId,
     database: &Database,
     stream_manager: &MessageStreamManager,
 ) {
+    let target_ids = retry_on_lock(|| async {
+        AggregatedMessage::find_deleted_target_ids_by_deletion_event_id(
+            event_id, group_id, database,
+        )
+        .await
+    })
+    .await;
+
     if let Err(e) = retry_on_lock(|| async {
         AggregatedMessage::unmark_deleted(event_id, group_id, database).await
     })
@@ -671,9 +701,20 @@ async fn cascade_deletion_failure(
         return;
     }
 
+    let target_ids = match target_ids {
+        Ok(target_ids) => target_ids,
+        Err(e) => {
+            tracing::error!(
+                target: "whitenoise::messages::delivery",
+                "Failed to restore reaction summaries for deletion {event_id} after retries: {e}",
+            );
+            return;
+        }
+    };
+
     // Restore each target. For reactions, re-add them to the parent's summary
     // (the optimistic delete path removed them). For messages, just re-emit.
-    for target_id in extract_deletion_target_ids(tags) {
+    for target_id in target_ids {
         // Check if the restored target is a reaction — if so, re-attach to parent
         if let Ok(Some(reaction)) =
             AggregatedMessage::find_reaction_by_id(&target_id, group_id, database).await


### PR DESCRIPTION
## Summary

Fixes marmot-protocol/marmot-security#94.

This enforces the NIP-09 deletion authorization rule inside MLS group message handling:

- Require the kind-5 deletion author to match the cached target message/reaction author before mutating local cache state.
- Preserve kind-5 deletion rows as audit/orphan records, but reject unauthorized orphan replay when the target message later arrives.
- Add an author predicate to `AggregatedMessage::mark_deleted` so the DB update is guarded too.
- Apply the same author check to outgoing optimistic deletion handling so local UI state cannot be rewritten for another author's target.

## Verification

- Confirmed the issue was real with a red regression test: `test_handle_mls_message_rejects_cross_author_deletion` failed before the fix because the target was marked deleted.
- `just test-unit` passed: 1737 unit tests + doctests.
- `just precommit-quick` passed.
- `just docker-up` passed.
- `just precommit` passed, including integration tests.
- `just docker-down` completed after validation.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deletions are now author-scoped—only the original message/reaction author can mark their content deleted
  * Orphaned-deletion tracking and cascade rollback respect author scoping and restore targets from stored mappings
  * Outgoing deletion handling skips mismatched targets and avoids incorrect "last message deleted" signals

* **Refactor**
  * Emission ordering improved: snapshot pre-mutation last-message is used to decide chat-list updates

* **Tests**
  * Added coverage for cross-author deletions, orphaned-deletion application, cascade rollback, and reaction scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/803)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->