### PR TITLE
[codex] Add one-time key package relay cleanup

### DIFF
--- a/src/whitenoise/database/account/maintenance_tasks.rs
+++ b/src/whitenoise/database/account/maintenance_tasks.rs
@@ -33,14 +33,11 @@ impl MaintenanceTasksRepo {
     }
 
     /// Mark `name` complete for this account.
-    ///
-    /// This is intentionally an upsert so retrying the same successful
-    /// maintenance task remains idempotent.
     pub async fn mark_completed(&self, name: &str) -> Result<()> {
         sqlx::query(
             "INSERT INTO account_maintenance_tasks (name, completed_at)
              VALUES (?, unixepoch())
-             ON CONFLICT(name) DO UPDATE SET completed_at = excluded.completed_at",
+             ON CONFLICT(name) DO NOTHING",
         )
         .bind(name)
         .execute(&self.db.inner.pool)
@@ -79,7 +76,8 @@ mod tests {
             .unwrap();
         sqlx::query(
             "CREATE TABLE account_maintenance_tasks (
-                name TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
                 completed_at INTEGER NOT NULL
             )",
         )
@@ -104,6 +102,18 @@ mod tests {
         let (repo, _dir) = setup().await;
 
         repo.mark_completed("cleanup").await.unwrap();
+        sqlx::query(
+            "UPDATE account_maintenance_tasks SET completed_at = 123 WHERE name = 'cleanup'",
+        )
+        .execute(&repo.db.inner.pool)
+        .await
+        .unwrap();
+        let first_completed_at: i64 = sqlx::query_scalar(
+            "SELECT completed_at FROM account_maintenance_tasks WHERE name = 'cleanup'",
+        )
+        .fetch_one(&repo.db.inner.pool)
+        .await
+        .unwrap();
         repo.mark_completed("cleanup").await.unwrap();
 
         let completed_count: i64 = sqlx::query_scalar(
@@ -113,5 +123,12 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(completed_count, 1);
+        let second_completed_at: i64 = sqlx::query_scalar(
+            "SELECT completed_at FROM account_maintenance_tasks WHERE name = 'cleanup'",
+        )
+        .fetch_one(&repo.db.inner.pool)
+        .await
+        .unwrap();
+        assert_eq!(second_completed_at, first_completed_at);
     }
 }

--- a/src/whitenoise/database/account/maintenance_tasks.rs
+++ b/src/whitenoise/database/account/maintenance_tasks.rs
@@ -1,0 +1,113 @@
+//! Per-account repository for one-time maintenance task markers.
+
+use std::sync::Arc;
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::account_db::AccountDatabase;
+use crate::whitenoise::error::Result;
+
+/// Repository for account-scoped maintenance task completion markers.
+#[derive(Clone, Debug)]
+pub struct MaintenanceTasksRepo {
+    db: Arc<AccountDatabase>,
+}
+
+impl MaintenanceTasksRepo {
+    pub(crate) fn new(db: Arc<AccountDatabase>) -> Self {
+        Self { db }
+    }
+
+    /// Returns true once `name` has completed successfully for this account.
+    pub async fn is_completed(&self, name: &str) -> Result<bool> {
+        let completed: i64 = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM account_maintenance_tasks WHERE name = ?
+             )",
+        )
+        .bind(name)
+        .fetch_one(&self.db.inner.pool)
+        .await
+        .map_err(DatabaseError::Sqlx)?;
+
+        Ok(completed != 0)
+    }
+
+    /// Mark `name` complete for this account.
+    ///
+    /// This is intentionally an upsert so retrying the same successful
+    /// maintenance task remains idempotent.
+    pub async fn mark_completed(&self, name: &str) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO account_maintenance_tasks (name, completed_at)
+             VALUES (?, unixepoch())
+             ON CONFLICT(name) DO UPDATE SET completed_at = excluded.completed_at",
+        )
+        .bind(name)
+        .execute(&self.db.inner.pool)
+        .await
+        .map_err(DatabaseError::Sqlx)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nostr_sdk::Keys;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    async fn setup() -> (MaintenanceTasksRepo, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let pubkey = Keys::generate().public_key();
+        let db = Arc::new(
+            AccountDatabase::new(pubkey, dir.path().join("acct.db"))
+                .await
+                .unwrap(),
+        );
+
+        sqlx::query("DROP TABLE IF EXISTS account_maintenance_tasks")
+            .execute(&db.inner.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE account_maintenance_tasks (
+                name TEXT PRIMARY KEY,
+                completed_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&db.inner.pool)
+        .await
+        .unwrap();
+
+        (MaintenanceTasksRepo::new(db), dir)
+    }
+
+    #[tokio::test]
+    async fn task_is_incomplete_until_marked() {
+        let (repo, _dir) = setup().await;
+
+        assert!(!repo.is_completed("cleanup").await.unwrap());
+        repo.mark_completed("cleanup").await.unwrap();
+        assert!(repo.is_completed("cleanup").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn mark_completed_is_idempotent() {
+        let (repo, _dir) = setup().await;
+
+        repo.mark_completed("cleanup").await.unwrap();
+        repo.mark_completed("cleanup").await.unwrap();
+
+        let completed_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM account_maintenance_tasks WHERE name = 'cleanup'",
+        )
+        .fetch_one(&repo.db.inner.pool)
+        .await
+        .unwrap();
+        assert_eq!(completed_count, 1);
+    }
+}

--- a/src/whitenoise/database/account/maintenance_tasks.rs
+++ b/src/whitenoise/database/account/maintenance_tasks.rs
@@ -69,6 +69,10 @@ mod tests {
                 .unwrap(),
         );
 
+        // Matches the project-wide account-DB test pattern: stamp the schema
+        // directly because `AccountDatabase::new` uses `open_without_migrations`.
+        // Keep this definition in sync with `fresh_account_schema.sql` until a
+        // shared `setup_account_db_with_migrations` helper exists.
         sqlx::query("DROP TABLE IF EXISTS account_maintenance_tasks")
             .execute(&db.inner.pool)
             .await

--- a/src/whitenoise/database/account/mod.rs
+++ b/src/whitenoise/database/account/mod.rs
@@ -12,6 +12,7 @@
 mod drafts;
 mod follows;
 mod group_push_tokens;
+mod maintenance_tasks;
 mod published_key_packages;
 mod push_registrations;
 mod settings;
@@ -23,6 +24,7 @@ use nostr_sdk::PublicKey;
 pub use self::drafts::DraftsRepo;
 pub use self::follows::AccountFollowsRepo;
 pub use self::group_push_tokens::GroupPushTokensRepo;
+pub use self::maintenance_tasks::MaintenanceTasksRepo;
 pub use self::published_key_packages::PublishedKeyPackagesRepo;
 pub use self::push_registrations::PushRegistrationsRepo;
 pub use self::settings::AccountSettingsRepo;
@@ -42,6 +44,8 @@ pub struct AccountRepositories {
     pub follows: AccountFollowsRepo,
     /// Published key package lifecycle tracking repository for this account.
     pub published_key_packages: PublishedKeyPackagesRepo,
+    /// One-time maintenance task marker repository for this account.
+    pub maintenance_tasks: MaintenanceTasksRepo,
     /// Push registration repository for this account.
     pub push_registrations: PushRegistrationsRepo,
     /// Cached group push tokens repository for this account.
@@ -62,6 +66,7 @@ impl AccountRepositories {
             follows: AccountFollowsRepo::new(account_db.clone(), db),
             push_registrations: PushRegistrationsRepo::new(account_pubkey, account_db.clone()),
             published_key_packages: PublishedKeyPackagesRepo::new(account_db.clone()),
+            maintenance_tasks: MaintenanceTasksRepo::new(account_db.clone()),
             group_push_tokens: GroupPushTokensRepo::new(account_pubkey, account_db),
         })
     }

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -59,6 +59,11 @@ impl PublishedKeyPackagesRepo {
         Ok(PublishedKeyPackage::find_eligible_for_cleanup(&self.db, quiet_period_secs).await?)
     }
 
+    /// Returns true if any consumed key package still falls within the quiet period.
+    pub async fn has_consumed_since(&self, quiet_period_secs: i64) -> Result<bool> {
+        Ok(PublishedKeyPackage::has_consumed_since(&self.db, quiet_period_secs).await?)
+    }
+
     /// Mark a published key package's key material as deleted by hash ref.
     pub async fn mark_key_material_deleted_by_hash_ref(&self, hash_ref: &[u8]) -> Result<()> {
         PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(&self.db, hash_ref).await?;

--- a/src/whitenoise/database/account/published_key_packages.rs
+++ b/src/whitenoise/database/account/published_key_packages.rs
@@ -182,4 +182,48 @@ mod tests {
             "by-id variant must only flip the canonical row"
         );
     }
+
+    #[tokio::test]
+    async fn has_consumed_since_tracks_recent_non_deleted_rows() {
+        let (repo, _dir) = setup().await;
+        let hash_ref = b"recent_hash";
+
+        repo.create(hash_ref, "evt_recent", Kind::Custom(443), None)
+            .await
+            .unwrap();
+        assert!(!repo.has_consumed_since(30).await.unwrap());
+
+        repo.mark_consumed("evt_recent").await.unwrap();
+        assert!(repo.has_consumed_since(30).await.unwrap());
+
+        repo.mark_key_material_deleted_by_hash_ref(hash_ref)
+            .await
+            .unwrap();
+        assert!(!repo.has_consumed_since(30).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn find_eligible_for_cleanup_delegates_quiet_period_filter() {
+        let (repo, _dir) = setup().await;
+        let hash_ref = b"eligible_hash";
+
+        repo.create(hash_ref, "evt_eligible", Kind::Custom(443), None)
+            .await
+            .unwrap();
+        repo.mark_consumed("evt_eligible").await.unwrap();
+        sqlx::query(
+            "UPDATE published_key_packages
+             SET consumed_at = unixepoch() - 60
+             WHERE event_id = ?",
+        )
+        .bind("evt_eligible")
+        .execute(&repo.db.inner.pool)
+        .await
+        .unwrap();
+
+        let eligible = repo.find_eligible_for_cleanup(30).await.unwrap();
+
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(eligible[0].event_id, "evt_eligible");
+    }
 }

--- a/src/whitenoise/database/account_db.rs
+++ b/src/whitenoise/database/account_db.rs
@@ -5,9 +5,10 @@
 //!
 //! **Current status (Phase 18d shipped):** physically separate file per
 //! account holding `account_settings`, `drafts`, `published_key_packages`,
-//! `published_events`, `account_follows`, the account-scoped subset of
-//! `processed_events`, plus `accounts_groups`, `push_registrations`, and
-//! `group_push_tokens`. Phase 18e will move message projections.
+//! `account_maintenance_tasks`, `published_events`, `account_follows`, the
+//! account-scoped subset of `processed_events`, plus `accounts_groups`,
+//! `push_registrations`, and `group_push_tokens`. Phase 18e will move message
+//! projections.
 
 use std::path::PathBuf;
 
@@ -21,7 +22,7 @@ use crate::whitenoise::database::{Database, DatabaseError, rust_migrations};
 /// Each account will have its own file, identified by the account's hex public
 /// key. Account-scoped tables: `account_settings`, `account_follows`,
 /// `accounts_groups`, `drafts`, `push_registrations`, `group_push_tokens`,
-/// `published_key_packages`, `published_events`,
+/// `published_key_packages`, `account_maintenance_tasks`, `published_events`,
 /// `processed_events` (account-level), `aggregated_messages`,
 /// `message_delivery_status`, `media_references`, and `mute_list`.
 ///

--- a/src/whitenoise/database/published_key_packages.rs
+++ b/src/whitenoise/database/published_key_packages.rs
@@ -227,6 +227,27 @@ impl PublishedKeyPackage {
         Ok(rows)
     }
 
+    /// Returns true if any consumed key package still falls within the quiet period.
+    #[perf_instrument("db::published_key_packages")]
+    pub(crate) async fn has_consumed_since(
+        db: &AccountDatabase,
+        quiet_period_secs: i64,
+    ) -> Result<bool, DatabaseError> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM published_key_packages
+                WHERE consumed_at IS NOT NULL
+                  AND key_material_deleted = 0
+                  AND consumed_at > unixepoch() - ?
+             )",
+        )
+        .bind(quiet_period_secs)
+        .fetch_one(&db.inner.pool)
+        .await?;
+
+        Ok(count != 0)
+    }
+
     /// Marks all rows sharing a key package hash as deleted.
     ///
     /// Dual-published kind:30443/kind:443 events point at the same local MLS
@@ -527,6 +548,54 @@ mod tests {
         assert!(
             eligible.is_empty(),
             "rows with key_material_deleted = 1 must not be returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_has_consumed_since_respects_quiet_period() {
+        let (db, _dir) = setup().await;
+
+        PublishedKeyPackage::create(&db, &[1, 2, 3], "recent", MLS_KEY_PACKAGE_KIND_LEGACY, None)
+            .await
+            .unwrap();
+        PublishedKeyPackage::mark_consumed(&db, "recent")
+            .await
+            .unwrap();
+
+        assert!(
+            PublishedKeyPackage::has_consumed_since(&db, 30)
+                .await
+                .unwrap()
+        );
+
+        PublishedKeyPackage::backdate_consumed_at(&db, "recent", 60)
+            .await
+            .unwrap();
+        assert!(
+            !PublishedKeyPackage::has_consumed_since(&db, 30)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_has_consumed_since_ignores_deleted_key_material() {
+        let (db, _dir) = setup().await;
+
+        PublishedKeyPackage::create(&db, &[1, 2, 3], "recent", MLS_KEY_PACKAGE_KIND_LEGACY, None)
+            .await
+            .unwrap();
+        PublishedKeyPackage::mark_consumed(&db, "recent")
+            .await
+            .unwrap();
+        PublishedKeyPackage::mark_key_material_deleted_by_hash_ref(&db, &[1, 2, 3])
+            .await
+            .unwrap();
+
+        assert!(
+            !PublishedKeyPackage::has_consumed_since(&db, 30)
+                .await
+                .unwrap()
         );
     }
 

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -49,6 +49,11 @@ CREATE INDEX IF NOT EXISTS idx_published_kp_event_id
 CREATE INDEX IF NOT EXISTS idx_published_kp_cleanup
     ON published_key_packages(consumed_at, key_material_deleted);
 
+CREATE TABLE IF NOT EXISTS account_maintenance_tasks (
+    name          TEXT PRIMARY KEY,
+    completed_at  INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS published_events (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     event_id    TEXT NOT NULL UNIQUE

--- a/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
+++ b/src/whitenoise/database/rust_migrations/fresh_account_schema.sql
@@ -50,7 +50,8 @@ CREATE INDEX IF NOT EXISTS idx_published_kp_cleanup
     ON published_key_packages(consumed_at, key_material_deleted);
 
 CREATE TABLE IF NOT EXISTS account_maintenance_tasks (
-    name          TEXT PRIMARY KEY,
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    name          TEXT NOT NULL UNIQUE,
     completed_at  INTEGER NOT NULL
 );
 

--- a/src/whitenoise/database/rust_migrations/m0046_account_maintenance_tasks.rs
+++ b/src/whitenoise/database/rust_migrations/m0046_account_maintenance_tasks.rs
@@ -24,7 +24,8 @@ impl LocalMigration for Migration {
     ) -> Result<(), DatabaseError> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS account_maintenance_tasks (
-                name TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
                 completed_at INTEGER NOT NULL
             )",
         )

--- a/src/whitenoise/database/rust_migrations/m0046_account_maintenance_tasks.rs
+++ b/src/whitenoise/database/rust_migrations/m0046_account_maintenance_tasks.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::whitenoise::database::DatabaseError;
+use crate::whitenoise::database::rust_migrations::LocalMigration;
+
+pub struct Migration;
+
+#[async_trait]
+impl LocalMigration for Migration {
+    fn version(&self) -> u32 {
+        46
+    }
+
+    fn description(&self) -> &'static str {
+        "Create account maintenance task markers"
+    }
+
+    async fn run_local(
+        &self,
+        tx: &mut SqliteConnection,
+        _global_db: &SqlitePool,
+        _account_pubkey: &str,
+    ) -> Result<(), DatabaseError> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS account_maintenance_tasks (
+                name TEXT PRIMARY KEY,
+                completed_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::whitenoise::database::rust_migrations::Migrator;
+
+    async fn pools() -> (SqlitePool, SqlitePool, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let local = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("local.db").display()
+        ))
+        .await
+        .unwrap();
+        let global = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("global.db").display()
+        ))
+        .await
+        .unwrap();
+        (local, global, dir)
+    }
+
+    #[tokio::test]
+    async fn creates_account_maintenance_tasks_table() {
+        let (local, global, _dir) = pools().await;
+
+        Migrator::new(vec![], vec![Box::new(Migration)])
+            .run(&global, Some((&local, &"aa".repeat(32))))
+            .await
+            .unwrap();
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+             WHERE type='table' AND name='account_maintenance_tasks')",
+        )
+        .fetch_one(&local)
+        .await
+        .unwrap();
+        assert!(exists);
+    }
+
+    #[tokio::test]
+    async fn migration_is_idempotent() {
+        let (local, global, _dir) = pools().await;
+        let migrator = Migrator::new(vec![], vec![Box::new(Migration)]);
+        let account = "bb".repeat(32);
+
+        migrator
+            .run(&global, Some((&local, &account)))
+            .await
+            .unwrap();
+        migrator
+            .run(&global, Some((&local, &account)))
+            .await
+            .unwrap();
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM _rust_migrations WHERE version = 46")
+                .fetch_one(&local)
+                .await
+                .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/src/whitenoise/database/rust_migrations/mod.rs
+++ b/src/whitenoise/database/rust_migrations/mod.rs
@@ -50,6 +50,7 @@ mod m0042_move_mute_list;
 mod m0043_drop_shared_mute_list;
 mod m0044_reparse_content_tokens;
 mod m0045_product_analytics_settings;
+mod m0046_account_maintenance_tasks;
 
 /// All global migrations, in version order. Lifted from individual modules
 /// so the test suite can build a globals-only `Migrator` for narrow tests.
@@ -107,6 +108,7 @@ pub fn all_local_migrations() -> Vec<Box<dyn LocalMigration>> {
         Box::new(m0039_move_message_delivery_status::Migration),
         Box::new(m0042_move_mute_list::Migration),
         Box::new(m0044_reparse_content_tokens::Migration),
+        Box::new(m0046_account_maintenance_tasks::Migration),
     ]
 }
 

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -266,6 +266,9 @@ pub enum WhitenoiseError {
     #[error("Key package publish failed: {0}")]
     KeyPackagePublishFailed(String),
 
+    #[error("Key package delete failed: {0}")]
+    KeyPackageDeleteFailed(String),
+
     #[error("MLS message unprocessable: {0}")]
     MlsMessageUnprocessable(String),
 

--- a/src/whitenoise/foreground_catchup.rs
+++ b/src/whitenoise/foreground_catchup.rs
@@ -1,12 +1,8 @@
 use std::collections::HashSet;
-#[cfg(not(test))]
 use std::time::Duration;
 
 use crate::perf_instrument;
-#[cfg(not(test))]
-use crate::whitenoise::session::key_packages::{
-    KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KeyPackageRelayCleanupOutcome,
-};
+use crate::whitenoise::session::key_packages::KeyPackageRelayCleanupOutcome;
 use crate::whitenoise::{
     Whitenoise,
     accounts::Account,
@@ -15,9 +11,11 @@ use crate::whitenoise::{
 };
 
 #[cfg(not(test))]
-const KEY_PACKAGE_RELAY_CLEANUP_DELAY: Duration =
-    Duration::from_secs(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS);
-#[cfg(not(test))]
+const KEY_PACKAGE_RELAY_CLEANUP_DELAY: Duration = Duration::from_secs(
+    crate::whitenoise::session::key_packages::KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS,
+);
+#[cfg(test)]
+const KEY_PACKAGE_RELAY_CLEANUP_DELAY: Duration = Duration::from_millis(50);
 const KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS: usize = 3;
 
 impl Whitenoise {
@@ -80,12 +78,15 @@ impl Whitenoise {
         .await;
     }
 
-    #[cfg(test)]
-    pub(crate) async fn run_key_package_relay_cleanup_after_grace(&self, _trigger: &'static str) {}
-
-    #[cfg(not(test))]
     pub(crate) async fn run_key_package_relay_cleanup_after_grace(&self, trigger: &'static str) {
         let mut shutdown_rx = self.scheduler_shutdown.subscribe();
+        if *shutdown_rx.borrow() {
+            tracing::debug!(
+                target: "whitenoise::foreground_catchup",
+                "Skipping delayed key package relay cleanup because shutdown already began"
+            );
+            return;
+        }
 
         for attempt in 1..=KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS {
             tokio::select! {
@@ -297,6 +298,73 @@ mod tests {
 
         whitenoise.resume_after_background().await.unwrap();
         whitenoise.resume_after_background().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn key_package_relay_cleanup_exits_when_shutdown_already_started() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let _ = whitenoise.scheduler_shutdown.send(true);
+        let wn = whitenoise.clone();
+
+        let handle =
+            tokio::spawn(async move { wn.run_key_package_relay_cleanup_after_grace("test").await });
+
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("cleanup should not sleep when shutdown was already requested")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn key_package_relay_cleanup_waits_for_grace_period() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let wn = whitenoise.clone();
+
+        let handle =
+            tokio::spawn(async move { wn.run_key_package_relay_cleanup_after_grace("test").await });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !handle.is_finished(),
+            "cleanup should wait through the invite grace period before running"
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("cleanup should finish after the test grace period")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn key_package_relay_cleanup_exits_when_shutdown_changes_during_delay() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let wn = whitenoise.clone();
+
+        let handle =
+            tokio::spawn(async move { wn.run_key_package_relay_cleanup_after_grace("test").await });
+
+        tokio::task::yield_now().await;
+        let _ = whitenoise.scheduler_shutdown.send(true);
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("cleanup should exit after shutdown changes")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn schedule_key_package_relay_cleanup_runs_background_task() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        whitenoise
+            .schedule_key_package_relay_cleanup_after_grace("test")
+            .await;
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            whitenoise.wait_for_pending_background_tasks(),
+        )
+        .await
+        .expect("scheduled cleanup should finish after the test grace period");
     }
 
     #[test]

--- a/src/whitenoise/foreground_catchup.rs
+++ b/src/whitenoise/foreground_catchup.rs
@@ -57,15 +57,11 @@ impl Whitenoise {
     pub async fn resume_after_background(&self) -> Result<()> {
         let accounts = self.force_foreground_subscription_catch_up().await?;
         self.replay_chat_list_stream_snapshots(&accounts).await;
-        self.schedule_key_package_relay_cleanup_after_grace("foreground")
-            .await;
+        self.schedule_key_package_relay_cleanup_after_grace().await;
         Ok(())
     }
 
-    pub(crate) async fn schedule_key_package_relay_cleanup_after_grace(
-        &self,
-        trigger: &'static str,
-    ) {
+    pub(crate) async fn schedule_key_package_relay_cleanup_after_grace(&self) {
         let Some(wn) = self.this.upgrade() else {
             tracing::warn!(
                 target: "whitenoise::foreground_catchup",
@@ -75,7 +71,8 @@ impl Whitenoise {
         };
 
         self.spawn_background(async move {
-            wn.run_key_package_relay_cleanup_after_grace(trigger).await;
+            wn.run_key_package_relay_cleanup_after_grace("foreground")
+                .await;
         })
         .await;
     }
@@ -378,7 +375,7 @@ mod tests {
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
         whitenoise
-            .schedule_key_package_relay_cleanup_after_grace("test")
+            .schedule_key_package_relay_cleanup_after_grace()
             .await;
 
         tokio::time::timeout(

--- a/src/whitenoise/foreground_catchup.rs
+++ b/src/whitenoise/foreground_catchup.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use tokio::sync::watch;
+
 use crate::perf_instrument;
 use crate::whitenoise::session::key_packages::KeyPackageRelayCleanupOutcome;
 use crate::whitenoise::{
@@ -89,67 +91,14 @@ impl Whitenoise {
         }
 
         for attempt in 1..=KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS {
-            tokio::select! {
-                _ = tokio::time::sleep(KEY_PACKAGE_RELAY_CLEANUP_DELAY) => {}
-                changed = shutdown_rx.changed() => {
-                    if changed.is_err() || *shutdown_rx.borrow() {
-                        tracing::debug!(
-                            target: "whitenoise::foreground_catchup",
-                            "Skipping delayed key package relay cleanup because shutdown began"
-                        );
-                        return;
-                    }
-                }
+            if Self::key_package_relay_cleanup_shutdown_started(&mut shutdown_rx).await {
+                return;
             }
 
-            let mut saw_deferred = false;
-            for session in self.account_manager.sessions_iter() {
-                match session
-                    .key_packages()
-                    .cleanup_relay_key_packages_once()
-                    .await
-                {
-                    Ok(KeyPackageRelayCleanupOutcome::AlreadyCompleted) => {
-                        tracing::debug!(
-                            target: "whitenoise::foreground_catchup",
-                            account = %session.account_pubkey.to_hex(),
-                            trigger,
-                            "One-time key package relay cleanup already completed"
-                        );
-                    }
-                    Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage) => {
-                        saw_deferred = true;
-                        tracing::info!(
-                            target: "whitenoise::foreground_catchup",
-                            account = %session.account_pubkey.to_hex(),
-                            trigger,
-                            attempt,
-                            "Deferring one-time key package relay cleanup until consumed \
-                             key packages leave the quiet period"
-                        );
-                    }
-                    Ok(KeyPackageRelayCleanupOutcome::DeletedAndPublished { deleted }) => {
-                        tracing::info!(
-                            target: "whitenoise::foreground_catchup",
-                            account = %session.account_pubkey.to_hex(),
-                            trigger,
-                            deleted,
-                            "Completed one-time key package relay cleanup"
-                        );
-                    }
-                    Err(error) => {
-                        tracing::warn!(
-                            target: "whitenoise::foreground_catchup",
-                            account = %session.account_pubkey.to_hex(),
-                            trigger,
-                            "One-time key package relay cleanup failed: {}",
-                            error
-                        );
-                    }
-                }
-            }
-
-            if !saw_deferred {
+            if !self
+                .run_key_package_relay_cleanup_sweep(trigger, attempt)
+                .await
+            {
                 return;
             }
         }
@@ -160,6 +109,79 @@ impl Whitenoise {
             attempts = KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS,
             "One-time key package relay cleanup remained deferred after all attempts"
         );
+    }
+
+    async fn key_package_relay_cleanup_shutdown_started(
+        shutdown_rx: &mut watch::Receiver<bool>,
+    ) -> bool {
+        tokio::select! {
+            _ = tokio::time::sleep(KEY_PACKAGE_RELAY_CLEANUP_DELAY) => false,
+            changed = shutdown_rx.changed() => {
+                if changed.is_err() || *shutdown_rx.borrow() {
+                    tracing::debug!(
+                        target: "whitenoise::foreground_catchup",
+                        "Skipping delayed key package relay cleanup because shutdown began"
+                    );
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    async fn run_key_package_relay_cleanup_sweep(
+        &self,
+        trigger: &'static str,
+        attempt: usize,
+    ) -> bool {
+        let mut saw_deferred = false;
+        for session in self.account_manager.sessions_iter() {
+            match session
+                .key_packages()
+                .cleanup_relay_key_packages_once()
+                .await
+            {
+                Ok(KeyPackageRelayCleanupOutcome::AlreadyCompleted) => {
+                    tracing::debug!(
+                        target: "whitenoise::foreground_catchup",
+                        account = %session.account_pubkey.to_hex(),
+                        trigger,
+                        "One-time key package relay cleanup already completed"
+                    );
+                }
+                Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage) => {
+                    saw_deferred = true;
+                    tracing::info!(
+                        target: "whitenoise::foreground_catchup",
+                        account = %session.account_pubkey.to_hex(),
+                        trigger,
+                        attempt,
+                        "Deferring one-time key package relay cleanup until consumed \
+                         key packages leave the quiet period"
+                    );
+                }
+                Ok(KeyPackageRelayCleanupOutcome::DeletedAndPublished { deleted }) => {
+                    tracing::info!(
+                        target: "whitenoise::foreground_catchup",
+                        account = %session.account_pubkey.to_hex(),
+                        trigger,
+                        deleted,
+                        "Completed one-time key package relay cleanup"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "whitenoise::foreground_catchup",
+                        account = %session.account_pubkey.to_hex(),
+                        trigger,
+                        "One-time key package relay cleanup failed: {}",
+                        error
+                    );
+                }
+            }
+        }
+        saw_deferred
     }
 
     async fn force_foreground_subscription_catch_up(&self) -> Result<Vec<Account>> {

--- a/src/whitenoise/foreground_catchup.rs
+++ b/src/whitenoise/foreground_catchup.rs
@@ -1,12 +1,24 @@
 use std::collections::HashSet;
+#[cfg(not(test))]
+use std::time::Duration;
 
 use crate::perf_instrument;
+#[cfg(not(test))]
+use crate::whitenoise::session::key_packages::{
+    KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KeyPackageRelayCleanupOutcome,
+};
 use crate::whitenoise::{
     Whitenoise,
     accounts::Account,
     chat_list_streaming::{ChatListUpdate, ChatListUpdateTrigger},
     error::{Result, WhitenoiseError},
 };
+
+#[cfg(not(test))]
+const KEY_PACKAGE_RELAY_CLEANUP_DELAY: Duration =
+    Duration::from_secs(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS);
+#[cfg(not(test))]
+const KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS: usize = 3;
 
 impl Whitenoise {
     /// Catch the main app process up after foreground resume or notification tap.
@@ -45,7 +57,108 @@ impl Whitenoise {
     pub async fn resume_after_background(&self) -> Result<()> {
         let accounts = self.force_foreground_subscription_catch_up().await?;
         self.replay_chat_list_stream_snapshots(&accounts).await;
+        self.schedule_key_package_relay_cleanup_after_grace("foreground")
+            .await;
         Ok(())
+    }
+
+    pub(crate) async fn schedule_key_package_relay_cleanup_after_grace(
+        &self,
+        trigger: &'static str,
+    ) {
+        let Some(wn) = self.this.upgrade() else {
+            tracing::warn!(
+                target: "whitenoise::foreground_catchup",
+                "Cannot schedule key package relay cleanup: Whitenoise handle is shutting down"
+            );
+            return;
+        };
+
+        self.spawn_background(async move {
+            wn.run_key_package_relay_cleanup_after_grace(trigger).await;
+        })
+        .await;
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn run_key_package_relay_cleanup_after_grace(&self, _trigger: &'static str) {}
+
+    #[cfg(not(test))]
+    pub(crate) async fn run_key_package_relay_cleanup_after_grace(&self, trigger: &'static str) {
+        let mut shutdown_rx = self.scheduler_shutdown.subscribe();
+
+        for attempt in 1..=KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS {
+            tokio::select! {
+                _ = tokio::time::sleep(KEY_PACKAGE_RELAY_CLEANUP_DELAY) => {}
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        tracing::debug!(
+                            target: "whitenoise::foreground_catchup",
+                            "Skipping delayed key package relay cleanup because shutdown began"
+                        );
+                        return;
+                    }
+                }
+            }
+
+            let mut saw_deferred = false;
+            for session in self.account_manager.sessions_iter() {
+                match session
+                    .key_packages()
+                    .cleanup_relay_key_packages_once()
+                    .await
+                {
+                    Ok(KeyPackageRelayCleanupOutcome::AlreadyCompleted) => {
+                        tracing::debug!(
+                            target: "whitenoise::foreground_catchup",
+                            account = %session.account_pubkey.to_hex(),
+                            trigger,
+                            "One-time key package relay cleanup already completed"
+                        );
+                    }
+                    Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage) => {
+                        saw_deferred = true;
+                        tracing::info!(
+                            target: "whitenoise::foreground_catchup",
+                            account = %session.account_pubkey.to_hex(),
+                            trigger,
+                            attempt,
+                            "Deferring one-time key package relay cleanup until consumed \
+                             key packages leave the quiet period"
+                        );
+                    }
+                    Ok(KeyPackageRelayCleanupOutcome::DeletedAndPublished { deleted }) => {
+                        tracing::info!(
+                            target: "whitenoise::foreground_catchup",
+                            account = %session.account_pubkey.to_hex(),
+                            trigger,
+                            deleted,
+                            "Completed one-time key package relay cleanup"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "whitenoise::foreground_catchup",
+                            account = %session.account_pubkey.to_hex(),
+                            trigger,
+                            "One-time key package relay cleanup failed: {}",
+                            error
+                        );
+                    }
+                }
+            }
+
+            if !saw_deferred {
+                return;
+            }
+        }
+
+        tracing::warn!(
+            target: "whitenoise::foreground_catchup",
+            trigger,
+            attempts = KEY_PACKAGE_RELAY_CLEANUP_MAX_ATTEMPTS,
+            "One-time key package relay cleanup remained deferred after all attempts"
+        );
     }
 
     async fn force_foreground_subscription_catch_up(&self) -> Result<Vec<Account>> {

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -1073,7 +1073,10 @@ impl Whitenoise {
                             target: "whitenoise::new",
                             "Background subscription setup failed: {error}"
                         );
+                        return;
                     }
+                    wn.run_key_package_relay_cleanup_after_grace("startup")
+                        .await;
                 })
                 .await;
         } else {

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -34,8 +34,7 @@ pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_TASK: &str = "key_package_relay_clean
 pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS: u64 = 30;
 
 /// Quiet period after a key package is consumed before relay cleanup may start.
-pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS: u64 =
-    KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS;
+pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS: u64 = 30;
 
 const KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS: u64 = 500;
 
@@ -44,6 +43,12 @@ pub(crate) enum KeyPackageRelayCleanupOutcome {
     AlreadyCompleted,
     DeferredRecentConsumedKeyPackage,
     DeletedAndPublished { deleted: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PublishedKeyPackagePair {
+    canonical: EventId,
+    legacy: Option<EventId>,
 }
 
 /// View over [`AccountSession`] for key package lifecycle operations.
@@ -103,7 +108,7 @@ impl<'a> KeyPackageOps<'a> {
                 .publish_pair(&key_package_data, canonical_created_at, &relay_urls)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(_) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(
                         target: "whitenoise::key_packages",
@@ -144,7 +149,8 @@ impl<'a> KeyPackageOps<'a> {
             self.prepare_canonical_publish_inputs(relays).await?;
         let relay_urls = Relay::urls(relays);
         self.publish_pair(&key_package_data, canonical_created_at, &relay_urls)
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Resolves persisted canonical-slot state and generates the key package
@@ -201,7 +207,7 @@ impl<'a> KeyPackageOps<'a> {
         key_package_data: &KeyPackageEventData,
         canonical_created_at: Timestamp,
         relay_urls: &[RelayUrl],
-    ) -> Result<()> {
+    ) -> Result<PublishedKeyPackagePair> {
         let canonical_event_id = self
             .publish_to_relays(
                 MLS_KEY_PACKAGE_KIND,
@@ -223,6 +229,7 @@ impl<'a> KeyPackageOps<'a> {
         )
         .await?;
 
+        let mut legacy_event_id = None;
         match self
             .publish_to_relays(
                 MLS_KEY_PACKAGE_KIND_LEGACY,
@@ -233,13 +240,14 @@ impl<'a> KeyPackageOps<'a> {
             )
             .await
         {
-            Ok(legacy_event_id) => {
+            Ok(published_legacy_event_id) => {
                 // Legacy tracking is best-effort: kind:443 is regular per
                 // NIP-01 (not addressable), so a missed row only affects
                 // audit-trail completeness, not future canonical
                 // replacement.
-                self.track_published_legacy(&key_package_data.hash_ref, &legacy_event_id)
+                self.track_published_legacy(&key_package_data.hash_ref, &published_legacy_event_id)
                     .await;
+                legacy_event_id = Some(published_legacy_event_id);
             }
             Err(e) => {
                 tracing::warn!(
@@ -252,7 +260,10 @@ impl<'a> KeyPackageOps<'a> {
             }
         }
 
-        Ok(())
+        Ok(PublishedKeyPackagePair {
+            canonical: canonical_event_id,
+            legacy: legacy_event_id,
+        })
     }
 
     #[perf_instrument("key_packages")]
@@ -271,7 +282,10 @@ impl<'a> KeyPackageOps<'a> {
     ///
     /// The cleanup deliberately deletes only relay events, never local MLS key
     /// material. Pending Welcome processing still needs the local material for
-    /// key packages that were consumed before this job runs.
+    /// key packages that were consumed before this job runs. Local rows and key
+    /// material for stale, unconsumed packages may remain orphaned; this bounded
+    /// one-time leak is intentional because deleting them here could break late
+    /// Welcome processing.
     #[perf_instrument("key_packages")]
     pub(crate) async fn cleanup_relay_key_packages_once(
         &self,
@@ -290,12 +304,8 @@ impl<'a> KeyPackageOps<'a> {
             return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
         }
 
-        let publish_relays = self.prepare_relays().await?;
+        let (publish_relays, cleanup_relay_urls) = self.cleanup_relay_scope().await?;
         if publish_relays.is_empty() {
-            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
-        }
-        let cleanup_relay_urls = self.cleanup_relay_urls().await?;
-        if cleanup_relay_urls.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
@@ -318,68 +328,83 @@ impl<'a> KeyPackageOps<'a> {
             return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
         }
 
-        let mut total_deleted = 0;
-        for round in 0..MAX_DELETE_ROUNDS {
-            let key_package_events = self
-                .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
-                .await?;
-            if key_package_events.is_empty() {
-                break;
-            }
-
-            let deleted = self
-                .delete_batch_from_relay_urls(key_package_events, false, 1, &cleanup_relay_urls)
-                .await?;
-            total_deleted += deleted;
-
-            if deleted == 0 {
-                let remaining = self
-                    .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
-                    .await?;
-                return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
-                    "one-time key package cleanup could not delete relay event(s): {} still \
-                     present after round {}",
-                    remaining.len(),
-                    round + 1
-                )));
-            }
-        }
-
-        let remaining = self
-            .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
-            .await?;
-        if !remaining.is_empty() {
-            return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
-                "one-time key package cleanup left {} relay event(s) after {} delete round(s)",
-                remaining.len(),
-                MAX_DELETE_ROUNDS
-            )));
-        }
-
         let (key_package_data, canonical_created_at) = self
             .prepare_canonical_publish_inputs(&publish_relays)
             .await?;
         let publish_relay_urls = Relay::urls(&publish_relays);
-        self.publish_pair(&key_package_data, canonical_created_at, &publish_relay_urls)
+        let published_pair = self
+            .publish_pair(&key_package_data, canonical_created_at, &publish_relay_urls)
             .await?;
+        let Some(legacy_event_id) = published_pair.legacy else {
+            return Err(WhitenoiseError::KeyPackagePublishFailed(
+                "one-time key package cleanup could not publish legacy replacement".to_string(),
+            ));
+        };
+        let replacement_event_ids = [published_pair.canonical, legacy_event_id];
 
         tokio::time::sleep(Duration::from_millis(
             KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS,
         ))
         .await;
 
-        let final_events = self
-            .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
-            .await?;
-        if !has_exact_key_package_pair(&final_events) {
-            let (canonical, legacy) = key_package_pair_counts(&final_events);
+        let mut total_deleted = 0;
+        for round in 0..MAX_DELETE_ROUNDS {
+            let stale_key_package_events = self
+                .fetch_all_from_relay_urls(&cleanup_relay_urls)
+                .await?
+                .into_iter()
+                .filter(|event| !replacement_event_ids.contains(&event.id))
+                .collect::<Vec<_>>();
+            if stale_key_package_events.is_empty() {
+                break;
+            }
+
+            let deleted = self
+                .delete_batch_from_relay_urls(
+                    stale_key_package_events,
+                    false,
+                    1,
+                    &cleanup_relay_urls,
+                )
+                .await?;
+            total_deleted += deleted;
+
+            if deleted == 0 {
+                let remaining = self
+                    .fetch_all_from_relay_urls(&cleanup_relay_urls)
+                    .await?
+                    .into_iter()
+                    .filter(|event| !replacement_event_ids.contains(&event.id))
+                    .count();
+                return Err(WhitenoiseError::KeyPackageDeleteFailed(format!(
+                    "one-time key package cleanup could not delete relay event(s): {} stale \
+                     event(s) still present after round {}",
+                    remaining,
+                    round + 1
+                )));
+            }
+        }
+
+        let remaining = self
+            .fetch_all_from_relay_urls(&cleanup_relay_urls)
+            .await?
+            .into_iter()
+            .filter(|event| !replacement_event_ids.contains(&event.id))
+            .count();
+        if remaining > 0 {
+            return Err(WhitenoiseError::KeyPackageDeleteFailed(format!(
+                "one-time key package cleanup left {} stale relay event(s) after {} delete round(s)",
+                remaining, MAX_DELETE_ROUNDS
+            )));
+        }
+
+        let final_events = self.fetch_all_from_relay_urls(&cleanup_relay_urls).await?;
+        if !published_key_package_pair_is_visible(&final_events, &replacement_event_ids) {
             return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
-                "one-time key package cleanup verification expected exactly one kind:{} and \
-                 one kind:{} event, found {} canonical, {} legacy, {} total",
-                MLS_KEY_PACKAGE_KIND.as_u16(),
-                MLS_KEY_PACKAGE_KIND_LEGACY.as_u16(),
-                canonical,
-                legacy,
+                "one-time key package cleanup verification did not find replacement events {} \
+                 and {}; {} key package event(s) visible",
+                replacement_event_ids[0].to_hex(),
+                replacement_event_ids[1].to_hex(),
                 final_events.len()
             )));
         }
@@ -402,17 +427,6 @@ impl<'a> KeyPackageOps<'a> {
             .fetch_key_packages_from_relays(relay_urls)
             .await?;
         Ok(self.filter_fetched_key_package_events(key_package_events))
-    }
-
-    async fn fetch_all_from_reachable_cleanup_relays(
-        &self,
-        relay_urls: &[RelayUrl],
-    ) -> Result<Vec<Event>> {
-        // This naming wrapper keeps cleanup call sites explicit. Partial-connect
-        // handling lives inside the ephemeral fetch path; cleanup should operate
-        // on relays that are reachable now without one disconnected relay
-        // blocking the rest.
-        self.fetch_all_from_relay_urls(relay_urls).await
     }
 
     fn filter_fetched_key_package_events(&self, key_package_events: Vec<Event>) -> Vec<Event> {
@@ -602,7 +616,6 @@ impl<'a> KeyPackageOps<'a> {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
 
-        let original_count = key_package_events.len();
         let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
 
         if delete_mls_stored_keys {
@@ -637,15 +650,15 @@ impl<'a> KeyPackageOps<'a> {
             }
         }
 
-        let deleted_count = original_count - pending_ids.len();
+        let deleted_count = original_ids.len() - pending_ids.len();
 
         if !pending_ids.is_empty() {
             tracing::warn!(
-                target: "whitenoise::key_packages",
-                "After {} retries, {} of {} key package(s) still not deleted for account {}",
+            target: "whitenoise::key_packages",
+            "After {} retries, {} of {} key package(s) still not deleted for account {}",
                 max_retries,
                 pending_ids.len(),
-                original_count,
+                original_ids.len(),
                 self.session.account_pubkey.to_hex()
             );
         }
@@ -774,7 +787,7 @@ impl<'a> KeyPackageOps<'a> {
             .await
     }
 
-    async fn cleanup_relay_urls(&self) -> Result<Vec<RelayUrl>> {
+    async fn cleanup_relay_scope(&self) -> Result<(Vec<Relay>, Vec<RelayUrl>)> {
         let user =
             User::find_by_pubkey(&self.session.account_pubkey, &self.session.shared.database)
                 .await
@@ -786,8 +799,8 @@ impl<'a> KeyPackageOps<'a> {
             .relays(RelayType::Nip65, &self.session.shared.database)
             .await?;
 
-        Ok(merge_cleanup_relay_urls(
-            key_package_relays.into_iter().map(|relay| relay.url),
+        let cleanup_relay_urls = merge_cleanup_relay_urls(
+            key_package_relays.iter().map(|relay| relay.url.clone()),
             nip65_relays.into_iter().map(|relay| relay.url),
             self.session
                 .shared
@@ -795,7 +808,9 @@ impl<'a> KeyPackageOps<'a> {
                 .default_account_relays
                 .iter()
                 .cloned(),
-        ))
+        );
+
+        Ok((key_package_relays, cleanup_relay_urls))
     }
 
     async fn has_recent_consumed_key_package(&self) -> Result<bool> {
@@ -944,16 +959,6 @@ impl<'a> KeyPackageOps<'a> {
     }
 }
 
-fn push_unique_relay_url(
-    relay_urls: &mut Vec<RelayUrl>,
-    seen: &mut HashSet<String>,
-    relay_url: RelayUrl,
-) {
-    if seen.insert(relay_url.as_str().to_owned()) {
-        relay_urls.push(relay_url);
-    }
-}
-
 fn merge_cleanup_relay_urls<KeyPackageRelays, Nip65Relays, DefaultRelays>(
     key_package_relays: KeyPackageRelays,
     nip65_relays: Nip65Relays,
@@ -964,36 +969,19 @@ where
     Nip65Relays: IntoIterator<Item = RelayUrl>,
     DefaultRelays: IntoIterator<Item = RelayUrl>,
 {
-    let mut relay_urls = Vec::new();
     let mut seen = HashSet::new();
-    for relay_url in key_package_relays {
-        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
-    }
-    for relay_url in nip65_relays {
-        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
-    }
-    for relay_url in default_relays {
-        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
-    }
-
-    relay_urls
+    key_package_relays
+        .into_iter()
+        .chain(nip65_relays)
+        .chain(default_relays)
+        .filter(|relay_url| seen.insert(relay_url.as_str().to_owned()))
+        .collect()
 }
 
-fn key_package_pair_counts(events: &[Event]) -> (usize, usize) {
-    let canonical = events
+fn published_key_package_pair_is_visible(events: &[Event], event_ids: &[EventId; 2]) -> bool {
+    event_ids
         .iter()
-        .filter(|event| event.kind == MLS_KEY_PACKAGE_KIND)
-        .count();
-    let legacy = events
-        .iter()
-        .filter(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY)
-        .count();
-    (canonical, legacy)
-}
-
-fn has_exact_key_package_pair(events: &[Event]) -> bool {
-    let (canonical, legacy) = key_package_pair_counts(events);
-    canonical == 1 && legacy == 1 && events.len() == 2
+        .all(|event_id| events.iter().any(|event| event.id == *event_id))
 }
 
 #[cfg(test)]
@@ -1004,7 +992,7 @@ mod tests {
         KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS,
         KEY_PACKAGE_RELAY_CLEANUP_TASK, KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS,
         KeyPackageRelayCleanupOutcome, MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY,
-        has_exact_key_package_pair, merge_cleanup_relay_urls,
+        merge_cleanup_relay_urls, published_key_package_pair_is_visible,
     };
     use crate::RelayType;
     use crate::whitenoise::error::WhitenoiseError;
@@ -1351,7 +1339,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cleanup_relay_urls_reads_key_package_nip65_and_default_sources() {
+    async fn cleanup_relay_scope_reads_key_package_nip65_and_default_sources() {
         let pk = Keys::generate().public_key();
         let session = test_session(pk).await;
         let user = User::find_by_pubkey(&pk, &session.shared.database)
@@ -1377,8 +1365,10 @@ mod tests {
             .await
             .unwrap();
 
-        let cleanup_urls = session.key_packages().cleanup_relay_urls().await.unwrap();
+        let (publish_relays, cleanup_urls) =
+            session.key_packages().cleanup_relay_scope().await.unwrap();
 
+        assert_eq!(Relay::urls(&publish_relays), vec![key_package_url.clone()]);
         assert!(cleanup_urls.contains(&key_package_url));
         assert!(cleanup_urls.contains(&nip65_url));
         for default_url in &session.shared.config.default_account_relays {
@@ -1423,7 +1413,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_pair_requires_one_canonical_and_one_legacy_event() {
+    fn published_pair_visibility_requires_both_replacement_event_ids() {
         let keys = Keys::generate();
         let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "canonical")
             .tags([Tag::parse(["d", "slot"]).unwrap()])
@@ -1435,18 +1425,15 @@ mod tests {
         let extra_legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "extra")
             .sign_with_keys(&keys)
             .unwrap();
+        let event_ids = [canonical.id, legacy.id];
 
-        assert!(has_exact_key_package_pair(&[
-            canonical.clone(),
-            legacy.clone()
-        ]));
-        assert!(!has_exact_key_package_pair(std::slice::from_ref(
-            &canonical
-        )));
-        assert!(!has_exact_key_package_pair(&[
-            canonical,
-            legacy,
-            extra_legacy
-        ]));
+        assert!(published_key_package_pair_is_visible(
+            &[canonical.clone(), legacy.clone(), extra_legacy],
+            &event_ids
+        ));
+        assert!(!published_key_package_pair_is_visible(
+            std::slice::from_ref(&canonical),
+            &event_ids
+        ));
     }
 }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -26,6 +26,22 @@ const MAX_PUBLISH_ATTEMPTS: u32 = 3;
 /// Maximum number of fetch-delete rounds before giving up.
 pub(crate) const MAX_DELETE_ROUNDS: u32 = 10;
 
+/// One-time per-account marker for the release cleanup that purges legacy
+/// relay-side key packages and republishes one fresh pair.
+pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_TASK: &str = "key_package_relay_cleanup_v1";
+
+/// Quiet period used before the one-time relay cleanup runs after foreground catch-up.
+pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS: u64 = 30;
+
+const KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS: u64 = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeyPackageRelayCleanupOutcome {
+    AlreadyCompleted,
+    DeferredRecentConsumedKeyPackage,
+    DeletedAndPublished { deleted: usize },
+}
+
 /// View over [`AccountSession`] for key package lifecycle operations.
 ///
 /// Obtain via [`AccountSession::key_packages`].
@@ -243,12 +259,169 @@ impl<'a> KeyPackageOps<'a> {
         }
 
         let relay_urls = Relay::urls(&relays);
+        self.fetch_all_from_relay_urls(&relay_urls).await
+    }
+
+    /// One-time release cleanup for accounts that may have accumulated extra
+    /// relay-side key package events.
+    ///
+    /// The cleanup deliberately deletes only relay events, never local MLS key
+    /// material. Pending Welcome processing still needs the local material for
+    /// key packages that were consumed before this job runs.
+    #[perf_instrument("key_packages")]
+    pub(crate) async fn cleanup_relay_key_packages_once(
+        &self,
+    ) -> Result<KeyPackageRelayCleanupOutcome> {
+        if self
+            .session
+            .repos
+            .maintenance_tasks
+            .is_completed(KEY_PACKAGE_RELAY_CLEANUP_TASK)
+            .await?
+        {
+            return Ok(KeyPackageRelayCleanupOutcome::AlreadyCompleted);
+        }
+
+        if self.has_recent_consumed_key_package().await? {
+            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
+        }
+
+        let publish_relays = self.prepare_relays().await?;
+        if publish_relays.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+        let cleanup_relay_urls = self.cleanup_relay_urls().await?;
+        if cleanup_relay_urls.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+
+        // Serialize against normal key package rotation. Welcomes may trigger
+        // a rotation at the same time this maintenance job is preparing to
+        // purge and republish.
+        let _publish_guard = self.session.key_package_publish_lock.lock().await;
+
+        if self
+            .session
+            .repos
+            .maintenance_tasks
+            .is_completed(KEY_PACKAGE_RELAY_CLEANUP_TASK)
+            .await?
+        {
+            return Ok(KeyPackageRelayCleanupOutcome::AlreadyCompleted);
+        }
+
+        if self.has_recent_consumed_key_package().await? {
+            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
+        }
+
+        let mut total_deleted = 0;
+        for round in 0..MAX_DELETE_ROUNDS {
+            let key_package_events = self
+                .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
+                .await?;
+            if key_package_events.is_empty() {
+                break;
+            }
+
+            let batch_size = key_package_events.len();
+            let deleted = self
+                .delete_batch_from_relay_urls(key_package_events, false, 1, &cleanup_relay_urls)
+                .await?;
+            total_deleted += deleted;
+
+            if deleted == 0 {
+                let remaining = self
+                    .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
+                    .await?;
+                return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
+                    "one-time key package cleanup could not delete {} remaining relay event(s) \
+                     after round {} found {} event(s)",
+                    remaining.len(),
+                    round + 1,
+                    batch_size
+                )));
+            }
+        }
+
+        let remaining = self
+            .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
+            .await?;
+        if !remaining.is_empty() {
+            return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
+                "one-time key package cleanup left {} relay event(s) after {} delete round(s)",
+                remaining.len(),
+                MAX_DELETE_ROUNDS
+            )));
+        }
+
+        if self.has_recent_consumed_key_package().await? {
+            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
+        }
+
+        let (key_package_data, canonical_created_at) = self
+            .prepare_canonical_publish_inputs(&publish_relays)
+            .await?;
+        let publish_relay_urls = Relay::urls(&publish_relays);
+        self.publish_pair(&key_package_data, canonical_created_at, &publish_relay_urls)
+            .await?;
+
+        tokio::time::sleep(Duration::from_millis(
+            KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS,
+        ))
+        .await;
+
+        let final_events = self
+            .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
+            .await?;
+        if !has_exact_key_package_pair(&final_events) {
+            let (canonical, legacy) = key_package_pair_counts(&final_events);
+            return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
+                "one-time key package cleanup verification expected exactly one kind:{} and \
+                 one kind:{} event, found {} canonical, {} legacy, {} total",
+                MLS_KEY_PACKAGE_KIND.as_u16(),
+                MLS_KEY_PACKAGE_KIND_LEGACY.as_u16(),
+                canonical,
+                legacy,
+                final_events.len()
+            )));
+        }
+
+        if self.has_recent_consumed_key_package().await? {
+            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
+        }
+
+        self.session
+            .repos
+            .maintenance_tasks
+            .mark_completed(KEY_PACKAGE_RELAY_CLEANUP_TASK)
+            .await?;
+
+        Ok(KeyPackageRelayCleanupOutcome::DeletedAndPublished {
+            deleted: total_deleted,
+        })
+    }
+
+    async fn fetch_all_from_relay_urls(&self, relay_urls: &[RelayUrl]) -> Result<Vec<Event>> {
         let key_package_events = self
             .session
             .ephemeral
-            .fetch_key_packages_from_relays(&relay_urls)
+            .fetch_key_packages_from_relays(relay_urls)
             .await?;
+        Ok(self.filter_fetched_key_package_events(key_package_events))
+    }
 
+    async fn fetch_all_from_reachable_cleanup_relays(
+        &self,
+        relay_urls: &[RelayUrl],
+    ) -> Result<Vec<Event>> {
+        // Keep this as one multi-relay request so the ephemeral relay plane can
+        // use its existing partial-connect behavior. Cleanup should operate on
+        // relays that are reachable now; one disconnected relay should not
+        // block cleanup of the rest.
+        self.fetch_all_from_relay_urls(relay_urls).await
+    }
+
+    fn filter_fetched_key_package_events(&self, key_package_events: Vec<Event>) -> Vec<Event> {
         let (key_package_events, dropped_wrong_kind, dropped_wrong_author) =
             filter_key_package_events_for_account(self.session.account_pubkey, key_package_events);
 
@@ -265,7 +438,7 @@ impl<'a> KeyPackageOps<'a> {
             );
         }
 
-        Ok(key_package_events)
+        key_package_events
     }
 
     /// Returns `true` if the deletion event was accepted by at least one relay.
@@ -406,14 +579,37 @@ impl<'a> KeyPackageOps<'a> {
             return Ok(0);
         }
 
-        let original_count = key_package_events.len();
-        let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
-
         let relays = self.prepare_relays().await?;
         if relays.is_empty() {
             return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
         }
         let relay_urls = Relay::urls(&relays);
+
+        self.delete_batch_from_relay_urls(
+            key_package_events,
+            delete_mls_stored_keys,
+            max_retries,
+            &relay_urls,
+        )
+        .await
+    }
+
+    async fn delete_batch_from_relay_urls(
+        &self,
+        key_package_events: Vec<Event>,
+        delete_mls_stored_keys: bool,
+        max_retries: u32,
+        relay_urls: &[RelayUrl],
+    ) -> Result<usize> {
+        if key_package_events.is_empty() {
+            return Ok(0);
+        }
+        if relay_urls.is_empty() {
+            return Err(WhitenoiseError::AccountMissingKeyPackageRelays);
+        }
+
+        let original_count = key_package_events.len();
+        let original_ids: HashSet<EventId> = key_package_events.iter().map(|e| e.id).collect();
 
         if delete_mls_stored_keys {
             self.delete_from_storage(&key_package_events)?;
@@ -432,10 +628,10 @@ impl<'a> KeyPackageOps<'a> {
                 );
             }
 
-            self.publish_deletion(&pending_ids, &relay_urls).await?;
+            self.publish_deletion(&pending_ids, relay_urls).await?;
             tokio::time::sleep(Duration::from_millis(500)).await;
 
-            let remaining_events = self.fetch_all().await?;
+            let remaining_events = self.fetch_all_from_relay_urls(relay_urls).await?;
             pending_ids = remaining_events
                 .iter()
                 .filter(|e| original_ids.contains(&e.id))
@@ -584,6 +780,38 @@ impl<'a> KeyPackageOps<'a> {
             .await
     }
 
+    async fn cleanup_relay_urls(&self) -> Result<Vec<RelayUrl>> {
+        let user =
+            User::find_by_pubkey(&self.session.account_pubkey, &self.session.shared.database)
+                .await
+                .map_err(|_| WhitenoiseError::AccountNotFound)?;
+        let key_package_relays = user
+            .relays(RelayType::KeyPackage, &self.session.shared.database)
+            .await?;
+        let nip65_relays = user
+            .relays(RelayType::Nip65, &self.session.shared.database)
+            .await?;
+
+        Ok(merge_cleanup_relay_urls(
+            key_package_relays.into_iter().map(|relay| relay.url),
+            nip65_relays.into_iter().map(|relay| relay.url),
+            self.session
+                .shared
+                .config
+                .default_account_relays
+                .iter()
+                .cloned(),
+        ))
+    }
+
+    async fn has_recent_consumed_key_package(&self) -> Result<bool> {
+        self.session
+            .repos
+            .published_key_packages
+            .has_consumed_since(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS as i64)
+            .await
+    }
+
     async fn delete_local_key_material(&self, event_id: &EventId) {
         match self
             .session
@@ -722,11 +950,69 @@ impl<'a> KeyPackageOps<'a> {
     }
 }
 
+fn push_unique_relay_url(
+    relay_urls: &mut Vec<RelayUrl>,
+    seen: &mut HashSet<String>,
+    relay_url: RelayUrl,
+) {
+    if seen.insert(relay_url.as_str().to_owned()) {
+        relay_urls.push(relay_url);
+    }
+}
+
+fn merge_cleanup_relay_urls<KeyPackageRelays, Nip65Relays, DefaultRelays>(
+    key_package_relays: KeyPackageRelays,
+    nip65_relays: Nip65Relays,
+    default_relays: DefaultRelays,
+) -> Vec<RelayUrl>
+where
+    KeyPackageRelays: IntoIterator<Item = RelayUrl>,
+    Nip65Relays: IntoIterator<Item = RelayUrl>,
+    DefaultRelays: IntoIterator<Item = RelayUrl>,
+{
+    let mut relay_urls = Vec::new();
+    let mut seen = HashSet::new();
+    for relay_url in key_package_relays {
+        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
+    }
+    for relay_url in nip65_relays {
+        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
+    }
+    for relay_url in default_relays {
+        push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
+    }
+
+    relay_urls.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+    relay_urls
+}
+
+fn key_package_pair_counts(events: &[Event]) -> (usize, usize) {
+    let canonical = events
+        .iter()
+        .filter(|event| event.kind == MLS_KEY_PACKAGE_KIND)
+        .count();
+    let legacy = events
+        .iter()
+        .filter(|event| event.kind == MLS_KEY_PACKAGE_KIND_LEGACY)
+        .count();
+    (canonical, legacy)
+}
+
+fn has_exact_key_package_pair(events: &[Event]) -> bool {
+    let (canonical, legacy) = key_package_pair_counts(events);
+    canonical == 1 && legacy == 1 && events.len() == 2
+}
+
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::{EventId, Keys, RelayUrl};
+    use nostr_sdk::{EventBuilder, EventId, Keys, RelayUrl, Tag};
 
-    use super::MLS_KEY_PACKAGE_KIND_LEGACY;
+    use super::{
+        KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_TASK,
+        KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS, KeyPackageRelayCleanupOutcome,
+        MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, has_exact_key_package_pair,
+        merge_cleanup_relay_urls,
+    };
     use crate::whitenoise::session::test_helpers::test_session;
 
     #[tokio::test]
@@ -806,5 +1092,68 @@ mod tests {
 
         let result = session.key_packages().delete_batch(vec![], false, 0).await;
         assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn relay_cleanup_policy_constants_are_stable() {
+        assert_eq!(
+            KEY_PACKAGE_RELAY_CLEANUP_TASK,
+            "key_package_relay_cleanup_v1"
+        );
+        assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, 30);
+        assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS, 500);
+        let outcomes = [
+            KeyPackageRelayCleanupOutcome::AlreadyCompleted,
+            KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage,
+            KeyPackageRelayCleanupOutcome::DeletedAndPublished { deleted: 2 },
+        ];
+        assert_eq!(outcomes.len(), 3);
+    }
+
+    #[test]
+    fn cleanup_relay_scope_merges_key_package_nip65_and_default_relays() {
+        let kp = RelayUrl::parse("wss://kp.example").unwrap();
+        let nip65 = RelayUrl::parse("wss://nip65.example").unwrap();
+        let default = RelayUrl::parse("wss://default.example").unwrap();
+
+        let merged = merge_cleanup_relay_urls(
+            [kp.clone(), default.clone()],
+            [nip65.clone(), kp.clone()],
+            [default.clone()],
+        );
+
+        assert_eq!(
+            merged,
+            vec![default, kp, nip65],
+            "cleanup scope should include all three sources and deduplicate"
+        );
+    }
+
+    #[test]
+    fn exact_pair_requires_one_canonical_and_one_legacy_event() {
+        let keys = Keys::generate();
+        let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, "canonical")
+            .tags([Tag::parse(["d", "slot"]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap();
+        let legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "legacy")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let extra_legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "extra")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        assert!(has_exact_key_package_pair(&[
+            canonical.clone(),
+            legacy.clone()
+        ]));
+        assert!(!has_exact_key_package_pair(std::slice::from_ref(
+            &canonical
+        )));
+        assert!(!has_exact_key_package_pair(&[
+            canonical,
+            legacy,
+            extra_legacy
+        ]));
     }
 }

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -33,6 +33,10 @@ pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_TASK: &str = "key_package_relay_clean
 /// Quiet period used before the one-time relay cleanup runs after foreground catch-up.
 pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS: u64 = 30;
 
+/// Quiet period after a key package is consumed before relay cleanup may start.
+pub(crate) const KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS: u64 =
+    KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS;
+
 const KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS: u64 = 500;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -323,7 +327,6 @@ impl<'a> KeyPackageOps<'a> {
                 break;
             }
 
-            let batch_size = key_package_events.len();
             let deleted = self
                 .delete_batch_from_relay_urls(key_package_events, false, 1, &cleanup_relay_urls)
                 .await?;
@@ -334,11 +337,10 @@ impl<'a> KeyPackageOps<'a> {
                     .fetch_all_from_reachable_cleanup_relays(&cleanup_relay_urls)
                     .await?;
                 return Err(WhitenoiseError::KeyPackagePublishFailed(format!(
-                    "one-time key package cleanup could not delete {} remaining relay event(s) \
-                     after round {} found {} event(s)",
+                    "one-time key package cleanup could not delete relay event(s): {} still \
+                     present after round {}",
                     remaining.len(),
-                    round + 1,
-                    batch_size
+                    round + 1
                 )));
             }
         }
@@ -382,10 +384,6 @@ impl<'a> KeyPackageOps<'a> {
             )));
         }
 
-        if self.has_recent_consumed_key_package().await? {
-            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
-        }
-
         self.session
             .repos
             .maintenance_tasks
@@ -410,10 +408,10 @@ impl<'a> KeyPackageOps<'a> {
         &self,
         relay_urls: &[RelayUrl],
     ) -> Result<Vec<Event>> {
-        // Keep this as one multi-relay request so the ephemeral relay plane can
-        // use its existing partial-connect behavior. Cleanup should operate on
-        // relays that are reachable now; one disconnected relay should not
-        // block cleanup of the rest.
+        // This naming wrapper keeps cleanup call sites explicit. Partial-connect
+        // handling lives inside the ephemeral fetch path; cleanup should operate
+        // on relays that are reachable now without one disconnected relay
+        // blocking the rest.
         self.fetch_all_from_relay_urls(relay_urls).await
     }
 
@@ -804,7 +802,7 @@ impl<'a> KeyPackageOps<'a> {
         self.session
             .repos
             .published_key_packages
-            .has_consumed_since(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS as i64)
+            .has_consumed_since(KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS as i64)
             .await
     }
 
@@ -978,7 +976,6 @@ where
         push_unique_relay_url(&mut relay_urls, &mut seen, relay_url);
     }
 
-    relay_urls.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
     relay_urls
 }
 
@@ -1004,10 +1001,10 @@ mod tests {
     use nostr_sdk::{EventBuilder, EventId, Keys, Kind, RelayUrl, Tag};
 
     use super::{
-        KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_TASK,
-        KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS, KeyPackageRelayCleanupOutcome,
-        MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, has_exact_key_package_pair,
-        merge_cleanup_relay_urls,
+        KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS,
+        KEY_PACKAGE_RELAY_CLEANUP_TASK, KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS,
+        KeyPackageRelayCleanupOutcome, MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY,
+        has_exact_key_package_pair, merge_cleanup_relay_urls,
     };
     use crate::RelayType;
     use crate::whitenoise::error::WhitenoiseError;
@@ -1396,6 +1393,7 @@ mod tests {
             "key_package_relay_cleanup_v1"
         );
         assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, 30);
+        assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS, 30);
         assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS, 500);
         let outcomes = [
             KeyPackageRelayCleanupOutcome::AlreadyCompleted,
@@ -1412,15 +1410,15 @@ mod tests {
         let default = RelayUrl::parse("wss://default.example").unwrap();
 
         let merged = merge_cleanup_relay_urls(
-            [kp.clone(), default.clone()],
+            [kp.clone()],
             [nip65.clone(), kp.clone()],
-            [default.clone()],
+            [default.clone(), nip65.clone()],
         );
 
         assert_eq!(
             merged,
-            vec![default, kp, nip65],
-            "cleanup scope should include all three sources and deduplicate"
+            vec![kp, nip65, default],
+            "cleanup scope should include all three sources, deduplicate, and preserve source order"
         );
     }
 

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -354,10 +354,6 @@ impl<'a> KeyPackageOps<'a> {
             )));
         }
 
-        if self.has_recent_consumed_key_package().await? {
-            return Ok(KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage);
-        }
-
         let (key_package_data, canonical_created_at) = self
             .prepare_canonical_publish_inputs(&publish_relays)
             .await?;
@@ -1005,7 +1001,7 @@ fn has_exact_key_package_pair(events: &[Event]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use nostr_sdk::{EventBuilder, EventId, Keys, RelayUrl, Tag};
+    use nostr_sdk::{EventBuilder, EventId, Keys, Kind, RelayUrl, Tag};
 
     use super::{
         KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_TASK,
@@ -1013,7 +1009,11 @@ mod tests {
         MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, has_exact_key_package_pair,
         merge_cleanup_relay_urls,
     };
+    use crate::RelayType;
+    use crate::whitenoise::error::WhitenoiseError;
+    use crate::whitenoise::relays::Relay;
     use crate::whitenoise::session::test_helpers::test_session;
+    use crate::whitenoise::users::User;
 
     #[tokio::test]
     async fn delete_keeps_local_material_when_no_relays() {
@@ -1092,6 +1092,301 @@ mod tests {
 
         let result = session.key_packages().delete_batch(vec![], false, 0).await;
         assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_batch_from_relay_urls_empty_returns_zero_before_relay_check() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let result = session
+            .key_packages()
+            .delete_batch_from_relay_urls(vec![], true, 0, &[])
+            .await;
+
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_batch_from_relay_urls_requires_relays_for_nonempty_batch() {
+        let keys = Keys::generate();
+        let session = test_session(keys.public_key()).await;
+        let event = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "key-package")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let result = session
+            .key_packages()
+            .delete_batch_from_relay_urls(vec![event], false, 0, &[])
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::AccountMissingKeyPackageRelays)
+        ));
+    }
+
+    #[tokio::test]
+    async fn filter_fetched_key_package_events_drops_wrong_kind_and_author() {
+        let account_keys = Keys::generate();
+        let session = test_session(account_keys.public_key()).await;
+        let matching = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "legacy")
+            .sign_with_keys(&account_keys)
+            .unwrap();
+        let wrong_kind = EventBuilder::new(Kind::TextNote, "not a key package")
+            .sign_with_keys(&account_keys)
+            .unwrap();
+        let wrong_author = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "wrong author")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        let filtered = session
+            .key_packages()
+            .filter_fetched_key_package_events(vec![matching.clone(), wrong_kind, wrong_author]);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, matching.id);
+    }
+
+    #[tokio::test]
+    async fn delete_local_key_material_marks_hash_ref_group_deleted() {
+        let account_keys = Keys::generate();
+        let pk = account_keys.public_key();
+        let session = test_session(pk).await;
+        let dummy_url = RelayUrl::parse("wss://test.invalid").unwrap();
+        let kp_data = session
+            .mdk
+            .create_key_package_for_event(&pk, vec![dummy_url])
+            .expect("create key package");
+        let canonical = EventBuilder::new(MLS_KEY_PACKAGE_KIND, &kp_data.content)
+            .tags(kp_data.tags_30443.to_vec())
+            .sign_with_keys(&account_keys)
+            .unwrap();
+        let legacy = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, &kp_data.content)
+            .tags(kp_data.tags_443.to_vec())
+            .sign_with_keys(&account_keys)
+            .unwrap();
+
+        session
+            .repos
+            .published_key_packages
+            .create(
+                &kp_data.hash_ref,
+                &canonical.id.to_hex(),
+                MLS_KEY_PACKAGE_KIND,
+                Some(&kp_data.d_tag),
+            )
+            .await
+            .unwrap();
+        session
+            .repos
+            .published_key_packages
+            .create(
+                &kp_data.hash_ref,
+                &legacy.id.to_hex(),
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                None,
+            )
+            .await
+            .unwrap();
+
+        session
+            .key_packages()
+            .delete_local_key_material(&canonical.id)
+            .await;
+
+        let records = session
+            .repos
+            .published_key_packages
+            .find_by_hash_ref(&kp_data.hash_ref)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().all(|record| record.key_material_deleted));
+    }
+
+    #[tokio::test]
+    async fn delete_local_key_material_handles_missing_and_already_deleted_records() {
+        let keys = Keys::generate();
+        let session = test_session(keys.public_key()).await;
+        let missing = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "missing")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        session
+            .key_packages()
+            .delete_local_key_material(&missing.id)
+            .await;
+
+        session
+            .repos
+            .published_key_packages
+            .create(
+                b"already-deleted",
+                &missing.id.to_hex(),
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                None,
+            )
+            .await
+            .unwrap();
+        let record = session
+            .repos
+            .published_key_packages
+            .find_by_event_id(&missing.id.to_hex())
+            .await
+            .unwrap()
+            .unwrap();
+        session
+            .repos
+            .published_key_packages
+            .mark_key_material_deleted(record.id)
+            .await
+            .unwrap();
+
+        session
+            .key_packages()
+            .delete_local_key_material(&missing.id)
+            .await;
+
+        let record = session
+            .repos
+            .published_key_packages
+            .find_by_event_id(&missing.id.to_hex())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(record.key_material_deleted);
+    }
+
+    #[tokio::test]
+    async fn delete_from_storage_deletes_parseable_events_and_ignores_invalid_events() {
+        let account_keys = Keys::generate();
+        let pk = account_keys.public_key();
+        let session = test_session(pk).await;
+        let dummy_url = RelayUrl::parse("wss://test.invalid").unwrap();
+        let kp_data = session
+            .mdk
+            .create_key_package_for_event(&pk, vec![dummy_url])
+            .expect("create key package");
+        let valid = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, &kp_data.content)
+            .tags(kp_data.tags_443.to_vec())
+            .sign_with_keys(&account_keys)
+            .unwrap();
+        let invalid = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "not-a-key-package")
+            .sign_with_keys(&account_keys)
+            .unwrap();
+
+        session
+            .key_packages()
+            .delete_from_storage(&[valid, invalid])
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_once_returns_already_completed_before_relay_resolution() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+        session
+            .repos
+            .maintenance_tasks
+            .mark_completed(KEY_PACKAGE_RELAY_CLEANUP_TASK)
+            .await
+            .unwrap();
+
+        let outcome = session
+            .key_packages()
+            .cleanup_relay_key_packages_once()
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, KeyPackageRelayCleanupOutcome::AlreadyCompleted);
+    }
+
+    #[tokio::test]
+    async fn cleanup_once_defers_recent_consumption_before_purge() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+        let event_id = EventId::all_zeros().to_hex();
+        session
+            .repos
+            .published_key_packages
+            .create(
+                b"recent-consumed",
+                &event_id,
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                None,
+            )
+            .await
+            .unwrap();
+        session
+            .repos
+            .published_key_packages
+            .mark_consumed(&event_id)
+            .await
+            .unwrap();
+
+        let outcome = session
+            .key_packages()
+            .cleanup_relay_key_packages_once()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_once_requires_publish_relays_when_not_deferred() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+
+        let result = session
+            .key_packages()
+            .cleanup_relay_key_packages_once()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(WhitenoiseError::AccountMissingKeyPackageRelays)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cleanup_relay_urls_reads_key_package_nip65_and_default_sources() {
+        let pk = Keys::generate().public_key();
+        let session = test_session(pk).await;
+        let user = User::find_by_pubkey(&pk, &session.shared.database)
+            .await
+            .unwrap();
+        let key_package_url = RelayUrl::parse("wss://cleanup-kp.example").unwrap();
+        let nip65_url = RelayUrl::parse("wss://cleanup-nip65.example").unwrap();
+        let key_package_relay =
+            Relay::find_or_create_by_url(&key_package_url, &session.shared.database)
+                .await
+                .unwrap();
+        let nip65_relay = Relay::find_or_create_by_url(&nip65_url, &session.shared.database)
+            .await
+            .unwrap();
+        user.add_relays(
+            &[key_package_relay],
+            RelayType::KeyPackage,
+            &session.shared.database,
+        )
+        .await
+        .unwrap();
+        user.add_relays(&[nip65_relay], RelayType::Nip65, &session.shared.database)
+            .await
+            .unwrap();
+
+        let cleanup_urls = session.key_packages().cleanup_relay_urls().await.unwrap();
+
+        assert!(cleanup_urls.contains(&key_package_url));
+        assert!(cleanup_urls.contains(&nip65_url));
+        for default_url in &session.shared.config.default_account_relays {
+            assert!(cleanup_urls.contains(default_url));
+        }
     }
 
     #[test]

--- a/src/whitenoise/session/key_packages.rs
+++ b/src/whitenoise/session/key_packages.rs
@@ -23,6 +23,9 @@ use crate::whitenoise::database::published_key_packages::PublishedKeyPackage;
 /// Maximum number of relay publish attempts before giving up.
 const MAX_PUBLISH_ATTEMPTS: u32 = 3;
 
+/// Legacy cleanup retries after the canonical replacement has already landed.
+const LEGACY_TWIN_RETRY_ATTEMPTS: u32 = 3;
+
 /// Maximum number of fetch-delete rounds before giving up.
 pub(crate) const MAX_DELETE_ROUNDS: u32 = 10;
 
@@ -229,26 +232,8 @@ impl<'a> KeyPackageOps<'a> {
         )
         .await?;
 
-        let mut legacy_event_id = None;
-        match self
-            .publish_to_relays(
-                MLS_KEY_PACKAGE_KIND_LEGACY,
-                &key_package_data.content,
-                relay_urls,
-                &key_package_data.tags_443,
-                None,
-            )
-            .await
-        {
-            Ok(published_legacy_event_id) => {
-                // Legacy tracking is best-effort: kind:443 is regular per
-                // NIP-01 (not addressable), so a missed row only affects
-                // audit-trail completeness, not future canonical
-                // replacement.
-                self.track_published_legacy(&key_package_data.hash_ref, &published_legacy_event_id)
-                    .await;
-                legacy_event_id = Some(published_legacy_event_id);
-            }
+        let legacy_event_id = match self.publish_legacy_twin(key_package_data, relay_urls).await {
+            Ok(published_legacy_event_id) => Some(published_legacy_event_id),
             Err(e) => {
                 tracing::warn!(
                     target: "whitenoise::key_packages",
@@ -257,8 +242,9 @@ impl<'a> KeyPackageOps<'a> {
                     self.session.account_pubkey.to_hex(),
                     e,
                 );
+                None
             }
-        }
+        };
 
         Ok(PublishedKeyPackagePair {
             canonical: canonical_event_id,
@@ -335,10 +321,12 @@ impl<'a> KeyPackageOps<'a> {
         let published_pair = self
             .publish_pair(&key_package_data, canonical_created_at, &publish_relay_urls)
             .await?;
-        let Some(legacy_event_id) = published_pair.legacy else {
-            return Err(WhitenoiseError::KeyPackagePublishFailed(
-                "one-time key package cleanup could not publish legacy replacement".to_string(),
-            ));
+        let legacy_event_id = match published_pair.legacy {
+            Some(event_id) => event_id,
+            None => {
+                self.publish_legacy_twin_with_retry(&key_package_data, &publish_relay_urls)
+                    .await?
+            }
         };
         let replacement_event_ids = [published_pair.canonical, legacy_event_id];
 
@@ -728,6 +716,61 @@ impl<'a> KeyPackageOps<'a> {
         Ok(*result.id())
     }
 
+    async fn publish_legacy_twin(
+        &self,
+        key_package_data: &KeyPackageEventData,
+        relay_urls: &[RelayUrl],
+    ) -> Result<EventId> {
+        let legacy_event_id = self
+            .publish_to_relays(
+                MLS_KEY_PACKAGE_KIND_LEGACY,
+                &key_package_data.content,
+                relay_urls,
+                &key_package_data.tags_443,
+                None,
+            )
+            .await?;
+        // Legacy tracking is best-effort: kind:443 is regular per NIP-01
+        // (not addressable), so a missed row only affects the audit trail.
+        self.track_published_legacy(&key_package_data.hash_ref, &legacy_event_id)
+            .await;
+        Ok(legacy_event_id)
+    }
+
+    async fn publish_legacy_twin_with_retry(
+        &self,
+        key_package_data: &KeyPackageEventData,
+        relay_urls: &[RelayUrl],
+    ) -> Result<EventId> {
+        let mut last_error = None;
+        for attempt in 1..=LEGACY_TWIN_RETRY_ATTEMPTS {
+            tokio::time::sleep(legacy_twin_retry_delay(attempt)).await;
+            match self.publish_legacy_twin(key_package_data, relay_urls).await {
+                Ok(legacy_event_id) => return Ok(legacy_event_id),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "whitenoise::key_packages",
+                        "Legacy key package cleanup retry {}/{} failed for account {}: {}",
+                        attempt,
+                        LEGACY_TWIN_RETRY_ATTEMPTS,
+                        self.session.account_pubkey.to_hex(),
+                        error,
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        Err(WhitenoiseError::KeyPackagePublishFailed(format!(
+            "one-time key package cleanup could not publish legacy replacement after {} retry \
+             attempt(s): {}",
+            LEGACY_TWIN_RETRY_ATTEMPTS,
+            last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "no retry attempted".to_string())
+        )))
+    }
+
     /// Tracks a canonical (kind:30443) publish in the per-account DB.
     ///
     /// Errors propagate to the caller because the d-tag reuse and
@@ -984,15 +1027,22 @@ fn published_key_package_pair_is_visible(events: &[Event], event_ids: &[EventId;
         .all(|event_id| events.iter().any(|event| event.id == *event_id))
 }
 
+fn legacy_twin_retry_delay(attempt: u32) -> Duration {
+    Duration::from_millis(250 * 2_u64.pow(attempt.saturating_sub(1)))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use nostr_sdk::{EventBuilder, EventId, Keys, Kind, RelayUrl, Tag};
 
     use super::{
         KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS,
         KEY_PACKAGE_RELAY_CLEANUP_TASK, KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS,
-        KeyPackageRelayCleanupOutcome, MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY,
-        merge_cleanup_relay_urls, published_key_package_pair_is_visible,
+        KeyPackageRelayCleanupOutcome, LEGACY_TWIN_RETRY_ATTEMPTS, MLS_KEY_PACKAGE_KIND,
+        MLS_KEY_PACKAGE_KIND_LEGACY, legacy_twin_retry_delay, merge_cleanup_relay_urls,
+        published_key_package_pair_is_visible,
     };
     use crate::RelayType;
     use crate::whitenoise::error::WhitenoiseError;
@@ -1385,6 +1435,7 @@ mod tests {
         assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_INVITE_GRACE_SECS, 30);
         assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_QUIET_PERIOD_SECS, 30);
         assert_eq!(KEY_PACKAGE_RELAY_CLEANUP_VERIFY_DELAY_MS, 500);
+        assert_eq!(LEGACY_TWIN_RETRY_ATTEMPTS, 3);
         let outcomes = [
             KeyPackageRelayCleanupOutcome::AlreadyCompleted,
             KeyPackageRelayCleanupOutcome::DeferredRecentConsumedKeyPackage,
@@ -1435,5 +1486,12 @@ mod tests {
             std::slice::from_ref(&canonical),
             &event_ids
         ));
+    }
+
+    #[test]
+    fn legacy_twin_retry_delay_uses_short_exponential_backoff() {
+        assert_eq!(legacy_twin_retry_delay(1), Duration::from_millis(250));
+        assert_eq!(legacy_twin_retry_delay(2), Duration::from_millis(500));
+        assert_eq!(legacy_twin_retry_delay(3), Duration::from_millis(1000));
     }
 }


### PR DESCRIPTION
## Summary

- add a one-time per-account key package relay cleanup marker
- wait through the invite quiet period, delete relay-side legacy/canonical key package events, then republish one legacy and one kind:30443 package
- broaden cleanup relay scope to key-package relays, NIP-65 relays, and default account relays while tolerating unreachable relays via the existing ephemeral relay plane

## Validation

- cargo test --features cli --lib whitenoise::session::key_packages::tests
- just precommit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic key-package relay cleanup after startup and on resume with grace windows, retries, verification, and idempotent completion marking.
  * New check to detect recently consumed key packages to defer cleanup when activity is recent.

* **Chores**
  * Per-account tracking for one-time maintenance task completion and accompanying database migration.

* **Tests**
  * Async tests for scheduling, deferral, task-marking idempotency, migration, and consumption/cleanup behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise-rs/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->