### PR TITLE
Reuse d_tag slot for kind:30443 publishes to enable NIP-33 replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
+source = "git+https://github.com/marmot-protocol/mdk?rev=65d02043744c2f5ebbebb2cba0ca21a8273ec442#65d02043744c2f5ebbebb2cba0ca21a8273ec442"
 dependencies = [
  "base64",
  "blurhash",
@@ -2709,12 +2709,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
+source = "git+https://github.com/marmot-protocol/mdk?rev=65d02043744c2f5ebbebb2cba0ca21a8273ec442#65d02043744c2f5ebbebb2cba0ca21a8273ec442"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
+source = "git+https://github.com/marmot-protocol/mdk?rev=65d02043744c2f5ebbebb2cba0ca21a8273ec442#65d02043744c2f5ebbebb2cba0ca21a8273ec442"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.8.0"
-source = "git+https://github.com/marmot-protocol/mdk?rev=28ee7badf24195343f452246ce5f4dad4a99ddf2#28ee7badf24195343f452246ce5f4dad4a99ddf2"
+source = "git+https://github.com/marmot-protocol/mdk?rev=65d02043744c2f5ebbebb2cba0ca21a8273ec442#65d02043744c2f5ebbebb2cba0ca21a8273ec442"
 dependencies = [
  "nostr",
  "openmls 0.8.1 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
@@ -3627,7 +3627,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4095,7 +4095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4152,7 +4152,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4518,7 +4518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4807,7 +4807,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5271,7 +5271,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5709,7 +5709,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5813,15 +5813,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5853,28 +5844,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5890,12 +5864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5906,12 +5874,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5926,22 +5888,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5956,12 +5906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5972,12 +5916,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5992,12 +5930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,12 +5940,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 members = [".", "crates/whitenoise-macros", "crates/whitenoise-cli"]
 
 [workspace.dependencies]
-mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2", features = [
+mdk-core = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "65d02043744c2f5ebbebb2cba0ca21a8273ec442", features = [
     "mip04",
     "mip05",
 ] }
-mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2" }
-mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "28ee7badf24195343f452246ce5f4dad4a99ddf2" }
+mdk-sqlite-storage = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "65d02043744c2f5ebbebb2cba0ca21a8273ec442" }
+mdk-storage-traits = { version = "0.8.0", git = "https://github.com/marmot-protocol/mdk", rev = "65d02043744c2f5ebbebb2cba0ca21a8273ec442" }
 nostr-sdk = { version = "0.44", features = ["nip04", "nip44", "nip47", "nip59"] }
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -305,7 +305,7 @@ async fn publish_backdated_key_package(
     // Get the encoded key package and tags
     let key_package_data = context
         .whitenoise
-        .encoded_key_package(account, relays)
+        .encoded_key_package(account, relays, None)
         .await?;
 
     // Get the account's secret key via public API

--- a/src/integration_tests/test_cases/shared/legacy_key_package.rs
+++ b/src/integration_tests/test_cases/shared/legacy_key_package.rs
@@ -68,7 +68,7 @@ pub(crate) async fn publish_legacy_capability_key_package(
     // Nostr-event capability tags below.
     let key_package_data = context
         .whitenoise
-        .encoded_key_package(account, relays)
+        .encoded_key_package(account, relays, None)
         .await?;
 
     // Pull the account's signer key via the public nsec export so we can

--- a/src/relay_control/ephemeral.rs
+++ b/src/relay_control/ephemeral.rs
@@ -346,9 +346,13 @@ impl EphemeralPlane {
         encoded_key_package: &str,
         relays: &[RelayUrl],
         tags: &[Tag],
+        custom_created_at: Option<Timestamp>,
         signer: Arc<dyn NostrSigner>,
     ) -> Result<Output<EventId>> {
-        let event_builder = EventBuilder::new(kind, encoded_key_package).tags(tags.to_vec());
+        let mut event_builder = EventBuilder::new(kind, encoded_key_package).tags(tags.to_vec());
+        if let Some(ts) = custom_created_at {
+            event_builder = event_builder.custom_created_at(ts);
+        }
 
         self.publish_event_builder_with_signer(event_builder, relays, signer)
             .await

--- a/src/relay_control/mod.rs
+++ b/src/relay_control/mod.rs
@@ -462,10 +462,18 @@ impl RelayControlPlane {
         encoded_key_package: &str,
         relays: &[RelayUrl],
         tags: &[nostr_sdk::Tag],
+        custom_created_at: Option<nostr_sdk::Timestamp>,
         signer: Arc<dyn nostr_sdk::NostrSigner>,
     ) -> NostrResult<nostr_sdk::prelude::Output<nostr_sdk::EventId>> {
         self.ephemeral
-            .publish_key_package_with_signer(kind, encoded_key_package, relays, tags, signer)
+            .publish_key_package_with_signer(
+                kind,
+                encoded_key_package,
+                relays,
+                tags,
+                custom_created_at,
+                signer,
+            )
             .await
     }
 

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -39,11 +39,6 @@ impl PublishedKeyPackagesRepo {
     }
 
     /// Return the most recently inserted row for a given event kind, if any.
-    ///
-    /// Canonical-slot consumers read both `d_tag` and `created_at` from
-    /// this single row. Folding the lookup into one query avoids the
-    /// implication that the d-tag and the insert timestamp could come
-    /// from two different prior publishes.
     pub async fn find_latest_by_kind(
         &self,
         kind: nostr_sdk::Kind,

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -38,6 +38,11 @@ impl PublishedKeyPackagesRepo {
         Ok(PublishedKeyPackage::find_by_hash_ref(&self.db, hash_ref).await?)
     }
 
+    /// Return the most recently recorded `d` tag for a given event kind, if any.
+    pub async fn find_latest_d_tag(&self, kind: nostr_sdk::Kind) -> Result<Option<String>> {
+        Ok(PublishedKeyPackage::find_latest_d_tag(&self.db, kind).await?)
+    }
+
     /// Mark a published key package as consumed (used by a Welcome).
     pub async fn mark_consumed(&self, event_id: &str) -> Result<bool> {
         Ok(PublishedKeyPackage::mark_consumed(&self.db, event_id).await?)

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -43,6 +43,11 @@ impl PublishedKeyPackagesRepo {
         Ok(PublishedKeyPackage::find_latest_d_tag(&self.db, kind).await?)
     }
 
+    /// Return the maximum `created_at` recorded for a given event kind, if any.
+    pub async fn find_max_created_at(&self, kind: nostr_sdk::Kind) -> Result<Option<i64>> {
+        Ok(PublishedKeyPackage::find_max_created_at(&self.db, kind).await?)
+    }
+
     /// Mark a published key package as consumed (used by a Welcome).
     pub async fn mark_consumed(&self, event_id: &str) -> Result<bool> {
         Ok(PublishedKeyPackage::mark_consumed(&self.db, event_id).await?)

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -38,14 +38,17 @@ impl PublishedKeyPackagesRepo {
         Ok(PublishedKeyPackage::find_by_hash_ref(&self.db, hash_ref).await?)
     }
 
-    /// Return the most recently recorded `d` tag for a given event kind, if any.
-    pub async fn find_latest_d_tag(&self, kind: nostr_sdk::Kind) -> Result<Option<String>> {
-        Ok(PublishedKeyPackage::find_latest_d_tag(&self.db, kind).await?)
-    }
-
-    /// Return the maximum `created_at` recorded for a given event kind, if any.
-    pub async fn find_max_created_at(&self, kind: nostr_sdk::Kind) -> Result<Option<i64>> {
-        Ok(PublishedKeyPackage::find_max_created_at(&self.db, kind).await?)
+    /// Return the most recently inserted row for a given event kind, if any.
+    ///
+    /// Canonical-slot consumers read both `d_tag` and `created_at` from
+    /// this single row. Folding the lookup into one query avoids the
+    /// implication that the d-tag and the insert timestamp could come
+    /// from two different prior publishes.
+    pub async fn find_latest_by_kind(
+        &self,
+        kind: nostr_sdk::Kind,
+    ) -> Result<Option<PublishedKeyPackage>> {
+        Ok(PublishedKeyPackage::find_latest_by_kind(&self.db, kind).await?)
     }
 
     /// Mark a published key package as consumed (used by a Welcome).

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -107,22 +107,37 @@ impl PublishedKeyPackage {
         Ok(row)
     }
 
-    /// Returns the most recently recorded `d` tag for a given event kind, if any.
+    /// Returns the most recently inserted row for a given event kind, if any.
     ///
-    /// Used by the kind:30443 publish path to reuse a single addressable-event
-    /// slot per NIP-33. MDK generates a fresh random `d` tag inside
-    /// `create_key_package_for_event` every time it's called, and the MDK
-    /// docs explicitly say "Callers SHOULD store and reuse this value when
-    /// rotating the KeyPackage." Without reuse, every publish lands as a
-    /// distinct event on relays instead of replacing the previous one.
+    /// Single query that covers both NIP-33 canonical-slot needs:
+    /// - `d_tag` — reuse the previously-published addressable-slot
+    ///   identifier so the next publish replaces the prior canonical event
+    ///   on relays instead of landing in a fresh slot. MDK generates a
+    ///   fresh random `d` tag every call to `create_key_package_for_event`
+    ///   and the MDK docs say "Callers SHOULD store and reuse this value
+    ///   when rotating the KeyPackage."
+    /// - `created_at` (the row's SQLite `unixepoch()` insert timestamp,
+    ///   not the Nostr event's `created_at`) — use as a lower bound when
+    ///   computing a strictly-monotonic event `created_at` for the next
+    ///   publish. NIP-01 says relays keep the lowest-id event on a tie,
+    ///   so reusing the d-tag alone isn't enough under same-second
+    ///   publishes. The row insert timestamp is always ≥ the event's
+    ///   `created_at` (INSERT runs after the publish round-trip), which
+    ///   makes it a sound upper bound for the prior event time.
+    ///
+    /// Folding both lookups into one query saves a DB roundtrip and makes
+    /// it explicit at the call site that the d-tag and the insert time
+    /// come from the *same* prior publish — not two separate rows.
     #[perf_instrument("db::published_key_packages")]
-    pub(crate) async fn find_latest_d_tag(
+    pub(crate) async fn find_latest_by_kind(
         db: &AccountDatabase,
         kind: Kind,
-    ) -> Result<Option<String>, DatabaseError> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT d_tag FROM published_key_packages
-             WHERE kind = ? AND d_tag IS NOT NULL
+    ) -> Result<Option<Self>, DatabaseError> {
+        let row = sqlx::query_as::<_, Self>(
+            "SELECT id, key_package_hash_ref, event_id, kind, d_tag,
+                    consumed_at, key_material_deleted, created_at
+             FROM published_key_packages
+             WHERE kind = ?
              ORDER BY created_at DESC, id DESC
              LIMIT 1",
         )
@@ -130,31 +145,7 @@ impl PublishedKeyPackage {
         .fetch_optional(&db.inner.pool)
         .await?;
 
-        Ok(row.map(|(d,)| d))
-    }
-
-    /// Returns the maximum `created_at` recorded for a given event kind, if any.
-    ///
-    /// Used as a lower bound when computing a monotonic Nostr `created_at`
-    /// for the next kind:30443 publish. NIP-01 says that if two replaceable
-    /// events share a `created_at`, the relay keeps the one with the lowest
-    /// event id — so reusing the d-tag alone is not enough to guarantee
-    /// replacement when two publishes land in the same second. Forcing the
-    /// new event's `created_at` strictly above the previous insert timestamp
-    /// (which is always ≥ the previous event's `created_at`) sidesteps the
-    /// tie entirely.
-    #[perf_instrument("db::published_key_packages")]
-    pub(crate) async fn find_max_created_at(
-        db: &AccountDatabase,
-        kind: Kind,
-    ) -> Result<Option<i64>, DatabaseError> {
-        let row: Option<(Option<i64>,)> =
-            sqlx::query_as("SELECT MAX(created_at) FROM published_key_packages WHERE kind = ?")
-                .bind(i64::from(kind.as_u16()))
-                .fetch_optional(&db.inner.pool)
-                .await?;
-
-        Ok(row.and_then(|(v,)| v))
+        Ok(row)
     }
 
     /// Looks up all published key packages sharing the same hash reference.
@@ -515,77 +506,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_latest_d_tag_returns_none_when_empty() {
+    async fn test_find_latest_by_kind_returns_none_when_empty() {
         let (db, _dir) = setup().await;
 
-        let result = PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND)
+        let result = PublishedKeyPackage::find_latest_by_kind(&db, MLS_KEY_PACKAGE_KIND)
             .await
             .unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
-    async fn test_find_latest_d_tag_returns_most_recent_for_kind() {
-        let (db, _dir) = setup().await;
-
-        // Track an older canonical row.
-        PublishedKeyPackage::create(
-            &db,
-            &[1, 1, 1],
-            "older-canonical",
-            MLS_KEY_PACKAGE_KIND,
-            Some("old-d-tag"),
-        )
-        .await
-        .unwrap();
-        // Bump the older row's created_at into the past so ORDER BY is unambiguous.
-        sqlx::query(
-            "UPDATE published_key_packages SET created_at = unixepoch() - 60 WHERE event_id = ?",
-        )
-        .bind("older-canonical")
-        .execute(&db.inner.pool)
-        .await
-        .unwrap();
-
-        PublishedKeyPackage::create(
-            &db,
-            &[2, 2, 2],
-            "newer-canonical",
-            MLS_KEY_PACKAGE_KIND,
-            Some("new-d-tag"),
-        )
-        .await
-        .unwrap();
-        // Legacy rows without d_tag must not be considered.
-        PublishedKeyPackage::create(&db, &[2, 2, 2], "legacy", MLS_KEY_PACKAGE_KIND_LEGACY, None)
-            .await
-            .unwrap();
-
-        let result = PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND)
-            .await
-            .unwrap();
-        assert_eq!(result.as_deref(), Some("new-d-tag"));
-
-        // Legacy kind has no d_tag rows.
-        let legacy_result =
-            PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND_LEGACY)
-                .await
-                .unwrap();
-        assert!(legacy_result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_find_max_created_at_returns_none_when_empty() {
-        let (db, _dir) = setup().await;
-
-        let result = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND)
-            .await
-            .unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_find_max_created_at_returns_most_recent_for_kind() {
+    async fn test_find_latest_by_kind_returns_most_recent_row_per_kind() {
         let (db, _dir) = setup().await;
 
         PublishedKeyPackage::create(
@@ -618,7 +549,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Legacy row at a higher timestamp must not bleed into the canonical max.
+        // A legacy row inserted later must not bleed into the canonical lookup.
         PublishedKeyPackage::create(&db, &[3, 3, 3], "legacy", MLS_KEY_PACKAGE_KIND_LEGACY, None)
             .await
             .unwrap();
@@ -628,15 +559,21 @@ mod tests {
             .await
             .unwrap();
 
-        let canonical_max = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND)
+        let canonical = PublishedKeyPackage::find_latest_by_kind(&db, MLS_KEY_PACKAGE_KIND)
             .await
-            .unwrap();
-        assert_eq!(canonical_max, Some(200));
+            .unwrap()
+            .expect("canonical row must exist");
+        assert_eq!(canonical.event_id, "newer");
+        assert_eq!(canonical.d_tag.as_deref(), Some("d-new"));
+        assert_eq!(canonical.created_at, 200);
 
-        let legacy_max = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND_LEGACY)
+        let legacy = PublishedKeyPackage::find_latest_by_kind(&db, MLS_KEY_PACKAGE_KIND_LEGACY)
             .await
-            .unwrap();
-        assert_eq!(legacy_max, Some(999));
+            .unwrap()
+            .expect("legacy row must exist");
+        assert_eq!(legacy.event_id, "legacy");
+        assert_eq!(legacy.created_at, 999);
+        assert!(legacy.d_tag.is_none());
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -107,6 +107,32 @@ impl PublishedKeyPackage {
         Ok(row)
     }
 
+    /// Returns the most recently recorded `d` tag for a given event kind, if any.
+    ///
+    /// Used by the kind:30443 publish path to reuse a single addressable-event
+    /// slot per NIP-33. MDK generates a fresh random `d` tag inside
+    /// `create_key_package_for_event` every time it's called, and the MDK
+    /// docs explicitly say "Callers SHOULD store and reuse this value when
+    /// rotating the KeyPackage." Without reuse, every publish lands as a
+    /// distinct event on relays instead of replacing the previous one.
+    #[perf_instrument("db::published_key_packages")]
+    pub(crate) async fn find_latest_d_tag(
+        db: &AccountDatabase,
+        kind: Kind,
+    ) -> Result<Option<String>, DatabaseError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT d_tag FROM published_key_packages
+             WHERE kind = ? AND d_tag IS NOT NULL
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(i64::from(kind.as_u16()))
+        .fetch_optional(&db.inner.pool)
+        .await?;
+
+        Ok(row.map(|(d,)| d))
+    }
+
     /// Looks up all published key packages sharing the same hash reference.
     #[perf_instrument("db::published_key_packages")]
     pub(crate) async fn find_by_hash_ref(
@@ -462,6 +488,66 @@ mod tests {
             .unwrap();
         assert_eq!(eligible.len(), 1);
         assert_eq!(eligible[0].event_id, "old");
+    }
+
+    #[tokio::test]
+    async fn test_find_latest_d_tag_returns_none_when_empty() {
+        let (db, _dir) = setup().await;
+
+        let result = PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_latest_d_tag_returns_most_recent_for_kind() {
+        let (db, _dir) = setup().await;
+
+        // Track an older canonical row.
+        PublishedKeyPackage::create(
+            &db,
+            &[1, 1, 1],
+            "older-canonical",
+            MLS_KEY_PACKAGE_KIND,
+            Some("old-d-tag"),
+        )
+        .await
+        .unwrap();
+        // Bump the older row's created_at into the past so ORDER BY is unambiguous.
+        sqlx::query(
+            "UPDATE published_key_packages SET created_at = unixepoch() - 60 WHERE event_id = ?",
+        )
+        .bind("older-canonical")
+        .execute(&db.inner.pool)
+        .await
+        .unwrap();
+
+        PublishedKeyPackage::create(
+            &db,
+            &[2, 2, 2],
+            "newer-canonical",
+            MLS_KEY_PACKAGE_KIND,
+            Some("new-d-tag"),
+        )
+        .await
+        .unwrap();
+        // Legacy rows without d_tag must not be considered.
+        PublishedKeyPackage::create(&db, &[2, 2, 2], "legacy", MLS_KEY_PACKAGE_KIND_LEGACY, None)
+            .await
+            .unwrap();
+
+        let result = PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND)
+            .await
+            .unwrap();
+        assert_eq!(result.as_deref(), Some("new-d-tag"));
+
+        // Legacy kind has no d_tag rows.
+        let legacy_result =
+            PublishedKeyPackage::find_latest_d_tag(&db, MLS_KEY_PACKAGE_KIND_LEGACY)
+                .await
+                .unwrap();
+        assert!(legacy_result.is_none());
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -133,6 +133,30 @@ impl PublishedKeyPackage {
         Ok(row.map(|(d,)| d))
     }
 
+    /// Returns the maximum `created_at` recorded for a given event kind, if any.
+    ///
+    /// Used as a lower bound when computing a monotonic Nostr `created_at`
+    /// for the next kind:30443 publish. NIP-01 says that if two replaceable
+    /// events share a `created_at`, the relay keeps the one with the lowest
+    /// event id — so reusing the d-tag alone is not enough to guarantee
+    /// replacement when two publishes land in the same second. Forcing the
+    /// new event's `created_at` strictly above the previous insert timestamp
+    /// (which is always ≥ the previous event's `created_at`) sidesteps the
+    /// tie entirely.
+    #[perf_instrument("db::published_key_packages")]
+    pub(crate) async fn find_max_created_at(
+        db: &AccountDatabase,
+        kind: Kind,
+    ) -> Result<Option<i64>, DatabaseError> {
+        let row: Option<(Option<i64>,)> =
+            sqlx::query_as("SELECT MAX(created_at) FROM published_key_packages WHERE kind = ?")
+                .bind(i64::from(kind.as_u16()))
+                .fetch_optional(&db.inner.pool)
+                .await?;
+
+        Ok(row.and_then(|(v,)| v))
+    }
+
     /// Looks up all published key packages sharing the same hash reference.
     #[perf_instrument("db::published_key_packages")]
     pub(crate) async fn find_by_hash_ref(
@@ -548,6 +572,71 @@ mod tests {
                 .await
                 .unwrap();
         assert!(legacy_result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_max_created_at_returns_none_when_empty() {
+        let (db, _dir) = setup().await;
+
+        let result = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_max_created_at_returns_most_recent_for_kind() {
+        let (db, _dir) = setup().await;
+
+        PublishedKeyPackage::create(
+            &db,
+            &[1, 1, 1],
+            "older",
+            MLS_KEY_PACKAGE_KIND,
+            Some("d-old"),
+        )
+        .await
+        .unwrap();
+        sqlx::query("UPDATE published_key_packages SET created_at = 100 WHERE event_id = ?")
+            .bind("older")
+            .execute(&db.inner.pool)
+            .await
+            .unwrap();
+
+        PublishedKeyPackage::create(
+            &db,
+            &[2, 2, 2],
+            "newer",
+            MLS_KEY_PACKAGE_KIND,
+            Some("d-new"),
+        )
+        .await
+        .unwrap();
+        sqlx::query("UPDATE published_key_packages SET created_at = 200 WHERE event_id = ?")
+            .bind("newer")
+            .execute(&db.inner.pool)
+            .await
+            .unwrap();
+
+        // Legacy row at a higher timestamp must not bleed into the canonical max.
+        PublishedKeyPackage::create(&db, &[3, 3, 3], "legacy", MLS_KEY_PACKAGE_KIND_LEGACY, None)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE published_key_packages SET created_at = 999 WHERE event_id = ?")
+            .bind("legacy")
+            .execute(&db.inner.pool)
+            .await
+            .unwrap();
+
+        let canonical_max = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND)
+            .await
+            .unwrap();
+        assert_eq!(canonical_max, Some(200));
+
+        let legacy_max = PublishedKeyPackage::find_max_created_at(&db, MLS_KEY_PACKAGE_KIND_LEGACY)
+            .await
+            .unwrap();
+        assert_eq!(legacy_max, Some(999));
     }
 
     #[tokio::test]

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -124,10 +124,6 @@ impl PublishedKeyPackage {
     ///   publishes. The row insert timestamp is always ≥ the event's
     ///   `created_at` (INSERT runs after the publish round-trip), which
     ///   makes it a sound upper bound for the prior event time.
-    ///
-    /// Folding both lookups into one query saves a DB roundtrip and makes
-    /// it explicit at the call site that the d-tag and the insert time
-    /// come from the *same* prior publish — not two separate rows.
     #[perf_instrument("db::published_key_packages")]
     pub(crate) async fn find_latest_by_kind(
         db: &AccountDatabase,

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -280,39 +280,6 @@ pub(crate) fn monotonic_canonical_created_at(prev_max: Option<i64>) -> Timestamp
     }
 }
 
-/// Returns the canonical kind:30443 tags and `d` tag to publish.
-///
-/// If `stored_d_tag` is `Some`, swaps the freshly-generated `Tag::identifier`
-/// in `key_package_data.tags_30443` for the stored value so the publish lands
-/// in the same NIP-33 addressable slot and replaces the prior event on relays.
-/// If `None`, returns the MDK-generated tags and `d` tag unchanged — this is
-/// the first publish for the account.
-pub(crate) fn apply_d_tag_override(
-    stored_d_tag: Option<&str>,
-    key_package_data: &KeyPackageEventData,
-) -> (Vec<Tag>, String) {
-    match stored_d_tag {
-        Some(d) => {
-            let tags = key_package_data
-                .tags_30443
-                .iter()
-                .map(|tag| {
-                    if tag.kind() == TagKind::d() {
-                        Tag::identifier(d)
-                    } else {
-                        tag.clone()
-                    }
-                })
-                .collect();
-            (tags, d.to_string())
-        }
-        None => (
-            key_package_data.tags_30443.clone(),
-            key_package_data.d_tag.clone(),
-        ),
-    }
-}
-
 /// Filters relay responses to key package events that match the expected kind and author.
 ///
 /// Returns `(valid_events, dropped_wrong_kind, dropped_wrong_author)`.
@@ -344,6 +311,13 @@ pub(crate) fn filter_key_package_events_for_account(
 impl Whitenoise {
     /// Helper method to create and encode a key package for the given account.
     ///
+    /// When `existing_d_tag` is `Some(d)`, MDK reuses that NIP-33
+    /// addressable-slot identifier instead of generating a fresh random
+    /// one — this is how consecutive publishes for the same account replace
+    /// the previous canonical event on relays per NIP-33 instead of
+    /// accumulating new distinct events. `None` lets MDK generate a fresh
+    /// slot (first publish for the account).
+    ///
     /// Returns a [`KeyPackageEventData`] containing the encoded content, tags
     /// for both event kinds, and the hash_ref for lifecycle tracking.
     #[perf_instrument("key_packages")]
@@ -351,12 +325,21 @@ impl Whitenoise {
         &self,
         account: &Account,
         key_package_relays: &[Relay],
+        existing_d_tag: Option<&str>,
     ) -> Result<KeyPackageEventData> {
         let mdk = self.create_mdk_for_account(account.pubkey)?;
 
         let key_package_relay_urls = Relay::urls(key_package_relays);
+        let options = mdk_core::key_packages::KeyPackageOptions {
+            protected: false,
+            existing_d_tag: existing_d_tag.map(str::to_owned),
+        };
         let data = mdk
-            .create_key_package_for_event(&account.pubkey, key_package_relay_urls)
+            .create_key_package_for_event_with_options(
+                &account.pubkey,
+                key_package_relay_urls,
+                options,
+            )
             .map_err(|e| WhitenoiseError::Configuration(format!("NostrMls error: {}", e)))?;
 
         Ok(data)
@@ -379,11 +362,14 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
-        let key_package_data = self.encoded_key_package(account, &relays).await?;
+        let (key_package_data, canonical_created_at) = self
+            .prepare_canonical_publish_inputs(account, &relays)
+            .await?;
         let relay_urls = Relay::urls(&relays);
         self.publish_key_package_pair_to_relays(
             account,
             &key_package_data,
+            canonical_created_at,
             &relay_urls,
             std::sync::Arc::new(signer),
         )
@@ -406,7 +392,9 @@ impl Whitenoise {
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
-        let key_package_data = self.encoded_key_package(account, relays).await?;
+        let (key_package_data, canonical_created_at) = self
+            .prepare_canonical_publish_inputs(account, relays)
+            .await?;
         let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
 
@@ -422,6 +410,7 @@ impl Whitenoise {
                     .publish_key_package_pair_to_relays(
                         &account,
                         &key_package_data,
+                        canonical_created_at,
                         &relay_urls,
                         signer,
                     )
@@ -438,7 +427,13 @@ impl Whitenoise {
         }
 
         match self
-            .publish_key_package_pair_to_relays(account, &key_package_data, &relay_urls, signer)
+            .publish_key_package_pair_to_relays(
+                account,
+                &key_package_data,
+                canonical_created_at,
+                &relay_urls,
+                signer,
+            )
             .await
         {
             Ok(()) => {}
@@ -454,11 +449,61 @@ impl Whitenoise {
         Ok(())
     }
 
+    /// Resolves persisted canonical-slot state and generates the key package
+    /// in one step.
+    ///
+    /// Looks up the previously-recorded NIP-33 `d` tag and the maximum
+    /// `created_at` for kind:30443 publishes, then calls MDK with the stored
+    /// d-tag so the new event lands in the same addressable slot. Returns a
+    /// strictly-monotonic canonical `created_at` so a same-second publish
+    /// can't lose the NIP-01 lowest-event-id tiebreaker.
+    ///
+    /// Fail-fast on DB read errors: a soft-fail `None` fallback would publish
+    /// into a fresh NIP-33 slot (slot drift) and risk losing the timestamp
+    /// tiebreaker — defeating the whole reuse path. The scheduler retries
+    /// publishing on its next tick, so transient SQLite errors aren't fatal
+    /// for the system.
+    async fn prepare_canonical_publish_inputs(
+        &self,
+        account: &Account,
+        relays: &[Relay],
+    ) -> Result<(KeyPackageEventData, Timestamp)> {
+        let session = self.require_session(&account.pubkey)?;
+
+        let stored_d_tag = session
+            .repos
+            .published_key_packages
+            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .await?;
+        let prev_canonical_max = session
+            .repos
+            .published_key_packages
+            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
+            .await?;
+
+        let key_package_data = self
+            .encoded_key_package(account, relays, stored_d_tag.as_deref())
+            .await?;
+        let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
+
+        Ok((key_package_data, canonical_created_at))
+    }
+
+    /// Publishes the canonical (kind:30443) and legacy (kind:443) key package
+    /// pair for an already-encoded `KeyPackageEventData`.
+    ///
+    /// Caller is responsible for resolving NIP-33 slot state via
+    /// [`Self::prepare_canonical_publish_inputs`] so the d-tag baked into
+    /// `key_package_data.tags_30443` by MDK is the persisted slot identifier
+    /// (not a fresh random one), and `canonical_created_at` is strictly
+    /// monotonic past the prior canonical insert. This function trusts those
+    /// inputs and just publishes + tracks.
     #[perf_instrument("key_packages")]
     async fn publish_key_package_pair_to_relays(
         &self,
         account: &Account,
         key_package_data: &KeyPackageEventData,
+        canonical_created_at: Timestamp,
         relay_urls: &[RelayUrl],
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<()> {
@@ -470,47 +515,12 @@ impl Whitenoise {
         // a local audit trail.
         let session = self.require_session(&account.pubkey)?;
 
-        // Reuse the previously-published kind:30443 `d` tag slot so this
-        // publish replaces the prior addressable event on relays per NIP-33.
-        // MDK generates a fresh random `d` tag inside
-        // `create_key_package_for_event`, and the MDK docs explicitly say
-        // "Callers SHOULD store and reuse this value when rotating the
-        // KeyPackage." Without reuse, every publish lands as a distinct event
-        // and relays accumulate stale key packages indefinitely.
-        //
-        // Fail fast if the lookup errors. Silently falling back to MDK's
-        // fresh d-tag would publish into a brand-new NIP-33 slot and orphan
-        // the existing canonical event on relays — defeating this fix. DB
-        // read failures on the per-account SQLite file are rare; the
-        // scheduler retries publishing on its next tick.
-        let stored_d_tag = session
-            .repos
-            .published_key_packages
-            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
-            .await?;
-
-        // Also look up the highest `created_at` recorded for the canonical
-        // slot. NIP-01 says if two replaceable events share a `created_at`,
-        // relays keep the one with the lowest event id — so reusing the
-        // d-tag alone is not enough to guarantee replacement when two
-        // publishes land in the same second. Force a strictly-monotonic
-        // canonical `created_at` so the new event always wins.
-        let prev_canonical_max = session
-            .repos
-            .published_key_packages
-            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
-            .await?;
-
-        let (canonical_tags, canonical_d_tag) =
-            apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);
-        let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
-
         let canonical_event_id = self
             .publish_key_package_to_relays(
                 MLS_KEY_PACKAGE_KIND,
                 &key_package_data.content,
                 relay_urls,
-                &canonical_tags,
+                &key_package_data.tags_30443,
                 Some(canonical_created_at),
                 signer.clone(),
             )
@@ -523,7 +533,7 @@ impl Whitenoise {
             &session,
             &key_package_data.hash_ref,
             &canonical_event_id,
-            &canonical_d_tag,
+            &key_package_data.d_tag,
         )
         .await?;
 
@@ -2111,24 +2121,6 @@ mod tests {
         assert!(result.is_err(), "Should fail when relay is unreachable");
     }
 
-    fn sample_key_package_event_data(d_tag: &str) -> KeyPackageEventData {
-        KeyPackageEventData {
-            content: "sample".to_string(),
-            tags_30443: vec![
-                Tag::identifier(d_tag),
-                Tag::custom(TagKind::MlsCiphersuite, [REQUIRED_MLS_CIPHERSUITE_TAG]),
-                Tag::custom(TagKind::MlsExtensions, vec!["0x000a", "0xf2ee"]),
-                Tag::custom(TagKind::Custom("encoding".into()), ["base64"]),
-            ],
-            tags_443: vec![Tag::custom(
-                TagKind::MlsCiphersuite,
-                [REQUIRED_MLS_CIPHERSUITE_TAG],
-            )],
-            hash_ref: vec![1, 2, 3],
-            d_tag: d_tag.to_string(),
-        }
-    }
-
     #[test]
     fn test_monotonic_canonical_created_at_uses_now_when_no_prior() {
         let now_secs = Timestamp::now().as_secs();
@@ -2169,55 +2161,6 @@ mod tests {
         let now_secs = Timestamp::now().as_secs();
         let ts = monotonic_canonical_created_at(Some(-5));
         assert!(ts.as_secs() >= now_secs);
-    }
-
-    #[test]
-    fn test_apply_d_tag_override_uses_stored_d_tag_when_present() {
-        let data = sample_key_package_event_data("fresh-from-mdk");
-
-        let (tags, d_tag) = apply_d_tag_override(Some("persisted-slot"), &data);
-
-        assert_eq!(d_tag, "persisted-slot");
-        let identifier = tags
-            .iter()
-            .find(|t| t.kind() == TagKind::d())
-            .expect("d tag must be present");
-        assert_eq!(identifier.content(), Some("persisted-slot"));
-
-        // Non-d tags are preserved unchanged so MLS metadata still validates.
-        assert!(tags.iter().any(|t| t.kind() == TagKind::MlsCiphersuite));
-        assert!(
-            tags.iter()
-                .any(|t| t.kind() == TagKind::Custom("encoding".into()))
-        );
-    }
-
-    #[test]
-    fn test_apply_d_tag_override_keeps_fresh_d_tag_when_none_stored() {
-        let data = sample_key_package_event_data("fresh-from-mdk");
-
-        let (tags, d_tag) = apply_d_tag_override(None, &data);
-
-        assert_eq!(d_tag, "fresh-from-mdk");
-        let identifier = tags
-            .iter()
-            .find(|t| t.kind() == TagKind::d())
-            .expect("d tag must be present");
-        assert_eq!(identifier.content(), Some("fresh-from-mdk"));
-    }
-
-    #[test]
-    fn test_apply_d_tag_override_replaces_only_d_tag() {
-        let data = sample_key_package_event_data("fresh");
-        let original_count = data.tags_30443.len();
-
-        let (tags, _) = apply_d_tag_override(Some("slot"), &data);
-
-        assert_eq!(tags.len(), original_count);
-        // Exactly one `d` tag, and it is the overridden one.
-        let d_tags: Vec<_> = tags.iter().filter(|t| t.kind() == TagKind::d()).collect();
-        assert_eq!(d_tags.len(), 1);
-        assert_eq!(d_tags[0].content(), Some("slot"));
     }
 
     #[tokio::test]
@@ -2409,7 +2352,7 @@ mod tests {
             .await
             .unwrap();
         let key_package_data = whitenoise
-            .encoded_key_package(&account, &relays)
+            .encoded_key_package(&account, &relays, None)
             .await
             .unwrap();
 

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -362,6 +362,12 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
+        // Serialize concurrent rotations for this account so the
+        // prepare/publish/track sequence stays atomic. See
+        // `AccountSession::key_package_publish_lock`.
+        let session = self.require_session(&account.pubkey)?;
+        let _publish_guard = session.key_package_publish_lock.lock().await;
+
         let (key_package_data, canonical_created_at) = self
             .prepare_canonical_publish_inputs(account, &relays)
             .await?;

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -453,22 +453,17 @@ impl Whitenoise {
         // "Callers SHOULD store and reuse this value when rotating the
         // KeyPackage." Without reuse, every publish lands as a distinct event
         // and relays accumulate stale key packages indefinitely.
-        let stored_d_tag = match session
+        //
+        // Fail fast if the lookup errors. Silently falling back to MDK's
+        // fresh d-tag would publish into a brand-new NIP-33 slot and orphan
+        // the existing canonical event on relays — defeating this fix. DB
+        // read failures on the per-account SQLite file are rare; the
+        // scheduler retries publishing on its next tick.
+        let stored_d_tag = session
             .repos
             .published_key_packages
             .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
-            .await
-        {
-            Ok(d) => d,
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::key_packages",
-                    "Failed to load latest d_tag for kind:30443, falling back to fresh d_tag: {}",
-                    e
-                );
-                None
-            }
-        };
+            .await?;
 
         let (canonical_tags, canonical_d_tag) =
             apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -516,14 +516,16 @@ impl Whitenoise {
             )
             .await?;
 
-        Self::track_published_key_package(
+        // Propagate canonical tracking failures: the d-tag reuse and
+        // monotonic-timestamp invariants both read this row on the next
+        // publish; silent loss would re-introduce slot drift.
+        Self::track_published_key_package_canonical(
             &session,
             &key_package_data.hash_ref,
             &canonical_event_id,
-            MLS_KEY_PACKAGE_KIND,
-            Some(&canonical_d_tag),
+            &canonical_d_tag,
         )
-        .await;
+        .await?;
 
         match self
             .publish_key_package_to_relays(
@@ -537,12 +539,13 @@ impl Whitenoise {
             .await
         {
             Ok(legacy_event_id) => {
-                Self::track_published_key_package(
+                // Legacy tracking is best-effort: kind:443 is regular
+                // (not addressable) per NIP-01, so a missed row only
+                // affects audit-trail completeness.
+                Self::track_published_key_package_legacy(
                     &session,
                     &key_package_data.hash_ref,
                     &legacy_event_id,
-                    MLS_KEY_PACKAGE_KIND_LEGACY,
-                    None,
                 )
                 .await;
             }
@@ -604,27 +607,56 @@ impl Whitenoise {
         Ok(*result.id())
     }
 
-    /// Records a successfully published key package in the lifecycle tracking table.
+    /// Records a successful canonical (kind:30443) publish.
     ///
-    /// Caller resolves the session beforehand so this can't lose a tracking
-    /// record because the session went away between publish and track.
+    /// Errors propagate to the caller because the d-tag reuse and
+    /// monotonic-timestamp logic both read from this row on the next
+    /// publish; silent loss would re-introduce slot drift. Caller resolves
+    /// the session beforehand so this can't lose a tracking record because
+    /// the session went away between publish and track.
     #[perf_instrument("key_packages")]
-    async fn track_published_key_package(
+    async fn track_published_key_package_canonical(
         session: &std::sync::Arc<crate::whitenoise::session::AccountSession>,
         hash_ref: &[u8],
         event_id: &EventId,
-        kind: Kind,
-        d_tag: Option<&str>,
+        d_tag: &str,
+    ) -> Result<()> {
+        session
+            .repos
+            .published_key_packages
+            .create(
+                hash_ref,
+                &event_id.to_hex(),
+                MLS_KEY_PACKAGE_KIND,
+                Some(d_tag),
+            )
+            .await
+    }
+
+    /// Records a successful legacy (kind:443) publish — best-effort.
+    ///
+    /// kind:443 is regular per NIP-01 (not addressable), so a missed row
+    /// only affects audit-trail completeness.
+    #[perf_instrument("key_packages")]
+    async fn track_published_key_package_legacy(
+        session: &std::sync::Arc<crate::whitenoise::session::AccountSession>,
+        hash_ref: &[u8],
+        event_id: &EventId,
     ) {
         if let Err(e) = session
             .repos
             .published_key_packages
-            .create(hash_ref, &event_id.to_hex(), kind, d_tag)
+            .create(
+                hash_ref,
+                &event_id.to_hex(),
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                None,
+            )
             .await
         {
             tracing::warn!(
                 target: "whitenoise::key_packages",
-                "Published key package but failed to track it: {}",
+                "Published legacy key package but failed to track it: {}",
                 e
             );
         }

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -256,6 +256,30 @@ pub(crate) fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey)
     Ok(())
 }
 
+/// Returns a strictly-monotonic `created_at` for the next kind:30443 publish.
+///
+/// NIP-01 specifies that when two replaceable events share a `created_at`,
+/// relays keep the one with the lowest event id. Reusing the d-tag alone
+/// does not guarantee that a fresh publish replaces the previous canonical
+/// event when both land in the same second — the new event might lose the
+/// id-comparison tiebreaker. Forcing `created_at` strictly above the
+/// previously-recorded insert timestamp (which is always ≥ the previous
+/// event's `created_at`) sidesteps the tie.
+pub(crate) fn monotonic_canonical_created_at(prev_max: Option<i64>) -> Timestamp {
+    let now = Timestamp::now();
+    match prev_max {
+        Some(prev) if prev >= 0 => {
+            let floor = u64::try_from(prev).unwrap_or(0).saturating_add(1);
+            if floor > now.as_secs() {
+                Timestamp::from_secs(floor)
+            } else {
+                now
+            }
+        }
+        _ => now,
+    }
+}
+
 /// Returns the canonical kind:30443 tags and `d` tag to publish.
 ///
 /// If `stored_d_tag` is `Some`, swaps the freshly-generated `Tag::identifier`
@@ -263,7 +287,7 @@ pub(crate) fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey)
 /// in the same NIP-33 addressable slot and replaces the prior event on relays.
 /// If `None`, returns the MDK-generated tags and `d` tag unchanged — this is
 /// the first publish for the account.
-fn apply_d_tag_override(
+pub(crate) fn apply_d_tag_override(
     stored_d_tag: Option<&str>,
     key_package_data: &KeyPackageEventData,
 ) -> (Vec<Tag>, String) {
@@ -465,8 +489,21 @@ impl Whitenoise {
             .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
             .await?;
 
+        // Also look up the highest `created_at` recorded for the canonical
+        // slot. NIP-01 says if two replaceable events share a `created_at`,
+        // relays keep the one with the lowest event id — so reusing the
+        // d-tag alone is not enough to guarantee replacement when two
+        // publishes land in the same second. Force a strictly-monotonic
+        // canonical `created_at` so the new event always wins.
+        let prev_canonical_max = session
+            .repos
+            .published_key_packages
+            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
+            .await?;
+
         let (canonical_tags, canonical_d_tag) =
             apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);
+        let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
 
         let canonical_event_id = self
             .publish_key_package_to_relays(
@@ -474,6 +511,7 @@ impl Whitenoise {
                 &key_package_data.content,
                 relay_urls,
                 &canonical_tags,
+                Some(canonical_created_at),
                 signer.clone(),
             )
             .await?;
@@ -493,6 +531,7 @@ impl Whitenoise {
                 &key_package_data.content,
                 relay_urls,
                 &key_package_data.tags_443,
+                None,
                 signer,
             )
             .await
@@ -533,12 +572,20 @@ impl Whitenoise {
         encoded_key_package: &str,
         relay_urls: &[RelayUrl],
         tags: &[Tag],
+        custom_created_at: Option<Timestamp>,
         signer: std::sync::Arc<dyn NostrSigner>,
     ) -> Result<EventId> {
         let result = self
             .shared
             .relay_control
-            .publish_key_package_with_signer(kind, encoded_key_package, relay_urls, tags, signer)
+            .publish_key_package_with_signer(
+                kind,
+                encoded_key_package,
+                relay_urls,
+                tags,
+                custom_created_at,
+                signer,
+            )
             .await?;
 
         if result.success.is_empty() {
@@ -2051,6 +2098,48 @@ mod tests {
     }
 
     #[test]
+    fn test_monotonic_canonical_created_at_uses_now_when_no_prior() {
+        let now_secs = Timestamp::now().as_secs();
+        let ts = monotonic_canonical_created_at(None);
+        assert!(
+            ts.as_secs() >= now_secs,
+            "with no prior publish the new timestamp must be at least the wall clock"
+        );
+    }
+
+    #[test]
+    fn test_monotonic_canonical_created_at_steps_past_future_prior() {
+        // Pin prior strictly in the future so we can prove the bump.
+        let now_secs = Timestamp::now().as_secs();
+        let prior = i64::try_from(now_secs + 3600).unwrap();
+        let ts = monotonic_canonical_created_at(Some(prior));
+        assert_eq!(
+            ts.as_secs(),
+            u64::try_from(prior).unwrap() + 1,
+            "must produce prev+1 when the wall clock is below the prior publish"
+        );
+    }
+
+    #[test]
+    fn test_monotonic_canonical_created_at_uses_now_when_prior_is_past() {
+        let now_secs = Timestamp::now().as_secs();
+        let prior = i64::try_from(now_secs.saturating_sub(3600)).unwrap();
+        let ts = monotonic_canonical_created_at(Some(prior));
+        assert!(
+            ts.as_secs() >= now_secs,
+            "wall clock wins when the prior publish is in the past"
+        );
+    }
+
+    #[test]
+    fn test_monotonic_canonical_created_at_ignores_negative_prior() {
+        // Defensive: a corrupt DB row shouldn't crash the publish path.
+        let now_secs = Timestamp::now().as_secs();
+        let ts = monotonic_canonical_created_at(Some(-5));
+        assert!(ts.as_secs() >= now_secs);
+    }
+
+    #[test]
     fn test_apply_d_tag_override_uses_stored_d_tag_when_present() {
         let data = sample_key_package_event_data("fresh-from-mdk");
 
@@ -2116,7 +2205,16 @@ mod tests {
             .unwrap()
             .expect("initial publish must record a d_tag for kind:30443");
 
-        // Trigger a second publish through the same code path.
+        let initial_fetch = session.key_packages().fetch_all().await.unwrap();
+        let initial_canonical = initial_fetch
+            .iter()
+            .find(|e| e.kind == MLS_KEY_PACKAGE_KIND)
+            .expect("relay must hold a canonical event after the first publish")
+            .clone();
+
+        // Trigger a second publish through the same code path *in the same
+        // wall-clock second* — the monotonic-created_at logic must keep the
+        // new event id from losing a NIP-01 tiebreaker.
         let keys = whitenoise
             .shared
             .secrets_store
@@ -2128,6 +2226,7 @@ mod tests {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
+        // DB invariant: every canonical row reuses the original slot.
         let canonical_rows: Vec<(String,)> = sqlx::query_as(
             "SELECT d_tag FROM published_key_packages
              WHERE kind = ? AND d_tag IS NOT NULL",
@@ -2145,10 +2244,32 @@ mod tests {
         for (d_tag,) in &canonical_rows {
             assert_eq!(
                 d_tag, &initial_d_tag,
-                "every kind:30443 publish must reuse the original d_tag slot \
-                 so relays NIP-33-replace the previous event instead of accumulating"
+                "every kind:30443 publish must reuse the original d_tag slot"
             );
         }
+
+        // Relay invariant: the relay surfaces exactly one canonical event for
+        // the (kind, pubkey, d) slot, and it is the NEW one — not the original.
+        let after_fetch = session.key_packages().fetch_all().await.unwrap();
+        let canonical_events: Vec<_> = after_fetch
+            .iter()
+            .filter(|e| e.kind == MLS_KEY_PACKAGE_KIND)
+            .collect();
+        assert_eq!(
+            canonical_events.len(),
+            1,
+            "NIP-33 must collapse kind:30443 events sharing the same d-tag to a single row \
+             after replacement; got {} canonical event(s)",
+            canonical_events.len()
+        );
+        assert_ne!(
+            canonical_events[0].id, initial_canonical.id,
+            "the new canonical event must replace the original on the relay"
+        );
+        assert!(
+            canonical_events[0].created_at >= initial_canonical.created_at,
+            "the replacement event must not be older than the one it replaces"
+        );
     }
 
     #[tokio::test]

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -262,19 +262,22 @@ pub(crate) fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey)
 /// relays keep the one with the lowest event id. Reusing the d-tag alone
 /// does not guarantee that a fresh publish replaces the previous canonical
 /// event when both land in the same second — the new event might lose the
-/// id-comparison tiebreaker. Forcing `created_at` strictly above the
-/// previously-recorded insert timestamp (which is always ≥ the previous
-/// event's `created_at`) sidesteps the tie.
+/// id-comparison tiebreaker.
+///
+/// `prev_max` is the maximum `created_at` recorded in the
+/// `published_key_packages` table for the canonical kind. That value is the
+/// SQLite `unixepoch()` at INSERT time, which happens *after* the relay
+/// round-trip, so it is always ≥ the previous Nostr event's `created_at`.
+/// Setting the new event's `created_at` to `max(now, prev_max + 1)`
+/// therefore lands strictly above any prior canonical event and sidesteps
+/// the NIP-01 tie entirely.
 pub(crate) fn monotonic_canonical_created_at(prev_max: Option<i64>) -> Timestamp {
     let now = Timestamp::now();
     match prev_max {
         Some(prev) if prev >= 0 => {
-            let floor = u64::try_from(prev).unwrap_or(0).saturating_add(1);
-            if floor > now.as_secs() {
-                Timestamp::from_secs(floor)
-            } else {
-                now
-            }
+            // `prev >= 0` guarantees the cast is value-preserving.
+            let floor = (prev as u64).saturating_add(1);
+            Timestamp::from_secs(floor.max(now.as_secs()))
         }
         _ => now,
     }
@@ -383,56 +386,92 @@ impl Whitenoise {
         Ok(())
     }
 
-    /// Like the session `create_and_publish()` flow, but the relay publish
-    /// Creates a key package, publishes it to the configured relays, and
-    /// records the published event in the database.
+    /// Creates and publishes a key package for a freshly-set-up account.
     ///
-    /// The MLS key material is always created synchronously (local, fast).
-    /// The relay broadcast + DB tracking run inline so that callers can rely
-    /// on the package being durably published (or surfaced as a warning) by
-    /// the time this function returns. Failures are non-fatal — the
-    /// `KeyPackageMaintenance` scheduler (10-min interval) retries any that
-    /// didn't land.
+    /// In production this spawns the publish so account-creation flows
+    /// don't block on relays; in tests it runs inline so assertions can
+    /// observe the published event deterministically. Either way, failures
+    /// only log a warning — the [`KeyPackageMaintenance`] scheduler retries
+    /// any publish that didn't land on its next tick (10 min).
+    ///
+    /// The full `lock → prepare → publish → track` sequence runs inside
+    /// the spawn/inline-await block: by the time this function returns,
+    /// `setup_subscriptions` has already wired up the giftwrap handler
+    /// (see `accounts/setup.rs`), so a welcome can arrive concurrently
+    /// with the spawn. Taking the per-account
+    /// [`key_package_publish_lock`] *inside* the spawned task is what
+    /// prevents the giftwrap-triggered `KeyPackageOps::publish` from
+    /// reading the same empty `published_key_packages` state and landing
+    /// in a *different* fresh NIP-33 slot — i.e. the slot-drift bug this
+    /// PR fixes.
+    ///
+    /// [`KeyPackageMaintenance`]: crate::whitenoise::scheduled_tasks::tasks::KeyPackageMaintenance
+    /// [`key_package_publish_lock`]: crate::whitenoise::session::AccountSession#structfield.key_package_publish_lock
     pub(crate) async fn create_key_package_and_background_publish(
         &self,
         account: &Account,
         relays: &[Relay],
     ) -> Result<()> {
-        let (key_package_data, canonical_created_at) = self
-            .prepare_canonical_publish_inputs(account, relays)
-            .await?;
-        let relay_urls = Relay::urls(relays);
         let signer = self.get_signer_for_account(account)?;
+        let relays = relays.to_vec();
 
-        // In unit tests publish synchronously so assertions can observe the
-        // published event without awaiting a spawned task. In production the
-        // spawn path keeps account creation responsive while the scheduler
-        // retries any publish that didn't land.
         #[cfg(not(test))]
         if let Ok(wn) = self.arc() {
             let account = account.clone();
             tokio::spawn(async move {
-                if let Err(e) = wn
-                    .publish_key_package_pair_to_relays(
-                        &account,
-                        &key_package_data,
-                        canonical_created_at,
-                        &relay_urls,
-                        signer,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        target: "whitenoise::key_packages",
-                        "Background key package publish failed, scheduler will retry: {}",
-                        e
-                    );
-                }
+                wn.locked_create_and_publish_canonical_pair(&account, &relays, signer)
+                    .await;
             });
             return Ok(());
         }
 
-        match self
+        self.locked_create_and_publish_canonical_pair(account, &relays, signer)
+            .await;
+        Ok(())
+    }
+
+    /// Acquires the per-account publish lock, then runs the full
+    /// `prepare → publish → track` sequence and swallows any failure as a
+    /// warning so callers always observe success.
+    ///
+    /// Used by the spawned and inline branches of
+    /// [`Self::create_key_package_and_background_publish`]. Holding the
+    /// lock across the entire sequence (rather than just publish) is what
+    /// prevents the slot-drift race documented on that function.
+    async fn locked_create_and_publish_canonical_pair(
+        &self,
+        account: &Account,
+        relays: &[Relay],
+        signer: std::sync::Arc<dyn NostrSigner>,
+    ) {
+        let session = match self.require_session(&account.pubkey) {
+            Ok(session) => session,
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Key package publish skipped, session resolution failed: {}",
+                    e
+                );
+                return;
+            }
+        };
+        let _publish_guard = session.key_package_publish_lock.lock().await;
+
+        let (key_package_data, canonical_created_at) =
+            match self.prepare_canonical_publish_inputs(account, relays).await {
+                Ok(prepared) => prepared,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Key package prepare failed, scheduler will retry: {}",
+                        e
+                    );
+                    return;
+                }
+            };
+        let relay_urls = Relay::urls(relays);
+
+        if let Err(e) = self
             .publish_key_package_pair_to_relays(
                 account,
                 &key_package_data,
@@ -442,17 +481,12 @@ impl Whitenoise {
             )
             .await
         {
-            Ok(()) => {}
-            Err(e) => {
-                tracing::warn!(
-                    target: "whitenoise::key_packages",
-                    "Key package publish failed, scheduler will retry: {}",
-                    e
-                );
-            }
+            tracing::warn!(
+                target: "whitenoise::key_packages",
+                "Key package publish failed, scheduler will retry: {}",
+                e
+            );
         }
-
-        Ok(())
     }
 
     /// Resolves persisted canonical-slot state and generates the key package
@@ -476,19 +510,19 @@ impl Whitenoise {
     ) -> Result<(KeyPackageEventData, Timestamp)> {
         let session = self.require_session(&account.pubkey)?;
 
-        let stored_d_tag = session
+        // Single query: the d-tag and the insert timestamp both come from the
+        // most recent canonical row. Folding the two lookups avoids the
+        // implication that they could disagree.
+        let latest_canonical = session
             .repos
             .published_key_packages
-            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .find_latest_by_kind(MLS_KEY_PACKAGE_KIND)
             .await?;
-        let prev_canonical_max = session
-            .repos
-            .published_key_packages
-            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
-            .await?;
+        let stored_d_tag = latest_canonical.as_ref().and_then(|r| r.d_tag.as_deref());
+        let prev_canonical_max = latest_canonical.as_ref().map(|r| r.created_at);
 
         let key_package_data = self
-            .encoded_key_package(account, relays, stored_d_tag.as_deref())
+            .encoded_key_package(account, relays, stored_d_tag)
             .await?;
         let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
 
@@ -2181,9 +2215,10 @@ mod tests {
         let initial_d_tag = session
             .repos
             .published_key_packages
-            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .find_latest_by_kind(MLS_KEY_PACKAGE_KIND)
             .await
             .unwrap()
+            .and_then(|row| row.d_tag)
             .expect("initial publish must record a d_tag for kind:30443");
 
         let initial_fetch = session.key_packages().fetch_all().await.unwrap();

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -538,6 +538,19 @@ impl Whitenoise {
     /// (not a fresh random one), and `canonical_created_at` is strictly
     /// monotonic past the prior canonical insert. This function trusts those
     /// inputs and just publishes + tracks.
+    ///
+    /// Why this still lives on `Whitenoise` rather than only on
+    /// [`KeyPackageOps`](crate::whitenoise::session::AccountSession#method.key_packages):
+    /// the external-signer login flow inserts the signer into
+    /// `Whitenoise.shared.external_signers` *before* `from_account` builds
+    /// the session, so `AccountSession::from_account` sees no local key and
+    /// leaves `session.signer = None`. Routing the initial external-signer
+    /// publish through `KeyPackageOps::publish_pair` would then trip
+    /// `require_signer() → SignerUnavailable`. Folding the two paths into
+    /// one means rewiring `from_account` (or `insert_account_session`) to
+    /// also consult the `external_signers` map — a session-signer-lifecycle
+    /// refactor that's out of scope for the d-tag-stability fix. See the
+    /// PR #835 review thread on this function for the discussion.
     #[perf_instrument("key_packages")]
     async fn publish_key_package_pair_to_relays(
         &self,

--- a/src/whitenoise/key_packages.rs
+++ b/src/whitenoise/key_packages.rs
@@ -256,6 +256,39 @@ pub(crate) fn validate_fetched_member_key_package(event: &Event, pk: &PublicKey)
     Ok(())
 }
 
+/// Returns the canonical kind:30443 tags and `d` tag to publish.
+///
+/// If `stored_d_tag` is `Some`, swaps the freshly-generated `Tag::identifier`
+/// in `key_package_data.tags_30443` for the stored value so the publish lands
+/// in the same NIP-33 addressable slot and replaces the prior event on relays.
+/// If `None`, returns the MDK-generated tags and `d` tag unchanged — this is
+/// the first publish for the account.
+fn apply_d_tag_override(
+    stored_d_tag: Option<&str>,
+    key_package_data: &KeyPackageEventData,
+) -> (Vec<Tag>, String) {
+    match stored_d_tag {
+        Some(d) => {
+            let tags = key_package_data
+                .tags_30443
+                .iter()
+                .map(|tag| {
+                    if tag.kind() == TagKind::d() {
+                        Tag::identifier(d)
+                    } else {
+                        tag.clone()
+                    }
+                })
+                .collect();
+            (tags, d.to_string())
+        }
+        None => (
+            key_package_data.tags_30443.clone(),
+            key_package_data.d_tag.clone(),
+        ),
+    }
+}
+
 /// Filters relay responses to key package events that match the expected kind and author.
 ///
 /// Returns `(valid_events, dropped_wrong_kind, dropped_wrong_author)`.
@@ -413,12 +446,39 @@ impl Whitenoise {
         // a local audit trail.
         let session = self.require_session(&account.pubkey)?;
 
+        // Reuse the previously-published kind:30443 `d` tag slot so this
+        // publish replaces the prior addressable event on relays per NIP-33.
+        // MDK generates a fresh random `d` tag inside
+        // `create_key_package_for_event`, and the MDK docs explicitly say
+        // "Callers SHOULD store and reuse this value when rotating the
+        // KeyPackage." Without reuse, every publish lands as a distinct event
+        // and relays accumulate stale key packages indefinitely.
+        let stored_d_tag = match session
+            .repos
+            .published_key_packages
+            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .await
+        {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Failed to load latest d_tag for kind:30443, falling back to fresh d_tag: {}",
+                    e
+                );
+                None
+            }
+        };
+
+        let (canonical_tags, canonical_d_tag) =
+            apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);
+
         let canonical_event_id = self
             .publish_key_package_to_relays(
                 MLS_KEY_PACKAGE_KIND,
                 &key_package_data.content,
                 relay_urls,
-                &key_package_data.tags_30443,
+                &canonical_tags,
                 signer.clone(),
             )
             .await?;
@@ -428,7 +488,7 @@ impl Whitenoise {
             &key_package_data.hash_ref,
             &canonical_event_id,
             MLS_KEY_PACKAGE_KIND,
-            Some(&key_package_data.d_tag),
+            Some(&canonical_d_tag),
         )
         .await;
 
@@ -1975,6 +2035,125 @@ mod tests {
             .await;
         tokio::time::resume();
         assert!(result.is_err(), "Should fail when relay is unreachable");
+    }
+
+    fn sample_key_package_event_data(d_tag: &str) -> KeyPackageEventData {
+        KeyPackageEventData {
+            content: "sample".to_string(),
+            tags_30443: vec![
+                Tag::identifier(d_tag),
+                Tag::custom(TagKind::MlsCiphersuite, [REQUIRED_MLS_CIPHERSUITE_TAG]),
+                Tag::custom(TagKind::MlsExtensions, vec!["0x000a", "0xf2ee"]),
+                Tag::custom(TagKind::Custom("encoding".into()), ["base64"]),
+            ],
+            tags_443: vec![Tag::custom(
+                TagKind::MlsCiphersuite,
+                [REQUIRED_MLS_CIPHERSUITE_TAG],
+            )],
+            hash_ref: vec![1, 2, 3],
+            d_tag: d_tag.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_apply_d_tag_override_uses_stored_d_tag_when_present() {
+        let data = sample_key_package_event_data("fresh-from-mdk");
+
+        let (tags, d_tag) = apply_d_tag_override(Some("persisted-slot"), &data);
+
+        assert_eq!(d_tag, "persisted-slot");
+        let identifier = tags
+            .iter()
+            .find(|t| t.kind() == TagKind::d())
+            .expect("d tag must be present");
+        assert_eq!(identifier.content(), Some("persisted-slot"));
+
+        // Non-d tags are preserved unchanged so MLS metadata still validates.
+        assert!(tags.iter().any(|t| t.kind() == TagKind::MlsCiphersuite));
+        assert!(
+            tags.iter()
+                .any(|t| t.kind() == TagKind::Custom("encoding".into()))
+        );
+    }
+
+    #[test]
+    fn test_apply_d_tag_override_keeps_fresh_d_tag_when_none_stored() {
+        let data = sample_key_package_event_data("fresh-from-mdk");
+
+        let (tags, d_tag) = apply_d_tag_override(None, &data);
+
+        assert_eq!(d_tag, "fresh-from-mdk");
+        let identifier = tags
+            .iter()
+            .find(|t| t.kind() == TagKind::d())
+            .expect("d tag must be present");
+        assert_eq!(identifier.content(), Some("fresh-from-mdk"));
+    }
+
+    #[test]
+    fn test_apply_d_tag_override_replaces_only_d_tag() {
+        let data = sample_key_package_event_data("fresh");
+        let original_count = data.tags_30443.len();
+
+        let (tags, _) = apply_d_tag_override(Some("slot"), &data);
+
+        assert_eq!(tags.len(), original_count);
+        // Exactly one `d` tag, and it is the overridden one.
+        let d_tags: Vec<_> = tags.iter().filter(|t| t.kind() == TagKind::d()).collect();
+        assert_eq!(d_tags.len(), 1);
+        assert_eq!(d_tags[0].content(), Some("slot"));
+    }
+
+    #[tokio::test]
+    async fn test_publish_key_package_pair_reuses_d_tag_across_publishes() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // First publish lands during account creation.
+        let account = whitenoise.create_identity().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        let initial_d_tag = session
+            .repos
+            .published_key_packages
+            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .await
+            .unwrap()
+            .expect("initial publish must record a d_tag for kind:30443");
+
+        // Trigger a second publish through the same code path.
+        let keys = whitenoise
+            .shared
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&account.pubkey)
+            .unwrap();
+        whitenoise
+            .publish_key_package_for_account_with_signer(&account, keys)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let canonical_rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT d_tag FROM published_key_packages
+             WHERE kind = ? AND d_tag IS NOT NULL",
+        )
+        .bind(i64::from(MLS_KEY_PACKAGE_KIND.as_u16()))
+        .fetch_all(&session.account_db.inner.pool)
+        .await
+        .unwrap();
+
+        assert!(
+            canonical_rows.len() >= 2,
+            "expected at least two kind:30443 publish rows, got {}",
+            canonical_rows.len()
+        );
+        for (d_tag,) in &canonical_rows {
+            assert_eq!(
+                d_tag, &initial_d_tag,
+                "every kind:30443 publish must reuse the original d_tag slot \
+                 so relays NIP-33-replace the previous event instead of accumulating"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -436,7 +436,9 @@ mod tests {
         account: &crate::whitenoise::accounts::Account,
         relays: &[Relay],
     ) -> Result<EventId, crate::whitenoise::error::WhitenoiseError> {
-        let key_package_data = whitenoise.encoded_key_package(account, relays).await?;
+        let key_package_data = whitenoise
+            .encoded_key_package(account, relays, None)
+            .await?;
 
         let nsec = whitenoise.export_account_nsec(account).await?;
         let secret_key =

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -143,13 +143,17 @@ impl<'a> KeyPackageOps<'a> {
                 Some(canonical_created_at),
             )
             .await?;
-        self.track_published(
+        // Propagate canonical tracking failures: the d-tag reuse and
+        // monotonic-timestamp invariants both depend on this row being
+        // persisted. If the publish landed but tracking silently fails, the
+        // next publish would think no slot exists and start a fresh one —
+        // the very bug this PR is fixing.
+        self.track_published_canonical(
             &key_package_data.hash_ref,
             &canonical_event_id,
-            MLS_KEY_PACKAGE_KIND,
-            Some(&canonical_d_tag),
+            &canonical_d_tag,
         )
-        .await;
+        .await?;
 
         match self
             .publish_to_relays(
@@ -162,13 +166,12 @@ impl<'a> KeyPackageOps<'a> {
             .await
         {
             Ok(legacy_event_id) => {
-                self.track_published(
-                    &key_package_data.hash_ref,
-                    &legacy_event_id,
-                    MLS_KEY_PACKAGE_KIND_LEGACY,
-                    None,
-                )
-                .await;
+                // Legacy tracking is best-effort: kind:443 is regular per
+                // NIP-01 (not addressable), so a missed row only affects
+                // audit-trail completeness, not future canonical
+                // replacement.
+                self.track_published_legacy(&key_package_data.hash_ref, &legacy_event_id)
+                    .await;
             }
             Err(e) => {
                 tracing::warn!(
@@ -455,24 +458,51 @@ impl<'a> KeyPackageOps<'a> {
         Ok(*result.id())
     }
 
+    /// Tracks a canonical (kind:30443) publish in the per-account DB.
+    ///
+    /// Errors propagate to the caller because the d-tag reuse and
+    /// monotonic-timestamp logic both read from this row on the next
+    /// publish; silent loss would re-introduce slot drift.
     #[perf_instrument("key_packages")]
-    async fn track_published(
+    async fn track_published_canonical(
         &self,
         hash_ref: &[u8],
         event_id: &EventId,
-        kind: Kind,
-        d_tag: Option<&str>,
-    ) {
+        d_tag: &str,
+    ) -> Result<()> {
+        self.session
+            .repos
+            .published_key_packages
+            .create(
+                hash_ref,
+                &event_id.to_hex(),
+                MLS_KEY_PACKAGE_KIND,
+                Some(d_tag),
+            )
+            .await
+    }
+
+    /// Tracks a legacy (kind:443) publish — best-effort.
+    ///
+    /// kind:443 is regular per NIP-01 (not addressable), so missing rows
+    /// only affect the audit trail. We log and continue.
+    #[perf_instrument("key_packages")]
+    async fn track_published_legacy(&self, hash_ref: &[u8], event_id: &EventId) {
         if let Err(e) = self
             .session
             .repos
             .published_key_packages
-            .create(hash_ref, &event_id.to_hex(), kind, d_tag)
+            .create(
+                hash_ref,
+                &event_id.to_hex(),
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                None,
+            )
             .await
         {
             tracing::warn!(
                 target: "whitenoise::key_packages",
-                "Published key package but failed to track it: {}",
+                "Published legacy key package but failed to track it: {}",
                 e
             );
         }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -11,8 +11,8 @@ use crate::RelayType;
 use crate::perf_instrument;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::key_packages::{
-    MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, apply_d_tag_override,
-    filter_key_package_events_for_account, monotonic_canonical_created_at,
+    MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, filter_key_package_events_for_account,
+    monotonic_canonical_created_at,
 };
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::users::User;
@@ -56,7 +56,8 @@ impl<'a> KeyPackageOps<'a> {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
-        let key_package_data = self.encoded_key_package(&relays).await?;
+        let (key_package_data, canonical_created_at) =
+            self.prepare_canonical_publish_inputs(&relays).await?;
         let relay_urls = Relay::urls(&relays);
         let mut last_error = None;
 
@@ -73,7 +74,10 @@ impl<'a> KeyPackageOps<'a> {
                 tokio::time::sleep(delay).await;
             }
 
-            match self.publish_pair(&key_package_data, &relay_urls).await {
+            match self
+                .publish_pair(&key_package_data, canonical_created_at, &relay_urls)
+                .await
+            {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(
@@ -99,24 +103,32 @@ impl<'a> KeyPackageOps<'a> {
     /// warnings, leaving the scheduler to retry.
     #[perf_instrument("key_packages")]
     pub(crate) async fn create_and_publish(&self, relays: &[Relay]) -> Result<()> {
-        let key_package_data = self.encoded_key_package(relays).await?;
+        let (key_package_data, canonical_created_at) =
+            self.prepare_canonical_publish_inputs(relays).await?;
         let relay_urls = Relay::urls(relays);
-        self.publish_pair(&key_package_data, &relay_urls).await
+        self.publish_pair(&key_package_data, canonical_created_at, &relay_urls)
+            .await
     }
 
-    /// Publish the canonical (kind:30443) and legacy (kind:443) key package
-    /// events for an already-encoded `KeyPackageEventData`.
+    /// Resolves persisted canonical-slot state and generates the key package
+    /// in one step.
     ///
-    /// Canonical publishing reuses the persisted `d` tag and bumps
-    /// `created_at` strictly past the last canonical insert timestamp so
-    /// NIP-33 reliably replaces the prior event. Legacy publishing is
-    /// best-effort: a failure logs a warning but does not fail the call,
-    /// matching the dual-publish behavior on the global Whitenoise path.
-    async fn publish_pair(
+    /// Looks up the previously-recorded NIP-33 `d` tag and the maximum
+    /// `created_at` for kind:30443 publishes, then hands the d-tag to MDK
+    /// via `KeyPackageOptions::existing_d_tag` so the new event lands in
+    /// the same addressable slot. Returns a strictly-monotonic canonical
+    /// `created_at` so a same-second publish can't lose the NIP-01
+    /// lowest-event-id tiebreaker.
+    ///
+    /// Fail-fast on DB read errors: a soft-fail `None` fallback would
+    /// publish into a fresh slot (slot drift) and risk losing the timestamp
+    /// tiebreaker — defeating the whole reuse path. Per-account SQLite
+    /// reads on a local file are rare to fail; the scheduler retries on
+    /// the next tick.
+    async fn prepare_canonical_publish_inputs(
         &self,
-        key_package_data: &KeyPackageEventData,
-        relay_urls: &[RelayUrl],
-    ) -> Result<()> {
+        relays: &[Relay],
+    ) -> Result<(KeyPackageEventData, Timestamp)> {
         let stored_d_tag = self
             .session
             .repos
@@ -130,16 +142,38 @@ impl<'a> KeyPackageOps<'a> {
             .find_max_created_at(MLS_KEY_PACKAGE_KIND)
             .await?;
 
-        let (canonical_tags, canonical_d_tag) =
-            apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);
+        let key_package_data = self
+            .encoded_key_package(relays, stored_d_tag.as_deref())
+            .await?;
         let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
 
+        Ok((key_package_data, canonical_created_at))
+    }
+
+    /// Publish the canonical (kind:30443) and legacy (kind:443) key package
+    /// events for an already-encoded `KeyPackageEventData`.
+    ///
+    /// Caller is responsible for resolving NIP-33 slot state via
+    /// [`Self::prepare_canonical_publish_inputs`] so the d-tag baked into
+    /// `key_package_data.tags_30443` by MDK is the persisted slot identifier
+    /// (not a fresh random one), and `canonical_created_at` is strictly
+    /// monotonic past the prior canonical insert. This function trusts
+    /// those inputs and just publishes + tracks.
+    ///
+    /// Legacy publishing is best-effort: a failure logs a warning but does
+    /// not fail the call.
+    async fn publish_pair(
+        &self,
+        key_package_data: &KeyPackageEventData,
+        canonical_created_at: Timestamp,
+        relay_urls: &[RelayUrl],
+    ) -> Result<()> {
         let canonical_event_id = self
             .publish_to_relays(
                 MLS_KEY_PACKAGE_KIND,
                 &key_package_data.content,
                 relay_urls,
-                &canonical_tags,
+                &key_package_data.tags_30443,
                 Some(canonical_created_at),
             )
             .await?;
@@ -151,7 +185,7 @@ impl<'a> KeyPackageOps<'a> {
         self.track_published_canonical(
             &key_package_data.hash_ref,
             &canonical_event_id,
-            &canonical_d_tag,
+            &key_package_data.d_tag,
         )
         .await?;
 
@@ -417,13 +451,32 @@ impl<'a> KeyPackageOps<'a> {
 
     // ── Private helpers ────────────────────────────────────────────────
 
+    /// Builds a fresh MLS key package and serializes it for relay publish.
+    ///
+    /// When `existing_d_tag` is `Some(d)`, MDK reuses that NIP-33
+    /// addressable-slot identifier (via `KeyPackageOptions::existing_d_tag`)
+    /// so the resulting event replaces the prior canonical event on relays
+    /// instead of accumulating a new addressable-event row. `None` lets MDK
+    /// generate a fresh slot (first publish for the account).
     #[perf_instrument("key_packages")]
-    async fn encoded_key_package(&self, relays: &[Relay]) -> Result<KeyPackageEventData> {
+    async fn encoded_key_package(
+        &self,
+        relays: &[Relay],
+        existing_d_tag: Option<&str>,
+    ) -> Result<KeyPackageEventData> {
         let key_package_relay_urls = Relay::urls(relays);
+        let options = mdk_core::key_packages::KeyPackageOptions {
+            protected: false,
+            existing_d_tag: existing_d_tag.map(str::to_owned),
+        };
         let data = self
             .session
             .mdk
-            .create_key_package_for_event(&self.session.account_pubkey, key_package_relay_urls)
+            .create_key_package_for_event_with_options(
+                &self.session.account_pubkey,
+                key_package_relay_urls,
+                options,
+            )
             .map_err(|e| WhitenoiseError::Configuration(format!("NostrMls error: {}", e)))?;
         Ok(data)
     }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -11,7 +11,8 @@ use crate::RelayType;
 use crate::perf_instrument;
 use crate::whitenoise::error::{Result, WhitenoiseError};
 use crate::whitenoise::key_packages::{
-    MLS_KEY_PACKAGE_KIND_LEGACY, filter_key_package_events_for_account,
+    MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, apply_d_tag_override,
+    filter_key_package_events_for_account, monotonic_canonical_created_at,
 };
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::users::User;
@@ -39,9 +40,15 @@ impl<'a> KeyPackageOps<'a> {
 
     // ── Public API ─────────────────────────────────────────────────────
 
-    /// Creates a single MLS key package, then retries relay publishing with
-    /// exponential backoff if publishing fails. The key package is created
-    /// only once to avoid orphaning unused key material in local MLS storage.
+    /// Creates a single MLS key package, then publishes both the canonical
+    /// (kind:30443) and legacy (kind:443) events with retry/backoff on the
+    /// canonical leg. The key package is created only once to avoid
+    /// orphaning unused key material in local MLS storage.
+    ///
+    /// The canonical publish reuses the previously-recorded NIP-33 `d` tag
+    /// slot and uses a strictly-monotonic `created_at`, so it replaces any
+    /// prior canonical event on relays instead of accumulating a new
+    /// addressable-event row.
     #[perf_instrument("key_packages")]
     pub async fn publish(&self) -> Result<()> {
         let relays = self.prepare_relays().await?;
@@ -66,20 +73,8 @@ impl<'a> KeyPackageOps<'a> {
                 tokio::time::sleep(delay).await;
             }
 
-            match self
-                .publish_to_relays(
-                    MLS_KEY_PACKAGE_KIND_LEGACY,
-                    &key_package_data.content,
-                    &relay_urls,
-                    &key_package_data.tags_443,
-                )
-                .await
-            {
-                Ok(event_id) => {
-                    self.track_published(&key_package_data.hash_ref, &event_id)
-                        .await;
-                    return Ok(());
-                }
+            match self.publish_pair(&key_package_data, &relay_urls).await {
+                Ok(()) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(
                         target: "whitenoise::key_packages",
@@ -98,20 +93,94 @@ impl<'a> KeyPackageOps<'a> {
     }
 
     /// Create a new key package and publish it (single attempt, no retry).
+    ///
+    /// Like [`Self::publish`] but without the retry loop. Used by the
+    /// account-setup path where failures are caught and surfaced as
+    /// warnings, leaving the scheduler to retry.
     #[perf_instrument("key_packages")]
     pub(crate) async fn create_and_publish(&self, relays: &[Relay]) -> Result<()> {
         let key_package_data = self.encoded_key_package(relays).await?;
         let relay_urls = Relay::urls(relays);
-        let event_id = self
+        self.publish_pair(&key_package_data, &relay_urls).await
+    }
+
+    /// Publish the canonical (kind:30443) and legacy (kind:443) key package
+    /// events for an already-encoded `KeyPackageEventData`.
+    ///
+    /// Canonical publishing reuses the persisted `d` tag and bumps
+    /// `created_at` strictly past the last canonical insert timestamp so
+    /// NIP-33 reliably replaces the prior event. Legacy publishing is
+    /// best-effort: a failure logs a warning but does not fail the call,
+    /// matching the dual-publish behavior on the global Whitenoise path.
+    async fn publish_pair(
+        &self,
+        key_package_data: &KeyPackageEventData,
+        relay_urls: &[RelayUrl],
+    ) -> Result<()> {
+        let stored_d_tag = self
+            .session
+            .repos
+            .published_key_packages
+            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .await?;
+        let prev_canonical_max = self
+            .session
+            .repos
+            .published_key_packages
+            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
+            .await?;
+
+        let (canonical_tags, canonical_d_tag) =
+            apply_d_tag_override(stored_d_tag.as_deref(), key_package_data);
+        let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
+
+        let canonical_event_id = self
+            .publish_to_relays(
+                MLS_KEY_PACKAGE_KIND,
+                &key_package_data.content,
+                relay_urls,
+                &canonical_tags,
+                Some(canonical_created_at),
+            )
+            .await?;
+        self.track_published(
+            &key_package_data.hash_ref,
+            &canonical_event_id,
+            MLS_KEY_PACKAGE_KIND,
+            Some(&canonical_d_tag),
+        )
+        .await;
+
+        match self
             .publish_to_relays(
                 MLS_KEY_PACKAGE_KIND_LEGACY,
                 &key_package_data.content,
-                &relay_urls,
+                relay_urls,
                 &key_package_data.tags_443,
+                None,
             )
-            .await?;
-        self.track_published(&key_package_data.hash_ref, &event_id)
-            .await;
+            .await
+        {
+            Ok(legacy_event_id) => {
+                self.track_published(
+                    &key_package_data.hash_ref,
+                    &legacy_event_id,
+                    MLS_KEY_PACKAGE_KIND_LEGACY,
+                    None,
+                )
+                .await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::key_packages",
+                    "Published canonical kind:30443 key package for account {} but failed \
+                     to publish legacy kind:443 twin: {}",
+                    self.session.account_pubkey.to_hex(),
+                    e,
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -363,11 +432,18 @@ impl<'a> KeyPackageOps<'a> {
         encoded_key_package: &str,
         relay_urls: &[RelayUrl],
         tags: &[Tag],
+        custom_created_at: Option<Timestamp>,
     ) -> Result<EventId> {
         let result = self
             .session
             .ephemeral
-            .publish_key_package(kind, encoded_key_package, relay_urls, tags)
+            .publish_key_package(
+                kind,
+                encoded_key_package,
+                relay_urls,
+                tags,
+                custom_created_at,
+            )
             .await?;
 
         if result.success.is_empty() {
@@ -380,17 +456,18 @@ impl<'a> KeyPackageOps<'a> {
     }
 
     #[perf_instrument("key_packages")]
-    async fn track_published(&self, hash_ref: &[u8], event_id: &EventId) {
+    async fn track_published(
+        &self,
+        hash_ref: &[u8],
+        event_id: &EventId,
+        kind: Kind,
+        d_tag: Option<&str>,
+    ) {
         if let Err(e) = self
             .session
             .repos
             .published_key_packages
-            .create(
-                hash_ref,
-                &event_id.to_hex(),
-                MLS_KEY_PACKAGE_KIND_LEGACY,
-                None,
-            )
+            .create(hash_ref, &event_id.to_hex(), kind, d_tag)
             .await
         {
             tracing::warn!(

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -56,6 +56,11 @@ impl<'a> KeyPackageOps<'a> {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
+        // Serialize concurrent rotations for this account so the
+        // prepare/publish/track sequence stays atomic — see the lock's
+        // docs on [`AccountSession`]. Held until the function returns.
+        let _publish_guard = self.session.key_package_publish_lock.lock().await;
+
         let (key_package_data, canonical_created_at) =
             self.prepare_canonical_publish_inputs(&relays).await?;
         let relay_urls = Relay::urls(&relays);
@@ -103,6 +108,18 @@ impl<'a> KeyPackageOps<'a> {
     /// warnings, leaving the scheduler to retry.
     #[perf_instrument("key_packages")]
     pub(crate) async fn create_and_publish(&self, relays: &[Relay]) -> Result<()> {
+        // Mirror `publish()`: empty relays means we have nowhere to publish
+        // to, so don't waste MLS key material generating a package we can't
+        // send. Fail with the same error variant so callers handle both
+        // paths uniformly.
+        if relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+
+        // Serialize concurrent rotations for this account so the
+        // prepare/publish/track sequence stays atomic.
+        let _publish_guard = self.session.key_package_publish_lock.lock().await;
+
         let (key_package_data, canonical_created_at) =
             self.prepare_canonical_publish_inputs(relays).await?;
         let relay_urls = Relay::urls(relays);

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -146,22 +146,19 @@ impl<'a> KeyPackageOps<'a> {
         &self,
         relays: &[Relay],
     ) -> Result<(KeyPackageEventData, Timestamp)> {
-        let stored_d_tag = self
+        // Single query: the d-tag and the insert timestamp both come from
+        // the most recent canonical row. Folding the two lookups avoids the
+        // implication that they could disagree.
+        let latest_canonical = self
             .session
             .repos
             .published_key_packages
-            .find_latest_d_tag(MLS_KEY_PACKAGE_KIND)
+            .find_latest_by_kind(MLS_KEY_PACKAGE_KIND)
             .await?;
-        let prev_canonical_max = self
-            .session
-            .repos
-            .published_key_packages
-            .find_max_created_at(MLS_KEY_PACKAGE_KIND)
-            .await?;
+        let stored_d_tag = latest_canonical.as_ref().and_then(|r| r.d_tag.as_deref());
+        let prev_canonical_max = latest_canonical.as_ref().map(|r| r.created_at);
 
-        let key_package_data = self
-            .encoded_key_package(relays, stored_d_tag.as_deref())
-            .await?;
+        let key_package_data = self.encoded_key_package(relays, stored_d_tag).await?;
         let canonical_created_at = monotonic_canonical_created_at(prev_canonical_max);
 
         Ok((key_package_data, canonical_created_at))

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -105,6 +105,15 @@ pub struct AccountSession {
     inbox: RwLock<Option<AccountInboxState>>,
     /// Serializes concurrent activate/deactivate operations.
     activation_lock: Mutex<()>,
+    /// Serializes concurrent kind:30443 rotations so the
+    /// read-d_tag/read-max/encode/publish/track sequence is atomic per
+    /// account. Two concurrent rotations would otherwise read the same
+    /// `find_latest_d_tag` / `find_max_created_at` values, generate two
+    /// different MLS key packages with the same `d` and the same
+    /// `created_at`, and let the relay's NIP-01 lowest-event-id tiebreaker
+    /// pick the winner — defeating the d-tag-reuse + monotonic-timestamp
+    /// invariants this module establishes.
+    pub(crate) key_package_publish_lock: Mutex<()>,
     /// In-memory coordination for delayed MIP-05 token-list responses.
     pub(crate) pending_push_token_responses: Arc<DashMap<(GroupId, EventId), ()>>,
     /// Bounds concurrently-active delayed MIP-05 token-list response tasks.
@@ -153,6 +162,7 @@ impl AccountSession {
             group_handle,
             inbox: RwLock::new(None),
             activation_lock: Mutex::new(()),
+            key_package_publish_lock: Mutex::new(()),
             pending_push_token_responses: Arc::new(DashMap::new()),
             token_response_semaphore: Arc::new(Semaphore::new(
                 crate::whitenoise::push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,

--- a/src/whitenoise/session/relay_handles.rs
+++ b/src/whitenoise/session/relay_handles.rs
@@ -115,11 +115,19 @@ impl AccountEphemeralHandle {
         encoded_key_package: &str,
         relays: &[RelayUrl],
         tags: &[Tag],
+        custom_created_at: Option<Timestamp>,
     ) -> Result<Output<EventId>> {
         let signer = self.require_signer().await?;
         Ok(self
             .ephemeral
-            .publish_key_package_with_signer(kind, encoded_key_package, relays, tags, signer)
+            .publish_key_package_with_signer(
+                kind,
+                encoded_key_package,
+                relays,
+                tags,
+                custom_created_at,
+                signer,
+            )
             .await?)
     }
 


### PR DESCRIPTION
## Summary

Implements d_tag reuse for MLS key package (kind:30443) publishes so that successive key package rotations replace the previous event on relays per NIP-33, rather than accumulating as distinct addressable events.

The MDK library generates a fresh random `d` tag on every `create_key_package_for_event()` call, but its documentation explicitly states: "Callers SHOULD store and reuse this value when rotating the KeyPackage." Without reuse, relays accumulate stale key packages indefinitely instead of replacing them.

## Key Changes

- **New helper function `apply_d_tag_override()`**: Conditionally swaps the freshly-generated `d` tag from MDK with a previously-stored one, preserving all other event tags (MLS metadata, ciphersuite, extensions, etc.)

- **Database layer (`published_key_packages.rs`)**: Added `find_latest_d_tag()` method to retrieve the most recently recorded `d` tag for a given event kind, ordered by creation time with fallback to ID ordering

- **Repository wrapper**: Exposed `find_latest_d_tag()` through the `PublishedKeyPackagesRepo` interface for session-based access

- **Key package publish flow**: Modified `publish_key_package_for_account_with_signer()` to:
  - Query the database for any previously-stored `d` tag before publishing
  - Apply the override if found (gracefully falls back to fresh d_tag on query failure)
  - Pass canonical tags and d_tag to the relay publish and database record operations

- **Comprehensive test coverage**:
  - Unit tests for `apply_d_tag_override()` covering both stored and fresh d_tag paths
  - Unit tests for `find_latest_d_tag()` with empty table, multiple rows, and kind filtering
  - Integration test verifying that successive key package publishes reuse the same d_tag slot across multiple publish cycles

## Implementation Details

- The override is applied at the event-building stage, before relay publication and database recording, ensuring consistency across all downstream operations
- Error handling is defensive: if the d_tag lookup fails, the system logs a warning and falls back to the fresh MDK-generated d_tag rather than failing the publish
- The database query uses `ORDER BY created_at DESC, id DESC` to handle both normal ordering and edge cases where multiple rows share the same timestamp
- All non-d tags are preserved unchanged to maintain MLS validation and metadata integrity

https://claude.ai/code/session_01VPRo2i9bcezUHXHDqfQvHj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical (30443) publishes now reuse a persisted replace identifier and support a monotonic publish timestamp so relays replace prior canonical events.
  * Publishing emits paired canonical+legacy events in a single operation; publish paths accept an optional custom timestamp.

* **Bug Fixes**
  * Canonical lifecycle tracking now reliably propagates failures; legacy tracking remains best-effort.

* **Tests**
  * Added unit and integration tests for identifier reuse, monotonic timestamps, override behavior, and canonical+legacy pairing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/835)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->