### PR TITLE
fix: restore sessions before sync_message_cache_on_startup

### DIFF
--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -838,6 +838,22 @@ impl Whitenoise {
 
         init_timing::record("discovery_plane");
 
+        // Restore account sessions before any startup step that resolves a
+        // session by pubkey. `sync_message_cache_on_startup` reads per-account
+        // `aggregated_messages` via `session.account_db` (post phase-18e), so
+        // sessions must be populated first or it raises `AccountNotFound`.
+        // Migrations were already applied in lockstep across shared and every
+        // on-disk per-account file via `MIGRATOR.run_all` at the top of
+        // `Whitenoise::new`, so `run_account_migrations` here is a no-op for
+        // already-stamped versions. Only newly-created accounts (e.g. first
+        // login post-boot) need it to fire the bootstrap migration.
+        let _ = whitenoise
+            .account_manager
+            .restore_sessions(&whitenoise)
+            .await;
+
+        init_timing::record("session_restore");
+
         tracing::info!(
             target: "whitenoise::new",
             "Synchronizing message cache with MDK..."
@@ -906,20 +922,6 @@ impl Whitenoise {
         }
 
         init_timing::record("background_tasks");
-
-        // Restore account sessions for all persisted accounts before setting up
-        // subscriptions so that each account has an MDK instance ready.
-        // Migrations were already applied in lockstep across shared and every
-        // on-disk per-account file via `MIGRATOR.run_all` at the top of
-        // `Whitenoise::new`, so `run_account_migrations` here is a no-op for
-        // already-stamped versions. Only newly-created accounts (e.g. first
-        // login post-boot) need it to fire the bootstrap migration.
-        let _ = whitenoise
-            .account_manager
-            .restore_sessions(&whitenoise)
-            .await;
-
-        init_timing::record("session_restore");
 
         // Fetch events and setup subscriptions after event processing has started
         whitenoise.setup_all_subscriptions().await?;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/8d71843701bcdd22218c1c96ed5a367d9000aecd5e9ff3b3f2f56d2e0f965360.jpg)

## What

Move `restore_sessions` ahead of `sync_message_cache_on_startup` in
`Whitenoise::new` so per-account sessions are populated before any
pubkey-keyed startup step runs.

## Why

Phase 18e (#796) moved `aggregated_messages` to per-account DBs and
changed `sync_cache_for_group` / `cache_needs_sync` (in
`src/whitenoise/messages.rs`) to read them via `session.account_db`.
The startup ordering in `Whitenoise::new` was not updated:
`sync_message_cache_on_startup` still ran before `restore_sessions`,
so `require_session` raised `WhitenoiseError::AccountNotFound` for
any account whose groups already had cached MDK messages.

It propagated out of `Whitenoise::new` and surfaced in the Flutter
app as:

```
ApiError.whitenoise(message: Account not found)
  ... initializeAppContainer (whitenoise/main.dart:74:3)
  ... main (whitenoise/main.dart:55:23)
```

The bug was most reproducible with multiple accounts because a
brand-new sole account short-circuits on `mdk_messages.is_empty()`,
while older accounts with history trip the session lookup. One
marmot in the burrow can dodge the trap; two marmots and somebody
ends up locked out.

## Fix

One-hunk move of the `restore_sessions` call (and its
`init_timing::record("session_restore")`) from after the
`background_tasks` marker to immediately after the `discovery_plane`
marker, right before `sync_message_cache_on_startup`. Nothing
between the new location and the old one depends on the session
manager being empty.

## Testing

- Migration framework, per-account DB, and session unit tests pass
  locally (146/147 in the relevant slice; the lone failure is a
  pre-existing Docker-relay flake that hits stock `arch-refactor`).
- Verified by Danny on a real multi-account install: the
  `Account not found` crash on `initializeAppContainer` is gone.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/817">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->