### PR TITLE
Make chat-list unread badges ignore blocked authors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
 dependencies = [
  "base64",
  "blurhash",
@@ -2719,12 +2719,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=634085a919ffac725323f7085291d945979af507#634085a919ffac725323f7085291d945979af507"
+source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
 dependencies = [
  "nostr",
  "openmls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ image = "0.25"
 indexmap = { version = "2", features = ["serde"] }
 infer = "0.19"
 keyring-core = "1"
-mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507", features = [
+mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507" }
-mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "634085a919ffac725323f7085291d945979af507" }
+mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c" }
+mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c" }
 
 nostr-blossom = "0.44"
 nostr-sdk = { version = "0.44", features = [

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use mdk_core::prelude::{GroupId, NostrGroupConfigData, NostrGroupDataUpdate, group_types};
-use nostr_sdk::{PublicKey, RelayUrl, Timestamp};
+use nostr_sdk::{EventId, PublicKey, RelayUrl, Timestamp};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
@@ -1006,8 +1006,43 @@ async fn add_members(
 
 #[derive(Serialize)]
 struct GroupShowResponse {
-    group: group_types::Group,
+    group: CliGroup,
     required_proposals: Vec<RequiredProposal>,
+}
+
+#[derive(Serialize)]
+struct CliGroup {
+    mls_group_id: GroupId,
+    nostr_group_id: [u8; 32],
+    name: String,
+    description: String,
+    image_hash: Option<[u8; 32]>,
+    admin_pubkeys: BTreeSet<PublicKey>,
+    last_message_id: Option<EventId>,
+    last_message_at: Option<Timestamp>,
+    last_message_processed_at: Option<Timestamp>,
+    epoch: u64,
+    state: group_types::GroupState,
+    self_update_state: group_types::SelfUpdateState,
+}
+
+impl From<group_types::Group> for CliGroup {
+    fn from(group: group_types::Group) -> Self {
+        Self {
+            mls_group_id: group.mls_group_id,
+            nostr_group_id: group.nostr_group_id,
+            name: group.name,
+            description: group.description,
+            image_hash: group.image_hash,
+            admin_pubkeys: group.admin_pubkeys,
+            last_message_id: group.last_message_id,
+            last_message_at: group.last_message_at,
+            last_message_processed_at: group.last_message_processed_at,
+            epoch: group.epoch,
+            state: group.state,
+            self_update_state: group.self_update_state,
+        }
+    }
 }
 
 #[perf_instrument("dispatch")]
@@ -1029,7 +1064,7 @@ async fn get_group(
         .into_iter()
         .collect();
     Ok(to_response(&GroupShowResponse {
-        group,
+        group: group.into(),
         required_proposals,
     }))
 }

--- a/src/whitenoise/chat_list.rs
+++ b/src/whitenoise/chat_list.rs
@@ -318,8 +318,12 @@ impl Whitenoise {
                 (gid.clone(), ag.last_read_message_id, cleared_ms)
             })
             .collect();
-        let unread_counts =
-            AggregatedMessage::count_unread_for_groups(&group_markers, &self.database).await?;
+        let unread_counts = AggregatedMessage::count_visible_unread_for_groups(
+            &group_markers,
+            &account.pubkey,
+            &self.database,
+        )
+        .await?;
 
         let mut items = assemble_chat_list_items(
             &groups,
@@ -435,9 +439,10 @@ impl Whitenoise {
         let cleared_ms = account_group
             .chat_cleared_at
             .map(|dt| dt.timestamp_millis());
-        let unread_count = AggregatedMessage::count_unread_for_group(
+        let unread_count = AggregatedMessage::count_visible_unread_for_group(
             group_id,
             account_group.last_read_message_id.as_ref(),
+            &account.pubkey,
             &self.database,
             cleared_ms,
         )
@@ -750,9 +755,28 @@ impl Whitenoise {
 mod tests {
     use super::*;
     use crate::whitenoise::aggregated_message::AggregatedMessage;
+    use crate::whitenoise::database::mute_list::MuteListEntry;
     use crate::whitenoise::message_aggregator::ChatMessage;
     use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
-    use nostr_sdk::{Metadata, Timestamp};
+    use nostr_sdk::{EventId, Metadata, Timestamp};
+
+    fn create_chat_list_test_message(seed: u8, author: PublicKey, timestamp: u64) -> ChatMessage {
+        ChatMessage {
+            id: format!("{:0>64}", format!("{seed:x}")),
+            author,
+            content: format!("message {seed}"),
+            created_at: Timestamp::from(timestamp),
+            tags: nostr_sdk::Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: false,
+            content_tokens: vec![],
+            reactions: Default::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+        }
+    }
 
     #[tokio::test]
     async fn test_get_chat_list_empty() {
@@ -785,6 +809,136 @@ mod tests {
         assert!(chat_list[0].welcomer_pubkey.is_none());
         // Groups should not have dm_peer_pubkey
         assert!(chat_list[0].dm_peer_pubkey.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_chat_list_unread_count_excludes_blocked_author() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let member = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
+        let group = whitenoise
+            .create_group(&creator, vec![member.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let message = create_chat_list_test_message(1, member.pubkey, 1_700_000_001);
+        AggregatedMessage::insert_message(&message, &group.mls_group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        MuteListEntry::insert(&creator.pubkey, &member.pubkey, true, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
+        let persisted = AggregatedMessage::find_messages_by_group(
+            &group.mls_group_id,
+            None,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(chat_list.len(), 1);
+        assert_eq!(chat_list[0].unread_count, 0);
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].id, message.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_chat_list_unread_count_includes_only_unblocked_authors() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let blocked_member = whitenoise.create_identity().await.unwrap();
+        let visible_member = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![
+            creator.pubkey,
+            blocked_member.pubkey,
+            visible_member.pubkey,
+        ]);
+        let group = whitenoise
+            .create_group(
+                &creator,
+                vec![blocked_member.pubkey, visible_member.pubkey],
+                config,
+                None,
+            )
+            .await
+            .unwrap();
+
+        for message in [
+            create_chat_list_test_message(2, blocked_member.pubkey, 1_700_000_002),
+            create_chat_list_test_message(3, visible_member.pubkey, 1_700_000_003),
+        ] {
+            AggregatedMessage::insert_message(&message, &group.mls_group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        }
+
+        MuteListEntry::insert(
+            &creator.pubkey,
+            &blocked_member.pubkey,
+            true,
+            &whitenoise.database,
+        )
+        .await
+        .unwrap();
+
+        let chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
+
+        assert_eq!(chat_list.len(), 1);
+        assert_eq!(chat_list[0].unread_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_chat_list_unread_count_restores_after_unblock() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator = whitenoise.create_identity().await.unwrap();
+        let member = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![creator.pubkey, member.pubkey]);
+        let group = whitenoise
+            .create_group(&creator, vec![member.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let read_message = create_chat_list_test_message(4, creator.pubkey, 1_700_000_004);
+        let unread_message = create_chat_list_test_message(5, member.pubkey, 1_700_000_005);
+        for message in [&read_message, &unread_message] {
+            AggregatedMessage::insert_message(message, &group.mls_group_id, &whitenoise.database)
+                .await
+                .unwrap();
+        }
+
+        let read_message_id = EventId::from_hex(&read_message.id).unwrap();
+        whitenoise
+            .mark_message_read(&creator, &read_message_id)
+            .await
+            .unwrap();
+        MuteListEntry::insert(&creator.pubkey, &member.pubkey, true, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let blocked_chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
+
+        MuteListEntry::delete(&creator.pubkey, &member.pubkey, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let unblocked_chat_list = whitenoise.get_chat_list(&creator).await.unwrap();
+        let last_read_message_id = whitenoise
+            .get_last_read_message_id(&creator, &group.mls_group_id)
+            .await
+            .unwrap();
+
+        assert_eq!(blocked_chat_list.len(), 1);
+        assert_eq!(blocked_chat_list[0].unread_count, 0);
+        assert_eq!(unblocked_chat_list.len(), 1);
+        assert_eq!(unblocked_chat_list[0].unread_count, 1);
+        assert_eq!(last_read_message_id, Some(read_message_id));
     }
 
     #[tokio::test]

--- a/src/whitenoise/chat_list_streaming/types.rs
+++ b/src/whitenoise/chat_list_streaming/types.rs
@@ -34,8 +34,8 @@ pub enum ChatListUpdateTrigger {
     /// Emitted to both active and archived channels since the group
     /// could be in either state at the time of deletion.
     ChatDeleted,
-    /// A user was blocked or unblocked. The DM chat with that user should
-    /// refresh to show/hide the block banner and swap the input area.
+    /// A user was blocked or unblocked. Chats for the account should refresh
+    /// block-sensitive projections such as unread counts and DM block banners.
     UserBlockChanged,
 }
 

--- a/src/whitenoise/database/aggregated_messages.rs
+++ b/src/whitenoise/database/aggregated_messages.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use mdk_core::prelude::{GroupId, message_types::Message};
 use nostr_sdk::prelude::*;
+use sqlx::Row;
 
 use super::{Database, DatabaseError, utils::parse_timestamp};
 use crate::nostr_manager::parser::SerializableToken;
@@ -1209,43 +1210,82 @@ impl AggregatedMessage {
         database: &Database,
         chat_cleared_at_ms: Option<i64>,
     ) -> Result<usize> {
-        let count: i64 = match read_marker {
-            Some(message_id) => {
-                // Count messages after the read marker's timestamp
-                sqlx::query_scalar(
-                    "SELECT COUNT(*) FROM aggregated_messages am
-                     WHERE am.mls_group_id = ?
-                       AND am.kind = 9
-                       AND am.deletion_event_id IS NULL
-                       AND am.created_at > COALESCE(
-                           (SELECT created_at FROM aggregated_messages
-                            WHERE message_id = ? AND mls_group_id = ?),
-                           0
-                       )
-                       AND am.created_at > COALESCE(?, 0)",
-                )
-                .bind(group_id.as_slice())
-                .bind(message_id.to_hex())
-                .bind(group_id.as_slice())
-                .bind(chat_cleared_at_ms)
-                .fetch_one(&database.pool)
-                .await?
-            }
-            None => {
-                // No read marker = all messages are unread
-                sqlx::query_scalar(
-                    "SELECT COUNT(*) FROM aggregated_messages
-                     WHERE mls_group_id = ?
-                       AND kind = 9
-                       AND deletion_event_id IS NULL
-                       AND created_at > COALESCE(?, 0)",
-                )
-                .bind(group_id.as_slice())
-                .bind(chat_cleared_at_ms)
-                .fetch_one(&database.pool)
-                .await?
-            }
-        };
+        Self::count_unread_for_group_filtered(
+            group_id,
+            read_marker,
+            database,
+            chat_cleared_at_ms,
+            None,
+        )
+        .await
+    }
+
+    /// Count chat-list-visible unread messages for a group.
+    ///
+    /// This is the same unread projection as `count_unread_for_group`, except it
+    /// excludes messages authored by users blocked by `account_pubkey`.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn count_visible_unread_for_group(
+        group_id: &GroupId,
+        read_marker: Option<&EventId>,
+        account_pubkey: &PublicKey,
+        database: &Database,
+        chat_cleared_at_ms: Option<i64>,
+    ) -> Result<usize> {
+        Self::count_unread_for_group_filtered(
+            group_id,
+            read_marker,
+            database,
+            chat_cleared_at_ms,
+            Some(account_pubkey),
+        )
+        .await
+    }
+
+    async fn count_unread_for_group_filtered(
+        group_id: &GroupId,
+        read_marker: Option<&EventId>,
+        database: &Database,
+        chat_cleared_at_ms: Option<i64>,
+        account_pubkey: Option<&PublicKey>,
+    ) -> Result<usize> {
+        let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+            "SELECT COUNT(*) FROM aggregated_messages am
+             WHERE am.mls_group_id = ",
+        );
+        qb.push_bind(group_id.as_slice());
+        qb.push(
+            " AND am.kind = 9
+              AND am.deletion_event_id IS NULL",
+        );
+
+        if let Some(message_id) = read_marker {
+            qb.push(
+                " AND am.created_at > COALESCE(
+                    (SELECT created_at FROM aggregated_messages
+                     WHERE message_id = ",
+            );
+            qb.push_bind(message_id.to_hex());
+            qb.push(" AND mls_group_id = ");
+            qb.push_bind(group_id.as_slice());
+            qb.push("), 0)");
+        }
+
+        qb.push(" AND am.created_at > COALESCE(");
+        qb.push_bind(chat_cleared_at_ms);
+        qb.push(", 0)");
+
+        if let Some(account_pubkey) = account_pubkey {
+            qb.push(
+                " AND NOT EXISTS (
+                    SELECT 1 FROM mute_list ml
+                    WHERE ml.account_pubkey = ",
+            );
+            qb.push_bind(account_pubkey.to_hex());
+            qb.push(" AND ml.muted_pubkey = am.author)");
+        }
+
+        let count: i64 = qb.build_query_scalar().fetch_one(&database.pool).await?;
 
         Ok(count as usize)
     }
@@ -1261,8 +1301,26 @@ impl AggregatedMessage {
         group_markers: &[(GroupId, Option<EventId>, Option<i64>)],
         database: &Database,
     ) -> Result<HashMap<GroupId, usize>> {
-        use sqlx::Row;
+        Self::count_unread_for_groups_filtered(group_markers, database, None).await
+    }
 
+    /// Count chat-list-visible unread messages for multiple groups.
+    ///
+    /// Excludes messages authored by users blocked by `account_pubkey`.
+    #[perf_instrument("db::aggregated_messages")]
+    pub async fn count_visible_unread_for_groups(
+        group_markers: &[(GroupId, Option<EventId>, Option<i64>)],
+        account_pubkey: &PublicKey,
+        database: &Database,
+    ) -> Result<HashMap<GroupId, usize>> {
+        Self::count_unread_for_groups_filtered(group_markers, database, Some(account_pubkey)).await
+    }
+
+    async fn count_unread_for_groups_filtered(
+        group_markers: &[(GroupId, Option<EventId>, Option<i64>)],
+        database: &Database,
+        account_pubkey: Option<&PublicKey>,
+    ) -> Result<HashMap<GroupId, usize>> {
         if group_markers.is_empty() {
             return Ok(HashMap::new());
         }
@@ -1331,17 +1389,31 @@ impl AggregatedMessage {
              WHERE am.mls_group_id IN (",
         );
 
-        let mut sep = qb.separated(", ");
-        for group_id in &all_group_ids {
-            sep.push_bind(group_id);
+        {
+            let mut sep = qb.separated(", ");
+            for group_id in &all_group_ids {
+                sep.push_bind(group_id);
+            }
         }
-        sep.push_unseparated(
+
+        qb.push(
             ") AND am.kind = 9 \
              AND am.deletion_event_id IS NULL \
              AND am.created_at > COALESCE(mt.created_at, 0) \
-             AND am.created_at > COALESCE(ct.cleared_at, 0) \
-             GROUP BY am.mls_group_id",
+             AND am.created_at > COALESCE(ct.cleared_at, 0)",
         );
+
+        if let Some(account_pubkey) = account_pubkey {
+            qb.push(
+                " AND NOT EXISTS ( \
+                    SELECT 1 FROM mute_list ml \
+                    WHERE ml.account_pubkey = ",
+            );
+            qb.push_bind(account_pubkey.to_hex());
+            qb.push(" AND ml.muted_pubkey = am.author)");
+        }
+
+        qb.push(" GROUP BY am.mls_group_id");
 
         let rows = qb.build().fetch_all(&database.pool).await?;
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1128,8 +1128,16 @@ mod tests {
             .unwrap();
         let group_id = &group.mls_group_id;
 
-        // Create a message ID that doesn't exist yet (simulating out-of-order delivery)
-        let future_message_id = EventId::all_zeros();
+        // Create the target message ID before processing it to simulate out-of-order delivery.
+        let mut actual_message = UnsignedEvent::new(
+            creator_account.pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "Late message".to_string(),
+        );
+        actual_message.ensure_id();
+        let future_message_id = actual_message.id.expect("message id should be set");
 
         // Send reaction to non-existent message (orphaned reaction)
         let mut orphaned_reaction = UnsignedEvent::new(
@@ -1164,14 +1172,6 @@ mod tests {
         );
 
         // Now send the actual message with the matching ID
-        let mut actual_message = UnsignedEvent::new(
-            creator_account.pubkey,
-            Timestamp::now(),
-            Kind::Custom(9),
-            vec![],
-            "Late message".to_string(),
-        );
-        actual_message.id = Some(future_message_id);
         let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise
@@ -1231,7 +1231,15 @@ mod tests {
             .unwrap();
         let group_id = &group.mls_group_id;
 
-        let future_message_id = EventId::all_zeros();
+        let mut actual_message = UnsignedEvent::new(
+            creator_account.pubkey,
+            Timestamp::now(),
+            Kind::Custom(9),
+            vec![],
+            "Target message".to_string(),
+        );
+        actual_message.ensure_id();
+        let future_message_id = actual_message.id.expect("message id should be set");
 
         // Send a VALID orphaned reaction
         let mut valid_reaction = UnsignedEvent::new(
@@ -1268,14 +1276,6 @@ mod tests {
             .unwrap();
 
         // Now send the target message - this should succeed despite invalid orphaned reaction
-        let mut actual_message = UnsignedEvent::new(
-            creator_account.pubkey,
-            Timestamp::now(),
-            Kind::Custom(9),
-            vec![],
-            "Target message".to_string(),
-        );
-        actual_message.id = Some(future_message_id);
         let message_event = mdk.create_message(group_id, actual_message, None).unwrap();
 
         let result = whitenoise

--- a/src/whitenoise/mute_list.rs
+++ b/src/whitenoise/mute_list.rs
@@ -62,7 +62,7 @@ impl Whitenoise {
             return Err(e);
         }
 
-        self.emit_block_changed(account, target_pubkey).await;
+        self.emit_block_changed(account).await;
 
         Ok(())
     }
@@ -122,7 +122,7 @@ impl Whitenoise {
             return Err(e);
         }
 
-        self.emit_block_changed(account, target_pubkey).await;
+        self.emit_block_changed(account).await;
 
         Ok(())
     }
@@ -254,8 +254,8 @@ impl Whitenoise {
         Some(entries)
     }
 
-    /// Replaces the mute list cache and emits `UserBlockChanged` for every
-    /// pubkey that was added or removed compared to the previous state.
+    /// Replaces the mute list cache and emits `UserBlockChanged` once if any
+    /// blocked pubkeys were added or removed compared to the previous state.
     pub(crate) async fn sync_and_emit(
         &self,
         account: &Account,
@@ -268,8 +268,8 @@ impl Whitenoise {
 
         let new_pubkeys: HashSet<PublicKey> = entries.iter().map(|(pk, _)| *pk).collect();
 
-        for pubkey in old_pubkeys.symmetric_difference(&new_pubkeys) {
-            self.emit_block_changed(account, pubkey).await;
+        if old_pubkeys != new_pubkeys {
+            self.emit_block_changed(account).await;
         }
 
         Ok(())
@@ -277,7 +277,7 @@ impl Whitenoise {
 
     /// Emits `UserBlockChanged` chat list updates for every visible chat owned
     /// by the account. Block state affects group unread counts, not just DMs.
-    async fn emit_block_changed(&self, account: &Account, _target_pubkey: &PublicKey) {
+    async fn emit_block_changed(&self, account: &Account) {
         let has_active = self
             .chat_list_stream_manager
             .has_subscribers(&account.pubkey);
@@ -522,9 +522,7 @@ mod tests {
         MuteListEntry::insert(&account.pubkey, &member.pubkey, true, &whitenoise.database)
             .await
             .unwrap();
-        whitenoise
-            .emit_block_changed(&account, &member.pubkey)
-            .await;
+        whitenoise.emit_block_changed(&account).await;
 
         let update = timeout(Duration::from_secs(2), subscription.updates.recv())
             .await
@@ -534,6 +532,41 @@ mod tests {
         assert_eq!(update.trigger, ChatListUpdateTrigger::UserBlockChanged);
         assert_eq!(update.item.mls_group_id, group.mls_group_id);
         assert_eq!(update.item.unread_count, 0);
+    }
+
+    #[tokio::test]
+    async fn sync_and_emit_sends_one_refresh_for_multiple_block_changes() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let member = whitenoise.create_identity().await.unwrap();
+        let other_target = Keys::generate().public_key();
+
+        let config = create_nostr_group_config_data(vec![account.pubkey, member.pubkey]);
+        let group = whitenoise
+            .create_group(&account, vec![member.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let mut subscription = whitenoise.subscribe_to_chat_list(&account).await.unwrap();
+
+        whitenoise
+            .sync_and_emit(&account, &[(member.pubkey, true), (other_target, true)])
+            .await
+            .unwrap();
+
+        let update = timeout(Duration::from_secs(2), subscription.updates.recv())
+            .await
+            .expect("block sync update should be emitted")
+            .expect("chat list stream should remain open");
+
+        assert_eq!(update.trigger, ChatListUpdateTrigger::UserBlockChanged);
+        assert_eq!(update.item.mls_group_id, group.mls_group_id);
+        assert!(
+            timeout(Duration::from_millis(200), subscription.updates.recv())
+                .await
+                .is_err(),
+            "sync should emit one chat-list refresh, not one per changed pubkey"
+        );
     }
 
     // ── get_blocked_users / is_user_blocked (pure DB, no relay) ─────────────

--- a/src/whitenoise/mute_list.rs
+++ b/src/whitenoise/mute_list.rs
@@ -275,28 +275,47 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Emits a `UserBlockChanged` chat list update for the DM group with the
-    /// target user, if one exists.
-    async fn emit_block_changed(&self, account: &Account, target_pubkey: &PublicKey) {
-        match AccountGroup::find_dm_group_id_by_peer(&account.pubkey, target_pubkey, &self.database)
-            .await
-        {
-            Ok(Some(group_id)) => {
-                self.emit_chat_list_update(
-                    account,
-                    &group_id,
-                    ChatListUpdateTrigger::UserBlockChanged,
-                )
-                .await;
+    /// Emits `UserBlockChanged` chat list updates for every visible chat owned
+    /// by the account. Block state affects group unread counts, not just DMs.
+    async fn emit_block_changed(&self, account: &Account, _target_pubkey: &PublicKey) {
+        let has_active = self
+            .chat_list_stream_manager
+            .has_subscribers(&account.pubkey);
+        let has_archived = self
+            .archived_chat_list_stream_manager
+            .has_subscribers(&account.pubkey);
+
+        if !has_active && !has_archived {
+            return;
+        }
+
+        let account_groups =
+            match AccountGroup::find_visible_for_account(&account.pubkey, &self.database).await {
+                Ok(account_groups) => account_groups,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::mute_list",
+                        "Failed to look up groups for block change emission: {}",
+                        e,
+                    );
+                    return;
+                }
+            };
+
+        for account_group in account_groups {
+            if account_group.is_archived() && !has_archived {
+                continue;
             }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::mute_list",
-                    "Failed to look up DM group for block change emission: {}",
-                    e,
-                );
+            if !account_group.is_archived() && !has_active {
+                continue;
             }
+
+            self.emit_chat_list_update(
+                account,
+                &account_group.mls_group_id,
+                ChatListUpdateTrigger::UserBlockChanged,
+            )
+            .await;
         }
     }
 
@@ -350,11 +369,38 @@ impl Whitenoise {
 
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::{EventBuilder, Keys, Kind, Tag};
+    use std::time::Duration;
+
+    use nostr_sdk::{EventBuilder, Keys, Kind, PublicKey, Tag, Tags, Timestamp};
+    use tokio::time::timeout;
 
     use super::*;
+    use crate::whitenoise::aggregated_message::AggregatedMessage;
     use crate::whitenoise::database::mute_list::MuteListEntry;
-    use crate::whitenoise::test_utils::create_mock_whitenoise;
+    use crate::whitenoise::message_aggregator::ChatMessage;
+    use crate::whitenoise::test_utils::{create_mock_whitenoise, create_nostr_group_config_data};
+
+    fn create_block_change_test_message(
+        seed: u8,
+        author: PublicKey,
+        timestamp: u64,
+    ) -> ChatMessage {
+        ChatMessage {
+            id: format!("{:0>64}", format!("{seed:x}")),
+            author,
+            content: format!("message {seed}"),
+            created_at: Timestamp::from(timestamp),
+            tags: Tags::new(),
+            is_reply: false,
+            reply_to_id: None,
+            is_deleted: false,
+            content_tokens: vec![],
+            reactions: Default::default(),
+            kind: 9,
+            media_attachments: vec![],
+            delivery_status: None,
+        }
+    }
 
     #[tokio::test]
     async fn parse_mute_list_entries_public_tags_only() {
@@ -450,6 +496,44 @@ mod tests {
             result.is_ok(),
             "unblock_user on non-blocked user should be a no-op"
         );
+    }
+
+    #[tokio::test]
+    async fn user_block_changed_update_recalculates_group_unread_count() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        let member = whitenoise.create_identity().await.unwrap();
+
+        let config = create_nostr_group_config_data(vec![account.pubkey, member.pubkey]);
+        let group = whitenoise
+            .create_group(&account, vec![member.pubkey], config, None)
+            .await
+            .unwrap();
+
+        let message = create_block_change_test_message(1, member.pubkey, 1_700_000_001);
+        AggregatedMessage::insert_message(&message, &group.mls_group_id, &whitenoise.database)
+            .await
+            .unwrap();
+
+        let mut subscription = whitenoise.subscribe_to_chat_list(&account).await.unwrap();
+        assert_eq!(subscription.initial_items.len(), 1);
+        assert_eq!(subscription.initial_items[0].unread_count, 1);
+
+        MuteListEntry::insert(&account.pubkey, &member.pubkey, true, &whitenoise.database)
+            .await
+            .unwrap();
+        whitenoise
+            .emit_block_changed(&account, &member.pubkey)
+            .await;
+
+        let update = timeout(Duration::from_secs(2), subscription.updates.recv())
+            .await
+            .expect("block change update should be emitted")
+            .expect("chat list stream should remain open");
+
+        assert_eq!(update.trigger, ChatListUpdateTrigger::UserBlockChanged);
+        assert_eq!(update.item.mls_group_id, group.mls_group_id);
+        assert_eq!(update.item.unread_count, 0);
     }
 
     // ── get_blocked_users / is_user_blocked (pure DB, no relay) ─────────────

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -2884,10 +2884,7 @@ mod tests {
             image_nonce: None,
             image_upload_key: None,
             admins: None,
-            relays: Some(vec![
-                RelayUrl::parse("ws://localhost:1").unwrap(),
-                RelayUrl::parse("ws://localhost:2").unwrap(),
-            ]),
+            relays: Some(vec![]),
             nostr_group_id: None,
         };
         whitenoise
@@ -2895,12 +2892,10 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::pause();
         let settings = whitenoise
             .update_notifications_enabled(&admin_account, false)
             .await
             .unwrap();
-        tokio::time::resume();
         assert!(!settings.notifications_enabled);
 
         let cached_after_disable = GroupPushToken::find_by_account_and_group(


### PR DESCRIPTION
## Summary
- Made chat-list unread counts block-aware by filtering out messages authored by blocked users in the Rust projection layer.
- Kept raw unread-count helpers intact for storage, history, and read-marker behavior.
- Updated block/unblock chat-list refreshes so streaming payloads recalculate visible unread counts.
- Added tests for blocked-only, mixed blocked/non-blocked, unblock restoration, and streaming update behavior.

## Testing
- `cargo test --lib test_get_chat_list_unread_count --features cli`
- `cargo test --lib user_block_changed_update_recalculates_group_unread_count --features cli`
- `just precommit-quick`
- `just coverage`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unread message counts now respect visibility (blocked/muted authors) and are recalculated across all visible chats when block/unblock changes occur.
  * Block/unblock actions now trigger a single, correct refresh for affected chats.

* **Tests**
  * Expanded coverage for unread-count behavior, block/unblock emission, and related flows.

* **New Features**
  * Improved CLI group response formatting for clearer group details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->