### PR TITLE
[codex] Update MDK and harden push token gossip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,9 @@ jobs:
           # - RUSTSEC-2026-0023: libcrux-ecdh X25519 validation (transitive via openmls_rust_crypto →
           #   hpke-rs → hpke-rs-libcrux; pre-existing on master, fix tracked separately)
           # - RUSTSEC-2026-0037: quinn-proto DoS via malformed QUIC handshake (transitive via nostr-blossom → reqwest → quinn; awaiting upstream fix)
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0384,RUSTSEC-2026-0002,RUSTSEC-2026-0023,RUSTSEC-2026-0037
+          # - RUSTSEC-2026-0124: libcrux-chacha20poly1305 panic (transitive optional hpke-rs libcrux backend;
+          #   not selected by our all-features/all-targets graph, awaiting upstream fix)
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0384,RUSTSEC-2026-0002,RUSTSEC-2026-0023,RUSTSEC-2026-0037,RUSTSEC-2026-0124
 
   # Fast Linux test lane for PR feedback
   test-linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
+source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
 dependencies = [
  "base64",
  "blurhash",
@@ -2709,12 +2709,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
+source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
+source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
+source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
 dependencies = [
  "nostr",
  "openmls 0.8.1 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
@@ -2980,7 +2980,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4095,7 +4095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4152,7 +4152,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4518,7 +4518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4807,7 +4807,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5271,7 +5271,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5709,7 +5709,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 members = [".", "crates/whitenoise-macros", "crates/whitenoise-cli"]
 
 [workspace.dependencies]
-mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c", features = [
+mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c" }
-mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "7f809f8549458a0d7f7d885bcdd694023abf299c" }
+mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2" }
+mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2" }
 nostr-sdk = { version = "0.44", features = ["nip04", "nip44", "nip47", "nip59"] }
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/whitenoise-cli/src/cli/dispatch.rs
+++ b/crates/whitenoise-cli/src/cli/dispatch.rs
@@ -1028,6 +1028,7 @@ async fn create_group(
         None, // image_nonce
         cli_group_relay_urls(),
         vec![account.pubkey], // admins — creator only
+        None,
     );
 
     let group = require_session(wn, &account.pubkey)?

--- a/justfile
+++ b/justfile
@@ -395,8 +395,9 @@ update:
 # - RUSTSEC-2024-0384: instant unmaintained (transitive via rust-nostr, low risk)
 # - RUSTSEC-2026-0002: lru unsound (transitive via nostr-sdk, awaiting upstream fix)
 # - RUSTSEC-2026-0037: quinn-proto DoS via malformed QUIC handshake (transitive via nostr-blossom → reqwest → quinn; awaiting upstream fix)
+# - RUSTSEC-2026-0124: libcrux-chacha20poly1305 panic (transitive optional hpke-rs libcrux backend; not selected by our all-features/all-targets graph, awaiting upstream fix)
 audit:
-    cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0002 --ignore RUSTSEC-2026-0037
+    cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0002 --ignore RUSTSEC-2026-0037 --ignore RUSTSEC-2026-0124
 
 # Generate and open documentation
 doc:

--- a/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
@@ -81,6 +81,7 @@ impl BenchmarkScenario for AddMembersPerformanceBenchmark {
             None,
             context.test_relays(),
             vec![admin.pubkey],
+            None,
         );
 
         let group = context

--- a/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
@@ -64,6 +64,7 @@ impl BenchmarkTestCase for CreateGroupBenchmark {
             None,
             context.test_relays(),
             admin_pubkeys,
+            None,
         );
 
         // Time only the create_group call

--- a/src/integration_tests/test_cases/chat_list/create_dm.rs
+++ b/src/integration_tests/test_cases/chat_list/create_dm.rs
@@ -54,6 +54,7 @@ impl TestCase for CreateDmTestCase {
                     None,
                     context.test_relays(),
                     vec![creator.pubkey, other.pubkey],
+                    None,
                 ),
                 None,
             )

--- a/src/integration_tests/test_cases/shared/create_group.rs
+++ b/src/integration_tests/test_cases/shared/create_group.rs
@@ -61,6 +61,7 @@ impl TestCase for CreateGroupTestCase {
                     None, // image_nonce
                     context.test_relays(),
                     admin_pubkeys,
+                    None,
                 ),
                 None,
             )

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -1155,6 +1155,7 @@ mod tests {
             None,
             vec![relay1.clone(), relay2.clone()],
             vec![creator_account.pubkey],
+            None,
         );
 
         let group = whitenoise
@@ -1545,6 +1546,7 @@ mod tests {
             None,
             vec![relay_url.clone()],
             vec![creator_account.pubkey],
+            None,
         );
 
         whitenoise
@@ -1582,6 +1584,7 @@ mod tests {
             None,
             vec![relay_url.clone()],
             vec![creator_account.pubkey],
+            None,
         );
 
         whitenoise

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -999,7 +999,7 @@ impl Whitenoise {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use mdk_core::mip05::{
         ENCRYPTED_TOKEN_LEN, LeafTokenTag, TokenTag, build_token_list_response_rumor,
@@ -1009,8 +1009,8 @@ mod tests {
 
     use super::*;
     use crate::whitenoise::{
-        aggregated_message::AggregatedMessage, message_aggregator::DeliveryStatus,
-        push_notifications::GroupPushToken, test_utils::*,
+        aggregated_message::AggregatedMessage, group_information::GroupInformation,
+        message_aggregator::DeliveryStatus, push_notifications::GroupPushToken, test_utils::*,
     };
 
     fn make_token_tag(seed: u8) -> TokenTag {
@@ -1032,6 +1032,66 @@ mod tests {
             member_account,
         )
         .await
+    }
+
+    async fn setup_three_member_accepted_group(
+        whitenoise: &Whitenoise,
+        admin_account: &Account,
+        member_one: &Account,
+        member_two: &Account,
+    ) -> GroupId {
+        let group_id =
+            setup_three_member_group(whitenoise, admin_account, member_one, member_two).await;
+
+        GroupInformation::create_for_group(whitenoise, &group_id, None, "Test group")
+            .await
+            .unwrap();
+
+        for account in [admin_account, member_one, member_two] {
+            let (account_group, _) =
+                AccountGroup::get_or_create(whitenoise, &account.pubkey, &group_id, None)
+                    .await
+                    .unwrap();
+            account_group.accept(whitenoise).await.unwrap();
+        }
+
+        group_id
+    }
+
+    async fn assert_cached_peer_tokens(
+        session: &Arc<AccountSession>,
+        group_id: &GroupId,
+        expected_tokens: &[(&Account, u32, &TokenTag)],
+    ) {
+        let stored = GroupPushToken::find_by_account_and_group(
+            &session.account_pubkey,
+            group_id,
+            &session.account_db.inner.pool,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stored.len(),
+            expected_tokens.len(),
+            "receiver should cache exactly the other participants' push tokens"
+        );
+
+        for (account, leaf_index, token_tag) in expected_tokens {
+            let cached_token = stored
+                .iter()
+                .find(|token| token.member_pubkey == account.pubkey)
+                .expect("expected participant token should be cached");
+            assert_eq!(cached_token.account_pubkey, session.account_pubkey);
+            assert_eq!(cached_token.mls_group_id, *group_id);
+            assert_eq!(cached_token.leaf_index, *leaf_index);
+            assert_eq!(cached_token.server_pubkey, token_tag.server_pubkey);
+            assert_eq!(cached_token.relay_hint, Some(token_tag.relay_hint.clone()));
+            assert_eq!(
+                cached_token.encrypted_token,
+                token_tag.encrypted_token.to_base64()
+            );
+        }
     }
 
     /// Test handling of different MLS message types: regular messages, reactions, and deletions
@@ -1715,6 +1775,210 @@ mod tests {
         .await
         .unwrap();
         assert!(cached_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_updates_token_request_cache_inside_response_cooldown() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_account = members[0].0.clone();
+        let member_session = whitenoise.require_session(&member_account.pubkey).unwrap();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_account]).await;
+
+        let group_id = setup_two_member_group(&whitenoise, &admin_account, &member_account).await;
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+        let admin_leaf_index = admin_mdk.own_leaf_index(&group_id).unwrap();
+
+        let first_token = make_token_tag(10);
+        let first_request =
+            build_token_request_rumor(admin_account.pubkey, Timestamp::now(), vec![first_token])
+                .unwrap();
+        let first_request_id = first_request.id.expect("447 rumor must have an event id");
+        let first_event = admin_mdk
+            .create_message(&group_id, first_request, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&member_session, &member_account, first_event)
+            .await
+            .unwrap();
+
+        let replacement_token = make_token_tag(11);
+        let expected_encrypted_token = replacement_token.encrypted_token.to_base64();
+        let replacement_request = build_token_request_rumor(
+            admin_account.pubkey,
+            Timestamp::now(),
+            vec![replacement_token],
+        )
+        .unwrap();
+        let replacement_request_id = replacement_request
+            .id
+            .expect("447 replacement rumor must have an event id");
+        let replacement_event = admin_mdk
+            .create_message(&group_id, replacement_request, None)
+            .unwrap();
+
+        whitenoise
+            .handle_mls_message(&member_session, &member_account, replacement_event)
+            .await
+            .unwrap();
+
+        let stored = GroupPushToken::find_by_account_and_group(
+            &member_account.pubkey,
+            &group_id,
+            &member_session.account_db.inner.pool,
+        )
+        .await
+        .unwrap();
+        let admin_token = stored
+            .iter()
+            .find(|token| token.leaf_index == admin_leaf_index)
+            .expect("admin token should stay cached");
+        assert_eq!(
+            admin_token.encrypted_token, expected_encrypted_token,
+            "rapid re-gossip should refresh cached encrypted token state"
+        );
+
+        assert!(
+            member_session
+                .pending_push_token_responses
+                .contains_key(&(group_id.clone(), first_request_id)),
+            "the first token request should still schedule one token-list response"
+        );
+        assert!(
+            !member_session
+                .pending_push_token_responses
+                .contains_key(&(group_id.clone(), replacement_request_id)),
+            "a rate-limited re-gossip must not schedule another token-list response"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_gossips_token_requests_to_all_other_participants() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let admin_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 2).await;
+        let member_one = members[0].0.clone();
+        let member_two = members[1].0.clone();
+
+        wait_for_key_package_publication(&whitenoise, &[&member_one, &member_two]).await;
+
+        let group_id = setup_three_member_accepted_group(
+            &whitenoise,
+            &admin_account,
+            &member_one,
+            &member_two,
+        )
+        .await;
+        let admin_session = whitenoise.require_session(&admin_account.pubkey).unwrap();
+        let member_one_session = whitenoise.require_session(&member_one.pubkey).unwrap();
+        let member_two_session = whitenoise.require_session(&member_two.pubkey).unwrap();
+
+        let admin_mdk = whitenoise
+            .create_mdk_for_account(admin_account.pubkey)
+            .unwrap();
+        let member_one_mdk = whitenoise
+            .create_mdk_for_account(member_one.pubkey)
+            .unwrap();
+        let member_two_mdk = whitenoise
+            .create_mdk_for_account(member_two.pubkey)
+            .unwrap();
+        let admin_leaf_index = admin_mdk.own_leaf_index(&group_id).unwrap();
+        let member_one_leaf_index = member_one_mdk.own_leaf_index(&group_id).unwrap();
+        let member_two_leaf_index = member_two_mdk.own_leaf_index(&group_id).unwrap();
+
+        let admin_token = make_token_tag(30);
+        let admin_request = build_token_request_rumor(
+            admin_account.pubkey,
+            Timestamp::now(),
+            vec![admin_token.clone()],
+        )
+        .unwrap();
+        let admin_event = admin_mdk
+            .create_message(&group_id, admin_request, None)
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&member_one_session, &member_one, admin_event.clone())
+            .await
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&member_two_session, &member_two, admin_event)
+            .await
+            .unwrap();
+
+        let member_one_token = make_token_tag(31);
+        let member_one_request = build_token_request_rumor(
+            member_one.pubkey,
+            Timestamp::now(),
+            vec![member_one_token.clone()],
+        )
+        .unwrap();
+        let member_one_event = member_one_mdk
+            .create_message(&group_id, member_one_request, None)
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, member_one_event.clone())
+            .await
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&member_two_session, &member_two, member_one_event)
+            .await
+            .unwrap();
+
+        let member_two_token = make_token_tag(32);
+        let member_two_request = build_token_request_rumor(
+            member_two.pubkey,
+            Timestamp::now(),
+            vec![member_two_token.clone()],
+        )
+        .unwrap();
+        let member_two_event = member_two_mdk
+            .create_message(&group_id, member_two_request, None)
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&admin_session, &admin_account, member_two_event.clone())
+            .await
+            .unwrap();
+        whitenoise
+            .handle_mls_message(&member_one_session, &member_one, member_two_event)
+            .await
+            .unwrap();
+
+        assert_cached_peer_tokens(
+            &admin_session,
+            &group_id,
+            &[
+                (&member_one, member_one_leaf_index, &member_one_token),
+                (&member_two, member_two_leaf_index, &member_two_token),
+            ],
+        )
+        .await;
+        assert_cached_peer_tokens(
+            &member_one_session,
+            &group_id,
+            &[
+                (&admin_account, admin_leaf_index, &admin_token),
+                (&member_two, member_two_leaf_index, &member_two_token),
+            ],
+        )
+        .await;
+        assert_cached_peer_tokens(
+            &member_two_session,
+            &group_id,
+            &[
+                (&admin_account, admin_leaf_index, &admin_token),
+                (&member_one, member_one_leaf_index, &member_one_token),
+            ],
+        )
+        .await;
+
+        admin_session.cancel();
+        member_one_session.cancel();
+        member_two_session.cancel();
     }
 
     #[tokio::test]

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -788,6 +788,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
 
         let update_result = whitenoise
@@ -854,6 +855,7 @@ mod tests {
             admins: Some(vec![new_admin_pubkey]),
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
         whitenoise
             .require_session(&creator_account.pubkey)
@@ -904,6 +906,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
         let update_result = whitenoise
             .require_session(&creator_account.pubkey)
@@ -1690,6 +1693,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
 
         let update_result = whitenoise
@@ -1854,6 +1858,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
 
         whitenoise
@@ -2197,6 +2202,7 @@ mod tests {
             admins: None,
             relays: Some(unreachable_urls),
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
         whitenoise
             .require_session(&creator.pubkey)
@@ -2329,6 +2335,7 @@ mod tests {
             admins: None,
             relays: None,
             nostr_group_id: None,
+            disappearing_message_secs: None,
         };
         let result = whitenoise
             .require_session(&creator.pubkey)

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1686,6 +1686,7 @@ pub mod test_utils {
             Some([2u8; 12]), // 12-byte nonce
             vec![RelayUrl::parse("ws://localhost:8080/").unwrap()],
             admins,
+            None,
         )
     }
 
@@ -4058,6 +4059,23 @@ mod tests {
                 .await
                 .unwrap();
 
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                let plane_count = whitenoise
+                    .shared
+                    .relay_control
+                    .group_plane_account_group_count(&creator_account.pubkey)
+                    .await;
+                if plane_count == 1 {
+                    break;
+                }
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "Timed out waiting for initial group-plane refresh"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+
             // Tear down subscriptions to simulate the welcome-processing
             // cascade failure (group exists in MDK but not in group plane)
             let session = whitenoise
@@ -4084,6 +4102,16 @@ mod tests {
                 )
                 .await
                 .unwrap();
+
+            assert_eq!(
+                whitenoise
+                    .shared
+                    .relay_control
+                    .group_plane_account_group_count(&creator_account.pubkey)
+                    .await,
+                0,
+                "test setup should leave MDK with one group and the group plane empty"
+            );
 
             let is_operational = whitenoise
                 .is_account_subscriptions_operational(&creator_account)

--- a/src/whitenoise/push_notifications.rs
+++ b/src/whitenoise/push_notifications.rs
@@ -122,7 +122,35 @@ pub struct GroupPushToken {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GroupPushDebugInfo {
     pub total_token_count: usize,
+    pub active_token_count: usize,
+    pub stale_token_count: usize,
+    pub missing_relay_hint_count: usize,
     pub last_token_list_updated_at: Option<DateTime<Utc>>,
+    pub local_registration: LocalPushRegistrationDebugInfo,
+    pub tokens: Vec<GroupPushTokenDebugEntry>,
+}
+
+/// Redacted local registration status for group push-token debugging.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LocalPushRegistrationDebugInfo {
+    pub registered: bool,
+    pub shareable: bool,
+    pub notifications_enabled: bool,
+    pub local_leaf_index: Option<u32>,
+    pub local_token_cached: bool,
+}
+
+/// Redacted cached group-token status for one MLS leaf.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GroupPushTokenDebugEntry {
+    pub member_pubkey: PublicKey,
+    pub leaf_index: u32,
+    pub server_pubkey: PublicKey,
+    pub has_relay_hint: bool,
+    pub active_leaf: bool,
+    pub member_matches_active_leaf: bool,
+    pub is_local_member: bool,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl fmt::Debug for PushRegistration {
@@ -159,7 +187,6 @@ impl fmt::Debug for GroupPushToken {
 /// Maximum number of concurrently-active delayed MIP-05 token-list response tasks.
 /// Tasks that cannot acquire a permit are dropped; the requester can retry via a
 /// subsequent token request event.
-#[cfg(test)]
 pub(crate) const MAX_CONCURRENT_TOKEN_RESPONSE_TASKS: usize = 10;
 
 const PUSH_GROUP_MESSAGE_KINDS: [u16; 3] = [
@@ -1557,11 +1584,38 @@ mod tests {
             .unwrap();
 
         assert_eq!(debug_info.total_token_count, 2);
+        assert_eq!(debug_info.active_token_count, 0);
+        assert_eq!(debug_info.stale_token_count, 2);
+        assert_eq!(debug_info.missing_relay_hint_count, 0);
         assert_eq!(
             debug_info.last_token_list_updated_at,
             [first_token.updated_at, second_token.updated_at]
                 .into_iter()
                 .max()
+        );
+        assert_eq!(
+            debug_info.local_registration,
+            LocalPushRegistrationDebugInfo {
+                registered: false,
+                shareable: false,
+                notifications_enabled: true,
+                local_leaf_index: None,
+                local_token_cached: false,
+            }
+        );
+        assert_eq!(debug_info.tokens.len(), 2);
+        assert!(debug_info.tokens.iter().all(|token| !token.active_leaf));
+        assert!(
+            debug_info
+                .tokens
+                .iter()
+                .all(|token| !token.member_matches_active_leaf)
+        );
+
+        let serialized = serde_json::to_string(&debug_info).unwrap();
+        assert!(
+            !serialized.contains("ciphertext-one") && !serialized.contains("ciphertext-two"),
+            "debug info must stay redacted when serialized"
         );
     }
 

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -107,6 +107,8 @@ pub struct AccountSession {
     activation_lock: Mutex<()>,
     /// In-memory coordination for delayed MIP-05 token-list responses.
     pub(crate) pending_push_token_responses: Arc<DashMap<(GroupId, EventId), ()>>,
+    /// Bounds concurrently-active delayed MIP-05 token-list response tasks.
+    token_response_semaphore: Arc<Semaphore>,
 }
 
 impl AccountSession {
@@ -152,6 +154,9 @@ impl AccountSession {
             inbox: RwLock::new(None),
             activation_lock: Mutex::new(()),
             pending_push_token_responses: Arc::new(DashMap::new()),
+            token_response_semaphore: Arc::new(Semaphore::new(
+                crate::whitenoise::push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,
+            )),
         })
     }
 
@@ -290,7 +295,28 @@ impl AccountSession {
         use crate::whitenoise::push_notifications::respond_to_token_request_with;
 
         let key = (group_id.clone(), request_event_id);
-        self.pending_push_token_responses.insert(key, ());
+        if self
+            .pending_push_token_responses
+            .insert(key.clone(), ())
+            .is_some()
+        {
+            return;
+        }
+
+        let permit = match self.token_response_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                tracing::warn!(
+                    target: "whitenoise::push_notifications",
+                    account = %self.account_pubkey.to_hex(),
+                    group_id = %hex::encode(group_id.as_slice()),
+                    request_event_id = %request_event_id.to_hex(),
+                    "Dropping MIP-05 token-list response task: concurrency limit reached"
+                );
+                self.pending_push_token_responses.remove(&key);
+                return;
+            }
+        };
 
         let mdk = Arc::clone(&self.mdk);
         let account_db = Arc::clone(&self.account_db);
@@ -305,6 +331,7 @@ impl AccountSession {
                 _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
                 _ = cancel_rx.changed() => {
                     pending.remove(&(group_id, request_event_id));
+                    drop(permit);
                     return;
                 }
             }
@@ -333,6 +360,8 @@ impl AccountSession {
                     "Failed to send delayed MIP-05 token-list response"
                 );
             }
+
+            drop(permit);
         });
     }
 
@@ -756,11 +785,13 @@ pub(crate) mod test_helpers {
 mod tests {
     use std::sync::Arc;
 
-    use nostr_sdk::Keys;
+    use mdk_core::prelude::GroupId;
+    use nostr_sdk::{EventId, Keys};
 
     use super::AccountManager;
     use super::test_helpers::test_session;
     use crate::whitenoise::accounts::DiscoveredRelayLists;
+    use crate::whitenoise::push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS;
 
     fn test_pubkey() -> nostr_sdk::PublicKey {
         Keys::generate().public_key()
@@ -927,6 +958,52 @@ mod tests {
         session.cancel();
         rx.changed().await.expect("channel not dropped");
         assert!(*rx.borrow(), "should be cancelled after cancel()");
+    }
+
+    #[tokio::test]
+    async fn schedule_pending_token_response_dedupes_duplicate_request() {
+        let pk = test_pubkey();
+        let session = test_session(pk).await;
+        let group_id = GroupId::from_slice(&[3; 32]);
+        let request_event_id = EventId::all_zeros();
+
+        session.schedule_pending_token_response(group_id.clone(), request_event_id);
+        session.schedule_pending_token_response(group_id.clone(), request_event_id);
+
+        assert_eq!(
+            session.pending_push_token_responses.len(),
+            1,
+            "duplicate token response keys should share one pending response"
+        );
+        assert!(
+            session
+                .pending_push_token_responses
+                .contains_key(&(group_id, request_event_id))
+        );
+
+        session.cancel();
+    }
+
+    #[tokio::test]
+    async fn schedule_pending_token_response_drops_when_concurrency_is_exhausted() {
+        let pk = test_pubkey();
+        let session = test_session(pk).await;
+        let group_id = GroupId::from_slice(&[4; 32]);
+        let request_event_id = EventId::all_zeros();
+        let _permit = session
+            .token_response_semaphore
+            .clone()
+            .try_acquire_many_owned(MAX_CONCURRENT_TOKEN_RESPONSE_TASKS as u32)
+            .expect("all permits should be initially available");
+
+        session.schedule_pending_token_response(group_id.clone(), request_event_id);
+
+        assert!(
+            !session
+                .pending_push_token_responses
+                .contains_key(&(group_id, request_event_id)),
+            "saturated scheduler should drop the response key so requesters can retry"
+        );
     }
 
     #[tokio::test]

--- a/src/whitenoise/session/push.rs
+++ b/src/whitenoise/session/push.rs
@@ -19,9 +19,9 @@ use crate::perf_instrument;
 use crate::whitenoise::accounts_groups::AccountGroup;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::push_notifications::{
-    PushPlatform, PushRegistration, TOKEN_REQUEST_COOLDOWN, TokenRateKind,
-    is_push_group_message_kind, publish_push_group_message_with, respond_to_token_request_with,
-    validate_raw_token,
+    GroupPushDebugInfo, GroupPushTokenDebugEntry, LocalPushRegistrationDebugInfo, PushPlatform,
+    PushRegistration, TOKEN_REQUEST_COOLDOWN, TokenRateKind, is_push_group_message_kind,
+    publish_push_group_message_with, respond_to_token_request_with, validate_raw_token,
 };
 
 /// Maximum number of groups to publish push token events to concurrently.
@@ -131,21 +131,72 @@ impl<'a> PushOps<'a> {
 
     /// Returns a non-sensitive summary of cached push-token state for a group.
     #[perf_instrument("push_notifications")]
-    pub async fn get_group_debug_info(
-        &self,
-        group_id: &GroupId,
-    ) -> Result<crate::whitenoise::push_notifications::GroupPushDebugInfo> {
+    pub async fn get_group_debug_info(&self, group_id: &GroupId) -> Result<GroupPushDebugInfo> {
         let cached_tokens = self
             .session
             .repos
             .group_push_tokens
             .find_by_group(group_id)
             .await?;
+        let active_leaf_map = self
+            .session
+            .mdk
+            .group_leaf_map(group_id)
+            .unwrap_or_default();
+        let local_leaf_index = self.session.mdk.own_leaf_index(group_id).ok();
+        let notifications_enabled = self.session.repos.settings.notifications_enabled().await?;
+        let registration = self.registration().await?;
+        let shareable = registration
+            .as_ref()
+            .map(PushRegistration::token_tag)
+            .transpose()?
+            .flatten()
+            .is_some();
+        let local_token_cached = local_leaf_index.is_some_and(|leaf_index| {
+            cached_tokens.iter().any(|token| {
+                token.leaf_index == leaf_index && token.member_pubkey == self.session.account_pubkey
+            })
+        });
         let last_token_list_updated_at = cached_tokens.iter().map(|token| token.updated_at).max();
 
-        Ok(crate::whitenoise::push_notifications::GroupPushDebugInfo {
+        let tokens: Vec<GroupPushTokenDebugEntry> = cached_tokens
+            .iter()
+            .map(|token| {
+                let active_member_pubkey = active_leaf_map.get(&token.leaf_index);
+                GroupPushTokenDebugEntry {
+                    member_pubkey: token.member_pubkey,
+                    leaf_index: token.leaf_index,
+                    server_pubkey: token.server_pubkey,
+                    has_relay_hint: token.relay_hint.is_some(),
+                    active_leaf: active_member_pubkey.is_some(),
+                    member_matches_active_leaf: active_member_pubkey
+                        .is_some_and(|pubkey| pubkey == &token.member_pubkey),
+                    is_local_member: token.member_pubkey == self.session.account_pubkey,
+                    updated_at: token.updated_at,
+                }
+            })
+            .collect();
+        let active_token_count = tokens
+            .iter()
+            .filter(|token| token.active_leaf && token.member_matches_active_leaf)
+            .count();
+        let stale_token_count = tokens.len() - active_token_count;
+        let missing_relay_hint_count = tokens.iter().filter(|token| !token.has_relay_hint).count();
+
+        Ok(GroupPushDebugInfo {
             total_token_count: cached_tokens.len(),
+            active_token_count,
+            stale_token_count,
+            missing_relay_hint_count,
             last_token_list_updated_at,
+            local_registration: LocalPushRegistrationDebugInfo {
+                registered: registration.is_some(),
+                shareable,
+                notifications_enabled,
+                local_leaf_index,
+                local_token_cached,
+            },
+            tokens,
         })
     }
 
@@ -173,6 +224,15 @@ impl<'a> PushOps<'a> {
                     )
                 })?;
 
+                let request_event_id = message.event.id;
+                self.merge_token_request(
+                    &message.mls_group_id,
+                    message.event.pubkey,
+                    leaf_index,
+                    request,
+                )
+                .await?;
+
                 if !self.check_token_request_rate(
                     &message.mls_group_id,
                     leaf_index,
@@ -187,15 +247,7 @@ impl<'a> PushOps<'a> {
                     return Ok(true);
                 }
 
-                self.merge_token_request(
-                    &message.mls_group_id,
-                    message.event.pubkey,
-                    leaf_index,
-                    request,
-                )
-                .await?;
-
-                if let Some(request_event_id) = message.event.id {
+                if let Some(request_event_id) = request_event_id {
                     self.session.schedule_pending_token_response(
                         message.mls_group_id.clone(),
                         request_event_id,


### PR DESCRIPTION
## Summary
- update MDK dependencies to latest master commit `28ee7badf24195343f452246ce5f4dad4a99ddf2`
- cache incoming MIP-05 token requests before applying response cooldown so rapid re-gossip refreshes peer tokens
- restore delayed token-list response dedupe and concurrency limiting at the account-session level
- expand redacted group push debug info and add token-gossip regression coverage
- adapt group metadata call sites to MDK `disappearing_message_secs` API addition

## Validation
- `cargo test --features cli test_handle_mls_message_updates_token_request_cache_inside_response_cooldown -- --nocapture`
- `cargo test --features cli test_handle_mls_message_gossips_token_requests_to_all_other_participants -- --nocapture`
- `cargo test --features cli schedule_pending_token_response_ -- --nocapture`
- `cargo test --features cli test_get_group_push_debug_info_returns_count_and_latest_update_time -- --nocapture`
- `cargo test --features cli test_publish_notification_requests_after_delivery_publishes_expected_446_tokens -- --nocapture`
- `cargo test --features cli test_publish_notification_batches_best_effort_publishes_multiple_1059_events_for_large_batch -- --nocapture`
- `cargo test --features cli test_is_account_operational_detects_group_count_mismatch -- --nocapture`
- `just fmt`
- `just precommit-quick`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer push-notification debug output with per-member token entries, counts, relay-hint info, redacted values, and timestamps
  * Per-session concurrency limits for token-response tasks with duplicate-request deduplication

* **Improvements**
  * More robust token-response scheduling, rate-limit handling, and gossip/token-cache behavior

* **Tests**
  * New and expanded tests for scheduling, semaphore saturation, push-debug contents/serialization, and gossip token flows

* **Chores**
  * Workspace dependency update and added RustSec advisory ignore in audit/configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/828)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->