### PR TITLE
Add text effects to whitenoise-markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Markdown text effects: `{name}…{/name}` inline syntax (e.g. `{big}`, `{small}`, `{shake}`) with arbitrary effect names and nested markdown content ([#849] [@dannym-arx])
 - Thumbhash support for media previews alongside existing blurhash, allowing clients to migrate over time ([#714] [@erskingardner])
 - Audio chat media metadata is now first-class in media records, including optional duration, waveform, and an imeta tag helper for app bindings ([#833] [@erskingardner])
 - CLI message reactions (react/unreact) ([#564] [@jgmontoya])
@@ -218,6 +219,7 @@ Complete architectural rewrite from Tauri desktop/mobile app to a pure Rust libr
 [@F3r10]: <https://github.com/F3r10>
 [@mubarakcoded]: <https://github.com/mubarakcoded> (nostr:npub1mlyye6fpsqnkuxwv3nzzf3cmrau8x6z3fhh095246me87ya0aprsun609q)
 [@johnathanCorgan]: <https://github.com/jcorgan>
+[@dannym-arx]: <https://github.com/dannym-arx>
 
 
 <!-- PRs -->
@@ -291,6 +293,7 @@ Complete architectural rewrite from Tauri desktop/mobile app to a pure Rust libr
 [#591]: https://github.com/marmot-protocol/whitenoise-rs/pull/591
 [#714]: https://github.com/marmot-protocol/whitenoise-rs/pull/714
 [#833]: https://github.com/marmot-protocol/whitenoise-rs/pull/833
+[#849]: https://github.com/marmot-protocol/whitenoise-rs/pull/849
 
 
 <!-- Tags -->

--- a/crates/whitenoise-markdown/src/ast.rs
+++ b/crates/whitenoise-markdown/src/ast.rs
@@ -83,6 +83,14 @@ pub enum Inline {
     Emph(Vec<Inline>),
     Strong(Vec<Inline>),
     Strikethrough(Vec<Inline>),
+    /// Text effect: `{name}children{/name}`. `name` is an
+    /// arbitrary `[A-Za-z][A-Za-z0-9_-]*` token (e.g. `big`, `small`,
+    /// `shake`); `children` are the markdown-parsed contents. Rendering of
+    /// the effect itself is left to the consumer.
+    Effect {
+        name: String,
+        children: Vec<Inline>,
+    },
     Link {
         dest: String,
         title: Option<String>,

--- a/crates/whitenoise-markdown/src/inline.rs
+++ b/crates/whitenoise-markdown/src/inline.rs
@@ -26,7 +26,7 @@ use crate::scanner;
 /// those letters.
 const INLINE_SPECIAL: [bool; 128] = {
     let mut t = [false; 128];
-    let chars = b"\\`$&[!*_~]<@nhmtw\n";
+    let chars = b"\\`$&[!*_~]<@nhmtw{\n";
     let mut k = 0;
     while k < chars.len() {
         t[chars[k] as usize] = true;
@@ -145,6 +145,17 @@ impl BracketDelim {
 
 /// Tokenize the raw paragraph/heading text. First-match-wins.
 pub(crate) fn tokenize(raw: &str, refs: &HashMap<String, LinkRef>) -> Vec<Inline> {
+    tokenize_inner(raw, refs, &[])
+}
+
+/// Inner tokenizer. `suppressed` carries the names of the text effects that
+/// enclose this text (an effect cannot nest inside one of the same name), so
+/// a `{name}` whose name is in `suppressed` is treated as literal `{`.
+fn tokenize_inner(
+    raw: &str,
+    refs: &HashMap<String, LinkRef>,
+    suppressed: &[String],
+) -> Vec<Inline> {
     let bytes = raw.as_bytes();
     let mut out: Vec<Inline> = Vec::new();
     // Entity decoding only ever shrinks bytes (e.g. `&amp;` → `&`), so
@@ -280,6 +291,16 @@ pub(crate) fn tokenize(raw: &str, refs: &HashMap<String, LinkRef>) -> Vec<Inline
                     i += 1;
                 }
             }
+            b'{' => {
+                if let Some((name, children, end)) = try_effect(bytes, i, refs, suppressed) {
+                    flush_text(&mut out, &mut buf, &delims);
+                    out.push(Inline::Effect { name, children });
+                    i = end;
+                } else {
+                    buf.push('{');
+                    i += 1;
+                }
+            }
             b'@' => try_or_literal!('@', try_nostr_mention(bytes, i), Inline::NostrMention),
             b'n' => {
                 if let Some((entity, end)) = try_nostr_uri(bytes, i) {
@@ -365,6 +386,19 @@ pub(crate) fn tokenize(raw: &str, refs: &HashMap<String, LinkRef>) -> Vec<Inline
                             // mid-word in prose.
                             if matches!(cc, b'h' | b'm' | b't' | b'w')
                                 && !looks_like_bare_url_start(bytes, i)
+                            {
+                                i += 1;
+                                continue;
+                            }
+                            // `{` is a tripwire for text effects (`{name}…`).
+                            // An effect name must start with an ASCII letter,
+                            // so a `{` not followed by one (set notation,
+                            // `${x}`, etc.) stays on the fast path.
+                            if cc == b'{'
+                                && !bytes
+                                    .get(i + 1)
+                                    .copied()
+                                    .is_some_and(|n| n.is_ascii_alphabetic())
                             {
                                 i += 1;
                                 continue;
@@ -1017,6 +1051,103 @@ fn try_nostr_uri(bytes: &[u8], i: usize) -> Option<(NostrEntity, usize)> {
     let (hrp, end) = nostr::classify_bech32(bytes, i + 6)?;
     let bech32 = std::str::from_utf8(&bytes[i + 6..end]).ok()?.to_string();
     Some((NostrEntity { hrp, bech32 }, end))
+}
+
+// ---------------------------------------------------------------------------
+// Text effects — `{name}…{/name}`
+// ---------------------------------------------------------------------------
+
+/// Max effect-name length. Bounds the open-tag scan and keeps a stray `{`
+/// followed by a long alnum run from being mistaken for a tag opener.
+const EFFECT_NAME_MAX: usize = 64;
+
+/// Characters allowed in an effect name after the leading letter.
+fn is_effect_name_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
+}
+
+/// Try to consume a text effect `{name}…{/name}` starting at byte `i` (which
+/// must point at `{`). Returns the name, the tokenized children, and the byte
+/// index just past the closing `{/name}`.
+///
+/// The name is `[A-Za-z][A-Za-z0-9_-]*`. The matching close balances nested
+/// opens of the *same* name and skips over code spans and backslash escapes,
+/// so a literal `{/name}` inside `` `…` `` does not close the effect. Content
+/// is recursively tokenized, so markdown (and *differently*-named effects)
+/// inside an effect parse normally — but an effect cannot nest inside one of
+/// the same name: `{name}` is added to `suppressed` for the recursive pass, so
+/// an inner `{name}…{/name}` stays literal inline text. An effect with no
+/// matching close stays literal.
+fn try_effect(
+    bytes: &[u8],
+    i: usize,
+    refs: &HashMap<String, LinkRef>,
+    suppressed: &[String],
+) -> Option<(String, Vec<Inline>, usize)> {
+    debug_assert_eq!(bytes[i], b'{');
+    // Parse the opening `{name}`.
+    let name_start = i + 1;
+    if !bytes.get(name_start).copied()?.is_ascii_alphabetic() {
+        return None;
+    }
+    let mut j = name_start + 1;
+    while j < bytes.len() && is_effect_name_char(bytes[j]) && (j - name_start) < EFFECT_NAME_MAX {
+        j += 1;
+    }
+    if bytes.get(j) != Some(&b'}') {
+        return None;
+    }
+    let name = &bytes[name_start..j];
+    // An effect of this name already encloses us — don't recognize a nested
+    // open of the same name; the caller emits a literal `{`.
+    if suppressed.iter().any(|s| s.as_bytes() == name) {
+        return None;
+    }
+    let content_start = j + 1;
+
+    // The close tag we're looking for: `{/name}`.
+    let close_len = name.len() + 3; // '{' '/' name '}'
+    let same_open_len = name.len() + 2; // '{' name '}'
+    let mut depth = 1usize;
+    let mut k = content_start;
+    while k < bytes.len() {
+        match bytes[k] {
+            b'\\' => {
+                // Skip the escaped byte so an escaped brace can't open/close.
+                k += 2;
+            }
+            b'`' => {
+                // Skip over a code span so a `{/name}` inside it is inert.
+                match try_code_span(bytes, k) {
+                    Some((_, end)) => k = end,
+                    None => k += 1,
+                }
+            }
+            b'{' if bytes.get(k + 1) == Some(&b'/')
+                && bytes.get(k + 2..k + 2 + name.len()) == Some(name)
+                && bytes.get(k + 2 + name.len()) == Some(&b'}') =>
+            {
+                depth -= 1;
+                if depth == 0 {
+                    let content = std::str::from_utf8(&bytes[content_start..k]).ok()?;
+                    let name = std::str::from_utf8(name).ok()?.to_string();
+                    let mut child_suppressed = suppressed.to_vec();
+                    child_suppressed.push(name.clone());
+                    let children = tokenize_inner(content, refs, &child_suppressed);
+                    return Some((name, children, k + close_len));
+                }
+                k += close_len;
+            }
+            b'{' if bytes.get(k + 1..k + 1 + name.len()) == Some(name)
+                && bytes.get(k + 1 + name.len()) == Some(&b'}') =>
+            {
+                depth += 1;
+                k += same_open_len;
+            }
+            _ => k += 1,
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/whitenoise-markdown/tests/common/mod.rs
+++ b/crates/whitenoise-markdown/tests/common/mod.rs
@@ -26,6 +26,12 @@ pub fn strike(children: Vec<Inline>) -> Inline {
 pub fn code(s: &str) -> Inline {
     Inline::Code(s.to_string())
 }
+pub fn effect(name: &str, children: Vec<Inline>) -> Inline {
+    Inline::Effect {
+        name: name.to_string(),
+        children,
+    }
+}
 
 /// Convert a raw multi-line string into the inline-token form the inline
 /// pass would emit for a paragraph or heading whose only content is plain

--- a/crates/whitenoise-markdown/tests/common/render.rs
+++ b/crates/whitenoise-markdown/tests/common/render.rs
@@ -165,6 +165,11 @@ fn render_inline(i: &Inline, out: &mut String) {
             render_inlines(c, out);
             out.push_str("</del>");
         }
+        Inline::Effect { name, children } => {
+            out.push_str(&format!("<span class=\"effect-{}\">", escape_attr(name)));
+            render_inlines(children, out);
+            out.push_str("</span>");
+        }
         Inline::Link {
             dest,
             title,
@@ -231,6 +236,7 @@ fn collect_text(inlines: &[Inline], out: &mut String) {
             Inline::Emph(c)
             | Inline::Strong(c)
             | Inline::Strikethrough(c)
+            | Inline::Effect { children: c, .. }
             | Inline::Link { children: c, .. } => collect_text(c, out),
             Inline::Image { alt: c, .. } => collect_text(c, out),
             Inline::SoftBreak | Inline::HardBreak => out.push(' '),

--- a/crates/whitenoise-markdown/tests/golden.rs
+++ b/crates/whitenoise-markdown/tests/golden.rs
@@ -113,3 +113,8 @@ fn nested_containers() {
 fn bare_urls() {
     assert_golden("bare_urls");
 }
+
+#[test]
+fn text_effects() {
+    assert_golden("text_effects");
+}

--- a/crates/whitenoise-markdown/tests/golden/text_effects.json
+++ b/crates/whitenoise-markdown/tests/golden/text_effects.json
@@ -1,0 +1,221 @@
+{
+  "blocks": [
+    {
+      "Heading": {
+        "level": 1,
+        "inlines": [
+          {
+            "Text": "Text effects"
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Plain "
+          },
+          {
+            "Effect": {
+              "name": "big",
+              "children": [
+                {
+                  "Text": "large text"
+                }
+              ]
+            }
+          },
+          {
+            "Text": " and "
+          },
+          {
+            "Effect": {
+              "name": "small",
+              "children": [
+                {
+                  "Text": "tiny text"
+                }
+              ]
+            }
+          },
+          {
+            "Text": " inline."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "A "
+          },
+          {
+            "Effect": {
+              "name": "shake",
+              "children": [
+                {
+                  "Text": "shaky "
+                },
+                {
+                  "Strong": [
+                    {
+                      "Text": "bold"
+                    }
+                  ]
+                },
+                {
+                  "Text": " and "
+                },
+                {
+                  "Emph": [
+                    {
+                      "Text": "italic"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "Text": " run mixes markdown."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Arbitrary names work: "
+          },
+          {
+            "Effect": {
+              "name": "WHATEVER",
+              "children": [
+                {
+                  "Text": "anything goes"
+                }
+              ]
+            }
+          },
+          {
+            "Text": "."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Nesting different effects: "
+          },
+          {
+            "Effect": {
+              "name": "big",
+              "children": [
+                {
+                  "Text": "outer "
+                },
+                {
+                  "Effect": {
+                    "name": "shake",
+                    "children": [
+                      {
+                        "Text": "inner"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Text": " tail"
+                }
+              ]
+            }
+          },
+          {
+            "Text": "."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Same-name nesting: "
+          },
+          {
+            "Effect": {
+              "name": "big",
+              "children": [
+                {
+                  "Text": "a {big}b{/big} c"
+                }
+              ]
+            }
+          },
+          {
+            "Text": "."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Effects do not fire inside code: "
+          },
+          {
+            "Code": "{big}literal{/big}"
+          },
+          {
+            "Text": " stays a code span,"
+          },
+          "SoftBreak",
+          {
+            "Text": "and "
+          },
+          {
+            "Effect": {
+              "name": "big",
+              "children": [
+                {
+                  "Text": "an effect wrapping a "
+                },
+                {
+                  "Code": "{/big}"
+                },
+                {
+                  "Text": " code span"
+                }
+              ]
+            }
+          },
+          {
+            "Text": " closes correctly."
+          }
+        ]
+      }
+    },
+    {
+      "CodeBlock": {
+        "kind": "Fenced",
+        "info": "",
+        "content": "{big}fenced code is untouched{/big}\n"
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Non-effects stay literal: {1, 2, 3}, {not closed, and {big}escaped{/big}."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/whitenoise-markdown/tests/golden/text_effects.md
+++ b/crates/whitenoise-markdown/tests/golden/text_effects.md
@@ -1,0 +1,20 @@
+# Text effects
+
+Plain {big}large text{/big} and {small}tiny text{/small} inline.
+
+A {shake}shaky **bold** and *italic*{/shake} run mixes markdown.
+
+Arbitrary names work: {WHATEVER}anything goes{/WHATEVER}.
+
+Nesting different effects: {big}outer {shake}inner{/shake} tail{/big}.
+
+Same-name nesting: {big}a {big}b{/big} c{/big}.
+
+Effects do not fire inside code: `{big}literal{/big}` stays a code span,
+and {big}an effect wrapping a `{/big}` code span{/big} closes correctly.
+
+```
+{big}fenced code is untouched{/big}
+```
+
+Non-effects stay literal: {1, 2, 3}, {not closed, and \{big\}escaped\{/big\}.

--- a/crates/whitenoise-markdown/tests/unit_effects.rs
+++ b/crates/whitenoise-markdown/tests/unit_effects.rs
@@ -1,0 +1,161 @@
+//! Text effects: `{name}…{/name}` (iMessage-style).
+
+use whitenoise_markdown::{Block, Inline};
+
+mod common;
+use common::{code, effect, parse_blocks, parse_inlines, strong, t};
+
+// ----- Basics ----------------------------------------------------------
+
+#[test]
+fn simple_effect() {
+    assert_eq!(
+        parse_inlines("{big}hi{/big}"),
+        vec![effect("big", vec![t("hi")])]
+    );
+}
+
+#[test]
+fn effect_among_text() {
+    assert_eq!(
+        parse_inlines("a {shake}boo{/shake} b"),
+        vec![t("a "), effect("shake", vec![t("boo")]), t(" b")]
+    );
+}
+
+#[test]
+fn arbitrary_name() {
+    assert_eq!(
+        parse_inlines("{WHATEVER}x{/WHATEVER}"),
+        vec![effect("WHATEVER", vec![t("x")])]
+    );
+}
+
+#[test]
+fn name_with_digits_and_separators() {
+    assert_eq!(
+        parse_inlines("{x_1-2}y{/x_1-2}"),
+        vec![effect("x_1-2", vec![t("y")])]
+    );
+}
+
+#[test]
+fn empty_content() {
+    assert_eq!(parse_inlines("{big}{/big}"), vec![effect("big", vec![])]);
+}
+
+// ----- Markdown inside --------------------------------------------------
+
+#[test]
+fn markdown_inside_effect() {
+    assert_eq!(
+        parse_inlines("{shake}**bold**{/shake}"),
+        vec![effect("shake", vec![strong(vec![t("bold")])])]
+    );
+}
+
+#[test]
+fn effect_inside_emphasis() {
+    // `{big}` is opaque to the surrounding emphasis pairing.
+    assert_eq!(
+        parse_inlines("**{big}x{/big}**"),
+        vec![strong(vec![effect("big", vec![t("x")])])]
+    );
+}
+
+// ----- Nesting ----------------------------------------------------------
+
+#[test]
+fn nested_different_names() {
+    assert_eq!(
+        parse_inlines("{big}a {shake}b{/shake} c{/big}"),
+        vec![effect(
+            "big",
+            vec![t("a "), effect("shake", vec![t("b")]), t(" c")]
+        )]
+    );
+}
+
+#[test]
+fn same_name_does_not_nest() {
+    // An effect can't nest inside one of the same name. The outer span still
+    // balances to the last `{/big}`, but the inner `{big}…{/big}` stays
+    // literal inline text rather than becoming a nested Effect node.
+    assert_eq!(
+        parse_inlines("{big}a {big}b{/big} c{/big}"),
+        vec![effect("big", vec![t("a {big}b{/big} c")])]
+    );
+}
+
+#[test]
+fn sibling_same_name_effects_stay_separate() {
+    // Balancing (not greedy-to-last) keeps two adjacent same-name effects
+    // distinct instead of merging them into one.
+    assert_eq!(
+        parse_inlines("{big}a{/big} b {big}c{/big}"),
+        vec![
+            effect("big", vec![t("a")]),
+            t(" b "),
+            effect("big", vec![t("c")])
+        ]
+    );
+}
+
+// ----- Non-triggers / literals -----------------------------------------
+
+#[test]
+fn unclosed_stays_literal() {
+    assert_eq!(parse_inlines("{big}hello"), vec![t("{big}hello")]);
+}
+
+#[test]
+fn mismatched_close_stays_literal() {
+    assert_eq!(parse_inlines("{big}hi{/small}"), vec![t("{big}hi{/small}")]);
+}
+
+#[test]
+fn set_notation_is_literal() {
+    assert_eq!(parse_inlines("{1, 2, 3}"), vec![t("{1, 2, 3}")]);
+}
+
+#[test]
+fn brace_with_space_is_literal() {
+    assert_eq!(parse_inlines("{ big }x{/big}"), vec![t("{ big }x{/big}")]);
+}
+
+#[test]
+fn escaped_braces_are_literal() {
+    assert_eq!(
+        parse_inlines("\\{big\\}hi\\{/big\\}"),
+        vec![t("{big}hi{/big}")]
+    );
+}
+
+// ----- Code is opaque ---------------------------------------------------
+
+#[test]
+fn close_inside_code_span_is_inert() {
+    // The `{/big}` lives in a code span, so it does not close the effect;
+    // the real close comes after.
+    assert_eq!(
+        parse_inlines("{big}a `{/big}` b{/big}"),
+        vec![effect("big", vec![t("a "), code("{/big}"), t(" b")])]
+    );
+}
+
+#[test]
+fn effect_markers_in_fenced_code_block_are_literal() {
+    let blocks = parse_blocks("```\n{big}x{/big}\n```");
+    match &blocks[0] {
+        Block::CodeBlock { content, .. } => assert_eq!(content, "{big}x{/big}\n"),
+        other => panic!("expected code block, got {other:?}"),
+    }
+}
+
+// ----- Serde sanity -----------------------------------------------------
+
+#[test]
+fn effect_is_a_distinct_variant() {
+    let inlines = parse_inlines("{big}hi{/big}");
+    assert!(matches!(inlines.as_slice(), [Inline::Effect { .. }]));
+}


### PR DESCRIPTION
![marmot](https://blossom.primal.net/0c5f7163a5c6446b044cd606714d7da3bdc1298411d8da9338fab9e24cc7e530.jpg)

Marmots like a bit of flair. This adds text effects to `whitenoise-markdown`: wrap any span in `{name}…{/name}` and the parser hands back a structured node for the app to render.

## What it does

- `{big}party{/big}`, `{small}quiet{/small}`, `{shake}wobble{/shake}`, and any name you invent. The name is `[A-Za-z][A-Za-z0-9_-]*`, so `{WHATEVER}…{/WHATEVER}` works too.
- The content is markdown. `{shake}**bold** and *italic*{/shake}` parses the emphasis inside, and effects with different names nest inside each other.
- A new `Inline::Effect { name, children }` AST node carries it. How to draw the effect is up to the consumer.

## Rules that keep it predictable

- Code stays code. A `{/big}` inside a code span or fenced block never closes an effect.
- An effect cannot nest inside one of the same name. `{big}a {big}b{/big} c{/big}` is one effect whose inner `{big}…{/big}` stays literal text.
- Junk stays literal: unclosed tags, set notation like `{1, 2}`, spaced braces, and `\{` / `\}` escapes.

Covered by a new `unit_effects` suite and a `text_effects` golden fixture.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for text effects using `{name}...{/name}` inline syntax in markdown
  * Effects support nesting with different names but not identical names
  * Effects render as HTML span elements with the specified effect class
  * Effects are inert inside code spans and fenced code blocks
  * Supports arbitrary effect names with alphanumeric characters and separators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->