### PR TITLE
Perf/whitenoise init

### DIFF
--- a/dev/toxiproxy.json
+++ b/dev/toxiproxy.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "nostr-rs-slow",
+    "listen": "0.0.0.0:18080",
+    "upstream": "nostr-rs-relay:8080",
+    "enabled": true
+  },
+  {
+    "name": "strfry-slow",
+    "listen": "0.0.0.0:17777",
+    "upstream": "strfry-nostr-relay:7777",
+    "enabled": true
+  }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,26 @@ services:
       setup:
         condition: service_completed_successfully
 
+  # Network-latency simulator used by the WAN-latency benchmark recipe.
+  # Profile-gated so `just docker-up` / `docker-down` ignore it; only the
+  # `benchmark-startup-wan` recipe enables it via `--profile latency`.
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.12.0
+    profiles: ["latency"]
+    ports:
+      - "127.0.0.1:8474:8474" # control API
+      - "127.0.0.1:18080:18080" # → nostr-rs-relay
+      - "127.0.0.1:17777:17777" # → strfry-nostr-relay
+    volumes:
+      - ./dev/toxiproxy.json:/etc/toxiproxy/proxies.json:ro
+    command: ["-host=0.0.0.0", "-config=/etc/toxiproxy/proxies.json"]
+    restart: unless-stopped
+    depends_on:
+      nostr-rs-relay:
+        condition: service_started
+      strfry-nostr-relay:
+        condition: service_started
+
   transponder:
     image: whitenoise-rs-transponder:latest
     build:
@@ -74,7 +94,14 @@ services:
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=16m
     healthcheck:
-      test: ["CMD", "/usr/local/bin/transponder", "healthcheck", "--url", "http://127.0.0.1:8080/health"]
+      test:
+        [
+          "CMD",
+          "/usr/local/bin/transponder",
+          "healthcheck",
+          "--url",
+          "http://127.0.0.1:8080/health",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/justfile
+++ b/justfile
@@ -89,47 +89,25 @@ int-test-flamegraph:
     CARGO_PROFILE_RELEASE_STRIP=false \
     cargo flamegraph --release --bin integration_test --features integration-tests --deterministic -- --data-dir ./dev/data/integration_test/ --logs-dir ./dev/data/integration_test/
 
-# Run performance benchmarks (not included in CI)
+# Run performance benchmarks (not included in CI).
+# Passing latency_ms>0 routes the bench through toxiproxy with that latency
+# applied per direction (validated by experiments/04-toxiproxy-validation).
 # Usage:
-#   just benchmark                      # Run all benchmarks
-#   just benchmark messaging-performance  # Run specific benchmark
-benchmark scenario="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    rm -rf ./dev/data/benchmark_test/
-    if [ -z "{{scenario}}" ]; then
-        echo "Running all benchmarks..."
-        RUST_LOG=warn,benchmark_test=info,whitenoise=info \
-        cargo run --bin benchmark_test --features benchmark-tests --release -- \
-        --data-dir ./dev/data/benchmark_test/ --logs-dir ./dev/data/benchmark_test/
-    else
-        echo "Running benchmark: {{scenario}}"
-        RUST_LOG=warn,benchmark_test=info,whitenoise=info \
-        cargo run --bin benchmark_test --features benchmark-tests --release -- \
-        --data-dir ./dev/data/benchmark_test/ --logs-dir ./dev/data/benchmark_test/ \
-        "{{scenario}}"
-    fi
-    rm -rf ./dev/data/benchmark_test/
+#   just benchmark                                 # all scenarios, fast localhost
+#   just benchmark messaging-performance           # specific scenario, fast localhost
+#   just benchmark messaging-performance 100       # specific scenario, 100ms WAN latency
+benchmark scenario="" latency_ms="0":
+    @bash scripts/benchmark.sh "{{scenario}}" "{{latency_ms}}"
 
-# Run benchmarks and emit JSON output
+# Run benchmarks and emit JSON output.
+# Passing latency_ms>0 routes the bench through toxiproxy; the latency value
+# is suffixed onto the output filename so WAN runs don't overwrite localhost runs.
 # Usage:
-#   just benchmark-json                      # All scenarios
-#   just benchmark-json messaging-performance  # Specific scenario
-benchmark-json scenario="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    mkdir -p ./benchmark_results
-    rm -rf ./dev/data/benchmark_test/ && mkdir -p ./dev/data/benchmark_test
-    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    SUFFIX=""
-    [ -n "{{scenario}}" ] && SUFFIX="_{{scenario}}"
-    RUST_LOG=warn,benchmark_test=info,whitenoise=info \
-        cargo run --release --features benchmark-tests --bin benchmark_test -- \
-        --data-dir ./dev/data/benchmark_test \
-        --logs-dir ./dev/data/benchmark_test/logs \
-        --output-json "./benchmark_results/result_${TIMESTAMP}${SUFFIX}.json" \
-        {{scenario}}
-    rm -rf ./dev/data/benchmark_test
+#   just benchmark-json                                 # all scenarios, fast localhost
+#   just benchmark-json messaging-performance           # specific scenario, fast localhost
+#   just benchmark-json messaging-performance 100       # specific scenario, 100ms WAN latency
+benchmark-json scenario="" latency_ms="0":
+    @bash scripts/benchmark-json.sh "{{scenario}}" "{{latency_ms}}"
 
 # Run only stable-tier benchmark scenarios and merge results into a single JSON.
 # Used by the merge-gating CI job so relay-tier failures cannot block a merge.
@@ -255,6 +233,17 @@ benchmark-startup iterations="1":
 #   just benchmark-startup-seeded 5 ./test_fixtures/nostr/other.json      # custom fixture
 benchmark-startup-seeded iterations="5" fixture="./test_fixtures/nostr/jeff_contacts.json":
     @bash scripts/benchmark-startup-seeded.sh {{iterations}} {{fixture}}
+
+# Measure initialization timing under a simulated WAN latency (toxiproxy).
+# Brings up the docker-compose `latency` profile, applies a one-way latency
+# toxic to both relay proxies, runs the seeded bench against the proxy ports,
+# and tears down on exit. Validated by experiments/04-toxiproxy-validation.
+# Usage:
+#   just benchmark-startup-wan                                              # 100ms, 5 warm runs
+#   just benchmark-startup-wan 200                                          # 200ms, 5 warm runs
+#   just benchmark-startup-wan 50 10                                        # 50ms, 10 warm runs
+benchmark-startup-wan latency_ms="100" iterations="5" fixture="./test_fixtures/nostr/jeff_contacts.json":
+    @bash scripts/benchmark-startup-wan.sh {{latency_ms}} {{iterations}} {{fixture}}
 
 # Run benchmarks and save results with timestamp
 # Usage:

--- a/scripts/benchmark-json.sh
+++ b/scripts/benchmark-json.sh
@@ -26,6 +26,11 @@ LATENCY_MS="${2:-0}"
 DATA_DIR="./dev/data/benchmark_test"
 RESULTS_DIR="./benchmark_results"
 
+if ! [[ "$LATENCY_MS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: latency_ms must be a non-negative integer (got: '$LATENCY_MS')" >&2
+    exit 1
+fi
+
 mkdir -p "$RESULTS_DIR"
 rm -rf "$DATA_DIR" && mkdir -p "$DATA_DIR"
 

--- a/scripts/benchmark-json.sh
+++ b/scripts/benchmark-json.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# benchmark-json.sh — Run a benchmark scenario through `benchmark_test` with
+# JSON output, optionally routed through toxiproxy with simulated WAN latency.
+#
+# Usage:
+#   ./scripts/benchmark-json.sh [scenario] [latency_ms]
+#     scenario     — empty means run all registered scenarios
+#     latency_ms   — 0 (default) means no toxiproxy; >0 brings up the latency
+#                    profile and applies that latency per direction on both
+#                    relay proxies before running the scenario.
+#
+# Output: ./benchmark_results/result_<timestamp>[_scenario][_wanNms].json
+#
+# Examples:
+#   ./scripts/benchmark-json.sh                            # all scenarios, fast localhost
+#   ./scripts/benchmark-json.sh message-aggregation       # one scenario, fast localhost
+#   ./scripts/benchmark-json.sh message-aggregation 100   # one scenario, 100 ms WAN
+
+set -euo pipefail
+
+source "$(dirname "$0")/toxiproxy-helpers.sh"
+
+SCENARIO="${1:-}"
+LATENCY_MS="${2:-0}"
+DATA_DIR="./dev/data/benchmark_test"
+RESULTS_DIR="./benchmark_results"
+
+mkdir -p "$RESULTS_DIR"
+rm -rf "$DATA_DIR" && mkdir -p "$DATA_DIR"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+SUFFIX=""
+[ -n "$SCENARIO" ] && SUFFIX="_${SCENARIO}"
+[ "$LATENCY_MS" -gt 0 ] && SUFFIX="${SUFFIX}_wan${LATENCY_MS}ms"
+OUTPUT="${RESULTS_DIR}/result_${TIMESTAMP}${SUFFIX}.json"
+
+CARGO_BIN=(cargo run --release --features benchmark-tests --bin benchmark_test --)
+RELAY_ARGS=()
+
+if [ "$LATENCY_MS" -gt 0 ]; then
+    trap toxiproxy_down EXIT
+    echo "=== Bringing up toxiproxy at ${LATENCY_MS}ms latency ==="
+    toxiproxy_up
+    toxiproxy_apply_latency "$LATENCY_MS"
+    RELAY_ARGS=(--relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}")
+fi
+
+ARGS=(
+    --data-dir "$DATA_DIR"
+    --logs-dir "${DATA_DIR}/logs"
+    --output-json "$OUTPUT"
+)
+[ ${#RELAY_ARGS[@]} -gt 0 ] && ARGS+=("${RELAY_ARGS[@]}")
+[ -n "$SCENARIO" ] && ARGS+=("$SCENARIO")
+
+RUST_LOG=warn,benchmark_test=info,whitenoise=info \
+    "${CARGO_BIN[@]}" "${ARGS[@]}"
+
+rm -rf "$DATA_DIR"
+echo "Wrote: $OUTPUT"

--- a/scripts/benchmark-startup-seeded.sh
+++ b/scripts/benchmark-startup-seeded.sh
@@ -22,7 +22,12 @@ set -euo pipefail
 ITERATIONS="${1:-5}"
 FIXTURE="${2:-./test_fixtures/nostr/jeff_contacts.json}"
 DATA_DIR="./dev/data/startup_bench"
-RELAYS="wss://nos.lol wss://relay.primal.net wss://relay.damus.io"
+# Publish to the local nostr-rs-relay (port 8080) only — strfry on port 7777
+# defaults to maxEventSize = 65 536 bytes and rejects contact lists larger
+# than ~64 KB. The benchmark binary hard-codes both local relays as discovery
+# relays, so an event landing on either one is enough for the warm-init runs
+# to sync follows.
+RELAYS="ws://localhost:8080"
 RUST_LOG_TIMING="warn,whitenoise::init_timing=info"
 RUST_LOG_LOGIN="warn,whitenoise=info"
 
@@ -43,16 +48,23 @@ echo ""
 
 # ---------------------------------------------------------------------------
 # Benchmark phases
+#
+# Every phase that opens an encrypted database wipes "$DATA_DIR" first.
+# The benchmark binary uses an in-memory mock keyring, so the random DB
+# encryption key generated in one process dies with it — reusing the same
+# data dir across processes opens encrypted SQLite files with an empty
+# keyring and fails. Each phase therefore starts from a clean slate it
+# owns the keys for.
 # ---------------------------------------------------------------------------
 
-rm -rf "$DATA_DIR"
-
 echo "=== Cold Init (empty database) ==="
+rm -rf "$DATA_DIR"
 RUST_LOG="$RUST_LOG_TIMING" \
 "${CARGO_BIN[@]}" --data-dir "$DATA_DIR" --logs-dir "$DATA_DIR" --init-only
 
 echo ""
 echo "=== Login (syncing contacts from relays) ==="
+rm -rf "$DATA_DIR"
 RUST_LOG="$RUST_LOG_LOGIN" \
 "${CARGO_BIN[@]}" --data-dir "$DATA_DIR" --logs-dir "$DATA_DIR" --login "$SEC"
 

--- a/scripts/benchmark-startup-wan.sh
+++ b/scripts/benchmark-startup-wan.sh
@@ -36,6 +36,15 @@ CONTACT_LIST_RELAY="ws://localhost:8080"
 RUST_LOG_TIMING="warn,whitenoise::init_timing=info"
 RUST_LOG_LOGIN="warn,whitenoise=info"
 
+if ! [[ "$LATENCY_MS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: latency_ms must be a non-negative integer (got: '$LATENCY_MS')" >&2
+    exit 1
+fi
+if ! [[ "$ITERATIONS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: iterations must be a positive integer (got: '$ITERATIONS')" >&2
+    exit 1
+fi
+
 CARGO_BIN=(cargo run --bin benchmark_test --features benchmark-tests --release --)
 
 trap toxiproxy_down EXIT

--- a/scripts/benchmark-startup-wan.sh
+++ b/scripts/benchmark-startup-wan.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# benchmark-startup-wan.sh — Measure Whitenoise::new() warm-init under a
+# simulated WAN latency.
+#
+# Mirrors `benchmark-startup-seeded.sh` but routes the benchmark binary's
+# relay traffic through toxiproxy (docker-compose `latency` profile), with a
+# configurable per-direction latency toxic on both proxies. Lets you measure
+# `setup_all_subscriptions` at realistic mobile-network RTTs without depending
+# on flaky public relays.
+#
+# Requirements:
+#   - nak (https://github.com/fiatjaf/nak)
+#   - Docker Compose with the project's stack already running (`just docker-up`)
+#   - `python3` (for JSON pretty-printing of error responses)
+#
+# Usage:
+#   ./scripts/benchmark-startup-wan.sh                                                # 100 ms, 5 iters
+#   ./scripts/benchmark-startup-wan.sh 200                                            # 200 ms, 5 iters
+#   ./scripts/benchmark-startup-wan.sh 50 10                                          # 50 ms, 10 iters
+#   ./scripts/benchmark-startup-wan.sh 100 5 ./test_fixtures/nostr/other.json         # custom fixture
+#
+# Validated by experiments/04-toxiproxy-validation. The first iteration may be
+# an outlier under high latency (TCP retry interaction); the default N=5 is
+# chosen to median past it.
+
+set -euo pipefail
+
+source "$(dirname "$0")/toxiproxy-helpers.sh"
+
+LATENCY_MS="${1:-100}"
+ITERATIONS="${2:-5}"
+FIXTURE="${3:-./test_fixtures/nostr/jeff_contacts.json}"
+DATA_DIR="./dev/data/startup_bench_wan"
+CONTACT_LIST_RELAY="ws://localhost:8080"
+RUST_LOG_TIMING="warn,whitenoise::init_timing=info"
+RUST_LOG_LOGIN="warn,whitenoise=info"
+
+CARGO_BIN=(cargo run --bin benchmark_test --features benchmark-tests --release --)
+
+trap toxiproxy_down EXIT
+
+echo "=== Bringing up toxiproxy (latency profile) ==="
+toxiproxy_up
+toxiproxy_apply_latency "$LATENCY_MS"
+echo "Latency toxic applied: ${LATENCY_MS}ms per direction (both proxies)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Seed + measure (mirrors benchmark-startup-seeded.sh)
+# ---------------------------------------------------------------------------
+
+SEC=$(nak key generate)
+PUB=$(echo "$SEC" | nak key public)
+echo "Generated keypair: $PUB"
+echo ""
+
+echo "=== Publishing contact list to ${CONTACT_LIST_RELAY} (direct, not proxied) ==="
+cat "$FIXTURE" | nak event --sec "$SEC" "$CONTACT_LIST_RELAY" 2>&1
+echo ""
+
+# Each phase that opens an encrypted database wipes "$DATA_DIR" first; the
+# benchmark binary's in-memory mock keyring dies with the process, so reusing
+# the directory across phases would fail to open the encrypted SQLite files.
+
+echo "=== Cold Init (empty database) ==="
+rm -rf "$DATA_DIR"
+RUST_LOG="$RUST_LOG_TIMING" \
+"${CARGO_BIN[@]}" --data-dir "$DATA_DIR" --logs-dir "$DATA_DIR" --init-only \
+    --relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}"
+
+echo ""
+echo "=== Login (syncing contacts from relays) ==="
+rm -rf "$DATA_DIR"
+RUST_LOG="$RUST_LOG_LOGIN" \
+"${CARGO_BIN[@]}" --data-dir "$DATA_DIR" --logs-dir "$DATA_DIR" --login "$SEC" \
+    --relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}"
+
+echo ""
+echo "=== Warm Init (account + $ITERATIONS runs @ ${LATENCY_MS}ms latency) ==="
+for i in $(seq 1 "$ITERATIONS"); do
+    [ "$ITERATIONS" -gt 1 ] && echo "--- Run $i/$ITERATIONS ---"
+    RUST_LOG="$RUST_LOG_TIMING" \
+    "${CARGO_BIN[@]}" --data-dir "$DATA_DIR" --logs-dir "$DATA_DIR" --seed-nsec "$SEC" --init-only \
+        --relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}"
+done
+
+rm -rf "$DATA_DIR"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# benchmark.sh — Run a benchmark scenario through `benchmark_test`, optionally
+# routed through toxiproxy with simulated WAN latency.
+#
+# Usage:
+#   ./scripts/benchmark.sh [scenario] [latency_ms]
+#     scenario     — empty means run all registered scenarios
+#     latency_ms   — 0 (default) means no toxiproxy; >0 brings up the latency
+#                    profile and applies that latency per direction on both
+#                    relay proxies before running the scenario.
+#
+# Examples:
+#   ./scripts/benchmark.sh                            # all scenarios, fast localhost
+#   ./scripts/benchmark.sh message-aggregation       # one scenario, fast localhost
+#   ./scripts/benchmark.sh message-aggregation 100   # one scenario, 100 ms WAN
+
+set -euo pipefail
+
+source "$(dirname "$0")/toxiproxy-helpers.sh"
+
+SCENARIO="${1:-}"
+LATENCY_MS="${2:-0}"
+DATA_DIR="./dev/data/benchmark_test"
+
+CARGO_BIN=(cargo run --bin benchmark_test --features benchmark-tests --release --)
+RELAY_ARGS=()
+
+if [ "$LATENCY_MS" -gt 0 ]; then
+    trap toxiproxy_down EXIT
+    echo "=== Bringing up toxiproxy at ${LATENCY_MS}ms latency ==="
+    toxiproxy_up
+    toxiproxy_apply_latency "$LATENCY_MS"
+    RELAY_ARGS=(--relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}")
+fi
+
+rm -rf "$DATA_DIR"
+
+ARGS=(--data-dir "$DATA_DIR" --logs-dir "$DATA_DIR")
+[ ${#RELAY_ARGS[@]} -gt 0 ] && ARGS+=("${RELAY_ARGS[@]}")
+[ -n "$SCENARIO" ] && ARGS+=("$SCENARIO")
+
+if [ -z "$SCENARIO" ]; then
+    echo "Running all benchmarks..."
+else
+    echo "Running benchmark: $SCENARIO${LATENCY_MS:+ at ${LATENCY_MS}ms latency}"
+fi
+
+RUST_LOG=warn,benchmark_test=info,whitenoise=info \
+    "${CARGO_BIN[@]}" "${ARGS[@]}"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -23,8 +23,14 @@ SCENARIO="${1:-}"
 LATENCY_MS="${2:-0}"
 DATA_DIR="./dev/data/benchmark_test"
 
+if ! [[ "$LATENCY_MS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: latency_ms must be a non-negative integer (got: '$LATENCY_MS')" >&2
+    exit 1
+fi
+
 CARGO_BIN=(cargo run --bin benchmark_test --features benchmark-tests --release --)
 RELAY_ARGS=()
+LATENCY_LABEL=""
 
 if [ "$LATENCY_MS" -gt 0 ]; then
     trap toxiproxy_down EXIT
@@ -32,6 +38,7 @@ if [ "$LATENCY_MS" -gt 0 ]; then
     toxiproxy_up
     toxiproxy_apply_latency "$LATENCY_MS"
     RELAY_ARGS=(--relays "${TOXIPROXY_RELAYS[0]}" --relays "${TOXIPROXY_RELAYS[1]}")
+    LATENCY_LABEL=" at ${LATENCY_MS}ms latency"
 fi
 
 rm -rf "$DATA_DIR"
@@ -41,9 +48,9 @@ ARGS=(--data-dir "$DATA_DIR" --logs-dir "$DATA_DIR")
 [ -n "$SCENARIO" ] && ARGS+=("$SCENARIO")
 
 if [ -z "$SCENARIO" ]; then
-    echo "Running all benchmarks..."
+    echo "Running all benchmarks${LATENCY_LABEL}..."
 else
-    echo "Running benchmark: $SCENARIO${LATENCY_MS:+ at ${LATENCY_MS}ms latency}"
+    echo "Running benchmark: ${SCENARIO}${LATENCY_LABEL}"
 fi
 
 RUST_LOG=warn,benchmark_test=info,whitenoise=info \

--- a/scripts/toxiproxy-helpers.sh
+++ b/scripts/toxiproxy-helpers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# toxiproxy-helpers.sh — Reusable lifecycle for the docker-compose `latency`
+# profile, plus its HTTP control API.
+#
+# Source this from any benchmark script that wants to inject WAN latency
+# between the bench binary and the local relays. Validated by
+# experiments/04-toxiproxy-validation.
+#
+# Provides:
+#   toxiproxy_up                 — bring up the `latency` profile, wait for control API
+#   toxiproxy_apply_latency N    — add an N-ms latency toxic (both directions, both proxies)
+#   toxiproxy_clear              — remove any toxics added by toxiproxy_apply_latency
+#   toxiproxy_down               — clear toxics and stop the toxiproxy container
+#   toxiproxy_relay_args         — echo `--relays ws://... --relays ws://...` for the proxy ports
+
+TOXIPROXY_API="${TOXIPROXY_API:-http://localhost:8474}"
+TOXIPROXY_RELAYS=(ws://localhost:18080 ws://localhost:17777)
+
+toxiproxy_up() {
+    docker compose --profile latency up -d toxiproxy >/dev/null
+    for _ in $(seq 1 30); do
+        if curl -sf "${TOXIPROXY_API}/version" >/dev/null 2>&1; then return 0; fi
+        sleep 0.5
+    done
+    echo "toxiproxy did not come up within 15s" >&2
+    return 1
+}
+
+toxiproxy_clear() {
+    for proxy in nostr-rs-slow strfry-slow; do
+        for direction in upstream downstream; do
+            curl -s -X DELETE "${TOXIPROXY_API}/proxies/${proxy}/toxics/wan-${direction}" >/dev/null 2>&1 || true
+        done
+    done
+}
+
+toxiproxy_apply_latency() {
+    local latency_ms="$1"
+    toxiproxy_clear
+    for proxy in nostr-rs-slow strfry-slow; do
+        for direction in upstream downstream; do
+            curl -sf -X POST "${TOXIPROXY_API}/proxies/${proxy}/toxics" \
+                -H 'Content-Type: application/json' \
+                -d "{\"name\":\"wan-${direction}\",\"type\":\"latency\",\"stream\":\"${direction}\",\"attributes\":{\"latency\":${latency_ms}}}" >/dev/null
+        done
+    done
+}
+
+toxiproxy_down() {
+    toxiproxy_clear
+    docker compose --profile latency stop toxiproxy >/dev/null 2>&1 || true
+}
+
+toxiproxy_relay_args() {
+    printf -- '--relays %s --relays %s' "${TOXIPROXY_RELAYS[0]}" "${TOXIPROXY_RELAYS[1]}"
+}

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -93,10 +93,24 @@ struct Args {
     #[clap(long, value_name = "PATH")]
     chrome_trace: Option<PathBuf>,
 
+    /// Relay URLs used both as discovery relays and as the seed value for new
+    /// accounts' NIP-65/Inbox/KeyPackage lists. Repeat for multiple relays.
+    /// Defaults to the local Docker relays on ports 8080 and 7777; override
+    /// with toxiproxy listen ports for WAN-latency benchmarks.
+    #[clap(long, value_name = "URL")]
+    relays: Vec<RelayUrl>,
+
     /// Optional scenario name to run a specific benchmark.
     /// If not provided, runs all benchmarks.
     #[clap(value_name = "SCENARIO")]
     scenario: Option<String>,
+}
+
+fn default_local_relays() -> Vec<RelayUrl> {
+    vec![
+        RelayUrl::parse("ws://localhost:8080").unwrap(),
+        RelayUrl::parse("ws://localhost:7777").unwrap(),
+    ]
 }
 
 fn git_sha() -> String {
@@ -290,10 +304,11 @@ async fn main() -> Result<(), WhitenoiseError> {
         restore_keyring_sidecar(&args.data_dir, nsec)?;
     }
 
-    let local_relays = vec![
-        RelayUrl::parse("ws://localhost:8080").unwrap(),
-        RelayUrl::parse("ws://localhost:7777").unwrap(),
-    ];
+    let local_relays = if args.relays.is_empty() {
+        default_local_relays()
+    } else {
+        args.relays.clone()
+    };
     let config = WhitenoiseConfig::new(&args.data_dir, &args.logs_dir, KEYRING_SERVICE)
         .with_database_key_id(BENCHMARK_WHITENOISE_DB_KEY_ID)
         .with_discovery_relays(local_relays.clone())

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -290,12 +290,14 @@ async fn main() -> Result<(), WhitenoiseError> {
         restore_keyring_sidecar(&args.data_dir, nsec)?;
     }
 
+    let local_relays = vec![
+        RelayUrl::parse("ws://localhost:8080").unwrap(),
+        RelayUrl::parse("ws://localhost:7777").unwrap(),
+    ];
     let config = WhitenoiseConfig::new(&args.data_dir, &args.logs_dir, KEYRING_SERVICE)
         .with_database_key_id(BENCHMARK_WHITENOISE_DB_KEY_ID)
-        .with_discovery_relays(vec![
-            RelayUrl::parse("ws://localhost:8080").unwrap(),
-            RelayUrl::parse("ws://localhost:7777").unwrap(),
-        ]);
+        .with_discovery_relays(local_relays.clone())
+        .with_default_account_relays(local_relays);
     let whitenoise = Whitenoise::new(config).await.inspect_err(|err| {
         tracing::error!(target: "whitenoise::benchmark", "Failed to initialize Whitenoise: {}", err);
     })?;

--- a/src/bin/benchmark_test.rs
+++ b/src/bin/benchmark_test.rs
@@ -258,6 +258,15 @@ fn restore_keyring_sidecar(data_dir: &std::path::Path, nsec: &str) -> Result<(),
     Ok(())
 }
 
+/// Drains tracing-appender workers when `main` returns by any path.
+struct FlushTracingOnDrop;
+
+impl Drop for FlushTracingOnDrop {
+    fn drop(&mut self) {
+        ::whitenoise::shutdown_tracing();
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), WhitenoiseError> {
     let args = Args::parse();
@@ -266,6 +275,7 @@ async fn main() -> Result<(), WhitenoiseError> {
     // the layer is part of the subscriber stack from the very first span.
     let perf_layer = init_perf_layer();
     init_tracing_with_perf_layer(&args.logs_dir, perf_layer);
+    let _flush_tracing = FlushTracingOnDrop;
 
     if args.detailed {
         DETAILED_MODE.store(true, Ordering::Relaxed);
@@ -286,13 +296,9 @@ async fn main() -> Result<(), WhitenoiseError> {
             RelayUrl::parse("ws://localhost:8080").unwrap(),
             RelayUrl::parse("ws://localhost:7777").unwrap(),
         ]);
-    let whitenoise = match Whitenoise::new(config).await {
-        Ok(wn) => wn,
-        Err(err) => {
-            tracing::error!("Failed to initialize Whitenoise: {}", err);
-            std::process::exit(1);
-        }
-    };
+    let whitenoise = Whitenoise::new(config).await.inspect_err(|err| {
+        tracing::error!(target: "whitenoise::benchmark", "Failed to initialize Whitenoise: {}", err);
+    })?;
 
     if let Some(ref nsec) = args.login {
         let account = whitenoise.login(nsec.clone()).await?;

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -8,6 +8,15 @@ use ::whitenoise::*;
 
 const INTEGRATION_WHITENOISE_DB_KEY_ID: &str = "integration.whitenoise.db.key.v1";
 
+/// Drains tracing-appender workers when `main` returns by any path.
+struct FlushTracingOnDrop;
+
+impl Drop for FlushTracingOnDrop {
+    fn drop(&mut self) {
+        ::whitenoise::shutdown_tracing();
+    }
+}
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 struct Args {
@@ -26,6 +35,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), WhitenoiseError> {
     let args = Args::parse();
+    let _flush_tracing = FlushTracingOnDrop;
 
     // Initialize mock keyring store for integration tests
     // This is required for MDK database encryption in test environments
@@ -43,13 +53,9 @@ async fn main() -> Result<(), WhitenoiseError> {
         RelayUrl::parse("ws://localhost:8080").unwrap(),
         RelayUrl::parse("ws://localhost:7777").unwrap(),
     ]);
-    let whitenoise = match Whitenoise::new(config).await {
-        Ok(wn) => wn,
-        Err(err) => {
-            tracing::error!("Failed to initialize Whitenoise: {}", err);
-            std::process::exit(1);
-        }
-    };
+    let whitenoise = Whitenoise::new(config).await.inspect_err(|err| {
+        tracing::error!(target: "whitenoise::integration_test", "Failed to initialize Whitenoise: {}", err);
+    })?;
 
     match args.scenario {
         Some(scenario_name) => {

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -43,16 +43,18 @@ async fn main() -> Result<(), WhitenoiseError> {
 
     tracing::info!("=== Starting Whitenoise Integration Test Suite ===");
 
+    let local_relays = vec![
+        RelayUrl::parse("ws://localhost:8080").unwrap(),
+        RelayUrl::parse("ws://localhost:7777").unwrap(),
+    ];
     let config = WhitenoiseConfig::new(
         &args.data_dir,
         &args.logs_dir,
         "com.whitenoise.integration-test",
     )
     .with_database_key_id(INTEGRATION_WHITENOISE_DB_KEY_ID)
-    .with_discovery_relays(vec![
-        RelayUrl::parse("ws://localhost:8080").unwrap(),
-        RelayUrl::parse("ws://localhost:7777").unwrap(),
-    ]);
+    .with_discovery_relays(local_relays.clone())
+    .with_default_account_relays(local_relays);
     let whitenoise = Whitenoise::new(config).await.inspect_err(|err| {
         tracing::error!(target: "whitenoise::integration_test", "Failed to initialize Whitenoise: {}", err);
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,28 @@ pub use whitenoise::zapstore::fetch_latest_zapstore_version;
 static TRACING_GUARDS: OnceLock<Mutex<Option<(WorkerGuard, WorkerGuard)>>> = OnceLock::new();
 static TRACING_INIT: OnceLock<()> = OnceLock::new();
 
+/// Flush the non-blocking tracing-appender workers and tear them down.
+///
+/// Dropping each `WorkerGuard` signals its writer thread to drain queued
+/// records before exiting. Statics are not dropped at process exit, so the
+/// guards held by the static `TRACING_GUARDS` cell would otherwise leak and
+/// the workers would be killed mid-flush — losing whatever log records were
+/// still in flight, including the error logged just before `main` returns
+/// `Err`.
+///
+/// Binaries should call this once before returning from `main`. The call is
+/// safe before initialisation (no-op) and safe to invoke more than once
+/// (subsequent calls are no-ops).
+pub fn shutdown_tracing() {
+    if let Some(mutex) = TRACING_GUARDS.get()
+        && let Ok(mut guard) = mutex.lock()
+    {
+        // Dropping the inner tuple joins the appender worker threads after
+        // they finish draining their channels.
+        let _ = guard.take();
+    }
+}
+
 /// Create non-blocking file and stdout writers, stash their guards in [`TRACING_GUARDS`],
 /// and return the two writers so callers can attach them to `fmt::Layer`s.
 ///

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -241,10 +241,10 @@ impl Whitenoise {
 
     #[perf_instrument("accounts")]
     pub(super) async fn load_default_relays(&self) -> Result<Vec<Relay>> {
-        let mut default_relays = Vec::new();
-        for Relay { url, .. } in Relay::defaults() {
-            let relay = self.find_or_create_relay_by_url(&url).await?;
-            default_relays.push(relay);
+        let urls = &self.config().default_account_relays;
+        let mut default_relays = Vec::with_capacity(urls.len());
+        for url in urls {
+            default_relays.push(self.find_or_create_relay_by_url(url).await?);
         }
         Ok(default_relays)
     }
@@ -1080,6 +1080,22 @@ mod tests {
     use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
     use crate::whitenoise::test_utils::*;
     use mdk_core::prelude::*;
+
+    #[tokio::test]
+    async fn test_load_default_relays_honours_with_default_account_relays() {
+        let override_urls = vec![
+            RelayUrl::parse("ws://override-relay-a:9999").unwrap(),
+            RelayUrl::parse("ws://override-relay-b:9999").unwrap(),
+        ];
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise_with(|config| {
+            config.with_default_account_relays(override_urls.clone())
+        })
+        .await;
+
+        let relays = whitenoise.load_default_relays().await.unwrap();
+
+        assert_eq!(Relay::urls(&relays), override_urls);
+    }
 
     #[tokio::test]
     async fn test_active_group_count_no_groups() {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -718,12 +718,24 @@ impl Whitenoise {
     /// This is the authoritative constructor: it sets up data and log
     /// directories, initializes logging and the database, seeds default
     /// relays and settings, spawns the event-processing loop, scheduled
-    /// tasks, discovery sync worker, and session subscriptions.
+    /// tasks, and the discovery sync worker.
+    ///
+    /// **Subscription setup is initiated asynchronously and continues after
+    /// this function returns.** A background task brings up per-account inbox
+    /// and group-plane subscriptions and signals the discovery sync worker;
+    /// the `subscription_health_check` scheduled task is the recovery safety
+    /// net. Callers that need synchronously-live subscriptions (for example,
+    /// the iOS background-push path) must call
+    /// [`Self::ensure_all_subscriptions`] before depending on inbound event
+    /// delivery — the existing FFI entry point in
+    /// [`crate::whitenoise::background_notifications`] already does this.
     ///
     /// Callers own the returned `Arc` for the lifetime of the process (or the
     /// test) and drop it to tear the instance down. Sessions and event
     /// handlers receive their own `Arc<Whitenoise>` clones internally via the
-    /// weak self-reference stamped at construction.
+    /// weak self-reference stamped at construction. The deferred subscription
+    /// task is registered with the background-task pool, so [`Self::shutdown`]
+    /// waits for it to complete before returning.
     #[perf_instrument("whitenoise")]
     pub async fn new(mut config: WhitenoiseConfig) -> Result<Arc<Self>> {
         init_timing::start();
@@ -953,10 +965,27 @@ impl Whitenoise {
 
         init_timing::record("background_tasks");
 
-        // Fetch events and setup subscriptions after event processing has started
-        whitenoise.setup_all_subscriptions().await?;
+        // Bring up subscriptions in the background. `ensure_all_subscriptions`
+        // is the right primitive here (not `setup_all_subscriptions`): it
+        // checks the operational state per account and skips accounts whose
+        // subscriptions were already set up by a concurrent `login` /
+        // `create_identity` call, so the deferred task composes safely with
+        // any account-creation work that runs after `Whitenoise::new` returns.
+        {
+            let wn = Arc::clone(&whitenoise);
+            whitenoise
+                .spawn_background(async move {
+                    if let Err(error) = wn.ensure_all_subscriptions().await {
+                        tracing::warn!(
+                            target: "whitenoise::new",
+                            "Background subscription setup failed: {error}"
+                        );
+                    }
+                })
+                .await;
+        }
 
-        init_timing::record("subscription_setup");
+        init_timing::record("subscription_setup_spawned");
 
         tracing::debug!(
             target: "whitenoise::new",

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -720,22 +720,30 @@ impl Whitenoise {
     /// relays and settings, spawns the event-processing loop, scheduled
     /// tasks, and the discovery sync worker.
     ///
-    /// **Subscription setup is initiated asynchronously and continues after
-    /// this function returns.** A background task brings up per-account inbox
-    /// and group-plane subscriptions and signals the discovery sync worker;
-    /// the `subscription_health_check` scheduled task is the recovery safety
-    /// net. Callers that need synchronously-live subscriptions (for example,
-    /// the iOS background-push path) must call
-    /// [`Self::ensure_all_subscriptions`] before depending on inbound event
-    /// delivery — the existing FFI entry point in
+    /// **Relay-bound init is performed asynchronously and continues after
+    /// this function returns.** Two background tasks are spawned: one brings
+    /// the discovery plane online (connecting to the configured discovery
+    /// relays and warming the ephemeral pool against the same URLs); the
+    /// other ensures per-account inbox / group-plane subscriptions are
+    /// operational and signals the discovery sync worker. Callers that need
+    /// synchronously-live subscriptions (for example, the iOS background-push
+    /// path) must call [`Self::ensure_all_subscriptions`] before depending on
+    /// inbound event delivery — the existing FFI entry point in
     /// [`crate::whitenoise::background_notifications`] already does this.
+    ///
+    /// Operations that read or publish through the discovery plane
+    /// (`fetch_user_relays`, the discovery sync worker's own rebuild, etc.)
+    /// will lazy-connect on first use if the background task has not yet
+    /// completed, so no caller has to wait explicitly. The
+    /// `subscription_health_check` scheduled task is the recovery safety net
+    /// for any transient relay failure within either deferred task.
     ///
     /// Callers own the returned `Arc` for the lifetime of the process (or the
     /// test) and drop it to tear the instance down. Sessions and event
     /// handlers receive their own `Arc<Whitenoise>` clones internally via the
-    /// weak self-reference stamped at construction. The deferred subscription
-    /// task is registered with the background-task pool, so [`Self::shutdown`]
-    /// waits for it to complete before returning.
+    /// weak self-reference stamped at construction. Both deferred tasks are
+    /// registered with the background-task pool, so [`Self::shutdown`] waits
+    /// for them to complete before returning.
     #[perf_instrument("whitenoise")]
     pub async fn new(mut config: WhitenoiseConfig) -> Result<Arc<Self>> {
         init_timing::start();
@@ -872,13 +880,31 @@ impl Whitenoise {
 
         init_timing::record("database_seeding");
 
-        whitenoise
-            .shared
-            .relay_control
-            .start_discovery_plane()
-            .await?;
+        // Two invariants make deferring the discovery-plane start safe:
+        //   1. No init step below (`restore_sessions`,
+        //      `sync_message_cache_on_startup`, `backfill_dm_peer_pubkeys`,
+        //      the worker spawns) touches the discovery plane. Preserve this
+        //      when adding steps here.
+        //   2. The deferred subscription setup signals the discovery worker,
+        //      whose `sync_discovery_subscriptions` itself calls
+        //      `discovery.start()`. Both paths converge on
+        //      `ensure_relays_connected`, which is idempotent at the
+        //      relay-client layer.
+        {
+            let wn = Arc::clone(&whitenoise);
+            whitenoise
+                .spawn_background(async move {
+                    if let Err(error) = wn.shared.relay_control.start_discovery_plane().await {
+                        tracing::warn!(
+                            target: "whitenoise::new",
+                            "Background discovery-plane start failed: {error}"
+                        );
+                    }
+                })
+                .await;
+        }
 
-        init_timing::record("discovery_plane");
+        init_timing::record("discovery_plane_spawned");
 
         // Restore account sessions before any startup step that resolves a
         // session by pubkey. `sync_message_cache_on_startup` reads per-account
@@ -965,11 +991,10 @@ impl Whitenoise {
 
         init_timing::record("background_tasks");
 
-        // Bring up subscriptions in the background. `ensure_all_subscriptions`
-        // is the right primitive here (not `setup_all_subscriptions`): it
-        // checks the operational state per account and skips accounts whose
-        // subscriptions were already set up by a concurrent `login` /
-        // `create_identity` call, so the deferred task composes safely with
+        // `ensure_all_subscriptions` is the right primitive here (not
+        // `setup_all_subscriptions`): it checks per-account operational state
+        // and skips accounts whose subscriptions were already set up by a
+        // concurrent `login` / `create_identity`, so this composes safely with
         // any account-creation work that runs after `Whitenoise::new` returns.
         {
             let wn = Arc::clone(&whitenoise);

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -151,6 +151,13 @@ pub struct WhitenoiseConfig {
 
     /// Configured discovery relays for the relay-control discovery plane.
     pub discovery_relays: Vec<RelayUrl>,
+
+    /// Relay URLs adopted as a freshly-created account's NIP-65, Inbox, and
+    /// KeyPackage lists when no existing relay-list events are found on the
+    /// network. Seeded from [`Relay::defaults`]; override with
+    /// [`Self::with_default_account_relays`] for benchmarks or private
+    /// (non-public-relay) deployments.
+    pub default_account_relays: Vec<RelayUrl>,
 }
 
 impl WhitenoiseConfig {
@@ -175,6 +182,7 @@ impl WhitenoiseConfig {
             #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
             database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
+            default_account_relays: Relay::urls(&Relay::defaults()),
         }
     }
 
@@ -201,11 +209,22 @@ impl WhitenoiseConfig {
             #[cfg(any(test, feature = "integration-tests", feature = "benchmark-tests"))]
             database_key_id: None,
             discovery_relays: DiscoveryPlaneConfig::curated_default_relays(),
+            default_account_relays: Relay::urls(&Relay::defaults()),
         }
     }
 
     pub fn with_discovery_relays(mut self, discovery_relays: Vec<RelayUrl>) -> Self {
         self.discovery_relays = discovery_relays;
+        self
+    }
+
+    /// Override the relay URLs adopted as a freshly-created account's NIP-65,
+    /// Inbox, and KeyPackage lists when the network has no existing relay-list
+    /// events for the account. Production callers should almost never set this
+    /// — it is intended for benchmarks and private (non-public-relay)
+    /// deployments where the public defaults are inappropriate.
+    pub fn with_default_account_relays(mut self, default_account_relays: Vec<RelayUrl>) -> Self {
+        self.default_account_relays = default_account_relays;
         self
     }
 
@@ -1459,18 +1478,24 @@ pub mod test_utils {
     ///   - `mpsc::Receiver<ProcessableEvent>`: The event receiver paired with the instance sender
     ///   - `TempDir`: The temporary directory for data storage
     ///   - `TempDir`: The temporary directory for log storage
-    async fn create_mock_whitenoise_internal() -> (
+    async fn create_mock_whitenoise_internal_with<F>(
+        customize: F,
+    ) -> (
         Arc<Whitenoise>,
         mpsc::Receiver<ProcessableEvent>,
         TempDir,
         TempDir,
-    ) {
+    )
+    where
+        F: FnOnce(WhitenoiseConfig) -> WhitenoiseConfig,
+    {
         Whitenoise::initialize_mock_keyring_store();
 
         // Wait for local relays to be ready in test environment
         wait_for_test_relays().await;
 
         let (config, data_temp, logs_temp) = create_test_config();
+        let config = customize(config);
 
         // Create directories manually to avoid issues
         std::fs::create_dir_all(&config.data_dir).unwrap();
@@ -1514,8 +1539,20 @@ pub mod test_utils {
     }
 
     pub(crate) async fn create_mock_whitenoise() -> (Arc<Whitenoise>, TempDir, TempDir) {
+        create_mock_whitenoise_with(|config| config).await
+    }
+
+    /// Build a mock Whitenoise with a customised [`WhitenoiseConfig`]. Use when
+    /// a test needs to exercise a non-default config knob (e.g. an overridden
+    /// `default_account_relays`).
+    pub(crate) async fn create_mock_whitenoise_with<F>(
+        customize: F,
+    ) -> (Arc<Whitenoise>, TempDir, TempDir)
+    where
+        F: FnOnce(WhitenoiseConfig) -> WhitenoiseConfig,
+    {
         let (whitenoise, _event_receiver, data_temp, logs_temp) =
-            create_mock_whitenoise_internal().await;
+            create_mock_whitenoise_internal_with(customize).await;
         (whitenoise, data_temp, logs_temp)
     }
 
@@ -2166,6 +2203,33 @@ mod tests {
                 config.discovery_relays,
                 DiscoveryPlaneConfig::curated_default_relays()
             );
+        }
+
+        #[test]
+        fn test_whitenoise_config_default_account_relays_seed() {
+            let data_dir = std::path::Path::new("/test/data");
+            let logs_dir = std::path::Path::new("/test/logs");
+            let config = WhitenoiseConfig::new(data_dir, logs_dir, "com.test.app");
+
+            assert_eq!(
+                config.default_account_relays,
+                Relay::urls(&Relay::defaults()),
+                "fresh config should seed default_account_relays from Relay::defaults()"
+            );
+        }
+
+        #[test]
+        fn test_whitenoise_config_with_default_account_relays_overrides_seed() {
+            let data_dir = std::path::Path::new("/test/data");
+            let logs_dir = std::path::Path::new("/test/logs");
+            let override_urls = vec![
+                RelayUrl::parse("ws://override-relay-a:9999").unwrap(),
+                RelayUrl::parse("ws://override-relay-b:9999").unwrap(),
+            ];
+            let config = WhitenoiseConfig::new(data_dir, logs_dir, "com.test.app")
+                .with_default_account_relays(override_urls.clone());
+
+            assert_eq!(config.default_account_relays, override_urls);
         }
 
         #[test]


### PR DESCRIPTION
Closes https://github.com/marmot-protocol/whitenoise-rs/issues/599

Moves the discovery plane initialization and the setup of subscriptions to be performed in the background and not block initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WAN latency simulation for benchmarks and new startup-under-latency benchmark command producing JSON results.
  * Benchmark runner scripts and helpers to run scenarios with optional latency and timestamped outputs.

* **Bug Fixes / Reliability**
  * Ensures tracing is flushed on shutdown to avoid lost logs.

* **Chores**
  * Compose profile and service added for latency testing; build tooling recipes updated for latency-aware benchmarks.
* **Tests**
  * Added tests and helpers for configurable default relays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/834)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->