### PR TITLE
Recover external signer subscriptions with NIP-65 inbox fallback

### DIFF
--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -4184,8 +4184,12 @@ mod tests {
 
     // External Signer Registry Tests
     mod external_signer_tests {
-        use super::*;
+        use std::collections::HashSet;
+
         use nostr_sdk::Keys;
+
+        use super::*;
+        use crate::whitenoise::relays::RelayType;
 
         /// Helper to create a test signer using Keys (which implements NostrSigner)
         fn create_test_signer() -> (Keys, PublicKey) {
@@ -4422,6 +4426,134 @@ mod tests {
             assert!(
                 after,
                 "register_external_signer should recover missing account subscriptions"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_register_recovers_only_the_target_account_subscriptions() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+            let keys_one = Keys::generate();
+            let account_one = whitenoise
+                .login_with_external_signer_for_test(keys_one.clone())
+                .await
+                .unwrap();
+
+            let keys_two = Keys::generate();
+            let account_two = whitenoise
+                .login_with_external_signer_for_test(keys_two.clone())
+                .await
+                .unwrap();
+
+            whitenoise.remove_external_signer(&account_one.pubkey);
+            whitenoise.remove_external_signer(&account_two.pubkey);
+            whitenoise
+                .relay_control
+                .deactivate_account_subscriptions(&account_one.pubkey)
+                .await;
+            whitenoise
+                .relay_control
+                .deactivate_account_subscriptions(&account_two.pubkey)
+                .await;
+
+            whitenoise
+                .register_external_signer(account_one.pubkey, keys_one)
+                .await
+                .unwrap();
+
+            let one_after_first_registration = whitenoise
+                .is_account_subscriptions_operational(&account_one)
+                .await
+                .unwrap();
+            let two_after_first_registration = whitenoise
+                .is_account_subscriptions_operational(&account_two)
+                .await
+                .unwrap();
+            assert!(
+                one_after_first_registration,
+                "Registering account one's signer should recover account one"
+            );
+            assert!(
+                !two_after_first_registration,
+                "Registering account one's signer should not recover account two"
+            );
+
+            whitenoise
+                .register_external_signer(account_two.pubkey, keys_two)
+                .await
+                .unwrap();
+
+            let two_after_second_registration = whitenoise
+                .is_account_subscriptions_operational(&account_two)
+                .await
+                .unwrap();
+            assert!(
+                two_after_second_registration,
+                "Registering account two's signer should recover account two"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_register_recovers_subscriptions_with_nip65_inbox_fallback() {
+            let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+            let keys = Keys::generate();
+            let account = whitenoise
+                .login_with_external_signer_for_test(keys.clone())
+                .await
+                .unwrap();
+
+            let nip65_relays = account.nip65_relays(&whitenoise).await.unwrap();
+            assert!(
+                !nip65_relays.is_empty(),
+                "test setup should give the account NIP-65 relays"
+            );
+
+            let user = account.user(&whitenoise.database).await.unwrap();
+            user.sync_relay_urls(&whitenoise, RelayType::Inbox, &HashSet::new(), None)
+                .await
+                .unwrap();
+
+            assert!(
+                account.inbox_relays(&whitenoise).await.unwrap().is_empty(),
+                "test setup should leave the account with no explicit inbox relays"
+            );
+            assert!(
+                !account
+                    .effective_inbox_relays(&whitenoise)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "effective inbox relay lookup should fall back to NIP-65 relays"
+            );
+
+            whitenoise.remove_external_signer(&account.pubkey);
+            whitenoise
+                .relay_control
+                .deactivate_account_subscriptions(&account.pubkey)
+                .await;
+
+            let before = whitenoise
+                .is_account_subscriptions_operational(&account)
+                .await
+                .unwrap();
+            assert!(
+                !before,
+                "Account subscriptions should be non-operational before signer re-registration"
+            );
+
+            whitenoise
+                .register_external_signer(account.pubkey, keys)
+                .await
+                .unwrap();
+
+            let after = whitenoise
+                .is_account_subscriptions_operational(&account)
+                .await
+                .unwrap();
+            assert!(
+                after,
+                "register_external_signer should recover subscriptions using NIP-65 fallback relays"
             );
         }
 

--- a/src/whitenoise/signer.rs
+++ b/src/whitenoise/signer.rs
@@ -49,9 +49,9 @@ impl Whitenoise {
         // On app restore, external accounts may exist before their signer is
         // re-registered. Startup subscription setup can fail in that gap.
         // Rebuild account subscriptions now that signing/decryption is available.
-        // Only inbox_relays is needed by setup_subscriptions; do not gate
-        // recovery on the nip65 lookup which is not used here.
-        match account.inbox_relays(self).await {
+        // Match startup behavior by using the effective inbox relay set, so
+        // legacy accounts without kind 10050 relays still fall back to NIP-65.
+        match account.effective_inbox_relays(self).await {
             Ok(inbox_relays) => {
                 if let Err(e) = self.setup_subscriptions(&account, &inbox_relays).await {
                     tracing::warn!(


### PR DESCRIPTION
## Summary
- Use `effective_inbox_relays()` when recovering external-signer accounts so restart recovery matches startup behavior.
- Add regression tests covering:
  - signer re-registration only restoring the target account
  - recovery when an external-signer account has no explicit Inbox relays and must fall back to NIP-65

## Testing
- `just fmt`
- `just precommit-quick`
- `just test-unit`
- `just int-test login-flow`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external signer registration to properly restore subscription state for legacy accounts that lack certain relay configurations. Subscriptions now correctly recover for only the account whose signer is registered, while other accounts' subscriptions remain appropriately unaffected until their own signer is registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->