### PR TITLE
fix(media_files): decode file_metadata column as BLOB

### DIFF
--- a/src/whitenoise/database/media_files.rs
+++ b/src/whitenoise/database/media_files.rs
@@ -104,7 +104,7 @@ struct ReferenceRow {
     original_file_hash: Option<String>,
     media_type: String,
     nostr_key: Option<String>,
-    file_metadata: Option<String>,
+    file_metadata: Option<Vec<u8>>,
     nonce: Option<String>,
     scheme_version: Option<String>,
     created_at: i64,
@@ -137,8 +137,9 @@ impl MediaFile {
         let original_file_hash = r
             .original_file_hash
             .and_then(|hex_str| hex::decode(&hex_str).ok());
-        let file_metadata: Option<FileMetadata> =
-            r.file_metadata.and_then(|s| serde_json::from_str(&s).ok());
+        let file_metadata: Option<FileMetadata> = r
+            .file_metadata
+            .and_then(|s| serde_json::from_slice(&s).ok());
         let created_at = match chrono::DateTime::from_timestamp_millis(r.created_at) {
             Some(ts) => ts,
             None => {
@@ -1990,6 +1991,102 @@ mod tests {
         assert!(
             retrieved.thumbhash.is_none(),
             "Old records without thumbhash should deserialize with None"
+        );
+    }
+
+    /// Regression: a non-null `file_metadata` written through the production
+    /// path must round-trip cleanly back into `MediaFile.file_metadata`.
+    ///
+    /// This exercises the read side of `media_references.file_metadata`,
+    /// which is declared `BLOB` in the schema. The internal `ReferenceRow`
+    /// must accept whatever SQLite stores there (TEXT or BLOB) without a
+    /// sqlx column-decode error.
+    #[tokio::test]
+    async fn test_file_metadata_blob_column_roundtrip() {
+        let t = setup_test_dbs().await;
+
+        let group_id = mdk_core::GroupId::from_slice(&[7u8; 8]);
+        let encrypted_hash = [77u8; 32];
+        let file_path = t._dir.path().join("blob_roundtrip.jpg");
+
+        let metadata = FileMetadata::new()
+            .with_filename("photo.jpg".to_string())
+            .with_dimensions("4032x3024".to_string())
+            .with_blurhash("L9AB*A%MfQ%M~qfQfQfQfQfQfQfQ".to_string())
+            .with_thumbhash("3OcRJYB4d3h_iIeHeYh3eIhw+j3A".to_string());
+
+        MediaFile::save(
+            &t.account_pool,
+            &t.shared,
+            &group_id,
+            &t.account_pubkey,
+            MediaFileParams {
+                file_path: &file_path,
+                original_file_hash: None,
+                encrypted_file_hash: &encrypted_hash,
+                mime_type: "image/jpeg",
+                media_type: "chat_media",
+                blossom_url: Some("https://blossom.example.com/77"),
+                nostr_key: None,
+                file_metadata: Some(&metadata),
+                nonce: None,
+                scheme_version: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Simulate the on-disk state reported in production: a row whose
+        // `file_metadata` cell carries SQLite's BLOB storage class, not TEXT.
+        // sqlx's `Json<T>` for SQLite encodes as TEXT, so the production
+        // BLOB-typed cells must have come from a path that wrote raw bytes —
+        // overwrite directly via `CAST(... AS BLOB)` to reproduce that state.
+        let metadata_bytes = serde_json::to_vec(&metadata).unwrap();
+        sqlx::query("UPDATE media_references SET file_metadata = CAST(? AS BLOB) WHERE encrypted_file_hash = ?")
+            .bind(&metadata_bytes)
+            .bind(hex::encode(encrypted_hash))
+            .execute(&t.account_pool)
+            .await
+            .unwrap();
+
+        // Sanity-check: the stored value's runtime storage class is now BLOB.
+        let storage_class: String = sqlx::query_scalar(
+            "SELECT typeof(file_metadata) FROM media_references WHERE encrypted_file_hash = ?",
+        )
+        .bind(hex::encode(encrypted_hash))
+        .fetch_one(&t.account_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            storage_class, "blob",
+            "test setup must reproduce the production storage class"
+        );
+
+        // Read back via the production path. Before the fix this fails with:
+        //   mismatched types; Rust type `core::option::Option<alloc::string::String>`
+        //   (as SQL type `TEXT`) is not compatible with SQL type `BLOB`
+        let found = MediaFile::find_by_hash(
+            &t.account_pool,
+            &t.shared,
+            &t.account_pubkey,
+            &encrypted_hash,
+        )
+        .await
+        .expect("decoding a BLOB-typed file_metadata cell must not error")
+        .expect("row must still be present");
+
+        let retrieved = found
+            .file_metadata
+            .expect("file_metadata must round-trip from BLOB storage");
+        assert_eq!(retrieved.original_filename, Some("photo.jpg".to_string()));
+        assert_eq!(retrieved.dimensions, Some("4032x3024".to_string()));
+        assert_eq!(
+            retrieved.blurhash,
+            Some("L9AB*A%MfQ%M~qfQfQfQfQfQfQfQ".to_string())
+        );
+        assert_eq!(
+            retrieved.thumbhash,
+            Some("3OcRJYB4d3h_iIeHeYh3eIhw+j3A".to_string())
         );
     }
 }


### PR DESCRIPTION
## Symptom

Migrated devices crash when sending or receiving messages in any chat that has
media history. Flutter log:

```
SEVERE MessageService sendMessage FAILED
error: ApiError.whitenoise(message: Database error: SQLx error:
error occurred while decoding column "file_metadata":
mismatched types; Rust type `core::option::Option<alloc::string::String>`
(as SQL type `TEXT`) is not compatible with SQL type `BLOB`)
```

Affects both send and receive because `MediaFile::find_by_hash` sits on every
message path that touches a referenced media row.

## Root cause

`ReferenceRow.file_metadata` in `src/whitenoise/database/media_files.rs` was
declared `Option<String>`, which sqlx maps to SQL `TEXT`. The
`media_references.file_metadata` column is declared `BLOB` in every schema:

- `m0013_media_blob_reference_split.rs:60`
- `m0029_move_media_references.rs:50,173,254`
- `rust_migrations/fresh_account_schema.sql:87`
- `rust_migrations/fresh_schema.sql:124`

Any production path that stored raw bytes there produced a BLOB-typed cell.
sqlx's strict decoder then refuses the BLOB → `Option<String>` coercion at
`try_get`, before the existing `serde_json::from_str` deserializer can run.

Not caused by the recent arch-refactor migrations (m0042/m0043). Latent
code/schema mismatch surfaced by data shape present on migrated devices.

## Fix

Read side only, single file (`src/whitenoise/database/media_files.rs`):

- `ReferenceRow.file_metadata`: `Option<String>` → `Option<Vec<u8>>`
- `assemble()`: `serde_json::from_str(&s)` → `serde_json::from_slice(&s)`

Write path at lines 341/379 (sqlx's `Json<T>` adapter) stays untouched. Public
`MediaFile.file_metadata: Option<FileMetadata>` shape stays untouched. The
deserialized value round-trips through the same `FileMetadata` type.

## Compatibility

Data on disk unchanged. The fix is decoder-side; existing BLOB-typed cells
decode cleanly under the new field type. No migration. No schema change.

## Test plan

- [x] Regression test added: `test_file_metadata_blob_column_roundtrip`
      forces a BLOB-typed cell via `CAST(? AS BLOB)`, asserts
      `typeof(file_metadata) = 'blob'` as a setup guard, then verifies
      `MediaFile::find_by_hash` round-trips `FileMetadata` fields
- [x] `cargo test --lib database::media_files` — passes
- [x] `just precommit-quick` — green

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/820">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->