### PR TITLE
[codex] Backfill canonical key packages during maintenance

### DIFF
--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -176,7 +176,7 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             context,
             &account,
             "maintenance to publish a replacement key package",
-            |packages| !packages.is_empty(),
+            has_key_package_pair,
         )
         .await?;
         tracing::info!(
@@ -230,7 +230,10 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             context,
             &account,
             "expired key package rotation to complete",
-            |packages| !packages.is_empty() && packages.iter().all(|e| e.id != expired_event_id),
+            |packages| {
+                has_key_package_pair(packages)
+                    && packages.iter().all(|event| event.id != expired_event_id)
+            },
         )
         .await?;
 
@@ -299,17 +302,18 @@ where
 
 fn assert_contains_key_package_pair(packages: &[Event], description: &str) {
     assert!(
-        packages
-            .iter()
-            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND),
-        "{description} should include a canonical kind:30443 key package"
+        has_key_package_pair(packages),
+        "{description} should include canonical kind:30443 and legacy kind:443 key packages"
     );
-    assert!(
-        packages
+}
+
+fn has_key_package_pair(packages: &[Event]) -> bool {
+    packages
+        .iter()
+        .any(|event| event.kind == MLS_KEY_PACKAGE_KIND)
+        && packages
             .iter()
-            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
-        "{description} should include a legacy kind:443 key package"
-    );
+            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY)
 }
 
 /// Publishes a key package with a backdated timestamp using test infrastructure.

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -312,10 +312,10 @@ fn has_key_package_pair(packages: &[Event]) -> bool {
     let mut has_legacy = false;
 
     for event in packages {
-        if event.kind == MLS_KEY_PACKAGE_KIND {
-            has_canonical = true;
-        } else if event.kind == MLS_KEY_PACKAGE_KIND_LEGACY {
-            has_legacy = true;
+        match event.kind {
+            kind if kind == MLS_KEY_PACKAGE_KIND => has_canonical = true,
+            kind if kind == MLS_KEY_PACKAGE_KIND_LEGACY => has_legacy = true,
+            _ => {}
         }
 
         if has_canonical && has_legacy {

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::WhitenoiseError;
 use crate::integration_tests::core::*;
-use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND_LEGACY;
+use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY};
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::scheduled_tasks::{KeyPackageMaintenance, Task};
 use async_trait::async_trait;
@@ -183,6 +183,7 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             "✓ Key package maintenance published {} key package(s)",
             after_publish.len()
         );
+        assert_contains_key_package_pair(&after_publish, "maintenance publish from empty relays");
 
         // Delete current key packages and publish an expired one.
         delete_all_relay_key_packages_for_test_setup(context, &account, true).await?;
@@ -245,6 +246,7 @@ impl TestCase for KeyPackageMaintenanceTestCase {
             !expired_still_exists,
             "Expired key package should have been deleted"
         );
+        assert_contains_key_package_pair(&after_rotate, "maintenance rotation replacement");
 
         tracing::info!(
             "✓ Rotation complete: expired package deleted, {} fresh package(s) exist",
@@ -293,6 +295,21 @@ where
         description,
     )
     .await
+}
+
+fn assert_contains_key_package_pair(packages: &[Event], description: &str) {
+    assert!(
+        packages
+            .iter()
+            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND),
+        "{description} should include a canonical kind:30443 key package"
+    );
+    assert!(
+        packages
+            .iter()
+            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+        "{description} should include a legacy kind:443 key package"
+    );
 }
 
 /// Publishes a key package with a backdated timestamp using test infrastructure.

--- a/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
+++ b/src/integration_tests/test_cases/scheduler/key_package_maintenance.rs
@@ -308,12 +308,22 @@ fn assert_contains_key_package_pair(packages: &[Event], description: &str) {
 }
 
 fn has_key_package_pair(packages: &[Event]) -> bool {
-    packages
-        .iter()
-        .any(|event| event.kind == MLS_KEY_PACKAGE_KIND)
-        && packages
-            .iter()
-            .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY)
+    let mut has_canonical = false;
+    let mut has_legacy = false;
+
+    for event in packages {
+        if event.kind == MLS_KEY_PACKAGE_KIND {
+            has_canonical = true;
+        } else if event.kind == MLS_KEY_PACKAGE_KIND_LEGACY {
+            has_legacy = true;
+        }
+
+        if has_canonical && has_legacy {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Publishes a key package with a backdated timestamp using test infrastructure.

--- a/src/whitenoise/accounts/setup.rs
+++ b/src/whitenoise/accounts/setup.rs
@@ -9,6 +9,7 @@ use crate::RelayType;
 use crate::perf_instrument;
 use crate::relay_control::groups::GroupSubscriptionSpec;
 use crate::whitenoise::error::Result;
+use crate::whitenoise::key_packages::MLS_KEY_PACKAGE_KIND;
 use crate::whitenoise::relays::Relay;
 use crate::whitenoise::session::AccountSession;
 use crate::whitenoise::users::User;
@@ -176,7 +177,9 @@ impl Whitenoise {
                 .fetch_user_key_package(account.pubkey, &relays_urls)
                 .await?
             {
-                if self.is_own_key_package(&account.pubkey, &event.id).await {
+                if event.kind == MLS_KEY_PACKAGE_KIND
+                    && self.is_own_key_package(&account.pubkey, &event.id).await
+                {
                     tracing::debug!(
                         target: "whitenoise::accounts",
                         "Found existing key package with live key material, skipping publish"
@@ -185,7 +188,7 @@ impl Whitenoise {
                 } else {
                     tracing::debug!(
                         target: "whitenoise::accounts",
-                        "Key package on relay was not published by this client or key material is gone, publishing new one"
+                        "Key package on relay is not a live canonical package published by this client, publishing new one"
                     );
                 }
             }
@@ -225,7 +228,7 @@ impl Whitenoise {
             .find_by_event_id(&event_id.to_hex())
             .await
         {
-            Ok(Some(pkg)) => !pkg.key_material_deleted,
+            Ok(Some(pkg)) => !pkg.key_material_deleted && pkg.consumed_at.is_none(),
             Ok(None) => false,
             Err(e) => {
                 tracing::warn!(
@@ -1495,6 +1498,79 @@ mod tests {
 
         let event_id = EventId::all_zeros();
         assert!(!whitenoise.is_own_key_package(&pubkey, &event_id).await);
+    }
+
+    #[tokio::test]
+    async fn test_setup_key_package_republishes_when_only_legacy_twin_remains() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        let relays = account
+            .key_package_relays(&whitenoise.shared)
+            .await
+            .unwrap();
+
+        let before = session.key_packages().fetch_all().await.unwrap();
+        assert!(
+            before
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND),
+            "precondition: account should start with a canonical key package"
+        );
+        assert!(
+            before
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "precondition: account should start with a legacy key package"
+        );
+
+        let canonical = before
+            .into_iter()
+            .find(|event| event.kind == MLS_KEY_PACKAGE_KIND)
+            .expect("canonical event exists");
+        assert!(
+            session
+                .key_packages()
+                .delete(&canonical.id, false)
+                .await
+                .unwrap(),
+            "test setup should delete the canonical key package from relays"
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let legacy_only = session.key_packages().fetch_all().await.unwrap();
+        assert!(
+            legacy_only
+                .iter()
+                .all(|event| event.kind != MLS_KEY_PACKAGE_KIND),
+            "precondition: canonical key package should be missing from relays"
+        );
+        assert!(
+            legacy_only
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "precondition: legacy key package should still be present on relays"
+        );
+
+        whitenoise
+            .setup_key_package(&account, false, &relays)
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let after = session.key_packages().fetch_all().await.unwrap();
+        assert!(
+            after.iter().any(|event| event.kind == MLS_KEY_PACKAGE_KIND),
+            "setup must not treat legacy-only relay state as healthy"
+        );
+        assert!(
+            after
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "setup should preserve pair publishing semantics"
+        );
     }
 
     #[test]

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -466,6 +466,47 @@ mod tests {
             .unwrap()
     }
 
+    fn key_package_event(kind: Kind) -> Event {
+        EventBuilder::new(kind, "test_content")
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_has_live_canonical_key_package_requires_canonical_kind() {
+        let canonical = live_package(key_package_event(MLS_KEY_PACKAGE_KIND), vec![1]);
+        let legacy = live_package(key_package_event(MLS_KEY_PACKAGE_KIND_LEGACY), vec![2]);
+        let legacy_only = std::slice::from_ref(&legacy);
+
+        assert!(!has_live_canonical_key_package(&[]));
+        assert!(!has_live_canonical_key_package(legacy_only));
+        assert!(has_live_canonical_key_package(&[legacy, canonical]));
+    }
+
+    #[test]
+    fn test_find_non_expired_packages_filters_whole_expired_hash_groups() {
+        let expired_canonical = live_package(key_package_event(MLS_KEY_PACKAGE_KIND), vec![1]);
+        let expired_legacy = live_package(key_package_event(MLS_KEY_PACKAGE_KIND_LEGACY), vec![1]);
+        let fresh_canonical = live_package(key_package_event(MLS_KEY_PACKAGE_KIND), vec![2]);
+        let fresh_legacy = live_package(key_package_event(MLS_KEY_PACKAGE_KIND_LEGACY), vec![2]);
+        let packages = vec![
+            expired_canonical.clone(),
+            expired_legacy.clone(),
+            fresh_canonical.clone(),
+            fresh_legacy.clone(),
+        ];
+        let expired_packages = vec![expired_canonical, expired_legacy];
+
+        let non_expired = find_non_expired_packages(&packages, &expired_packages);
+
+        assert_eq!(non_expired.len(), 2);
+        assert!(
+            non_expired
+                .iter()
+                .all(|package| package.key_package_hash_ref == vec![2])
+        );
+    }
+
     /// Publishes a key package without the encoding tag for testing outdated package rotation.
     async fn publish_outdated_key_package(
         whitenoise: &Whitenoise,

--- a/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
+++ b/src/whitenoise/scheduled_tasks/tasks/key_package_maintenance.rs
@@ -12,7 +12,7 @@ use crate::whitenoise::Whitenoise;
 use crate::whitenoise::accounts::Account;
 use crate::whitenoise::error::WhitenoiseError;
 use crate::whitenoise::key_packages::{
-    REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_strict,
+    MLS_KEY_PACKAGE_KIND, REQUIRED_MLS_CIPHERSUITE_TAG, validate_marmot_key_package_strict,
 };
 use crate::whitenoise::scheduled_tasks::Task;
 
@@ -191,6 +191,15 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
     let our_expired_packages = find_expired_packages(&our_packages);
 
     if our_expired_packages.is_empty() {
+        if !has_live_canonical_key_package(&our_packages) {
+            tracing::info!(
+                target: "whitenoise::scheduler::key_package_maintenance",
+                "Account {} has live legacy key package state but no live canonical kind:30443 event, publishing new pair",
+                account.pubkey.to_hex()
+            );
+            return publish_new_key_package(whitenoise, account).await;
+        }
+
         tracing::debug!(
             target: "whitenoise::scheduler::key_package_maintenance",
             "Account {} has {} live compatible tracked key package(s), none expired",
@@ -200,14 +209,17 @@ async fn maintain_key_packages(whitenoise: &Whitenoise, account: &Account) -> Ma
         return MaintenanceResult::Fresh;
     }
 
-    // Delete expired packages, only republishing if all our packages are
-    // expired (so we'd have zero left after deletion).
+    // Delete expired packages, publishing a replacement first if the state
+    // left after deletion would not include a live canonical kind:30443.
     let total_package_group_count = count_key_package_hash_groups(&our_packages);
+    let non_expired_packages = find_non_expired_packages(&our_packages, &our_expired_packages);
+    let needs_replacement_before_delete = !has_live_canonical_key_package(&non_expired_packages);
     rotate_expired_packages(
         whitenoise,
         account,
         our_expired_packages,
         total_package_group_count,
+        needs_replacement_before_delete,
     )
     .await
 }
@@ -270,6 +282,28 @@ fn count_key_package_hash_groups(packages: &[LivePublishedKeyPackage]) -> usize 
         .len()
 }
 
+fn has_live_canonical_key_package(packages: &[LivePublishedKeyPackage]) -> bool {
+    packages
+        .iter()
+        .any(|package| package.event.kind == MLS_KEY_PACKAGE_KIND)
+}
+
+fn find_non_expired_packages(
+    packages: &[LivePublishedKeyPackage],
+    expired_packages: &[LivePublishedKeyPackage],
+) -> Vec<LivePublishedKeyPackage> {
+    let expired_hash_refs: HashSet<&Vec<u8>> = expired_packages
+        .iter()
+        .map(|package| &package.key_package_hash_ref)
+        .collect();
+
+    packages
+        .iter()
+        .filter(|package| !expired_hash_refs.contains(&package.key_package_hash_ref))
+        .cloned()
+        .collect()
+}
+
 /// Returns relay key packages that this device published and still has usable local state for.
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn find_live_published_key_packages(
@@ -328,15 +362,16 @@ async fn publish_new_key_package(whitenoise: &Whitenoise, account: &Account) -> 
 
 /// Deletes expired key packages, only publishing a replacement if needed.
 ///
-/// If the account would be left with zero key packages after deletion, a new one is
-/// published first to avoid a gap. Otherwise, only the expired packages are deleted
-/// without republishing, since the account already has a valid package.
+/// If the account would be left without a live canonical kind:30443 package after deletion, a new
+/// pair is published first to avoid a gap. Otherwise, only the expired packages are deleted without
+/// republishing, since the account already has a valid canonical package.
 #[perf_instrument("scheduled::key_package_maintenance")]
 async fn rotate_expired_packages(
     whitenoise: &Whitenoise,
     account: &Account,
     expired_packages: Vec<LivePublishedKeyPackage>,
     total_package_group_count: usize,
+    needs_replacement_before_delete: bool,
 ) -> MaintenanceResult {
     let expired_group_count = count_key_package_hash_groups(&expired_packages);
     let non_expired_group_count = total_package_group_count.saturating_sub(expired_group_count);
@@ -358,8 +393,11 @@ async fn rotate_expired_packages(
         return MaintenanceResult::Skipped;
     };
 
-    // Only publish a new key package if deleting the expired ones would leave zero packages
-    if non_expired_group_count == 0 {
+    // Publish a new pair if deleting the expired groups would leave no live
+    // canonical key package behind. The usual case is "all groups expired",
+    // but this also repairs legacy-only non-expired leftovers before deleting
+    // an expired canonical group.
+    if needs_replacement_before_delete {
         if let Err(e) = session.key_packages().publish().await {
             match e {
                 WhitenoiseError::AccountMissingKeyPackageRelays => {
@@ -398,9 +436,7 @@ async fn rotate_expired_packages(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::whitenoise::key_packages::{
-        MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, MLS_PROPOSALS_TAG_KEY,
-    };
+    use crate::whitenoise::key_packages::{MLS_KEY_PACKAGE_KIND_LEGACY, MLS_PROPOSALS_TAG_KEY};
     use crate::whitenoise::relays::Relay;
     use crate::whitenoise::test_utils::create_mock_whitenoise;
     use nostr_sdk::prelude::*;
@@ -536,6 +572,86 @@ mod tests {
         assert!(
             !live_after.is_empty(),
             "Maintenance should publish a fresh key package when relay packages no longer match live local state"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_republishes_when_only_legacy_twin_has_live_tracking() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        let account = whitenoise.create_identity().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let session = whitenoise.require_session(&account.pubkey).unwrap();
+        let before = session.key_packages().fetch_all().await.unwrap();
+        assert_eq!(
+            before.len(),
+            2,
+            "Should start with the canonical and legacy key package twins"
+        );
+
+        let canonical = before
+            .into_iter()
+            .find(|event| event.kind == MLS_KEY_PACKAGE_KIND)
+            .expect("canonical event exists");
+        assert!(
+            session
+                .key_packages()
+                .delete(&canonical.id, false)
+                .await
+                .unwrap(),
+            "test setup should delete the canonical key package from relays"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let legacy_only = session.key_packages().fetch_all().await.unwrap();
+        assert!(
+            legacy_only
+                .iter()
+                .all(|event| event.kind != MLS_KEY_PACKAGE_KIND),
+            "precondition: relay should have no canonical key package"
+        );
+        assert!(
+            legacy_only
+                .iter()
+                .any(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "precondition: relay should still have a legacy key package"
+        );
+
+        let live_before =
+            find_live_published_key_packages(&whitenoise, &account, legacy_only.clone())
+                .await
+                .unwrap();
+        assert!(
+            !live_before.is_empty(),
+            "precondition: legacy key package should still have live local tracking"
+        );
+        assert!(
+            live_before
+                .iter()
+                .all(|package| package.event.kind != MLS_KEY_PACKAGE_KIND),
+            "precondition: live relay state should be legacy-only"
+        );
+
+        let task = KeyPackageMaintenance;
+        task.execute(whitenoise.clone()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let after = session.key_packages().fetch_all().await.unwrap();
+        let live_after = find_live_published_key_packages(&whitenoise, &account, after)
+            .await
+            .unwrap();
+        assert!(
+            live_after
+                .iter()
+                .any(|package| package.event.kind == MLS_KEY_PACKAGE_KIND),
+            "Maintenance should not report legacy-only live state as fresh"
+        );
+        assert!(
+            live_after
+                .iter()
+                .any(|package| package.event.kind == MLS_KEY_PACKAGE_KIND_LEGACY),
+            "Maintenance republish should preserve the legacy twin"
         );
     }
 


### PR DESCRIPTION
## Summary
- require login key package setup to see a live canonical kind:30443 before treating relay state as healthy
- make key package maintenance republish a 30443 + 443 pair when live tracked state is legacy-only
- tighten scheduler integration coverage so maintenance publish and rotation assert both twins

## Root Cause
Maintenance and login could treat a tracked legacy kind:443 key package as fully healthy. That let production recovery paths leave an account without the canonical D-tagged kind:30443 twin while local MLS material still existed.

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" just int-test scheduler`
- `PATH="$HOME/.cargo/bin:$PATH" just precommit-quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents maintenance from leaving only legacy key packages; ensures a canonical key package is published or preserved so accounts aren’t treated as fresh.
  * Tightens health checks so legacy-only relay state is no longer considered healthy and triggers republish when needed.

* **Tests**
  * Added tests validating republish behavior, stricter rotation completion, and preservation of canonical+legacy pairs.

* **Refactor**
  * Clarified rotation/publish decision logic and added helpers to detect canonical vs legacy package states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->