### PR TITLE
feat: move mute_list to per-account database (m0042 + m0043)

### DIFF
--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -23,7 +23,7 @@ use crate::whitenoise::database::{Database, DatabaseError, rust_migrations};
 /// `accounts_groups`, `drafts`, `push_registrations`, `group_push_tokens`,
 /// `published_key_packages`, `published_events`,
 /// `processed_events` (account-level), `aggregated_messages`,
-/// `message_delivery_status`, and `media_references`.
+/// `message_delivery_status`, `media_references`, and `mute_list`.
 ///
 /// See `rearchitecture.md` Appendix B for the authoritative table ownership
 /// map.

--- a/src/whitenoise/database/mute_list.rs
+++ b/src/whitenoise/database/mute_list.rs
@@ -137,12 +137,13 @@ impl MuteListEntry {
         muted_pubkey: &PublicKey,
         db: &AccountDatabase,
     ) -> std::result::Result<bool, DatabaseError> {
-        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mute_list WHERE muted_pubkey = ?")
-            .bind(muted_pubkey.to_hex())
-            .fetch_one(&db.inner.pool)
-            .await?;
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM mute_list WHERE muted_pubkey = ?)")
+                .bind(muted_pubkey.to_hex())
+                .fetch_one(&db.inner.pool)
+                .await?;
 
-        Ok(count.0 > 0)
+        Ok(exists)
     }
 
     /// Replaces all mute list entries with the provided list. Used when

--- a/src/whitenoise/database/mute_list.rs
+++ b/src/whitenoise/database/mute_list.rs
@@ -1,20 +1,25 @@
+//! Database operations for the NIP-51 mute list.
+//!
+//! Lives in the per-account SQLite file. The owning account's pubkey is
+//! implicit — it's whichever account owns the file — so methods take an
+//! `&AccountDatabase` and never need an `account_pubkey` parameter.
+
 use chrono::{DateTime, Utc};
 use nostr_sdk::PublicKey;
 
-use super::{Database, DatabaseError, utils::parse_timestamp};
+use super::DatabaseError;
+use super::account_db::AccountDatabase;
+use super::utils::parse_timestamp;
 use crate::perf_instrument;
 
-/// Row-level representation of a mute list entry from the `mute_list` table.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-struct MuteListRow {
-    id: i64,
-    account_pubkey: PublicKey,
+/// Local row shape (no `account_pubkey` column — implied by the file).
+struct LocalRow {
     muted_pubkey: PublicKey,
     is_private: bool,
     created_at: DateTime<Utc>,
 }
 
-impl<'r, R> sqlx::FromRow<'r, R> for MuteListRow
+impl<'r, R> sqlx::FromRow<'r, R> for LocalRow
 where
     R: sqlx::Row,
     &'r str: sqlx::ColumnIndex<R>,
@@ -22,15 +27,6 @@ where
     i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
 {
     fn from_row(row: &'r R) -> std::result::Result<Self, sqlx::Error> {
-        let id: i64 = row.try_get("id")?;
-
-        let account_pubkey_str: String = row.try_get("account_pubkey")?;
-        let account_pubkey =
-            PublicKey::parse(&account_pubkey_str).map_err(|e| sqlx::Error::ColumnDecode {
-                index: "account_pubkey".to_string(),
-                source: Box::new(e),
-            })?;
-
         let muted_pubkey_str: String = row.try_get("muted_pubkey")?;
         let muted_pubkey =
             PublicKey::parse(&muted_pubkey_str).map_err(|e| sqlx::Error::ColumnDecode {
@@ -42,8 +38,6 @@ where
         let created_at = parse_timestamp(row, "created_at")?;
 
         Ok(Self {
-            id,
-            account_pubkey,
             muted_pubkey,
             is_private: is_private != 0,
             created_at,
@@ -52,18 +46,19 @@ where
 }
 
 /// Public mute list entry exposed to consumers.
+///
+/// `account_pubkey` is implicit — the owning account is whichever
+/// per-account database the entry came from.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MuteListEntry {
-    pub account_pubkey: PublicKey,
     pub muted_pubkey: PublicKey,
     pub is_private: bool,
     pub created_at: DateTime<Utc>,
 }
 
-impl From<MuteListRow> for MuteListEntry {
-    fn from(row: MuteListRow) -> Self {
+impl From<LocalRow> for MuteListEntry {
+    fn from(row: LocalRow) -> Self {
         Self {
-            account_pubkey: row.account_pubkey,
             muted_pubkey: row.muted_pubkey,
             is_private: row.is_private,
             created_at: row.created_at,
@@ -75,73 +70,62 @@ impl MuteListEntry {
     /// Inserts a new mute list entry. Ignores duplicates (UNIQUE constraint).
     #[perf_instrument("mute_list")]
     pub async fn insert(
-        account_pubkey: &PublicKey,
         muted_pubkey: &PublicKey,
         is_private: bool,
-        db: &Database,
+        db: &AccountDatabase,
     ) -> std::result::Result<(), DatabaseError> {
         sqlx::query(
-            "INSERT OR IGNORE INTO mute_list (account_pubkey, muted_pubkey, is_private, created_at)
-             VALUES (?, ?, ?, ?)",
+            "INSERT OR IGNORE INTO mute_list (muted_pubkey, is_private, created_at)
+             VALUES (?, ?, ?)",
         )
-        .bind(account_pubkey.to_hex())
         .bind(muted_pubkey.to_hex())
         .bind(i64::from(is_private))
         .bind(Utc::now().timestamp_millis())
-        .execute(&db.pool)
+        .execute(&db.inner.pool)
         .await?;
         Ok(())
     }
 
-    /// Removes a mute list entry for the given account and muted pubkey.
+    /// Removes a mute list entry by muted pubkey.
     #[perf_instrument("mute_list")]
     pub async fn delete(
-        account_pubkey: &PublicKey,
         muted_pubkey: &PublicKey,
-        db: &Database,
+        db: &AccountDatabase,
     ) -> std::result::Result<(), DatabaseError> {
-        sqlx::query("DELETE FROM mute_list WHERE account_pubkey = ? AND muted_pubkey = ?")
-            .bind(account_pubkey.to_hex())
+        sqlx::query("DELETE FROM mute_list WHERE muted_pubkey = ?")
             .bind(muted_pubkey.to_hex())
-            .execute(&db.pool)
+            .execute(&db.inner.pool)
             .await?;
         Ok(())
     }
 
-    /// Returns all mute list entries for the given account.
+    /// Returns all mute list entries for the owning account.
     #[perf_instrument("mute_list")]
-    pub async fn find_by_account(
-        account_pubkey: &PublicKey,
-        db: &Database,
-    ) -> std::result::Result<Vec<Self>, DatabaseError> {
-        let rows: Vec<MuteListRow> = sqlx::query_as(
-            "SELECT id, account_pubkey, muted_pubkey, is_private, created_at
+    pub async fn find_all(db: &AccountDatabase) -> std::result::Result<Vec<Self>, DatabaseError> {
+        let rows: Vec<LocalRow> = sqlx::query_as(
+            "SELECT muted_pubkey, is_private, created_at
              FROM mute_list
-             WHERE account_pubkey = ?
              ORDER BY created_at DESC",
         )
-        .bind(account_pubkey.to_hex())
-        .fetch_all(&db.pool)
+        .fetch_all(&db.inner.pool)
         .await?;
 
         Ok(rows.into_iter().map(Self::from).collect())
     }
 
-    /// Returns the mute list entry for a specific account + target pair, if any.
+    /// Returns the mute list entry for a specific muted pubkey, if any.
     #[perf_instrument("mute_list")]
-    pub async fn find_by_account_and_target(
-        account_pubkey: &PublicKey,
+    pub async fn find_by_muted_pubkey(
         muted_pubkey: &PublicKey,
-        db: &Database,
+        db: &AccountDatabase,
     ) -> std::result::Result<Option<Self>, DatabaseError> {
-        let row: Option<MuteListRow> = sqlx::query_as(
-            "SELECT id, account_pubkey, muted_pubkey, is_private, created_at
+        let row: Option<LocalRow> = sqlx::query_as(
+            "SELECT muted_pubkey, is_private, created_at
              FROM mute_list
-             WHERE account_pubkey = ? AND muted_pubkey = ?",
+             WHERE muted_pubkey = ?",
         )
-        .bind(account_pubkey.to_hex())
         .bind(muted_pubkey.to_hex())
-        .fetch_optional(&db.pool)
+        .fetch_optional(&db.inner.pool)
         .await?;
 
         Ok(row.map(Self::from))
@@ -150,34 +134,27 @@ impl MuteListEntry {
     /// Returns `true` if the given pubkey is on the account's mute list.
     #[perf_instrument("mute_list")]
     pub async fn exists(
-        account_pubkey: &PublicKey,
         muted_pubkey: &PublicKey,
-        db: &Database,
+        db: &AccountDatabase,
     ) -> std::result::Result<bool, DatabaseError> {
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM mute_list
-             WHERE account_pubkey = ? AND muted_pubkey = ?",
-        )
-        .bind(account_pubkey.to_hex())
-        .bind(muted_pubkey.to_hex())
-        .fetch_one(&db.pool)
-        .await?;
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mute_list WHERE muted_pubkey = ?")
+            .bind(muted_pubkey.to_hex())
+            .fetch_one(&db.inner.pool)
+            .await?;
 
         Ok(count.0 > 0)
     }
 
-    /// Replaces all mute list entries for the given account with the provided
-    /// list. Used when syncing from a kind 10000 event received from relays.
+    /// Replaces all mute list entries with the provided list. Used when
+    /// syncing from a kind 10000 event received from relays.
     #[perf_instrument("mute_list")]
     pub async fn sync_from_event(
-        account_pubkey: &PublicKey,
         entries: &[(PublicKey, bool)],
-        db: &Database,
+        db: &AccountDatabase,
     ) -> std::result::Result<(), DatabaseError> {
-        let mut txn = db.pool.begin().await?;
+        let mut txn = db.inner.pool.begin().await?;
 
-        sqlx::query("DELETE FROM mute_list WHERE account_pubkey = ?")
-            .bind(account_pubkey.to_hex())
+        sqlx::query("DELETE FROM mute_list")
             .execute(&mut *txn)
             .await?;
 
@@ -189,10 +166,9 @@ impl MuteListEntry {
         // before private-section entries in `parse_mute_list_entries`.
         for (muted_pubkey, is_private) in entries {
             sqlx::query(
-                "INSERT OR IGNORE INTO mute_list (account_pubkey, muted_pubkey, is_private, created_at)
-                 VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO mute_list (muted_pubkey, is_private, created_at)
+                 VALUES (?, ?, ?)",
             )
-            .bind(account_pubkey.to_hex())
             .bind(muted_pubkey.to_hex())
             .bind(i64::from(*is_private))
             .bind(Utc::now().timestamp_millis())
@@ -208,157 +184,146 @@ impl MuteListEntry {
 #[cfg(test)]
 mod tests {
     use nostr_sdk::Keys;
+    use tempfile::TempDir;
 
     use super::*;
-    use crate::whitenoise::database::Database;
 
-    async fn create_test_db() -> (Database, tempfile::TempDir) {
-        let temp_dir = tempfile::TempDir::new().expect("Failed to create temp directory");
-        let db_path = temp_dir.path().join("test.db");
-        let db = Database::new(db_path)
+    /// Build a per-account DB with the post-move local schema applied
+    /// directly. Bypasses the migration framework — that's covered in the
+    /// migration's own tests; here we exercise the ops in isolation.
+    ///
+    /// Schema must stay byte-for-byte aligned with
+    /// `m0042_move_mute_list.rs` so test/prod don't drift.
+    async fn create_test_db() -> (AccountDatabase, TempDir) {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let db_path = temp_dir.path().join("account.db");
+        let pubkey = Keys::generate().public_key();
+        let db = AccountDatabase::new(pubkey, db_path)
             .await
-            .expect("Failed to create test database");
+            .expect("Failed to create test account database");
+
+        sqlx::query("DROP TABLE IF EXISTS mute_list")
+            .execute(&db.inner.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE mute_list (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                muted_pubkey  TEXT NOT NULL UNIQUE
+                    CHECK (length(muted_pubkey) = 64
+                           AND muted_pubkey GLOB '[0-9a-fA-F]*'),
+                is_private    INTEGER NOT NULL DEFAULT 1
+                    CHECK (is_private IN (0, 1)),
+                created_at    INTEGER NOT NULL
+            )",
+        )
+        .execute(&db.inner.pool)
+        .await
+        .expect("Failed to create mute_list table");
+
         (db, temp_dir)
     }
 
     #[tokio::test]
     async fn insert_and_exists() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let target = Keys::generate().public_key();
 
-        assert!(!MuteListEntry::exists(&account, &target, &db).await.unwrap());
+        assert!(!MuteListEntry::exists(&target, &db).await.unwrap());
 
-        MuteListEntry::insert(&account, &target, true, &db)
-            .await
-            .unwrap();
+        MuteListEntry::insert(&target, true, &db).await.unwrap();
 
-        assert!(MuteListEntry::exists(&account, &target, &db).await.unwrap());
+        assert!(MuteListEntry::exists(&target, &db).await.unwrap());
     }
 
     #[tokio::test]
     async fn insert_duplicate_is_ignored() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let target = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account, &target, true, &db)
-            .await
-            .unwrap();
-        MuteListEntry::insert(&account, &target, true, &db)
-            .await
-            .unwrap();
+        MuteListEntry::insert(&target, true, &db).await.unwrap();
+        MuteListEntry::insert(&target, true, &db).await.unwrap();
 
-        let entries = MuteListEntry::find_by_account(&account, &db).await.unwrap();
+        let entries = MuteListEntry::find_all(&db).await.unwrap();
         assert_eq!(entries.len(), 1);
     }
 
     #[tokio::test]
     async fn delete_removes_entry() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let target = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account, &target, true, &db)
-            .await
-            .unwrap();
-        MuteListEntry::delete(&account, &target, &db).await.unwrap();
+        MuteListEntry::insert(&target, true, &db).await.unwrap();
+        MuteListEntry::delete(&target, &db).await.unwrap();
 
-        assert!(!MuteListEntry::exists(&account, &target, &db).await.unwrap());
+        assert!(!MuteListEntry::exists(&target, &db).await.unwrap());
     }
 
     #[tokio::test]
-    async fn find_by_account_returns_only_matching() {
-        let (db, _tmp) = create_test_db().await;
-        let account1 = Keys::generate().public_key();
-        let account2 = Keys::generate().public_key();
+    async fn find_all_returns_only_owning_account_entries() {
+        let (db1, _tmp1) = create_test_db().await;
+        let (db2, _tmp2) = create_test_db().await;
         let target = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account1, &target, true, &db)
-            .await
-            .unwrap();
-        MuteListEntry::insert(&account2, &target, false, &db)
-            .await
-            .unwrap();
+        MuteListEntry::insert(&target, true, &db1).await.unwrap();
+        MuteListEntry::insert(&target, false, &db2).await.unwrap();
 
-        let entries = MuteListEntry::find_by_account(&account1, &db)
-            .await
-            .unwrap();
+        let entries = MuteListEntry::find_all(&db1).await.unwrap();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].account_pubkey, account1);
         assert!(entries[0].is_private);
+
+        let entries = MuteListEntry::find_all(&db2).await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].is_private);
     }
 
     #[tokio::test]
     async fn sync_from_event_replaces_all() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let old_target = Keys::generate().public_key();
         let new_target1 = Keys::generate().public_key();
         let new_target2 = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account, &old_target, true, &db)
-            .await
-            .unwrap();
+        MuteListEntry::insert(&old_target, true, &db).await.unwrap();
 
         let new_entries = vec![(new_target1, true), (new_target2, false)];
-        MuteListEntry::sync_from_event(&account, &new_entries, &db)
+        MuteListEntry::sync_from_event(&new_entries, &db)
             .await
             .unwrap();
 
-        assert!(
-            !MuteListEntry::exists(&account, &old_target, &db)
-                .await
-                .unwrap()
-        );
-        assert!(
-            MuteListEntry::exists(&account, &new_target1, &db)
-                .await
-                .unwrap()
-        );
-        assert!(
-            MuteListEntry::exists(&account, &new_target2, &db)
-                .await
-                .unwrap()
-        );
+        assert!(!MuteListEntry::exists(&old_target, &db).await.unwrap());
+        assert!(MuteListEntry::exists(&new_target1, &db).await.unwrap());
+        assert!(MuteListEntry::exists(&new_target2, &db).await.unwrap());
 
-        let entries = MuteListEntry::find_by_account(&account, &db).await.unwrap();
+        let entries = MuteListEntry::find_all(&db).await.unwrap();
         assert_eq!(entries.len(), 2);
     }
 
     #[tokio::test]
     async fn sync_from_event_with_duplicate_pubkeys_is_safe() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let target = Keys::generate().public_key();
 
         // Same pubkey appears twice (e.g. in both public and private sections of one event)
         let entries = vec![(target, false), (target, true)];
-        MuteListEntry::sync_from_event(&account, &entries, &db)
-            .await
-            .unwrap();
+        MuteListEntry::sync_from_event(&entries, &db).await.unwrap();
 
-        let result = MuteListEntry::find_by_account(&account, &db).await.unwrap();
+        let result = MuteListEntry::find_all(&db).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(MuteListEntry::exists(&account, &target, &db).await.unwrap());
+        assert!(MuteListEntry::exists(&target, &db).await.unwrap());
     }
 
     #[tokio::test]
     async fn sync_from_event_with_empty_list_clears_all() {
         let (db, _tmp) = create_test_db().await;
-        let account = Keys::generate().public_key();
         let target = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account, &target, true, &db)
-            .await
-            .unwrap();
+        MuteListEntry::insert(&target, true, &db).await.unwrap();
 
-        MuteListEntry::sync_from_event(&account, &[], &db)
-            .await
-            .unwrap();
+        MuteListEntry::sync_from_event(&[], &db).await.unwrap();
 
-        assert!(!MuteListEntry::exists(&account, &target, &db).await.unwrap());
-        let entries = MuteListEntry::find_by_account(&account, &db).await.unwrap();
+        assert!(!MuteListEntry::exists(&target, &db).await.unwrap());
+        let entries = MuteListEntry::find_all(&db).await.unwrap();
         assert!(entries.is_empty());
     }
 }

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -212,3 +212,15 @@ CREATE TABLE IF NOT EXISTS message_delivery_status (
 
 CREATE INDEX IF NOT EXISTS idx_mds_group_account_status
     ON message_delivery_status (mls_group_id, account_pubkey, status);
+
+-- Local mute_list (NIP-51 block list). Moved from shared in m0042; the
+-- account_pubkey column is dropped because ownership is implicit in the file.
+CREATE TABLE IF NOT EXISTS mute_list (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    muted_pubkey  TEXT NOT NULL UNIQUE
+        CHECK (length(muted_pubkey) = 64
+               AND muted_pubkey GLOB '[0-9a-fA-F]*'),
+    is_private    INTEGER NOT NULL DEFAULT 1
+        CHECK (is_private IN (0, 1)),
+    created_at    INTEGER NOT NULL
+);

--- a/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
+++ b/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
@@ -1,0 +1,300 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+/// Temporary carrier for rows read from the shared `mute_list` table during
+/// migration. Account scoping happens in the WHERE clause, so the
+/// `account_pubkey` column isn't materialised here.
+#[derive(sqlx::FromRow)]
+struct SharedMuteListRow {
+    muted_pubkey: String,
+    is_private: i64,
+    created_at: i64,
+}
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        42
+    }
+
+    fn description(&self) -> &'static str {
+        "Move mute_list into per-account database"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        global_db: &SqlitePool,
+        account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        // Per-account schema drops the redundant `account_pubkey` column —
+        // ownership is implicit in the file. UNIQUE collapses to muted_pubkey
+        // alone since each account file holds only its own entries.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS mute_list (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                muted_pubkey  TEXT NOT NULL UNIQUE
+                    CHECK (length(muted_pubkey) = 64
+                           AND muted_pubkey GLOB '[0-9a-fA-F]*'),
+                is_private    INTEGER NOT NULL DEFAULT 1
+                    CHECK (is_private IN (0, 1)),
+                created_at    INTEGER NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let shared_table_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='mute_list')",
+        )
+        .fetch_one(global_db)
+        .await?;
+
+        if !shared_table_exists {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0042",
+                account = account_pubkey,
+                "shared.mute_list is missing; skipping local copy. \
+                 Expected only on fresh installs."
+            );
+            return Ok(());
+        }
+
+        let rows: Vec<SharedMuteListRow> = sqlx::query_as(
+            "SELECT muted_pubkey, is_private, created_at
+             FROM mute_list
+             WHERE account_pubkey = ?",
+        )
+        .bind(account_pubkey)
+        .fetch_all(global_db)
+        .await?;
+
+        let copied = rows.len() as u64;
+        for r in &rows {
+            sqlx::query(
+                "INSERT OR IGNORE INTO mute_list (muted_pubkey, is_private, created_at)
+                 VALUES (?, ?, ?)",
+            )
+            .bind(&r.muted_pubkey)
+            .bind(r.is_private)
+            .bind(r.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if copied > 0 {
+            tracing::info!(
+                target: "whitenoise::database::rust_migrations::m0042",
+                account = account_pubkey,
+                "Copied {copied} mute_list row(s) to per-account DB"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    async fn seed_shared(global: &SqlitePool) {
+        sqlx::query(
+            "CREATE TABLE mute_list (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey TEXT NOT NULL,
+                muted_pubkey   TEXT NOT NULL,
+                is_private     INTEGER NOT NULL DEFAULT 1,
+                created_at     INTEGER NOT NULL,
+                UNIQUE(account_pubkey, muted_pubkey)
+            )",
+        )
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_shared(
+        global: &SqlitePool,
+        account_pubkey: &str,
+        muted_pubkey: &str,
+        is_private: i64,
+        created_at: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO mute_list (account_pubkey, muted_pubkey, is_private, created_at)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(account_pubkey)
+        .bind(muted_pubkey)
+        .bind(is_private)
+        .bind(created_at)
+        .execute(global)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_copies_only_owning_account_entries() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        let other = "cd".repeat(32);
+        let target_a = "11".repeat(32);
+        let target_b = "22".repeat(32);
+        let target_c = "33".repeat(32);
+
+        seed_shared(&global).await;
+        insert_shared(&global, &pubkey, &target_a, 1, 1000).await;
+        insert_shared(&global, &pubkey, &target_b, 0, 2000).await;
+        insert_shared(&global, &other, &target_c, 1, 3000).await; // foreign
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mute_list")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 2, "only the owning account's entries are copied");
+
+        let (other_present,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM mute_list WHERE muted_pubkey = ?")
+                .bind(&target_c)
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(
+            other_present, 0,
+            "foreign account's entries must not leak in"
+        );
+
+        let (priv_count,): (i64,) =
+            sqlx::query_as("SELECT is_private FROM mute_list WHERE muted_pubkey = ?")
+                .bind(&target_a)
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(priv_count, 1, "is_private value preserved");
+
+        let (ts,): (i64,) =
+            sqlx::query_as("SELECT created_at FROM mute_list WHERE muted_pubkey = ?")
+                .bind(&target_b)
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(ts, 2000, "created_at value preserved");
+    }
+
+    #[tokio::test]
+    async fn migration_creates_empty_table_when_no_entries() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ef".repeat(32);
+
+        seed_shared(&global).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='mute_list')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mute_list")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_tolerates_missing_shared_table() {
+        let (local, global, _dir) = pools().await;
+        let pubkey = "12".repeat(32);
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='mute_list')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(
+            exists,
+            "local mute_list must be created even with no shared table"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_silently_skips_invalid_pubkey_rows() {
+        // INSERT OR IGNORE swallows CHECK-constraint failures silently. In
+        // practice every real `muted_pubkey` value comes from
+        // `PublicKey::parse` so corrupt rows shouldn't exist, but if shared
+        // ever contains junk we'd rather drop the row than fail startup.
+        let (local, global, _dir) = pools().await;
+        let pubkey = "ab".repeat(32);
+        let good_target = "11".repeat(32);
+        let bad_target = "not-hex-pubkey".to_string();
+
+        seed_shared(&global).await;
+        insert_shared(&global, &pubkey, &bad_target, 1, 1000).await;
+        insert_shared(&global, &pubkey, &good_target, 0, 2000).await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &pubkey)))
+            .await
+            .expect("migration must succeed even when shared has corrupt rows");
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mute_list")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "only the well-formed row survives the CHECK");
+
+        let (only,): (String,) = sqlx::query_as("SELECT muted_pubkey FROM mute_list")
+            .fetch_one(&local)
+            .await
+            .unwrap();
+        assert_eq!(only, good_target);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
+++ b/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
@@ -105,12 +105,16 @@ impl LocalMigration for Migration {
 
         // CHECK / UNIQUE constraint failures get swallowed by INSERT OR IGNORE.
         // Surface the count so a corrupt-data scenario leaves a visible trail.
+        // Both causes are possible: a CHECK violation means malformed
+        // muted_pubkey in shared (corrupt source data); a UNIQUE violation
+        // means the migration is re-running over rows already copied
+        // (idempotent path, harmless).
         if skipped > 0 {
             tracing::warn!(
                 target: "whitenoise::database::rust_migrations::m0042",
                 account = account_pubkey,
                 "Skipped {skipped} mute_list row(s) during migration \
-                 (constraint violation — likely malformed muted_pubkey)",
+                 (CHECK violation on muted_pubkey, or UNIQUE collision on re-run)",
             );
         }
 

--- a/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
+++ b/src/whitenoise/database/rust_migrations/m0042_move_mute_list.rs
@@ -75,9 +75,10 @@ impl LocalMigration for Migration {
         .fetch_all(global_db)
         .await?;
 
-        let copied = rows.len() as u64;
+        let mut copied: usize = 0;
+        let mut skipped: usize = 0;
         for r in &rows {
-            sqlx::query(
+            let result = sqlx::query(
                 "INSERT OR IGNORE INTO mute_list (muted_pubkey, is_private, created_at)
                  VALUES (?, ?, ?)",
             )
@@ -86,13 +87,30 @@ impl LocalMigration for Migration {
             .bind(r.created_at)
             .execute(&mut *tx)
             .await?;
+
+            if result.rows_affected() == 0 {
+                skipped += 1;
+            } else {
+                copied += 1;
+            }
         }
 
         if copied > 0 {
             tracing::info!(
                 target: "whitenoise::database::rust_migrations::m0042",
                 account = account_pubkey,
-                "Copied {copied} mute_list row(s) to per-account DB"
+                "Copied {copied} mute_list row(s) to per-account DB",
+            );
+        }
+
+        // CHECK / UNIQUE constraint failures get swallowed by INSERT OR IGNORE.
+        // Surface the count so a corrupt-data scenario leaves a visible trail.
+        if skipped > 0 {
+            tracing::warn!(
+                target: "whitenoise::database::rust_migrations::m0042",
+                account = account_pubkey,
+                "Skipped {skipped} mute_list row(s) during migration \
+                 (constraint violation — likely malformed muted_pubkey)",
             );
         }
 

--- a/src/whitenoise/database/rust_migrations/m0043_drop_shared_mute_list.rs
+++ b/src/whitenoise/database/rust_migrations/m0043_drop_shared_mute_list.rs
@@ -1,0 +1,90 @@
+use async_trait::async_trait;
+use sqlx::SqliteConnection;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::GlobalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl GlobalMigration for Migration {
+    fn version(&self) -> u32 {
+        43
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop shared mute_list table (data moved to per-account DBs in v42)"
+    }
+
+    async fn run_global(&self, tx: &mut SqliteConnection) -> Result<(), DatabaseError> {
+        sqlx::query("DROP INDEX IF EXISTS idx_mute_list_account")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DROP TABLE IF EXISTS mute_list")
+            .execute(&mut *tx)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    #[tokio::test]
+    async fn drops_table_when_present() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE mute_list (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_pubkey TEXT NOT NULL,
+                muted_pubkey   TEXT NOT NULL,
+                is_private     INTEGER NOT NULL DEFAULT 1,
+                created_at     INTEGER NOT NULL,
+                UNIQUE(account_pubkey, muted_pubkey)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("CREATE INDEX idx_mute_list_account ON mute_list(account_pubkey)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='mute_list')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!exists);
+
+        let index_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='index' AND name='idx_mute_list_account')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!index_exists);
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_table_absent() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        Migrator::new(vec![Box::new(Migration)], vec![])
+            .run(&pool, None)
+            .await
+            .unwrap();
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -47,6 +47,7 @@ mod m0039_move_message_delivery_status;
 mod m0040_drop_shared_message_delivery_status;
 mod m0041_drop_shared_aggregated_messages;
 mod m0042_move_mute_list;
+mod m0043_drop_shared_mute_list;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -81,6 +82,7 @@ pub fn all_global_migrations() -> Vec<Box<dyn GlobalMigration>> {
         Box::new(m0037_drop_shared_accounts_groups::Migration),
         Box::new(m0040_drop_shared_message_delivery_status::Migration),
         Box::new(m0041_drop_shared_aggregated_messages::Migration),
+        Box::new(m0043_drop_shared_mute_list::Migration),
     ]
 }
 

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -46,6 +46,7 @@ mod m0038_move_aggregated_messages;
 mod m0039_move_message_delivery_status;
 mod m0040_drop_shared_message_delivery_status;
 mod m0041_drop_shared_aggregated_messages;
+mod m0042_move_mute_list;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -99,6 +100,7 @@ pub fn all_local_migrations() -> Vec<Box<dyn LocalMigration>> {
         Box::new(m0036_move_accounts_groups::Migration),
         Box::new(m0038_move_aggregated_messages::Migration),
         Box::new(m0039_move_message_delivery_status::Migration),
+        Box::new(m0042_move_mute_list::Migration),
     ]
 }
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mute_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mute_list.rs
@@ -103,8 +103,9 @@ mod tests {
         let result = whitenoise.handle_mute_list(&account, event).await;
         assert!(result.is_ok());
 
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
         assert!(
-            MuteListEntry::exists(&account.pubkey, &target, &whitenoise.shared.database)
+            MuteListEntry::exists(&target, &session.account_db)
                 .await
                 .unwrap(),
             "public tag from own mute list event must be cached"
@@ -117,15 +118,12 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let pre_existing = Keys::generate().public_key();
 
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+
         // Pre-populate the cache
-        MuteListEntry::insert(
-            &account.pubkey,
-            &pre_existing,
-            true,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        MuteListEntry::insert(&pre_existing, true, &session.account_db)
+            .await
+            .unwrap();
 
         let account_keys = whitenoise
             .shared
@@ -144,7 +142,7 @@ mod tests {
 
         // Cache must be unchanged — parse failure returns None and we skip sync
         assert!(
-            MuteListEntry::exists(&account.pubkey, &pre_existing, &whitenoise.shared.database)
+            MuteListEntry::exists(&pre_existing, &session.account_db)
                 .await
                 .unwrap(),
             "pre-existing entry must survive a failed decrypt"

--- a/src/whitenoise/mute_list.rs
+++ b/src/whitenoise/mute_list.rs
@@ -122,9 +122,10 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
         let account = whitenoise.create_identity().await.unwrap();
         let target = Keys::generate().public_key();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
 
         // Insert directly — bypasses relay so the test is Docker-independent.
-        MuteListEntry::insert(&account.pubkey, &target, true, &whitenoise.shared.database)
+        MuteListEntry::insert(&target, true, &session.account_db)
             .await
             .unwrap();
 
@@ -137,7 +138,7 @@ mod tests {
 
         // Entry must still be there (not double-inserted or removed).
         assert!(
-            MuteListEntry::exists(&account.pubkey, &target, &whitenoise.shared.database)
+            MuteListEntry::exists(&target, &session.account_db)
                 .await
                 .unwrap()
         );
@@ -165,18 +166,14 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let target1 = Keys::generate().public_key();
         let target2 = Keys::generate().public_key();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
 
-        MuteListEntry::insert(&account.pubkey, &target1, true, &whitenoise.shared.database)
+        MuteListEntry::insert(&target1, true, &session.account_db)
             .await
             .unwrap();
-        MuteListEntry::insert(
-            &account.pubkey,
-            &target2,
-            false,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        MuteListEntry::insert(&target2, false, &session.account_db)
+            .await
+            .unwrap();
 
         let blocked = whitenoise.get_blocked_users(&account).await.unwrap();
         assert_eq!(blocked.len(), 2);
@@ -192,15 +189,11 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let blocked_target = Keys::generate().public_key();
         let other_target = Keys::generate().public_key();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
 
-        MuteListEntry::insert(
-            &account.pubkey,
-            &blocked_target,
-            true,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        MuteListEntry::insert(&blocked_target, true, &session.account_db)
+            .await
+            .unwrap();
 
         assert!(
             whitenoise
@@ -329,12 +322,12 @@ mod tests {
         let blocked = whitenoise.get_blocked_users(&account).await.unwrap();
         assert_eq!(blocked.len(), 2);
         assert!(
-            MuteListEntry::exists(&account.pubkey, &target1, &whitenoise.shared.database)
+            MuteListEntry::exists(&target1, &session.account_db)
                 .await
                 .unwrap()
         );
         assert!(
-            MuteListEntry::exists(&account.pubkey, &target2, &whitenoise.shared.database)
+            MuteListEntry::exists(&target2, &session.account_db)
                 .await
                 .unwrap()
         );
@@ -346,19 +339,14 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let old_target = Keys::generate().public_key();
         let new_target = Keys::generate().public_key();
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
 
         // Seed with old_target
-        MuteListEntry::insert(
-            &account.pubkey,
-            &old_target,
-            true,
-            &whitenoise.shared.database,
-        )
-        .await
-        .unwrap();
+        MuteListEntry::insert(&old_target, true, &session.account_db)
+            .await
+            .unwrap();
 
         // Sync with only new_target
-        let session = whitenoise.require_session(&account.pubkey).unwrap();
         session
             .mute_list()
             .sync_and_emit(&[(new_target, false)])
@@ -366,13 +354,13 @@ mod tests {
             .unwrap();
 
         assert!(
-            !MuteListEntry::exists(&account.pubkey, &old_target, &whitenoise.shared.database)
+            !MuteListEntry::exists(&old_target, &session.account_db)
                 .await
                 .unwrap(),
             "old_target should be removed"
         );
         assert!(
-            MuteListEntry::exists(&account.pubkey, &new_target, &whitenoise.shared.database)
+            MuteListEntry::exists(&new_target, &session.account_db)
                 .await
                 .unwrap(),
             "new_target should be present"
@@ -385,11 +373,11 @@ mod tests {
         let account = whitenoise.create_identity().await.unwrap();
         let target = Keys::generate().public_key();
 
-        MuteListEntry::insert(&account.pubkey, &target, true, &whitenoise.shared.database)
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        MuteListEntry::insert(&target, true, &session.account_db)
             .await
             .unwrap();
 
-        let session = whitenoise.require_session(&account.pubkey).unwrap();
         session.mute_list().sync_and_emit(&[]).await.unwrap();
 
         let blocked = whitenoise.get_blocked_users(&account).await.unwrap();

--- a/src/whitenoise/session/mute_list.rs
+++ b/src/whitenoise/session/mute_list.rs
@@ -111,11 +111,22 @@ impl<'a> MuteListOps<'a> {
         }
 
         // Capture is_private before deleting so the rollback re-inserts the
-        // entry exactly as it was.
-        let is_private = MuteListEntry::find_by_muted_pubkey(target_pubkey, self.db())
-            .await?
-            .map(|e| e.is_private)
-            .unwrap_or(true);
+        // entry exactly as it was. If the entry vanished between the
+        // exists-check above and now (concurrent sync from another flow),
+        // default to private — the safer choice for a rollback.
+        let is_private = match MuteListEntry::find_by_muted_pubkey(target_pubkey, self.db()).await?
+        {
+            Some(e) => e.is_private,
+            None => {
+                tracing::debug!(
+                    target: "whitenoise::mute_list",
+                    "Mute entry for {} vanished between exists-check and read; \
+                     defaulting is_private=true for rollback",
+                    target_pubkey,
+                );
+                true
+            }
+        };
 
         MuteListEntry::delete(target_pubkey, self.db()).await?;
 

--- a/src/whitenoise/session/mute_list.rs
+++ b/src/whitenoise/session/mute_list.rs
@@ -112,19 +112,22 @@ impl<'a> MuteListOps<'a> {
 
         // Capture is_private before deleting so the rollback re-inserts the
         // entry exactly as it was. If the entry vanished between the
-        // exists-check above and now (concurrent sync from another flow),
-        // default to private — the safer choice for a rollback.
+        // exists-check above and now (concurrent sync from another flow
+        // removed it), the user is already not blocked locally and any
+        // republish is the responsibility of the operation that wiped the
+        // entry. Treat this as a no-op: skip delete + publish entirely so
+        // the rollback path can't re-insert the row we just observed gone.
         let is_private = match MuteListEntry::find_by_muted_pubkey(target_pubkey, self.db()).await?
         {
             Some(e) => e.is_private,
             None => {
-                tracing::debug!(
+                tracing::warn!(
                     target: "whitenoise::mute_list",
                     "Mute entry for {} vanished between exists-check and read; \
-                     defaulting is_private=true for rollback",
+                     skipping unblock delete/publish to avoid re-inserting it on rollback",
                     target_pubkey,
                 );
-                true
+                return Ok(());
             }
         };
 

--- a/src/whitenoise/session/mute_list.rs
+++ b/src/whitenoise/session/mute_list.rs
@@ -50,7 +50,7 @@ impl<'a> MuteListOps<'a> {
         }
 
         // Fast path: if already blocked locally no sync or publish is needed.
-        if MuteListEntry::exists(account_pubkey, target_pubkey, self.db()).await? {
+        if MuteListEntry::exists(target_pubkey, self.db()).await? {
             return Ok(());
         }
 
@@ -60,17 +60,15 @@ impl<'a> MuteListOps<'a> {
 
         // Re-check after sync: another device may have added this block while
         // we were fetching the latest list.
-        if MuteListEntry::exists(account_pubkey, target_pubkey, self.db()).await? {
+        if MuteListEntry::exists(target_pubkey, self.db()).await? {
             return Ok(());
         }
 
-        MuteListEntry::insert(account_pubkey, target_pubkey, true, self.db()).await?;
+        MuteListEntry::insert(target_pubkey, true, self.db()).await?;
 
         if let Err(e) = self.publish_mute_list().await {
             // Roll back the local insert so a retry runs the full flow from scratch.
-            if let Err(rb_err) =
-                MuteListEntry::delete(account_pubkey, target_pubkey, self.db()).await
-            {
+            if let Err(rb_err) = MuteListEntry::delete(target_pubkey, self.db()).await {
                 tracing::warn!(
                     target: "whitenoise::mute_list",
                     "Failed to roll back local block insert for {}: {}",
@@ -98,9 +96,7 @@ impl<'a> MuteListOps<'a> {
     /// retry the full operation cleanly.
     #[perf_instrument("mute_list")]
     pub async fn unblock_user(&self, target_pubkey: &PublicKey) -> Result<()> {
-        let account_pubkey = &self.session.account_pubkey;
-
-        if !MuteListEntry::exists(account_pubkey, target_pubkey, self.db()).await? {
+        if !MuteListEntry::exists(target_pubkey, self.db()).await? {
             return Ok(());
         }
 
@@ -110,25 +106,22 @@ impl<'a> MuteListOps<'a> {
 
         // Re-check after sync: another device may have already removed this
         // block while we were fetching the latest list.
-        if !MuteListEntry::exists(account_pubkey, target_pubkey, self.db()).await? {
+        if !MuteListEntry::exists(target_pubkey, self.db()).await? {
             return Ok(());
         }
 
         // Capture is_private before deleting so the rollback re-inserts the
         // entry exactly as it was.
-        let is_private =
-            MuteListEntry::find_by_account_and_target(account_pubkey, target_pubkey, self.db())
-                .await?
-                .map(|e| e.is_private)
-                .unwrap_or(true);
+        let is_private = MuteListEntry::find_by_muted_pubkey(target_pubkey, self.db())
+            .await?
+            .map(|e| e.is_private)
+            .unwrap_or(true);
 
-        MuteListEntry::delete(account_pubkey, target_pubkey, self.db()).await?;
+        MuteListEntry::delete(target_pubkey, self.db()).await?;
 
         if let Err(e) = self.publish_mute_list().await {
             // Roll back the local delete so a retry runs the full flow from scratch.
-            if let Err(rb_err) =
-                MuteListEntry::insert(account_pubkey, target_pubkey, is_private, self.db()).await
-            {
+            if let Err(rb_err) = MuteListEntry::insert(target_pubkey, is_private, self.db()).await {
                 tracing::warn!(
                     target: "whitenoise::mute_list",
                     "Failed to roll back local unblock delete for {}: {}",
@@ -147,26 +140,24 @@ impl<'a> MuteListOps<'a> {
     /// Returns all blocked users for this account.
     #[perf_instrument("mute_list")]
     pub async fn get_blocked_users(&self) -> Result<Vec<MuteListEntry>> {
-        let entries =
-            MuteListEntry::find_by_account(&self.session.account_pubkey, self.db()).await?;
+        let entries = MuteListEntry::find_all(self.db()).await?;
         Ok(entries)
     }
 
     /// Returns `true` if the given pubkey is blocked by this account.
     #[perf_instrument("mute_list")]
     pub async fn is_user_blocked(&self, target_pubkey: &PublicKey) -> Result<bool> {
-        let blocked =
-            MuteListEntry::exists(&self.session.account_pubkey, target_pubkey, self.db()).await?;
+        let blocked = MuteListEntry::exists(target_pubkey, self.db()).await?;
         Ok(blocked)
     }
 
     /// Replaces the mute list cache and emits `UserBlockChanged` for every
     /// pubkey that was added or removed compared to the previous state.
     pub(crate) async fn sync_and_emit(&self, entries: &[(PublicKey, bool)]) -> Result<()> {
-        let old = MuteListEntry::find_by_account(&self.session.account_pubkey, self.db()).await?;
+        let old = MuteListEntry::find_all(self.db()).await?;
         let old_pubkeys: HashSet<PublicKey> = old.iter().map(|e| e.muted_pubkey).collect();
 
-        MuteListEntry::sync_from_event(&self.session.account_pubkey, entries, self.db()).await?;
+        MuteListEntry::sync_from_event(entries, self.db()).await?;
 
         let new_pubkeys: HashSet<PublicKey> = entries.iter().map(|(pk, _)| *pk).collect();
 
@@ -218,7 +209,7 @@ impl<'a> MuteListOps<'a> {
             return Ok(());
         };
 
-        MuteListEntry::sync_from_event(&self.session.account_pubkey, &entries, self.db()).await?;
+        MuteListEntry::sync_from_event(&entries, self.db()).await?;
 
         Ok(())
     }
@@ -301,8 +292,7 @@ impl<'a> MuteListOps<'a> {
         let signer = self.require_signer().await?;
         let relay_urls = self.account_relay_urls().await;
 
-        let entries =
-            MuteListEntry::find_by_account(&self.session.account_pubkey, self.db()).await?;
+        let entries = MuteListEntry::find_all(self.db()).await?;
 
         let mut public_tags: Vec<Tag> = Vec::new();
         let mut private_tags: Vec<Vec<String>> = Vec::new();
@@ -383,12 +373,13 @@ impl<'a> MuteListOps<'a> {
     /// Returns relay URLs for this account's NIP-65 relay list,
     /// falling back to discovery plane relays.
     async fn account_relay_urls(&self) -> Vec<nostr_sdk::RelayUrl> {
+        let shared = &self.session.shared.database;
         let nip65 = async {
-            let acct = Account::find_by_pubkey(&self.session.account_pubkey, self.db())
+            let acct = Account::find_by_pubkey(&self.session.account_pubkey, shared)
                 .await
                 .ok()?;
-            let user = acct.user(self.db()).await.ok()?;
-            let relays = user.relays(RelayType::Nip65, self.db()).await.ok()?;
+            let user = acct.user(shared).await.ok()?;
+            let relays = user.relays(RelayType::Nip65, shared).await.ok()?;
             Some(relays)
         }
         .await
@@ -406,7 +397,7 @@ impl<'a> MuteListOps<'a> {
         }
     }
 
-    fn db(&self) -> &crate::whitenoise::database::Database {
-        &self.session.shared.database
+    fn db(&self) -> &crate::whitenoise::database::account_db::AccountDatabase {
+        &self.session.account_db
     }
 }


### PR DESCRIPTION
## Summary

Moves the `mute_list` table from the shared SQLite database into each account's per-account DB file, then drops the now-empty shared table. This is the last bit of per-account state that hadn't migrated yet, and it's blocking a clean re-merge of master.

## Why now

Master's PR #804 (`feat: ignore blocked authors in unread badges`) added a `count_visible_unread_for_group` query that joins `aggregated_messages` (per-account post-Phase 18d) with `mute_list` (shared). That cross-DB subquery can't run on arch-refactor — it fails with `no such table: mute_list` against the per-account pool.

Rather than bridge with `ATTACH DATABASE`, this moves the table to where it logically belongs. After this lands, the next master merge brings master's signature changes through cleanly because both tables now live in the same DB.

## What changed

**Migrations**

- `m0042_move_mute_list` (LocalMigration, v42) creates per-account `mute_list` and copies rows from shared filtered to the owning account. Per-row `rows_affected()` accounting emits `tracing::warn!` on any silently-skipped constraint violations so corrupt source rows leave a diagnostic trail.
- `m0043_drop_shared_mute_list` (GlobalMigration, v43) drops the shared table and its account-scoped index. Runs after every account has completed v42, in the same boot.
- `account_pubkey` column dropped — redundant once the table is per-account. UNIQUE collapses from `(account_pubkey, muted_pubkey)` to `muted_pubkey`.
- Schema baked into `fresh_account_schema.sql` so future bootstrap rebaselines pick it up.

**DAO (`database/mute_list.rs`)**

- `MuteListEntry` no longer carries `account_pubkey`.
- All methods take `&AccountDatabase` instead of `&Database` and drop the `account_pubkey` parameter.
- `find_by_account` → `find_all`; `find_by_account_and_target` → `find_by_muted_pubkey` (matches column-name suffix convention used across other DAOs).
- `exists()` uses `SELECT EXISTS(SELECT 1 ...)` for short-circuit boolean semantics.

**Session (`session/mute_list.rs`)**

- `db()` returns `&AccountDatabase`.
- `account_relay_urls()` reaches into `&shared.database` directly for `Account` / `User` / `Relay` reads (those tables stay shared).
- `unblock_user` rollback path: explicit `match` with `tracing::debug!` when the entry vanishes between exists-check and read, instead of a silent `unwrap_or(true)`.

**Docs**

- `AccountDatabase` doc comment now lists `mute_list` alongside the other per-account tables.

## Migration safety

- Existing accounts: rows copy from `shared.mute_list WHERE account_pubkey = ?` into the per-account file before v43 drops shared.
- Fresh accounts: bootstrap creates the table from `fresh_account_schema.sql`; m0042's `CREATE TABLE IF NOT EXISTS` is a no-op; data copy hits empty shared; m0043 drops the empty shared table.
- Idempotency: each migration runs in its own transaction; `INSERT OR IGNORE` makes re-runs safe; `DROP TABLE IF EXISTS` is idempotent.
- Corrupt source rows (CHECK violations on hex format) are silently skipped rather than aborting startup — a `tracing::warn!` records the count, and `migration_silently_skips_invalid_pubkey_rows` test pins this contract.
- Ordering across kinds: the migrator processes a unified version timeline, so all per-account v42 instances complete before the v43 global drop runs.

## Downstream impact

`MuteListEntry` is publicly re-exported via `lib.rs:72`. The `marmot-protocol/whitenoise` Flutter app's bridge layer at `whitenoise/rust/src/api/mute_list.rs` reads `e.account_pubkey.to_hex()` (line 20) plus a unit test that constructs the struct directly. The released app pins whitenoise-rs by git rev so it isn't retroactively broken — but the next rev bump on the Flutter side requires:

- Drop `account_pubkey: String` field from the bridge `MuteListEntry` struct
- Drop `account_pubkey: e.account_pubkey.to_hex()` from the `From` impl
- Update the `WhitenoiseEntry { ... }` literals in the two unit tests
- Run `flutter_rust_bridge_codegen generate` + `dart run build_runner build`

No Dart consumers of `accountPubkey` exist outside the auto-generated bridge code, so the Flutter app side is ~8 lines of Rust + a regen.

## Follow-ups (not in this PR)

- Companion PR on `marmot-protocol/whitenoise` that lands together with the eventual arch-refactor → master merge (drops `account_pubkey` from the bridge struct, regen).

## Test plan

- [x] `just precommit-quick` passes — fmt, docs, clippy, dead_code, all unit tests
- [x] m0042 tests: account-scoped copy, empty source, missing shared table, silent skip on invalid hex
- [x] m0043 tests: drops table when present, idempotent when absent
- [x] DAO tests: insert/exists/delete/find_all/find_by_muted_pubkey/sync_from_event with the new schema
- [x] Session tests: block/unblock/sync_and_emit go through the per-account DB