### PR TITLE
Add default GitHub code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all files
+* @erskingardner @dannym-arx @mubarakcoded @jgmontoya


### PR DESCRIPTION
## Summary
- Add a repository-wide `.github/CODEOWNERS` file
- Set the default reviewers for all files to `@erskingardner`, `@dannym-arx`, `@mubarakcoded`, and `@jgmontoya`

## Testing
- Not run (not requested)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/807">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->