### PR TITLE
fix(push): make joined-group token iteration `for<'a> Send` for flutter_rust_bridge

### DIFF
--- a/src/whitenoise/session/push.rs
+++ b/src/whitenoise/session/push.rs
@@ -300,12 +300,23 @@ impl<'a> PushOps<'a> {
     pub(crate) async fn remove_local_token_from_joined_groups(&self) -> Result<()> {
         let groups = self.session.mdk.get_groups()?;
 
-        let failures: Vec<String> = stream::iter(groups.iter())
-            .map(|group| self.remove_token_from_single_group(&group.mls_group_id, group.state))
-            .buffer_unordered(MAX_CONCURRENT_GROUP_PUBLISHES)
-            .filter_map(|r| async move { r.err() })
-            .collect()
-            .await;
+        // Pre-extract owned (GroupId, GroupState) so the async stream below does
+        // not borrow `&Group`. The borrow yields a closure type that only
+        // implements `Send` for a specific lifetime, not `for<'a>`, which
+        // breaks any caller crossed by flutter_rust_bridge's `wrap_async`.
+        let group_pairs: Vec<(GroupId, GroupState)> = groups
+            .iter()
+            .map(|g| (g.mls_group_id.clone(), g.state))
+            .collect();
+        let failures: Vec<String> =
+            stream::iter(group_pairs.into_iter())
+                .map(|(gid, state)| async move {
+                    self.remove_token_from_single_group(&gid, state).await
+                })
+                .buffer_unordered(MAX_CONCURRENT_GROUP_PUBLISHES)
+                .filter_map(|r| async move { r.err() })
+                .collect()
+                .await;
 
         if failures.is_empty() {
             Ok(())
@@ -405,17 +416,19 @@ impl<'a> PushOps<'a> {
     async fn share_token_to_joined_groups(&self, token_tag: &TokenTag) -> Result<()> {
         let groups = self.session.mdk.get_groups()?;
 
-        let failures: Vec<String> = stream::iter(groups.iter())
-            .map(|group| async move {
-                if !self
-                    .is_push_gossip_eligible(&group.mls_group_id, group.state)
-                    .await
-                {
+        // Same owned-iteration trick as `remove_local_token_from_joined_groups`
+        let group_pairs: Vec<(GroupId, GroupState)> = groups
+            .iter()
+            .map(|g| (g.mls_group_id.clone(), g.state))
+            .collect();
+        let failures: Vec<String> = stream::iter(group_pairs.into_iter())
+            .map(|(gid, state)| async move {
+                if !self.is_push_gossip_eligible(&gid, state).await {
                     return Ok(());
                 }
-                self.share_token_to_group(&group.mls_group_id, token_tag)
+                self.share_token_to_group(&gid, token_tag)
                     .await
-                    .map_err(|e| format!("{}: {e}", hex::encode(group.mls_group_id.as_slice())))
+                    .map_err(|e| format!("{}: {e}", hex::encode(gid.as_slice())))
             })
             .buffer_unordered(MAX_CONCURRENT_GROUP_PUBLISHES)
             .filter_map(|r| async move { r.err() })


### PR DESCRIPTION
![marmot](https://blossom.primal.net/eabd28097b533db69aaa829f578ffb55561acd1c0d980719a55ae9bf91892018.png)

Two `PushOps` methods that walk joined MLS groups, `remove_local_token_from_joined_groups` and `share_token_to_joined_groups`, fed `&Group` borrows into async closures driven by `stream::iter(...).buffer_unordered(...)`. The borrow tied the resulting closure's `Send` impl to one concrete lifetime, so the future was not `for<'a> Send`.

`flutter_rust_bridge::wrap_async` needs `for<'a> Send`. Any path through the bridge that touched these methods failed to compile, and push-token housekeeping went dark for the Flutter app. No tokens out, no notifications back, sad marmots all around.

The fix collects owned `(GroupId, GroupState)` pairs up front and drives the stream from owned values. No borrow, no lifetime-locked `Send`, and the bridge accepts the futures again.

### What changed

- `remove_local_token_from_joined_groups`: build a `Vec<(GroupId, GroupState)>` before streaming, then iterate by value.
- `share_token_to_joined_groups`: same trick; calls to `is_push_gossip_eligible` and `share_token_to_group` now take the owned `gid` and `state`.
- A comment in each method records the lifetime quirk so the next marmot through here keeps the trick in place.

### Why this shape

Lifting the inputs out of the borrow is the smallest change that clears the lifetime tie. Wrapping the closures in `move` or boxing the futures would also compile, but neither addresses the borrow itself, and either path invites the same bug back the next time someone refactors the stream.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/816">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->