### PR TITLE
feat(cli wnd): add --discovery-relays flag to wnd to be able to use local relays

### DIFF
--- a/src/bin/wnd.rs
+++ b/src/bin/wnd.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use nostr_sdk::RelayUrl;
 
 use whitenoise::cli::config::{Config, KEYRING_SERVICE_ID};
+use whitenoise::cli::error::CliError;
 use whitenoise::cli::server;
 use whitenoise::{Whitenoise, WhitenoiseConfig};
 
@@ -14,6 +16,11 @@ struct Args {
 
     #[clap(long, value_name = "PATH")]
     logs_dir: Option<PathBuf>,
+
+    /// Comma-separated discovery relay URLs that override the curated default set.
+    /// Used to point the daemon at local relays for end-to-end testing.
+    #[clap(long, value_name = "URLS", value_delimiter = ',')]
+    discovery_relays: Vec<String>,
 }
 
 #[tokio::main]
@@ -21,7 +28,19 @@ async fn main() -> whitenoise::cli::Result<()> {
     let args = Args::parse();
     let config = Config::resolve(args.data_dir.as_ref(), args.logs_dir.as_ref());
 
-    let wn_config = WhitenoiseConfig::new(&config.data_dir, &config.logs_dir, KEYRING_SERVICE_ID);
+    let mut wn_config =
+        WhitenoiseConfig::new(&config.data_dir, &config.logs_dir, KEYRING_SERVICE_ID);
+    if !args.discovery_relays.is_empty() {
+        let relays = args
+            .discovery_relays
+            .iter()
+            .map(|raw| {
+                RelayUrl::parse(raw)
+                    .map_err(|e| CliError::msg(format!("invalid --discovery-relays {raw:?}: {e}")))
+            })
+            .collect::<whitenoise::cli::Result<Vec<_>>>()?;
+        wn_config = wn_config.with_discovery_relays(relays);
+    }
     Whitenoise::initialize_whitenoise(wn_config).await?;
 
     server::run(&config).await

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -14,23 +14,14 @@
 
 #![cfg(all(feature = "cli", feature = "integration-tests"))]
 
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 #[path = "support/cli.rs"]
 mod cli_support;
 
-use cli_support::{Daemon, group_id_hex, poll_until, wait_for_group, wait_for_message, wn};
-
-async fn wait_for_key_package(socket: &PathBuf, pubkey: &str) {
-    let msg = format!("did not see a valid key package for {pubkey} within 30s");
-    poll_until(Duration::from_secs(30), &msg, || {
-        wn(socket, &["keys", "check", pubkey])
-            .get("status")
-            .and_then(|status| status.as_str())
-            == Some("valid")
-    })
-    .await;
-}
+use cli_support::{
+    Daemon, group_id_hex, wait_for_group, wait_for_key_package, wait_for_message, wn,
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -190,15 +181,18 @@ async fn group_metadata_and_membership() {
 
     wait_for_group(&bob.socket, &bob_pk).await;
 
-    // groups show returns the MLS group object
+    // groups show returns { group, required_proposals }
     let detail = wn(
         &alice.socket,
         &["--account", &alice_pk, "groups", "show", &gid],
     );
     assert!(detail.is_object(), "group detail should be a JSON object");
     assert!(
-        detail.get("mls_group_id").is_some(),
-        "should contain mls_group_id"
+        detail
+            .get("group")
+            .and_then(|g| g.get("mls_group_id"))
+            .is_some(),
+        "should contain group.mls_group_id"
     );
 
     // members includes both Alice and Bob

--- a/tests/cli_relay_control_e2e.rs
+++ b/tests/cli_relay_control_e2e.rs
@@ -20,7 +20,8 @@ use whitenoise::test_fixtures::nostr::{
 mod cli_support;
 
 use cli_support::{
-    Daemon, bytes_field_hex, group_id_hex, poll_until, wait_for_group, wait_for_message, wn,
+    Daemon, bytes_field_hex, group_id_hex, poll_until, wait_for_group, wait_for_key_package,
+    wait_for_message, wn,
 };
 
 const LOCAL_DEV_RELAYS: &[&str] = &["ws://localhost:8080", "ws://localhost:7777"];
@@ -183,6 +184,7 @@ async fn relay_control_snapshot_tracks_live_planes() {
         .as_str()
         .unwrap()
         .to_string();
+    wait_for_key_package(&bob.socket, &bob_pk).await;
 
     let group = wn(
         &alice.socket,

--- a/tests/support/cli.rs
+++ b/tests/support/cli.rs
@@ -23,6 +23,10 @@ impl Daemon {
         let child = Command::new(env!("CARGO_BIN_EXE_wnd"))
             .args(["--data-dir", &data_dir.display().to_string()])
             .args(["--logs-dir", &logs_dir.display().to_string()])
+            .args([
+                "--discovery-relays",
+                "ws://localhost:8080,ws://localhost:7777",
+            ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
@@ -148,6 +152,22 @@ pub(crate) async fn poll_until(
         assert!(Instant::now() < deadline, "{timeout_msg}");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+/// Wait for a daemon to report a valid published key package for `pubkey` (up to 30s).
+///
+/// Used to cover the asynchronous publish that happens after `create-identity`
+/// returns. Without it, callers can race ahead and try to pull the key package
+/// before it has reached the relays.
+pub(crate) async fn wait_for_key_package(socket: &PathBuf, pubkey: &str) {
+    let msg = format!("did not see a valid key package for {pubkey} within 30s");
+    poll_until(Duration::from_secs(30), &msg, || {
+        wn(socket, &["keys", "check", pubkey])
+            .get("status")
+            .and_then(|status| status.as_str())
+            == Some("valid")
+    })
+    .await;
 }
 
 /// Wait for a daemon to see at least one group (up to 60s).


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/805">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI users can now specify discovery relay URLs via a new command-line option using comma-separated values for relay configuration
* **Changes**
  * The groups show command output format has been restructured to organize group information in a nested format for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->