### PR TITLE
fix(relays): make WhitenoiseConfig the single source of truth for relay fallbacks so benchmarks, integration tests, and the CLI honor the operator's configured relays instead of compile-time public defaults

### DIFF
--- a/crates/whitenoise-cli/src/bin/wnd.rs
+++ b/crates/whitenoise-cli/src/bin/wnd.rs
@@ -21,6 +21,22 @@ struct Args {
     /// Used to point the daemon at local relays for end-to-end testing.
     #[clap(long, value_name = "URLS", value_delimiter = ',')]
     discovery_relays: Vec<String>,
+
+    /// Comma-separated relay URLs adopted as a freshly-created account's
+    /// NIP-65, Inbox, and KeyPackage lists when no existing relay-list events
+    /// are found on the network. Used to point the daemon at private or local
+    /// relays for end-to-end testing and self-hosted deployments.
+    #[clap(long, value_name = "URLS", value_delimiter = ',')]
+    default_account_relays: Vec<String>,
+}
+
+fn parse_relay_urls(values: &[String], flag: &str) -> whitenoise_cli::Result<Vec<RelayUrl>> {
+    values
+        .iter()
+        .map(|raw| {
+            RelayUrl::parse(raw).map_err(|e| CliError::msg(format!("invalid {flag} {raw:?}: {e}")))
+        })
+        .collect()
 }
 
 #[tokio::main]
@@ -31,15 +47,16 @@ async fn main() -> whitenoise_cli::Result<()> {
     let mut wn_config =
         WhitenoiseConfig::new(&config.data_dir, &config.logs_dir, KEYRING_SERVICE_ID);
     if !args.discovery_relays.is_empty() {
-        let relays = args
-            .discovery_relays
-            .iter()
-            .map(|raw| {
-                RelayUrl::parse(raw)
-                    .map_err(|e| CliError::msg(format!("invalid --discovery-relays {raw:?}: {e}")))
-            })
-            .collect::<whitenoise_cli::Result<Vec<_>>>()?;
-        wn_config = wn_config.with_discovery_relays(relays);
+        wn_config = wn_config.with_discovery_relays(parse_relay_urls(
+            &args.discovery_relays,
+            "--discovery-relays",
+        )?);
+    }
+    if !args.default_account_relays.is_empty() {
+        wn_config = wn_config.with_default_account_relays(parse_relay_urls(
+            &args.default_account_relays,
+            "--default-account-relays",
+        )?);
     }
     let whitenoise = Whitenoise::new(wn_config).await?;
 

--- a/crates/whitenoise-cli/src/cli/dispatch.rs
+++ b/crates/whitenoise-cli/src/cli/dispatch.rs
@@ -999,11 +999,15 @@ async fn resolve_display_name(wn: &Whitenoise, pubkey: &PublicKey) -> Option<Str
         .cloned()
 }
 
-fn cli_group_relay_urls() -> Vec<RelayUrl> {
-    whitenoise::Relay::defaults()
-        .into_iter()
-        .map(|r| r.url)
-        .collect()
+/// Relay URLs adopted by newly-created MLS groups.
+///
+/// Reads the operator-configured `default_account_relays` set so a
+/// private-relay deployment bakes its own relays into newly-created groups
+/// instead of the public bootstrap defaults. The relay set is persisted into
+/// the MLS group config at creation time and is not refreshed on later boots,
+/// so this is the load-bearing decision for the group's lifetime.
+fn cli_group_relay_urls(wn: &Whitenoise) -> Vec<RelayUrl> {
+    wn.config().default_account_relays.clone()
 }
 
 async fn create_group(
@@ -1026,7 +1030,7 @@ async fn create_group(
         None, // image_hash
         None, // image_key
         None, // image_nonce
-        cli_group_relay_urls(),
+        cli_group_relay_urls(wn),
         vec![account.pubkey], // admins — creator only
         None,
     );

--- a/crates/whitenoise-cli/tests/cli_e2e.rs
+++ b/crates/whitenoise-cli/tests/cli_e2e.rs
@@ -188,15 +188,22 @@ async fn group_metadata_and_membership() {
 
     wait_for_group(&bob.socket, &bob_pk).await;
 
-    // groups show returns the MLS group object
+    // groups show returns { group: <Group>, required_proposals: [...] }.
     let detail = wn(
         &alice.socket,
         &["--account", &alice_pk, "groups", "show", &gid],
     );
     assert!(detail.is_object(), "group detail should be a JSON object");
+    let group_detail = detail
+        .get("group")
+        .expect("group detail should contain a 'group' field");
     assert!(
-        detail.get("mls_group_id").is_some(),
-        "should contain mls_group_id"
+        group_detail.get("mls_group_id").is_some(),
+        "group should contain mls_group_id"
+    );
+    assert!(
+        detail.get("required_proposals").is_some(),
+        "show response should expose required_proposals"
     );
 
     // members includes both Alice and Bob
@@ -247,6 +254,67 @@ async fn group_metadata_and_membership() {
             "Renamed Group",
         ],
     );
+}
+
+/// Verifies that `cli_group_relay_urls` reads the operator-configured
+/// `default_account_relays` set rather than the compile-time
+/// `Relay::defaults()` bootstrap. Pins the Phase 2 fix that prevents a
+/// private deployment from baking public relays into newly-created groups'
+/// persisted config.
+#[tokio::test]
+async fn group_relays_use_configured_default_account_relays() {
+    let alice = Daemon::start().await;
+    let bob = Daemon::start().await;
+
+    let alice_pk = wn(&alice.socket, &["create-identity"])["pubkey"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let bob_pk = wn(&bob.socket, &["create-identity"])["pubkey"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    wait_for_key_package(&bob.socket, &bob_pk).await;
+
+    let group = wn(
+        &alice.socket,
+        &[
+            "--account",
+            &alice_pk,
+            "groups",
+            "create",
+            "Relay Config Test",
+            &bob_pk,
+        ],
+    );
+    let gid = group_id_hex(&group);
+
+    let group_relays = wn(
+        &alice.socket,
+        &["--account", &alice_pk, "groups", "relays", &gid],
+    );
+    let group_relay_urls: Vec<String> = group_relays
+        .as_array()
+        .expect("group relays should be an array")
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    assert!(
+        !group_relay_urls.is_empty(),
+        "group relays should not be empty"
+    );
+    for url in &group_relay_urls {
+        assert!(
+            url.starts_with("ws://localhost:"),
+            "group relay {url} should be a local URL configured via --default-account-relays"
+        );
+    }
+    for forbidden in ["relay.damus.io", "relay.primal.net", "nos.lol"] {
+        assert!(
+            group_relay_urls.iter().all(|u| !u.contains(forbidden)),
+            "group relays should not contain public default {forbidden}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/whitenoise-cli/tests/cli_relay_control_e2e.rs
+++ b/crates/whitenoise-cli/tests/cli_relay_control_e2e.rs
@@ -99,7 +99,8 @@ fn search_updates_include_pubkey(updates: &[serde_json::Value], pubkey_hex: &str
 
 #[tokio::test]
 async fn relay_control_snapshot_tracks_seeded_discovery_graph() {
-    publish_user_search_seed_events(LOCAL_DEV_RELAYS)
+    let seed_relays: Vec<String> = LOCAL_DEV_RELAYS.iter().map(|s| (*s).to_string()).collect();
+    publish_user_search_seed_events(&seed_relays)
         .await
         .expect("publish search seed events");
 

--- a/crates/whitenoise-cli/tests/support/cli.rs
+++ b/crates/whitenoise-cli/tests/support/cli.rs
@@ -27,6 +27,10 @@ impl Daemon {
                 "--discovery-relays",
                 "ws://localhost:8080,ws://localhost:7777",
             ])
+            .args([
+                "--default-account-relays",
+                "ws://localhost:8080,ws://localhost:7777",
+            ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()

--- a/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/add_members_performance.rs
@@ -79,7 +79,7 @@ impl BenchmarkScenario for AddMembersPerformanceBenchmark {
             None,
             None,
             None,
-            context.test_relays(),
+            context.default_account_relay_urls(),
             vec![admin.pubkey],
             None,
         );

--- a/src/integration_tests/benchmarks/scenarios/login_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/login_performance.rs
@@ -90,7 +90,7 @@ impl BenchmarkScenario for LoginPerformanceBenchmark {
     async fn setup(&mut self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let config = self.config();
         let total_iterations = (config.iterations + config.warmup_iterations) as usize;
-        let relay_urls: Vec<String> = context.dev_relays.iter().map(|s| s.to_string()).collect();
+        let publish_relays = context.default_account_relays.clone();
 
         tracing::info!(
             "Setting up login benchmark: {} iterations, {} follows per account",
@@ -110,15 +110,20 @@ impl BenchmarkScenario for LoginPerformanceBenchmark {
         let follow_keys: Vec<Keys> = (0..self.follow_count).map(|_| Keys::generate()).collect();
         let follow_pubkeys: Vec<PublicKey> = follow_keys.iter().map(|k| k.public_key()).collect();
 
-        // Publish metadata + relay lists for each follow user concurrently
-        let dev_relays = context.dev_relays.clone();
+        // Publish metadata + relay lists for each follow user concurrently.
+        // Followed-user fixtures are read by the discovery plane (background
+        // metadata + follow-list lookups), so publish to discovery relays. The
+        // NIP-65 payload lists default-account relays — the same role the
+        // account being benchmarked uses for its own published lists.
+        let follow_publish_relays = context.discovery_relays.clone();
+        let follow_payload_relays = context.default_account_relays.clone();
 
         let error_count: usize = stream::iter(follow_keys.into_iter().enumerate())
             .map(|(i, keys)| {
-                let dev_relays = dev_relays.clone();
-                let relay_urls = relay_urls.clone();
+                let follow_publish_relays = follow_publish_relays.clone();
+                let follow_payload_relays = follow_payload_relays.clone();
                 async move {
-                    let test_client = match create_test_client(&dev_relays, keys).await {
+                    let test_client = match create_test_client(&follow_publish_relays, keys).await {
                         Ok(client) => client,
                         Err(e) => return Some(e.to_string()),
                     };
@@ -131,7 +136,7 @@ impl BenchmarkScenario for LoginPerformanceBenchmark {
                         )
                         .await?;
 
-                        publish_relay_lists(&test_client, relay_urls).await?;
+                        publish_relay_lists(&test_client, follow_payload_relays).await?;
                         Ok(())
                     }
                     .await;
@@ -169,7 +174,7 @@ impl BenchmarkScenario for LoginPerformanceBenchmark {
 
         for i in 0..total_iterations {
             let keys = Keys::generate();
-            let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
+            let test_client = create_test_client(&publish_relays, keys.clone()).await?;
 
             // Publish metadata
             publish_test_metadata(
@@ -180,7 +185,7 @@ impl BenchmarkScenario for LoginPerformanceBenchmark {
             .await?;
 
             // Publish relay lists (NIP-65, Inbox, KeyPackage) pointing to test relays
-            publish_relay_lists(&test_client, relay_urls.clone()).await?;
+            publish_relay_lists(&test_client, publish_relays.clone()).await?;
 
             // Publish the large contact list
             publish_follow_list(&test_client, &follow_pubkeys).await?;

--- a/src/integration_tests/benchmarks/scenarios/login_start_performance.rs
+++ b/src/integration_tests/benchmarks/scenarios/login_start_performance.rs
@@ -54,7 +54,7 @@ impl BenchmarkScenario for LoginStartPerformanceBenchmark {
     async fn setup(&mut self, context: &mut ScenarioContext) -> Result<(), WhitenoiseError> {
         let config = self.config();
         let total_iterations = (config.iterations + config.warmup_iterations) as usize;
-        let relay_urls: Vec<String> = context.dev_relays.iter().map(|s| s.to_string()).collect();
+        let publish_relays = context.default_account_relays.clone();
 
         tracing::info!(
             "Setting up login-start benchmark: {} iterations",
@@ -65,7 +65,7 @@ impl BenchmarkScenario for LoginStartPerformanceBenchmark {
 
         for i in 0..total_iterations {
             let keys = Keys::generate();
-            let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
+            let test_client = create_test_client(&publish_relays, keys.clone()).await?;
 
             publish_test_metadata(
                 &test_client,
@@ -75,7 +75,7 @@ impl BenchmarkScenario for LoginStartPerformanceBenchmark {
             .await?;
 
             // Publish all 3 relay lists so login_start finds them
-            publish_relay_lists(&test_client, relay_urls.clone()).await?;
+            publish_relay_lists(&test_client, publish_relays.clone()).await?;
 
             test_client.disconnect().await;
             prepared_keys.push(keys);

--- a/src/integration_tests/benchmarks/scenarios/user_discovery.rs
+++ b/src/integration_tests/benchmarks/scenarios/user_discovery.rs
@@ -71,7 +71,7 @@ impl BenchmarkScenario for UserDiscoveryBenchmark {
             pubkeys.push(pubkey);
 
             // Create test client and publish metadata
-            let test_client = create_test_client(&context.dev_relays, keys).await?;
+            let test_client = create_test_client(&context.discovery_relays, keys).await?;
             let metadata = Metadata::new()
                 .name(format!("Benchmark User {}", i))
                 .about("User for benchmark testing");

--- a/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
+++ b/src/integration_tests/benchmarks/test_cases/groups/create_group_benchmark.rs
@@ -62,7 +62,7 @@ impl BenchmarkTestCase for CreateGroupBenchmark {
             None,
             None,
             None,
-            context.test_relays(),
+            context.default_account_relay_urls(),
             admin_pubkeys,
             None,
         );

--- a/src/integration_tests/core/context.rs
+++ b/src/integration_tests/core/context.rs
@@ -6,10 +6,25 @@ use mdk_core::prelude::group_types::Group;
 use nostr_sdk::prelude::RelayUrl;
 use std::collections::HashMap;
 
+/// Per-scenario state shared across test cases.
+///
+/// The two relay fields are derived from the live [`WhitenoiseConfig`] at
+/// construction time so test scaffolding inherits the same relay configuration
+/// the binary passed in. They are intentionally kept distinct so a private-relay
+/// deployment can configure them differently without test scaffolding falling
+/// back to a compile-time relay choice.
+///
+/// [`WhitenoiseConfig`]: crate::WhitenoiseConfig
 #[derive(Clone)]
 pub struct ScenarioContext {
     pub whitenoise: Arc<Whitenoise>,
-    pub dev_relays: Vec<&'static str>,
+    /// Relays this Whitenoise instance gossips on for other users' metadata,
+    /// follow lists, and discovery. Mirrors `WhitenoiseConfig::discovery_relays`.
+    pub discovery_relays: Vec<String>,
+    /// Relays adopted as a freshly-created account's NIP-65, Inbox, and
+    /// KeyPackage lists, and the initial lookup target for login flows. Mirrors
+    /// `WhitenoiseConfig::default_account_relays`.
+    pub default_account_relays: Vec<String>,
     pub accounts: HashMap<String, Account>,
     pub groups: HashMap<String, Group>,
     pub messages_ids: HashMap<String, String>,
@@ -20,18 +35,21 @@ pub struct ScenarioContext {
 
 impl ScenarioContext {
     pub fn new(whitenoise: Arc<Whitenoise>) -> Self {
-        let relays = if cfg!(debug_assertions) {
-            vec!["ws://localhost:8080", "ws://localhost:7777"]
-        } else {
-            vec![
-                "wss://relay.damus.io",
-                "wss://relay.primal.net",
-                "wss://nos.lol",
-            ]
-        };
+        let config = whitenoise.config();
+        let discovery_relays = config
+            .discovery_relays
+            .iter()
+            .map(|url| url.to_string())
+            .collect();
+        let default_account_relays = config
+            .default_account_relays
+            .iter()
+            .map(|url| url.to_string())
+            .collect();
         Self {
             whitenoise,
-            dev_relays: relays,
+            discovery_relays,
+            default_account_relays,
             accounts: HashMap::new(),
             groups: HashMap::new(),
             messages_ids: HashMap::new(),
@@ -89,11 +107,25 @@ impl ScenarioContext {
         }
     }
 
-    /// Returns the test relays as parsed `RelayUrl` instances.
-    pub fn test_relays(&self) -> Vec<RelayUrl> {
-        self.dev_relays
+    /// Discovery-plane relays as parsed `RelayUrl` instances.
+    ///
+    /// Use this when seeding fixture data the Whitenoise instance should find
+    /// through its discovery plane (metadata, follow lists, user discovery).
+    pub fn discovery_relay_urls(&self) -> Vec<RelayUrl> {
+        self.discovery_relays
             .iter()
-            .filter_map(|r| RelayUrl::parse(r).ok())
+            .filter_map(|url| RelayUrl::parse(url).ok())
+            .collect()
+    }
+
+    /// Default-account relays as parsed `RelayUrl` instances.
+    ///
+    /// Use this for login fixtures (publish destination and NIP-65 / Inbox /
+    /// KeyPackage event payloads) and for MLS group relay configs.
+    pub fn default_account_relay_urls(&self) -> Vec<RelayUrl> {
+        self.default_account_relays
+            .iter()
+            .filter_map(|url| RelayUrl::parse(url).ok())
             .collect()
     }
 }

--- a/src/integration_tests/core/test_clients.rs
+++ b/src/integration_tests/core/test_clients.rs
@@ -1,10 +1,10 @@
 use crate::WhitenoiseError;
 use nostr_sdk::prelude::*;
 
-pub async fn create_test_client(relays: &[&str], keys: Keys) -> Result<Client, WhitenoiseError> {
+pub async fn create_test_client(relays: &[String], keys: Keys) -> Result<Client, WhitenoiseError> {
     let client = Client::default();
     for relay in relays {
-        client.add_relay(*relay).await?;
+        client.add_relay(relay.as_str()).await?;
     }
 
     client.connect().await;

--- a/src/integration_tests/test_cases/account_management/login.rs
+++ b/src/integration_tests/test_cases/account_management/login.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::integration_tests::core::*;
 use crate::{RelayType, WhitenoiseError};
 use async_trait::async_trait;
@@ -7,25 +9,14 @@ pub struct LoginTestCase {
     account_name: String,
     metadata_name: Option<String>,
     metadata_about: Option<String>,
-    relays: Vec<&'static str>,
 }
 
 impl LoginTestCase {
     pub fn new(account_name: &str) -> Self {
-        let relays = if cfg!(debug_assertions) {
-            vec!["ws://localhost:8080"]
-        } else {
-            vec![
-                "wss://relay.damus.io",
-                "wss://relay.primal.net",
-                "wss://nos.lol",
-            ]
-        };
         Self {
             account_name: account_name.to_string(),
             metadata_name: None,
             metadata_about: None,
-            relays,
         }
     }
 
@@ -44,38 +35,34 @@ impl TestCase for LoginTestCase {
         let keys = Keys::generate();
         let expected_pubkey = keys.public_key();
 
-        // Publish test events first via external client
-        let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
+        // login_start reads from `default_account_relays`, so both the publish
+        // destination and the payload values come from that role.
+        let publish_relays = &context.default_account_relays;
+        let test_client = create_test_client(publish_relays, keys.clone()).await?;
 
-        // Publish metadata if specified
         if let (Some(name), Some(about)) = (&self.metadata_name, &self.metadata_about) {
             publish_test_metadata(&test_client, name, about).await?;
         }
 
-        // Publish relay list
-        let relay_urls: Vec<String> = self.relays.iter().map(|s| s.to_string()).collect();
-        publish_relay_lists(&test_client, relay_urls).await?;
+        publish_relay_lists(&test_client, publish_relays.clone()).await?;
 
         test_client.disconnect().await;
 
-        // Login with the keys
         let account = context
             .whitenoise
             .login(keys.secret_key().to_secret_hex())
             .await?;
 
         assert_eq!(account.pubkey, expected_pubkey);
-        let relays = account
+        let stored_relays = account
             .relays(RelayType::Nip65, &context.whitenoise.shared)
             .await?;
-        assert_eq!(relays.len(), self.relays.len());
-        for relay in relays {
-            assert!(
-                self.relays.contains(&relay.url.as_str()),
-                "Relay {} not found in expected relays",
-                relay.url
-            );
-        }
+        let expected: HashSet<String> = publish_relays.iter().cloned().collect();
+        let actual: HashSet<String> = stored_relays.iter().map(|r| r.url.to_string()).collect();
+        assert_eq!(
+            actual, expected,
+            "stored NIP-65 relay set should exactly match the published set"
+        );
         context.add_account(&self.account_name, account);
 
         tracing::info!("✓ Successfully logged in account: {}", self.account_name);

--- a/src/integration_tests/test_cases/chat_list/create_dm.rs
+++ b/src/integration_tests/test_cases/chat_list/create_dm.rs
@@ -52,7 +52,7 @@ impl TestCase for CreateDmTestCase {
                     None,
                     None,
                     None,
-                    context.test_relays(),
+                    context.default_account_relay_urls(),
                     vec![creator.pubkey, other.pubkey],
                     None,
                 ),

--- a/src/integration_tests/test_cases/login_flow/login_custom_relay.rs
+++ b/src/integration_tests/test_cases/login_flow/login_custom_relay.rs
@@ -27,25 +27,20 @@ impl TestCase for LoginCustomRelayTestCase {
         let keys = Keys::generate();
         let expected_pubkey = keys.public_key();
 
-        // In the test environment we have two local relays.
-        // Publish relay lists only on the SECOND relay so that login_start
-        // (which queries default relays) won't find them on the first attempt
-        // if there were separate pools. In practice with local Docker relays
-        // both relays are defaults, so we publish to a specific one and then
-        // use it as the "custom" relay.
-        //
-        // Since the test Docker environment has ws://localhost:8080 and
-        // ws://localhost:7777, we publish to the second relay and use it as
-        // the custom search target.
-        let custom_relay = if context.dev_relays.len() > 1 {
-            context.dev_relays[1]
-        } else {
-            context.dev_relays[0]
-        };
+        // login_start queries the configured default-account relays; pick a
+        // distinct one as the "custom" relay so we exercise the custom-relay
+        // path when there is more than one configured. Falls back to the
+        // first entry when only one default-account relay is configured.
+        let custom_relay = context
+            .default_account_relays
+            .get(1)
+            .or_else(|| context.default_account_relays.first())
+            .cloned()
+            .expect("test requires at least one configured default-account relay");
 
-        let test_client = create_test_client(&[custom_relay], keys.clone()).await?;
-        let relay_urls = vec![custom_relay.to_string()];
-        publish_relay_lists(&test_client, relay_urls).await?;
+        let publish_relays = vec![custom_relay.clone()];
+        let test_client = create_test_client(&publish_relays, keys.clone()).await?;
+        publish_relay_lists(&test_client, publish_relays).await?;
         test_client.disconnect().await;
 
         // Step 1: login_start -- since the relay lists exist on a relay that
@@ -73,7 +68,7 @@ impl TestCase for LoginCustomRelayTestCase {
         }
 
         // Step 2: Provide the custom relay where lists are published.
-        let custom_relay_url = RelayUrl::parse(custom_relay)?;
+        let custom_relay_url = RelayUrl::parse(&custom_relay)?;
         let result = context
             .whitenoise
             .login_with_custom_relay(&expected_pubkey, custom_relay_url)

--- a/src/integration_tests/test_cases/login_flow/login_custom_relay_not_found.rs
+++ b/src/integration_tests/test_cases/login_flow/login_custom_relay_not_found.rs
@@ -46,7 +46,11 @@ impl TestCase for LoginCustomRelayNotFoundTestCase {
 
         // Step 2: Try a custom relay -- lists won't be there either since
         // we never published anything.
-        let custom_relay_url = RelayUrl::parse(context.dev_relays[0])?;
+        let custom_relay = context
+            .default_account_relays
+            .first()
+            .expect("test requires at least one configured default-account relay");
+        let custom_relay_url = RelayUrl::parse(custom_relay)?;
         let result = context
             .whitenoise
             .login_with_custom_relay(&expected_pubkey, custom_relay_url)

--- a/src/integration_tests/test_cases/login_flow/login_start_happy_path.rs
+++ b/src/integration_tests/test_cases/login_flow/login_start_happy_path.rs
@@ -26,10 +26,11 @@ impl TestCase for LoginStartHappyPathTestCase {
         let keys = Keys::generate();
         let expected_pubkey = keys.public_key();
 
-        // Publish relay lists via an external client so they exist on the network.
-        let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
-        let relay_urls: Vec<String> = context.dev_relays.iter().map(|s| s.to_string()).collect();
-        publish_relay_lists(&test_client, relay_urls).await?;
+        // Publish relay lists via an external client so login_start finds them
+        // on the same relays it queries (the configured default-account set).
+        let publish_relays = &context.default_account_relays;
+        let test_client = create_test_client(publish_relays, keys.clone()).await?;
+        publish_relay_lists(&test_client, publish_relays.clone()).await?;
         test_client.disconnect().await;
 
         // login_start should find the relay lists and return Complete.

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -327,7 +327,7 @@ async fn publish_backdated_key_package(
     let event_id = event.id;
 
     // Create a test client and publish
-    let relay_urls: Vec<&str> = relays.iter().map(|r| r.url.as_str()).collect();
+    let relay_urls: Vec<String> = relays.iter().map(|r| r.url.to_string()).collect();
     let client = create_test_client(&relay_urls, keys).await?;
     client.send_event(&event).await?;
     client.disconnect().await;

--- a/src/integration_tests/test_cases/shared/create_group.rs
+++ b/src/integration_tests/test_cases/shared/create_group.rs
@@ -59,7 +59,7 @@ impl TestCase for CreateGroupTestCase {
                     None, // image_hash
                     None, // image_key
                     None, // image_nonce
-                    context.test_relays(),
+                    context.default_account_relay_urls(),
                     admin_pubkeys,
                     None,
                 ),

--- a/src/integration_tests/test_cases/shared/legacy_key_package.rs
+++ b/src/integration_tests/test_cases/shared/legacy_key_package.rs
@@ -138,7 +138,7 @@ pub(crate) async fn publish_legacy_capability_key_package(
         .map_err(|e| WhitenoiseError::Internal(e.to_string()))?;
     let event_id = event.id;
 
-    let relay_urls: Vec<&str> = relays.iter().map(|r| r.url.as_str()).collect();
+    let relay_urls: Vec<String> = relays.iter().map(|r| r.url.to_string()).collect();
     let client = create_test_client(&relay_urls, keys).await?;
     client.send_event(&event).await?;
     client.disconnect().await;
@@ -184,7 +184,7 @@ pub(crate) async fn publish_legacy_leaf_key_package(
     let relays = account
         .key_package_relays(&context.whitenoise.shared)
         .await?;
-    let relay_urls: Vec<&str> = relays.iter().map(|relay| relay.url.as_str()).collect();
+    let relay_urls: Vec<String> = relays.iter().map(|relay| relay.url.to_string()).collect();
     let client = create_test_client(&relay_urls, keys).await?;
     client.send_event(&event).await?;
     client.disconnect().await;

--- a/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
+++ b/src/integration_tests/test_cases/subscription_processing/publish_subscription_update.rs
@@ -64,12 +64,8 @@ impl PublishSubscriptionUpdateTestCase {
         context: &ScenarioContext,
         keys: &Keys,
     ) -> Result<Client, WhitenoiseError> {
-        let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
-        let relay_urls: Vec<String> = context
-            .dev_relays
-            .iter()
-            .map(|url| url.to_string())
-            .collect();
+        let test_client = create_test_client(&context.discovery_relays, keys.clone()).await?;
+        let relay_urls = context.discovery_relays.clone();
         publish_relay_lists(&test_client, relay_urls).await?;
         tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
         Ok(test_client)
@@ -134,12 +130,8 @@ impl PublishSubscriptionUpdateTestCase {
     ) -> Result<(), WhitenoiseError> {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        // Create complete relay list (dev relays + new relay)
-        let mut relay_urls: Vec<String> = context
-            .dev_relays
-            .iter()
-            .map(|url| url.to_string())
-            .collect();
+        // Create complete relay list (discovery relays + new relay)
+        let mut relay_urls = context.discovery_relays.clone();
         relay_urls.push(new_relay_url.to_string());
 
         let nip65_tags: Vec<Tag> = relay_urls

--- a/src/integration_tests/test_cases/subscription_processing/verify_last_synced_timestamp.rs
+++ b/src/integration_tests/test_cases/subscription_processing/verify_last_synced_timestamp.rs
@@ -96,7 +96,7 @@ impl VerifyLastSyncedTimestampTestCase {
         let account = context.whitenoise.find_account_by_pubkey(&pubkey).await?;
         let nsec = context.whitenoise.export_account_nsec(&account).await?;
         let keys = Keys::parse(&nsec)?;
-        let client = create_test_client(&context.dev_relays, keys.clone()).await?;
+        let client = create_test_client(&context.discovery_relays, keys.clone()).await?;
         let contact = Keys::generate().public_key();
 
         let tags = vec![Tag::custom(TagKind::p(), [contact.to_hex()])];
@@ -118,7 +118,7 @@ impl VerifyLastSyncedTimestampTestCase {
         event_timestamp: Timestamp,
     ) -> Result<(), WhitenoiseError> {
         let keys = Keys::generate();
-        let client = create_test_client(&context.dev_relays, keys.clone()).await?;
+        let client = create_test_client(&context.discovery_relays, keys.clone()).await?;
         let metadata = Metadata {
             name: Some("Test metadata for sync verification".to_string()),
             ..Default::default()

--- a/src/integration_tests/test_cases/user_discovery/resolve_user.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user.rs
@@ -2,7 +2,7 @@ use crate::WhitenoiseError;
 use crate::integration_tests::core::test_clients::{create_test_client, publish_relay_lists};
 use crate::integration_tests::core::*;
 use async_trait::async_trait;
-use nostr_sdk::{Keys, Metadata, RelayUrl};
+use nostr_sdk::{Keys, Metadata};
 
 /// Tests `resolve_user` for a new user whose metadata is still unknown locally.
 ///
@@ -14,7 +14,6 @@ use nostr_sdk::{Keys, Metadata, RelayUrl};
 pub struct ResolveUserTestCase {
     test_keys: Keys,
     test_metadata: Metadata,
-    test_relays: Vec<RelayUrl>,
 }
 
 impl ResolveUserTestCase {
@@ -32,22 +31,9 @@ impl Default for ResolveUserTestCase {
             .display_name("Background Display")
             .about("Testing resolve_user background discovery");
 
-        let test_relays = if cfg!(debug_assertions) {
-            vec![
-                RelayUrl::parse("ws://localhost:8080").unwrap(),
-                RelayUrl::parse("ws://localhost:7777").unwrap(),
-            ]
-        } else {
-            vec![
-                RelayUrl::parse("wss://relay.damus.io").unwrap(),
-                RelayUrl::parse("wss://relay.primal.net").unwrap(),
-            ]
-        };
-
         Self {
             test_keys: keys,
             test_metadata: metadata,
-            test_relays,
         }
     }
 }
@@ -61,16 +47,18 @@ impl TestCase for ResolveUserTestCase {
         // Create an identity so we can subscribe to events
         context.whitenoise.create_identity().await?;
 
-        // Publish test data
-        let test_client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+        // Publish fixture data to the discovery plane so the background fetch
+        // can find it. The NIP-65 payload lists the same relays so any
+        // subsequent protocol-correct lookup stays local.
+        let discovery_relays = &context.discovery_relays;
+        let test_client = create_test_client(discovery_relays, self.test_keys.clone()).await?;
 
         tracing::info!("Publishing test metadata and relays for test pubkey");
         test_client
             .send_event_builder(nostr_sdk::EventBuilder::metadata(&self.test_metadata))
             .await?;
 
-        let relay_urls: Vec<String> = self.test_relays.iter().map(|url| url.to_string()).collect();
-        publish_relay_lists(&test_client, relay_urls).await?;
+        publish_relay_lists(&test_client, discovery_relays.clone()).await?;
         test_client.disconnect().await;
 
         // `resolve_user` should return the local snapshot immediately.

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_blocking.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_blocking.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use nostr_sdk::{EventId, Keys, Metadata, RelayUrl};
 
@@ -22,7 +24,6 @@ pub struct ResolveUserBlockingTestCase {
     should_have_metadata: bool,
     should_have_relays: bool,
     test_metadata: Option<Metadata>,
-    test_relays: Vec<RelayUrl>,
 }
 
 impl ResolveUserBlockingTestCase {
@@ -33,7 +34,6 @@ impl ResolveUserBlockingTestCase {
             should_have_metadata: false,
             should_have_relays: false,
             test_metadata: None,
-            test_relays: vec![],
         }
     }
 
@@ -49,21 +49,7 @@ impl ResolveUserBlockingTestCase {
     }
 
     pub fn with_relays(mut self) -> Self {
-        let test_relays = if cfg!(debug_assertions) {
-            vec![
-                RelayUrl::parse("ws://localhost:8080").unwrap(),
-                RelayUrl::parse("ws://localhost:7777").unwrap(),
-            ]
-        } else {
-            vec![
-                RelayUrl::parse("wss://relay.damus.io").unwrap(),
-                RelayUrl::parse("wss://relay.primal.net").unwrap(),
-                RelayUrl::parse("wss://nos.lol").unwrap(),
-            ]
-        };
-
         self.should_have_relays = true;
-        self.test_relays = test_relays;
         self
     }
 
@@ -71,7 +57,8 @@ impl ResolveUserBlockingTestCase {
         &self,
         context: &ScenarioContext,
     ) -> Result<EventId, WhitenoiseError> {
-        let test_client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+        let test_client =
+            create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
 
         let metadata = self
             .test_metadata
@@ -87,12 +74,16 @@ impl ResolveUserBlockingTestCase {
         Ok(event_id)
     }
 
-    async fn publish_relays_data(&self, context: &ScenarioContext) -> Result<(), WhitenoiseError> {
-        let test_client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+    async fn publish_relays_data(
+        &self,
+        context: &ScenarioContext,
+        published_relays: &[String],
+    ) -> Result<(), WhitenoiseError> {
+        let test_client =
+            create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
 
         tracing::info!(target: LOG_TARGET, "Publishing test relay list for test pubkey");
-        let relay_urls: Vec<String> = self.test_relays.iter().map(|url| url.to_string()).collect();
-        publish_relay_lists(&test_client, relay_urls).await?;
+        publish_relay_lists(&test_client, published_relays.to_vec()).await?;
 
         test_client.disconnect().await;
         Ok(())
@@ -108,6 +99,13 @@ impl TestCase for ResolveUserBlockingTestCase {
             "Testing resolve_user_blocking for pubkey: {}",
             test_pubkey
         );
+
+        // The user's published NIP-65 payload lists the configured
+        // `default_account_relays`. Both sides of the post-resolution assertion
+        // derive from the same source so the invariant remains "the user has
+        // exactly the relays we published".
+        let published_relays = context.default_account_relays.clone();
+
         let user_exists = context
             .whitenoise
             .find_user_by_pubkey(&test_pubkey)
@@ -123,7 +121,7 @@ impl TestCase for ResolveUserBlockingTestCase {
         if self.should_have_metadata {
             let metadata_event_id = self.publish_metadata(context).await?;
             let metadata_client =
-                create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+                create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
             wait_for_latest_metadata_event(
                 &metadata_client,
                 test_pubkey,
@@ -135,10 +133,10 @@ impl TestCase for ResolveUserBlockingTestCase {
         }
 
         if self.should_have_relays {
-            self.publish_relays_data(context).await?;
+            self.publish_relays_data(context, &published_relays).await?;
 
             let relay_client =
-                create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+                create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
             wait_for_relay_list_indexed(&relay_client, test_pubkey).await?;
             relay_client.disconnect().await;
         }
@@ -215,14 +213,21 @@ impl TestCase for ResolveUserBlockingTestCase {
                 )
                 .await?;
 
-            let relay_urls: Vec<&RelayUrl> = user_relays.iter().map(|r| &r.url).collect();
-            for expected_relay in &self.test_relays {
-                assert!(
-                    relay_urls.contains(&expected_relay),
-                    "User should have relay {} that was published",
-                    expected_relay
-                );
-            }
+            let expected: HashSet<RelayUrl> = published_relays
+                .iter()
+                .map(|s| {
+                    RelayUrl::parse(s).map_err(|e| {
+                        WhitenoiseError::Internal(format!(
+                            "Invalid relay URL in default_account_relays: {s} ({e})"
+                        ))
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            let actual: HashSet<RelayUrl> = user_relays.iter().map(|r| r.url.clone()).collect();
+            assert_eq!(
+                actual, expected,
+                "stored NIP-65 relay set should exactly match the published set"
+            );
 
             tracing::info!(
                 target: LOG_TARGET,

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_known_metadata_no_refresh.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_known_metadata_no_refresh.rs
@@ -45,7 +45,7 @@ impl TestCase for ResolveUserKnownMetadataNoRefreshTestCase {
 
         context.whitenoise.create_identity().await?;
 
-        let client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+        let client = create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
 
         let initial_event_id = *client
             .send_event_builder(EventBuilder::metadata(&self.initial_metadata))

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_preserves_newer_processed_metadata.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_preserves_newer_processed_metadata.rs
@@ -55,7 +55,7 @@ impl TestCase for ResolveUserPreservesNewerProcessedMetadataTestCase {
         let newer_timestamp = Timestamp::now();
         let older_timestamp = Timestamp::from(newer_timestamp.as_secs().saturating_sub(3600));
 
-        let client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
+        let client = create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
         let newer_event_id = *client
             .send_event_builder(
                 EventBuilder::metadata(&self.newer_metadata).custom_created_at(newer_timestamp),

--- a/src/integration_tests/test_cases/user_discovery/resolve_user_unknown_metadata_no_result.rs
+++ b/src/integration_tests/test_cases/user_discovery/resolve_user_unknown_metadata_no_result.rs
@@ -45,8 +45,8 @@ impl TestCase for ResolveUserUnknownMetadataNoResultTestCase {
             test_pubkey
         );
 
-        let client = create_test_client(&context.dev_relays, self.test_keys.clone()).await?;
-        let expected_relays = context.test_relays();
+        let client = create_test_client(&context.discovery_relays, self.test_keys.clone()).await?;
+        let expected_relays = context.discovery_relay_urls();
         let relay_urls = expected_relays
             .iter()
             .map(|relay_url| relay_url.to_string())

--- a/src/integration_tests/test_cases/user_search/search_direct_follows.rs
+++ b/src/integration_tests/test_cases/user_search/search_direct_follows.rs
@@ -42,7 +42,7 @@ impl TestCase for SearchDirectFollowsTestCase {
         let followed_pubkey = followed_keys.public_key();
         let followed_name = "DirectFollow";
 
-        let client = create_test_client(&context.dev_relays, followed_keys).await?;
+        let client = create_test_client(&context.discovery_relays, followed_keys).await?;
         publish_test_metadata(&client, followed_name, "A directly followed user").await?;
         client.disconnect().await;
 
@@ -62,7 +62,8 @@ impl TestCase for SearchDirectFollowsTestCase {
         let unfollowed_keys = Keys::generate();
         let unfollowed_pubkey = unfollowed_keys.public_key();
 
-        let unfollowed_client = create_test_client(&context.dev_relays, unfollowed_keys).await?;
+        let unfollowed_client =
+            create_test_client(&context.discovery_relays, unfollowed_keys).await?;
         publish_test_metadata(
             &unfollowed_client,
             "DirectUnfollowed",

--- a/src/integration_tests/test_cases/user_search/search_empty_metadata.rs
+++ b/src/integration_tests/test_cases/user_search/search_empty_metadata.rs
@@ -47,7 +47,7 @@ impl TestCase for SearchEmptyMetadataTestCase {
         let target_name = "EmptyMetaTarget";
 
         // Step 1: Publish metadata to relays
-        let test_client = create_test_client(&context.dev_relays, target_keys).await?;
+        let test_client = create_test_client(&context.discovery_relays, target_keys).await?;
         publish_test_metadata(&test_client, target_name, "Published via relay").await?;
         test_client.disconnect().await;
         tracing::info!(

--- a/src/integration_tests/test_cases/user_search/search_fallback_seed.rs
+++ b/src/integration_tests/test_cases/user_search/search_fallback_seed.rs
@@ -43,7 +43,7 @@ impl TestCase for SearchFallbackSeedTestCase {
 
         // Seed Jeff's metadata, contact list, and Max's metadata to local relays
         // so the pipeline can resolve them without hitting the public network.
-        publish_user_search_seed_events(&context.dev_relays).await?;
+        publish_user_search_seed_events(&context.discovery_relays).await?;
         tracing::info!("Seeded fallback events to local relays");
 
         // --- Search 1: "Jeff" should find the fallback seed itself ---

--- a/src/integration_tests/test_cases/user_search/search_follows_of_follows.rs
+++ b/src/integration_tests/test_cases/user_search/search_follows_of_follows.rs
@@ -54,7 +54,7 @@ impl TestCase for SearchFollowsOfFollowsTestCase {
         let target_name = "FoFTarget";
 
         // Publish TargetUser's metadata to relays
-        let target_client = create_test_client(&context.dev_relays, target_keys).await?;
+        let target_client = create_test_client(&context.discovery_relays, target_keys).await?;
         publish_test_metadata(&target_client, target_name, "A friend of a friend").await?;
         target_client.disconnect().await;
         tracing::info!(
@@ -63,7 +63,8 @@ impl TestCase for SearchFollowsOfFollowsTestCase {
         );
 
         // Publish MiddleUser's metadata and follow list (pointing to TargetUser)
-        let middle_client = create_test_client(&context.dev_relays, middle_keys.clone()).await?;
+        let middle_client =
+            create_test_client(&context.discovery_relays, middle_keys.clone()).await?;
         publish_test_metadata(&middle_client, "MiddleUser", "Connects searcher to target").await?;
         publish_follow_list(&middle_client, &[target_pubkey]).await?;
         middle_client.disconnect().await;

--- a/src/integration_tests/test_cases/user_search/search_incremental_radius.rs
+++ b/src/integration_tests/test_cases/user_search/search_incremental_radius.rs
@@ -49,7 +49,7 @@ impl TestCase for SearchIncrementalRadiusTestCase {
         let target_name = "IncrTarget";
 
         // Publish TargetUser's metadata to relays
-        let target_client = create_test_client(&context.dev_relays, target_keys).await?;
+        let target_client = create_test_client(&context.discovery_relays, target_keys).await?;
         publish_test_metadata(&target_client, target_name, "Incremental radius target").await?;
         target_client.disconnect().await;
         tracing::info!(
@@ -58,7 +58,8 @@ impl TestCase for SearchIncrementalRadiusTestCase {
         );
 
         // Publish MiddleUser's metadata and follow list (pointing to TargetUser)
-        let middle_client = create_test_client(&context.dev_relays, middle_keys.clone()).await?;
+        let middle_client =
+            create_test_client(&context.discovery_relays, middle_keys.clone()).await?;
         publish_test_metadata(&middle_client, "IncrMiddle", "Connects searcher to target").await?;
         publish_follow_list(&middle_client, &[target_pubkey]).await?;
         middle_client.disconnect().await;

--- a/src/test_fixtures/nostr.rs
+++ b/src/test_fixtures/nostr.rs
@@ -40,10 +40,10 @@ fn parse_seed_events() -> Vec<Event> {
 }
 
 /// Publishes the shared user-search seed events to the given relays.
-pub async fn publish_user_search_seed_events(relays: &[&str]) -> Result<(), WhitenoiseError> {
+pub async fn publish_user_search_seed_events(relays: &[String]) -> Result<(), WhitenoiseError> {
     let client = Client::default();
     for relay in relays {
-        client.add_relay(*relay).await?;
+        client.add_relay(relay.as_str()).await?;
     }
     client.connect().await;
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -869,10 +869,12 @@ impl Whitenoise {
 
         init_timing::record("core_services");
 
-        // Create default relays in the database if they don't exist
-        // TODO: Make this batch fetch and insert all relays at once
-        for relay in Relay::defaults() {
-            let _ = whitenoise.find_or_create_relay_by_url(&relay.url).await?;
+        // Seed the relays table with the configured default-account relays so
+        // a private-relay deployment does not carry stale rows for relays it
+        // never uses. The discovery plane owns its own relay set elsewhere.
+        // TODO: Make this batch fetch and insert all relays at once.
+        for url in &whitenoise.config().default_account_relays {
+            let _ = whitenoise.find_or_create_relay_by_url(url).await?;
         }
 
         // Create default app settings in the database if they don't exist

--- a/src/whitenoise/relays.rs
+++ b/src/whitenoise/relays.rs
@@ -97,6 +97,23 @@ impl Relay {
         }
     }
 
+    /// Seed value for [`WhitenoiseConfig::default_account_relays`].
+    ///
+    /// This is intentionally a *compile-time* seed: in `debug_assertions`
+    /// builds it returns localhost relays so a developer running
+    /// `cargo run` against the local Docker stack works without
+    /// configuration; in release builds it returns the public bootstrap
+    /// set so first-time end users have somewhere to publish.
+    ///
+    /// **Do not** call this as a runtime fallback. The single source of
+    /// truth for fallback decisions is [`WhitenoiseConfig`] — read
+    /// `config().default_account_relays` (for account-published lists) or
+    /// `shared.fallback_relay_urls()` (for discovery-plane fallbacks).
+    /// Bypassing the config leaks public-relay traffic in private-relay
+    /// deployments. See `docs/` for the relay-configuration design.
+    ///
+    /// [`WhitenoiseConfig`]: crate::WhitenoiseConfig
+    /// [`WhitenoiseConfig::default_account_relays`]: crate::WhitenoiseConfig::default_account_relays
     pub fn defaults() -> Vec<Relay> {
         let urls: &[&str] = if cfg!(debug_assertions) {
             &["ws://localhost:8080", "ws://localhost:7777"]

--- a/src/whitenoise/users.rs
+++ b/src/whitenoise/users.rs
@@ -533,7 +533,7 @@ impl Whitenoise {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::whitenoise::test_utils::create_mock_whitenoise;
+    use crate::whitenoise::test_utils::{create_mock_whitenoise, create_mock_whitenoise_with};
     use chrono::{Duration, Utc};
     use std::collections::HashSet;
 
@@ -1330,6 +1330,37 @@ mod tests {
             assert!(
                 !urls.is_empty(),
                 "Configured discovery relays should be available as the fallback"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_returns_empty_when_no_relays_configured_anywhere() {
+            // A private-relay deployment with no discovery relays configured
+            // (and no user-published lists) must NOT fall back to a built-in
+            // public default set — that would leak metadata to public
+            // infrastructure. Returning an empty list is the correct,
+            // fail-closed behaviour; `key_package_lookup` already handles it
+            // gracefully via `KeyPackageLookup::NotFound`.
+            let (whitenoise, _data_temp, _logs_temp) =
+                create_mock_whitenoise_with(|config| config.with_discovery_relays(vec![])).await;
+            let test_pubkey = nostr_sdk::Keys::generate().public_key();
+            let user = User {
+                id: None,
+                pubkey: test_pubkey,
+                metadata: Metadata::new(),
+                created_at: Utc::now(),
+                metadata_known_at: None,
+                updated_at: Utc::now(),
+            };
+            let saved_user = user.save(&whitenoise.shared.database).await.unwrap();
+
+            let urls = saved_user
+                .key_package_relay_urls(&whitenoise.shared)
+                .await
+                .unwrap();
+            assert!(
+                urls.is_empty(),
+                "Expected empty relay list when nothing is configured; got {urls:?}"
             );
         }
     }

--- a/src/whitenoise/users/key_package.rs
+++ b/src/whitenoise/users/key_package.rs
@@ -33,8 +33,15 @@ impl User {
     /// Fallback order:
     /// 1. User's KeyPackage relays (kind 10051)
     /// 2. User's NIP-65 relays (kind 10002)
-    /// 3. Whitenoise discovery/fallback relays
-    /// 4. Default bootstrap relays from `Relay::defaults()`
+    /// 3. Whitenoise's configured discovery relays
+    ///
+    /// May return an empty vector when the user has no published lists and the
+    /// deployment has no configured discovery relays. Callers must treat this
+    /// as "lookup not possible" — the immediate caller `key_package_lookup`
+    /// maps it to `KeyPackageLookup::NotFound`. This is the correct
+    /// fail-closed behaviour for private-relay deployments; falling back to a
+    /// built-in public default set would leak metadata to public
+    /// infrastructure.
     #[perf_instrument("users")]
     pub async fn key_package_relay_urls(
         &self,
@@ -62,25 +69,15 @@ impl User {
             self.pubkey
         );
 
-        let fallback_relays = shared.fallback_relay_urls().await;
-        if !fallback_relays.is_empty() {
-            return Ok(fallback_relays);
-        }
-
-        tracing::warn!(
-            target: "whitenoise::users::key_package",
-            "User {} has no configured discovery relays available either, trying default relays",
-            self.pubkey
-        );
-
-        Ok(Relay::urls(&Relay::defaults()))
+        Ok(shared.fallback_relay_urls().await)
     }
 
     /// Fetches the user's MLS key package event from relays.
     ///
     /// Relay resolution follows [`key_package_relay_urls`](Self::key_package_relay_urls):
-    /// the user's KeyPackage relays, then NIP-65, then configured discovery
-    /// relays, then default bootstrap relays.
+    /// the user's KeyPackage relays, then NIP-65, then this deployment's
+    /// configured discovery relays. Returns `Ok(None)` when no relays are
+    /// available for the lookup.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI option to set default account relay URLs for the daemon.

* **Improvements**
  * Groups now inherit configured default account relays at creation instead of bootstrap defaults.
  * Relay resolution now prefers deployment configuration (discovery/fallback) and avoids falling back to public bootstrap relays.

* **Tests**
  * Added and updated end-to-end and benchmark tests to validate and use configured discovery and default-account relays.

* **Documentation**
  * Clarified behavior of default relay seeding and relay-resolution order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->