### PR TITLE
Per-account gift-wrap decrypt throttle with deferral semantics

### DIFF
--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -86,6 +86,12 @@ pub enum WhitenoiseError {
     #[error("Signer unavailable for account {0} — external signer not yet registered")]
     SignerUnavailable(PublicKey),
 
+    #[error("Inbound gift-wrap dropped: per-account decryption budget exhausted")]
+    GiftwrapThrottled,
+
+    #[error("Inbound gift-wrap deferred: signer backend transiently unavailable")]
+    GiftwrapDeferred,
+
     #[error("MDK error: {0}")]
     MdkCoreError(#[from] mdk_core::Error),
 

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -143,57 +143,25 @@ impl Whitenoise {
                             );
                         }
                     }
-                    Kind::GiftWrap => {
-                        // Use rumor timestamp for advancement per NIP-59
-                        match self
-                            .extract_rumor_timestamp_for_advancement(&event, &session)
-                            .await
-                        {
-                            Ok(Some(rumor_timestamp)) => {
-                                let safe_timestamp = cap_timestamp_to_now(rumor_timestamp);
-                                let created_ms = (safe_timestamp.as_secs() as i64) * 1000;
-
-                                if let Err(e) = Account::update_last_synced_max(
-                                    &account.pubkey,
-                                    created_ms,
-                                    &self.shared.database,
-                                )
-                                .await
-                                {
-                                    tracing::warn!(
-                                        target: "whitenoise::event_processor::process_account_event",
-                                        "Failed to advance last_synced_at with rumor timestamp for {}: {}",
-                                        account.pubkey.to_hex(),
-                                        e
-                                    );
-                                } else {
-                                    tracing::debug!(
-                                        target: "whitenoise::event_processor::process_account_event",
-                                        "Updated last_synced_at (if older) for {} with rumor timestamp {} (ms) [capped from original {}]",
-                                        account.pubkey.to_hex(),
-                                        created_ms,
-                                        rumor_timestamp.as_secs() * 1000
-                                    );
-                                }
-                            }
-                            Ok(None) => {
-                                tracing::debug!(
-                                    target: "whitenoise::event_processor::process_account_event",
-                                    "Skipping timestamp advancement for giftwrap with failed rumor extraction"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "whitenoise::event_processor::process_account_event",
-                                    "Failed to extract rumor timestamp for {}: {}",
-                                    account.pubkey.to_hex(),
-                                    e
-                                );
-                            }
-                        }
-                    }
+                    // GiftWrap watermark advancement is handled inside
+                    // handle_giftwrap so a single decrypt serves both
+                    // Welcome processing and sync advancement.
                     _ => {}
                 }
+            }
+            Err(WhitenoiseError::GiftwrapThrottled | WhitenoiseError::GiftwrapDeferred) => {
+                // Deliberate defer (throttle budget exhausted or signer
+                // backend transiently unavailable), not a failure. Do
+                // NOT record as processed (relay replay must redeliver
+                // once the bucket refills or the signer recovers) and
+                // do NOT schedule a retry (in-process retry would hit
+                // the same condition with no new information).
+                tracing::debug!(
+                    target: "whitenoise::event_processor::process_account_event",
+                    account = %account.pubkey.to_hex(),
+                    event_id = %event.id.to_hex(),
+                    "Gift-wrap deferred; awaiting relay redelivery"
+                );
             }
             Err(e) => {
                 // Handle retry logic for actual processing errors
@@ -360,27 +328,6 @@ impl Whitenoise {
                 );
                 Ok(()) // Unhandled events are not errors
             }
-        }
-    }
-
-    /// Extract rumor timestamp from giftwrap event for sync advancement.
-    ///
-    /// Only called after `handle_giftwrap` succeeds. A missing signer here
-    /// is surfaced as `SignerUnavailable` so it is distinguishable from an
-    /// actual rumor-extraction failure in the caller's logs.
-    #[perf_instrument("event_processor")]
-    async fn extract_rumor_timestamp_for_advancement(
-        &self,
-        event: &Event,
-        session: &Arc<AccountSession>,
-    ) -> Result<Option<Timestamp>> {
-        let signer = session
-            .get_signer()
-            .ok_or(WhitenoiseError::SignerUnavailable(session.account_pubkey))?;
-
-        match extract_rumor(&signer, event).await {
-            Ok(unwrapped) => Ok(Some(unwrapped.rumor.created_at)),
-            Err(_) => Ok(None), // Don't advance on extraction failure
         }
     }
 }
@@ -697,6 +644,267 @@ mod tests {
                 .await
                 .unwrap(),
             "Event should not be tracked when session is missing"
+        );
+    }
+
+    /// When the per-account gift-wrap throttle is exhausted, a validly-
+    /// targeted kind:1059 event must NOT be recorded as processed.
+    ///
+    /// If it were, relay replay deduplication
+    /// (`already_processed_account_event`) would silently drop the same
+    /// event id on its next redelivery — defeating the throttle's deferral
+    /// semantics and permanently losing legitimate Welcomes that arrived
+    /// in the same burst as the spam.
+    ///
+    /// This test locks the contract in place: a future refactor that
+    /// collapses `GiftwrapThrottled` back into the generic `Ok(())` /
+    /// `Err(_)` paths will fail here.
+    #[tokio::test]
+    async fn test_throttled_giftwrap_is_not_recorded_as_processed() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let victim_account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&victim_account.pubkey).unwrap();
+
+        // Drain the bucket so the next handle_giftwrap returns GiftwrapThrottled.
+        while session.giftwrap_throttle.try_acquire() {}
+
+        // Build a kind:1059 event whose `p` tag points at the victim. The
+        // content is irrelevant — the throttle fires before decryption is
+        // attempted, so any bytes are fine.
+        let attacker_keys = Keys::generate();
+        let event = EventBuilder::new(Kind::GiftWrap, "ciphertext")
+            .tag(Tag::public_key(victim_account.pubkey))
+            .sign(&attacker_keys)
+            .await
+            .unwrap();
+
+        let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
+        whitenoise
+            .process_account_event(
+                event.clone(),
+                EventSource::RelaySubscription(SubscriptionContext {
+                    plane: RelayPlane::AccountInbox,
+                    account_pubkey: Some(victim_account.pubkey),
+                    relay_url,
+                    stream: SubscriptionStream::AccountInboxGiftwraps,
+                    group_ids: Vec::new(),
+                }),
+                Default::default(),
+            )
+            .await;
+
+        assert!(
+            !whitenoise
+                .shared
+                .event_tracker
+                .already_processed_account_event(&event.id, &victim_account.pubkey)
+                .await
+                .unwrap(),
+            "throttled gift-wrap must not be recorded as processed; \
+             relay replay must be free to redeliver it after the bucket refills"
+        );
+    }
+
+    /// An undecryptable gift-wrap MUST be marked processed and MUST consume
+    /// exactly one throttle token — not eleven.
+    ///
+    /// Bogus or mis-targeted NIP-44 ciphertext will never decrypt no matter
+    /// how many times we retry. Routing such failures through the generic
+    /// `schedule_retry` path (max 10 attempts) would re-enqueue the same
+    /// event and re-acquire a token on each attempt — letting a small burst
+    /// of garbage gift-wraps drain the per-account decrypt budget many
+    /// times over and starve legitimate Welcomes.
+    ///
+    /// This test pins the contract: a single bogus event consumes exactly
+    /// one token and is recorded as processed so any subsequent redelivery
+    /// is deduped.
+    #[tokio::test]
+    async fn test_undecryptable_giftwrap_is_terminal_not_retried() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let victim_account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&victim_account.pubkey).unwrap();
+        let tokens_before = session.giftwrap_throttle.tokens();
+
+        // Build a kind:1059 event targeted at the victim, but with garbage
+        // bytes that NIP-44 will fail to decrypt. The `p` tag is required
+        // so the event clears `validate_giftwrap_target`.
+        let attacker_keys = Keys::generate();
+        let event = EventBuilder::new(Kind::GiftWrap, "not-a-valid-nip44-payload")
+            .tag(Tag::public_key(victim_account.pubkey))
+            .sign(&attacker_keys)
+            .await
+            .unwrap();
+
+        let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
+        whitenoise
+            .process_account_event(
+                event.clone(),
+                EventSource::RelaySubscription(SubscriptionContext {
+                    plane: RelayPlane::AccountInbox,
+                    account_pubkey: Some(victim_account.pubkey),
+                    relay_url,
+                    stream: SubscriptionStream::AccountInboxGiftwraps,
+                    group_ids: Vec::new(),
+                }),
+                Default::default(),
+            )
+            .await;
+
+        assert!(
+            whitenoise
+                .shared
+                .event_tracker
+                .already_processed_account_event(&event.id, &victim_account.pubkey)
+                .await
+                .unwrap(),
+            "undecryptable gift-wrap must be marked processed so subsequent \
+             redeliveries (relay replay or in-process retry) are deduped"
+        );
+
+        // Refill during the processing window is bounded by wallclock and
+        // capped at capacity, so the delta is essentially exactly 1.
+        // Tolerance of ±0.2 absorbs scheduler jitter without admitting an
+        // 11-token retry storm (which would show a delta of ~11).
+        let tokens_after = session.giftwrap_throttle.tokens();
+        let consumed = tokens_before - tokens_after;
+        assert!(
+            (0.8..=1.2).contains(&consumed),
+            "decrypt-failed event should consume exactly one throttle token, \
+             consumed {consumed} (before {tokens_before} → after {tokens_after}). \
+             A value near 11 indicates the retry loop was reintroduced."
+        );
+    }
+
+    /// External-signer transport failure during gift-wrap decryption MUST
+    /// defer (not track, not retry) so relay replay can redeliver once the
+    /// signer is reachable again.
+    ///
+    /// The library wraps deterministic local-crypto errors and transient
+    /// external-signer transport errors identically as
+    /// `nip59::Error::Signer(SignerError)`. The only way to distinguish
+    /// them is by the signer's backend. This test exercises a non-Keys
+    /// signer whose `nip44_decrypt` always fails and asserts that the
+    /// event is deferred — neither recorded as processed nor scheduled
+    /// for retry.
+    #[tokio::test]
+    async fn test_external_signer_decrypt_failure_is_deferred_not_terminal() {
+        use std::pin::Pin;
+
+        use nostr::SignerBackend;
+        use nostr::signer::SignerError;
+        use nostr::util::BoxedFuture;
+
+        // Minimal mock NostrSigner whose backend is `Custom` (non-Keys)
+        // and whose `nip44_decrypt` always returns an error. Other
+        // methods are unreachable for this test path because
+        // `extract_rumor` only ever calls `nip44_decrypt`.
+        #[derive(Debug)]
+        struct FailingExternalSigner;
+
+        impl NostrSigner for FailingExternalSigner {
+            fn backend(&self) -> SignerBackend {
+                SignerBackend::Custom(std::borrow::Cow::Borrowed("test-failing-signer"))
+            }
+            fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+                Box::pin(async { Err(SignerError::from("not implemented in test")) })
+            }
+            fn sign_event(
+                &self,
+                _unsigned: UnsignedEvent,
+            ) -> BoxedFuture<Result<Event, SignerError>> {
+                Box::pin(async { Err(SignerError::from("not implemented in test")) })
+            }
+            fn nip04_encrypt<'a>(
+                &'a self,
+                _public_key: &'a PublicKey,
+                _content: &'a str,
+            ) -> BoxedFuture<'a, Result<String, SignerError>> {
+                Box::pin(async { Err(SignerError::from("not implemented in test")) })
+            }
+            fn nip04_decrypt<'a>(
+                &'a self,
+                _public_key: &'a PublicKey,
+                _encrypted_content: &'a str,
+            ) -> BoxedFuture<'a, Result<String, SignerError>> {
+                Box::pin(async { Err(SignerError::from("not implemented in test")) })
+            }
+            fn nip44_encrypt<'a>(
+                &'a self,
+                _public_key: &'a PublicKey,
+                _content: &'a str,
+            ) -> BoxedFuture<'a, Result<String, SignerError>> {
+                Box::pin(async { Err(SignerError::from("not implemented in test")) })
+            }
+            fn nip44_decrypt<'a>(
+                &'a self,
+                _public_key: &'a PublicKey,
+                _payload: &'a str,
+            ) -> Pin<Box<dyn std::future::Future<Output = Result<String, SignerError>> + Send + 'a>>
+            {
+                Box::pin(async { Err(SignerError::from("signer transport unavailable")) })
+            }
+        }
+
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let victim_account = whitenoise.create_identity().await.unwrap();
+        let session = whitenoise.require_session(&victim_account.pubkey).unwrap();
+
+        // Swap the session's signer for our failing external-style mock.
+        session
+            .set_signer(std::sync::Arc::new(FailingExternalSigner))
+            .await;
+
+        let tokens_before = session.giftwrap_throttle.tokens();
+
+        // Build a kind:1059 event targeted at the victim. The content
+        // doesn't matter — our mock signer fails on every nip44_decrypt.
+        let attacker_keys = Keys::generate();
+        let event = EventBuilder::new(Kind::GiftWrap, "any-ciphertext")
+            .tag(Tag::public_key(victim_account.pubkey))
+            .sign(&attacker_keys)
+            .await
+            .unwrap();
+
+        let relay_url = RelayUrl::parse("ws://localhost:8080/").unwrap();
+        whitenoise
+            .process_account_event(
+                event.clone(),
+                EventSource::RelaySubscription(SubscriptionContext {
+                    plane: RelayPlane::AccountInbox,
+                    account_pubkey: Some(victim_account.pubkey),
+                    relay_url,
+                    stream: SubscriptionStream::AccountInboxGiftwraps,
+                    group_ids: Vec::new(),
+                }),
+                Default::default(),
+            )
+            .await;
+
+        // External-signer decrypt failure must NOT be recorded as
+        // processed: relay replay needs to redeliver the event after
+        // the signer recovers. Without this contract a transient
+        // signer outage would permanently lose welcomes that landed
+        // during the outage window.
+        assert!(
+            !whitenoise
+                .shared
+                .event_tracker
+                .already_processed_account_event(&event.id, &victim_account.pubkey)
+                .await
+                .unwrap(),
+            "external-signer transport failure must defer, not mark processed"
+        );
+
+        // One token consumed by the attempt — but not eleven. A value
+        // near 11 would indicate the retry loop fired on this error
+        // class, which would let a signer-disturbance attack amplify
+        // bucket consumption.
+        let tokens_after = session.giftwrap_throttle.tokens();
+        let consumed = tokens_before - tokens_after;
+        assert!(
+            (0.8..=1.2).contains(&consumed),
+            "deferred external-signer failure should consume exactly one token, \
+             consumed {consumed} (before {tokens_before} → after {tokens_after})"
         );
     }
 }

--- a/src/whitenoise/event_processor/account_event_processor.rs
+++ b/src/whitenoise/event_processor/account_event_processor.rs
@@ -790,10 +790,6 @@ mod tests {
     async fn test_external_signer_decrypt_failure_is_deferred_not_terminal() {
         use std::pin::Pin;
 
-        use nostr::SignerBackend;
-        use nostr::signer::SignerError;
-        use nostr::util::BoxedFuture;
-
         // Minimal mock NostrSigner whose backend is `Custom` (non-Keys)
         // and whose `nip44_decrypt` always returns an error. Other
         // methods are unreachable for this test path because
@@ -802,16 +798,16 @@ mod tests {
         struct FailingExternalSigner;
 
         impl NostrSigner for FailingExternalSigner {
-            fn backend(&self) -> SignerBackend {
+            fn backend(&self) -> SignerBackend<'_> {
                 SignerBackend::Custom(std::borrow::Cow::Borrowed("test-failing-signer"))
             }
-            fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+            fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
                 Box::pin(async { Err(SignerError::from("not implemented in test")) })
             }
             fn sign_event(
                 &self,
                 _unsigned: UnsignedEvent,
-            ) -> BoxedFuture<Result<Event, SignerError>> {
+            ) -> BoxedFuture<'_, Result<Event, SignerError>> {
                 Box::pin(async { Err(SignerError::from("not implemented in test")) })
             }
             fn nip04_encrypt<'a>(

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -73,7 +73,7 @@ impl Whitenoise {
         // identically as `nip59::Error::Signer(SignerError(String))` —
         // the only way to distinguish them is by what kind of signer
         // produced the error.
-        let signer_backend_is_keys = matches!(signer.backend(), nostr::SignerBackend::Keys);
+        let signer_backend_is_keys = matches!(signer.backend(), SignerBackend::Keys);
 
         let _decrypt_span = perf_span!("event_handlers::giftwrap_decrypt");
         let unwrapped = match extract_rumor(&signer, &event).await {
@@ -88,7 +88,7 @@ impl Whitenoise {
             // reachable. Skipping the retry queue here also prevents an
             // attacker able to disturb the signer transport from
             // amplifying token consumption.
-            Err(nostr::nips::nip59::Error::Signer(e)) if !signer_backend_is_keys => {
+            Err(nip59::Error::Signer(e)) if !signer_backend_is_keys => {
                 tracing::warn!(
                     target: "whitenoise::event_handlers::handle_giftwrap",
                     account = %account.pubkey.to_hex(),

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -5,6 +5,7 @@ use mdk_core::GroupId;
 use nostr_sdk::prelude::*;
 
 use crate::{
+    nostr_manager::utils::cap_timestamp_to_now,
     perf_instrument, perf_span,
     whitenoise::{
         Whitenoise,
@@ -35,16 +36,108 @@ impl Whitenoise {
         // that hasn't re-registered after restart). The event stays
         // unprocessed and relay replay will deliver it again once the
         // signer slot is filled via register_external_signer().
-        let _decrypt_span = perf_span!("event_handlers::giftwrap_decrypt");
         let signer = session
             .get_signer()
             .ok_or(WhitenoiseError::SignerUnavailable(account.pubkey))?;
 
-        let unwrapped = extract_rumor(&signer, &event).await.map_err(|e| {
-            WhitenoiseError::Configuration(format!("Failed to decrypt giftwrap: {}", e))
-        })?;
+        // Bound per-account NIP-44 decryption budget on inbound gift-wraps.
+        // Kind:1059 events are addressed to a public pubkey with no sender
+        // authentication, and the KeyPackage reference that would identify
+        // the inviter sits inside the encrypted rumor — there is no way to
+        // pre-filter at the transport layer. Without this gate, anyone who
+        // knows the recipient's pubkey can force unbounded ECDH+decrypt work
+        // on the recipient's device.
+        //
+        // The token is acquired AFTER the signer check so accounts whose
+        // signer is temporarily unavailable do not drain their budget on
+        // events that never reach decryption.
+        //
+        // On exhaustion, return `GiftwrapThrottled` rather than `Ok(())` so
+        // the outer processor skips the "processed" tracking step. Relay
+        // replay on the next subscription resume will redeliver the event
+        // once the bucket has refilled.
+        if !session.giftwrap_throttle.try_acquire() {
+            tracing::warn!(
+                target: "whitenoise::event_handlers::handle_giftwrap",
+                account = %account.pubkey.to_hex(),
+                event_id = %event.id.to_hex(),
+                tokens_remaining = session.giftwrap_throttle.tokens(),
+                "Dropping inbound gift-wrap: per-account decrypt budget exhausted"
+            );
+            return Err(WhitenoiseError::GiftwrapThrottled);
+        }
+
+        // Capture the signer backend so we can classify any subsequent
+        // decrypt failure. The library wraps both deterministic local
+        // crypto errors and transient external-signer transport errors
+        // identically as `nip59::Error::Signer(SignerError(String))` —
+        // the only way to distinguish them is by what kind of signer
+        // produced the error.
+        let signer_backend_is_keys = matches!(signer.backend(), nostr::SignerBackend::Keys);
+
+        let _decrypt_span = perf_span!("event_handlers::giftwrap_decrypt");
+        let unwrapped = match extract_rumor(&signer, &event).await {
+            Ok(u) => u,
+            // External-signer-backend decrypt failure. May be transient
+            // (signer disconnected, timed out, user dismissed the
+            // prompt) rather than a deterministic crypto failure — and
+            // the library does not expose enough information to tell
+            // them apart. Be conservative: defer rather than mark
+            // processed. Relay replay will redeliver the event on the
+            // next subscription resume; by then the signer may be
+            // reachable. Skipping the retry queue here also prevents an
+            // attacker able to disturb the signer transport from
+            // amplifying token consumption.
+            Err(nostr::nips::nip59::Error::Signer(e)) if !signer_backend_is_keys => {
+                tracing::warn!(
+                    target: "whitenoise::event_handlers::handle_giftwrap",
+                    account = %account.pubkey.to_hex(),
+                    event_id = %event.id.to_hex(),
+                    error = %e,
+                    "Deferring gift-wrap: external signer decrypt failed; awaiting redelivery"
+                );
+                return Err(WhitenoiseError::GiftwrapDeferred);
+            }
+            // Any other decrypt/parse failure is terminal. This covers
+            // local `Keys` signer decrypt failures (deterministic
+            // crypto) and structural errors like wrong event kind, JSON
+            // parse failure, or sender/seal pubkey mismatch — none of
+            // which can succeed on a later attempt. Routing them
+            // through the retry path would let a small burst of garbage
+            // drain the throttle bucket many times over (one bogus
+            // event = up to 11 token consumptions = 1 initial + 10
+            // retries). Marking processed dedupes future redelivery.
+            Err(e) => {
+                tracing::warn!(
+                    target: "whitenoise::event_handlers::handle_giftwrap",
+                    account = %account.pubkey.to_hex(),
+                    event_id = %event.id.to_hex(),
+                    error = %e,
+                    "Dropping undecryptable gift-wrap as terminal; recorded as processed to prevent retry storm"
+                );
+                return Ok(());
+            }
+        };
 
         drop(_decrypt_span);
+
+        // Advance the account sync watermark using the inner rumor timestamp.
+        // A single NIP-44 decrypt now serves both Welcome processing and sync
+        // advancement; the previous design decrypted each gift-wrap twice,
+        // doubling the work the recipient performed on every event.
+        let safe_timestamp = cap_timestamp_to_now(unwrapped.rumor.created_at);
+        let created_ms = (safe_timestamp.as_secs() as i64) * 1000;
+        if let Err(e) =
+            Account::update_last_synced_max(&account.pubkey, created_ms, &self.shared.database)
+                .await
+        {
+            tracing::warn!(
+                target: "whitenoise::event_handlers::handle_giftwrap",
+                "Failed to advance last_synced_at with rumor timestamp for {}: {}",
+                account.pubkey.to_hex(),
+                e
+            );
+        }
 
         match unwrapped.rumor.kind {
             Kind::MlsWelcome => {

--- a/src/whitenoise/event_processor/giftwrap_throttle.rs
+++ b/src/whitenoise/event_processor/giftwrap_throttle.rs
@@ -1,0 +1,216 @@
+//! Per-account token bucket gating NIP-44 decryption of inbound kind:1059
+//! gift-wrap events. Bounds the CPU and battery a single account can spend
+//! on gift-wrap processing per unit time, regardless of attacker fan-out or
+//! relay count.
+//!
+//! Kind:1059 events are addressed to a public pubkey with no sender
+//! authentication, and the KeyPackage reference identifying the inviter sits
+//! inside the encrypted rumor — so transport-layer pre-filtering is
+//! impossible. Without this bucket, anyone who knows a recipient's pubkey
+//! can force unbounded ECDH+decrypt work on that recipient's device.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Token bucket sized for gift-wrap decryption budget on a single account.
+///
+/// Refills continuously at `refill_per_sec`, up to `capacity`. `try_acquire`
+/// is the only consumer; it returns `true` and deducts one token when
+/// budget exists, `false` otherwise. It does NOT block — back-pressure is
+/// the caller's choice (whitenoise currently drops on `false`; relay replay
+/// will redeliver the event on the next subscription resume).
+///
+/// **Thread-safety:** the bucket is `Send + Sync` via the inner `Mutex`.
+/// Lock duration is bounded by a handful of float ops, so contention from
+/// the single account event-processor task is negligible.
+///
+/// **Fail-open:** if the inner mutex is poisoned (a panic somewhere else
+/// holding the lock), `try_acquire` returns `true` rather than locking the
+/// account out of receiving welcomes. The DoS we are defending against is a
+/// flood, not a deadlock.
+pub struct GiftwrapThrottle {
+    capacity: f64,
+    refill_per_sec: f64,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl GiftwrapThrottle {
+    /// Construct a throttle with the given burst capacity and refill rate.
+    ///
+    /// `capacity` is the maximum number of gift-wrap decrypts that may
+    /// happen in a burst after an idle period. `refill_per_sec` is the
+    /// sustained rate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity == 0` or `refill_per_sec <= 0.0`. Misconfiguration
+    /// here would silently disable all gift-wrap processing for the account,
+    /// which is worse than the panic surfacing the bug.
+    pub fn new(capacity: u32, refill_per_sec: f64) -> Self {
+        assert!(capacity > 0, "GiftwrapThrottle capacity must be > 0");
+        assert!(
+            refill_per_sec > 0.0,
+            "GiftwrapThrottle refill_per_sec must be > 0.0"
+        );
+        Self {
+            capacity: capacity as f64,
+            refill_per_sec,
+            inner: Mutex::new(Inner {
+                tokens: capacity as f64,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+
+    /// Default parameters for inbound welcome processing on a real user.
+    ///
+    /// Capacity 60: a legitimate user joining many groups in one burst (e.g.
+    /// being added to a workspace) sees no throttling.
+    /// Refill 2/sec: sustained throughput ceiling. At 2/sec the victim's
+    /// CPU budget for gift-wrap decryption is ~400 µs/sec (well below 0.1%
+    /// of one core), making the attack invisible to UI or battery.
+    pub fn default_for_account() -> Self {
+        Self::new(60, 2.0)
+    }
+
+    /// Try to deduct one token. Returns `true` if a token was available.
+    pub fn try_acquire(&self) -> bool {
+        self.try_acquire_at(Instant::now())
+    }
+
+    /// Test-visible variant that takes an explicit `now`, allowing the unit
+    /// test to drive virtual time without depending on `tokio::time::pause`.
+    pub(crate) fn try_acquire_at(&self, now: Instant) -> bool {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => return true, // fail-open on poison
+        };
+        let elapsed = now
+            .checked_duration_since(inner.last_refill)
+            .unwrap_or(Duration::ZERO)
+            .as_secs_f64();
+        inner.tokens = (inner.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        inner.last_refill = now;
+        if inner.tokens >= 1.0 {
+            inner.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Best-effort snapshot of current token count. For telemetry only.
+    pub fn tokens(&self) -> f64 {
+        self.inner.lock().map(|i| i.tokens).unwrap_or(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trickle_at_legitimate_rate_never_throttles() {
+        // 1 welcome per second for 30 seconds — well under refill of 2/sec.
+        let bucket = GiftwrapThrottle::new(60, 2.0);
+        let start = Instant::now();
+        let mut accepted = 0u32;
+        for i in 0..30 {
+            let t = start + Duration::from_secs(i);
+            if bucket.try_acquire_at(t) {
+                accepted += 1;
+            }
+        }
+        assert_eq!(accepted, 30, "all legitimate welcomes must pass");
+    }
+
+    #[test]
+    fn flood_is_capped_at_capacity_then_refills() {
+        // 10_000 events at t=0 — only `capacity` should pass.
+        let bucket = GiftwrapThrottle::new(60, 2.0);
+        let t0 = Instant::now();
+        let mut accepted_burst = 0u32;
+        for _ in 0..10_000 {
+            if bucket.try_acquire_at(t0) {
+                accepted_burst += 1;
+            }
+        }
+        assert_eq!(accepted_burst, 60, "burst must be bounded by capacity");
+
+        // 10 seconds later, refill should have added 20 tokens (2/sec * 10s).
+        let t1 = t0 + Duration::from_secs(10);
+        let mut accepted_refill = 0u32;
+        for _ in 0..10_000 {
+            if bucket.try_acquire_at(t1) {
+                accepted_refill += 1;
+            }
+        }
+        assert_eq!(
+            accepted_refill, 20,
+            "post-burst refill must be exactly refill_per_sec * elapsed"
+        );
+    }
+
+    #[test]
+    fn refill_caps_at_capacity_not_unbounded() {
+        // Long idle then a burst — capacity must cap accumulated tokens.
+        let bucket = GiftwrapThrottle::new(60, 2.0);
+        let t0 = Instant::now();
+        // Idle for an hour. Naive refill would credit 7200 tokens.
+        let t1 = t0 + Duration::from_secs(3600);
+        let mut accepted = 0u32;
+        for _ in 0..1_000 {
+            if bucket.try_acquire_at(t1) {
+                accepted += 1;
+            }
+        }
+        assert_eq!(
+            accepted, 60,
+            "accumulated tokens must be capped at capacity"
+        );
+    }
+
+    #[test]
+    fn under_sustained_flood_throughput_equals_refill_rate() {
+        // 1000 events/sec for 5 seconds. Acceptance should be ~ capacity + 5 * refill.
+        let bucket = GiftwrapThrottle::new(60, 2.0);
+        let t0 = Instant::now();
+        let mut accepted = 0u32;
+        for s in 0..5 {
+            for i in 0..1_000 {
+                // Spread the 1000 events over 1 second.
+                let t = t0 + Duration::from_millis(s * 1000 + i);
+                if bucket.try_acquire_at(t) {
+                    accepted += 1;
+                }
+            }
+        }
+        // capacity (60) at t=0 + 2/sec * ~5s = 70. Allow ±1 for floating-point.
+        assert!(
+            (69..=71).contains(&accepted),
+            "expected ~70 accepted under sustained flood, got {accepted}"
+        );
+    }
+
+    #[test]
+    fn poisoned_lock_fails_open() {
+        // Defense-in-depth: a panic in some unrelated holder of the mutex
+        // must not lock the account out of welcome processing.
+        use std::sync::Arc;
+        use std::thread;
+        let bucket = Arc::new(GiftwrapThrottle::new(60, 2.0));
+        let b2 = bucket.clone();
+        let _ = thread::spawn(move || {
+            let _guard = b2.inner.lock().unwrap();
+            panic!("poisoning");
+        })
+        .join();
+        // Bucket is now poisoned — must fail-open.
+        assert!(bucket.try_acquire());
+    }
+}

--- a/src/whitenoise/event_processor/mod.rs
+++ b/src/whitenoise/event_processor/mod.rs
@@ -16,7 +16,10 @@ use crate::{
 
 mod account_event_processor;
 mod event_handlers;
+mod giftwrap_throttle;
 mod global_event_processor;
+
+pub(crate) use giftwrap_throttle::GiftwrapThrottle;
 
 impl Whitenoise {
     /// Start the event processing loop in a background task

--- a/src/whitenoise/session/mod.rs
+++ b/src/whitenoise/session/mod.rs
@@ -40,6 +40,7 @@ use crate::whitenoise::accounts::{Account, DiscoveredRelayLists};
 use crate::whitenoise::database::account::AccountRepositories;
 use crate::whitenoise::database::account_db::AccountDatabase;
 use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::event_processor::GiftwrapThrottle;
 
 /// Returns the per-account SQLite path under the given data directory.
 pub(crate) fn account_db_path(
@@ -118,6 +119,13 @@ pub struct AccountSession {
     pub(crate) pending_push_token_responses: Arc<DashMap<(GroupId, EventId), ()>>,
     /// Bounds concurrently-active delayed MIP-05 token-list response tasks.
     token_response_semaphore: Arc<Semaphore>,
+    /// Per-account budget for inbound gift-wrap (kind:1059) NIP-44 decryption.
+    /// Gates `extract_rumor` calls to bound CPU and battery spent on welcome
+    /// spam regardless of attacker fan-out. The KeyPackage reference that
+    /// could identify the inviter sits inside the encrypted rumor, so
+    /// pre-decrypt filtering is structurally impossible — a token bucket on
+    /// the outer gift-wrap is the only client-side defense.
+    pub(crate) giftwrap_throttle: Arc<GiftwrapThrottle>,
 }
 
 impl AccountSession {
@@ -167,6 +175,7 @@ impl AccountSession {
             token_response_semaphore: Arc::new(Semaphore::new(
                 crate::whitenoise::push_notifications::MAX_CONCURRENT_TOKEN_RESPONSE_TASKS,
             )),
+            giftwrap_throttle: Arc::new(GiftwrapThrottle::default_for_account()),
         })
     }
 


### PR DESCRIPTION
## Summary

Adds a per-account token bucket gating NIP-44 decryption of inbound gift-wrap (`kind:1059`) events, with three-way result classification so each event class has the right outcome.

## Motivation

Inbound `kind:1059` events have no sender authentication discoverable before NIP-44 decryption — the recipient must perform secp256k1 ECDH and AEAD decrypt on every event addressed to them, and the KeyPackage reference that would identify the inviter sits inside the encrypted rumor. Without a budget, anyone who knows a recipient's pubkey can force unbounded per-event ECDH work on the recipient's device.

This change bounds that work at the client without changing the protocol.

## What changed

**Throttle.** `GiftwrapThrottle` is a per-account token bucket on `AccountSession` (capacity 60, refill 2/sec). Acquired immediately before `extract_rumor` and after the signer-availability check, so unavailable signers don't drain the budget.

**Single decrypt per event.** Sync-watermark advancement (`update_last_synced_max`) is now done inside `handle_giftwrap` using the rumor timestamp returned by the same `extract_rumor` call, removing the previous post-success second decrypt of the same event.

**Three-way outcome classification.** `extract_rumor` failures are mapped at the source:

| Class | Detection | Outer outcome |
|---|---|---|
| Throttled | bucket empty | `Err(GiftwrapThrottled)` → no track, no retry (relay replay redelivers after refill) |
| External-signer decrypt failed | `nip59::Error::Signer` with non-`Keys` backend | `Err(GiftwrapDeferred)` → no track, no retry (relay replay redelivers after signer recovers) |
| Terminal (malformed payload / local Keys decrypt failed) | any other `Err` | `Ok(())` + warn log → tracked, deduped against future redelivery |
| Success | — | `Ok(())` → tracked, watermark advanced |

The deferral cases deliberately avoid the in-process retry queue, which would re-acquire a token on each of up to 10 retries (`RetryInfo::max_attempts`).

## Tests

Five new unit tests in `giftwrap_throttle::tests` cover the bucket math (trickle, flood, refill cap, sustained-flood throughput, mutex-poison fail-open). Three new integration tests in `account_event_processor::tests` pin the contracts at the boundary:

- `test_throttled_giftwrap_is_not_recorded_as_processed` — exhausts the bucket, sends a valid `kind:1059`, asserts the event is NOT in `already_processed_account_event`.
- `test_undecryptable_giftwrap_is_terminal_not_retried` — sends garbage ciphertext with a local Keys signer, asserts the event IS marked processed AND exactly one token (not eleven) was consumed.
- `test_external_signer_decrypt_failure_is_deferred_not_terminal` — installs a `FailingExternalSigner` (`SignerBackend::Custom`, every `nip44_decrypt` fails), asserts the event is NOT marked processed AND exactly one token was consumed.

## Test plan

- [x] `just precommit-quick` green locally (verified)
- [ ] Manual sanity on physical device after merge: confirm no regression in normal welcome flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-account rate limiting for encrypted message decryption to prevent resource exhaustion.

* **Bug Fixes**
  * Improved error handling to distinguish between permanent decryption failures and temporary signer unavailability.
  * Transient signer backend issues now trigger retry logic instead of marking messages as permanently failed.
  * Fixed synchronization state tracking for encrypted messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->