### PR TITLE
docs: fix wn/wnd CLI install commands (currently install nothing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Install both binaries to `~/.cargo/bin`:
 ```sh
 just install-cli
 # or, equivalently:
-cargo install --path . --features cli
+cargo install --path crates/whitenoise-cli
 ```
 
 Or build from source without installing:
 
 ```sh
-cargo build --release --features cli --bin wn --bin wnd
+cargo build --release -p whitenoise-cli --bin wn --bin wnd
 ```
 
 Quick tour:

--- a/justfile
+++ b/justfile
@@ -447,7 +447,7 @@ build-release:
 
 # Install wn and wnd CLI binaries to ~/.cargo/bin
 install-cli:
-    cargo install --path . --features cli
+    cargo install --path crates/whitenoise-cli
 
 ######################
 # Docker


### PR DESCRIPTION
## Problem

The documented CLI install/build commands don't actually install the `wn`/`wnd` binaries.

`cargo install --path . --features cli` (README, and `just install-cli`) targets the **workspace root** crate, whose only `[[bin]]` targets are gated behind the `benchmark-tests` / `integration-tests` features. So it exits with:

```
warning: none of the package's binaries are available for install using the selected features
```

…and installs nothing. Similarly, `cargo build --release --features cli --bin wn --bin wnd` fails with `no bin target named wn in default-run packages`, because `wn`/`wnd` live in the `whitenoise-cli` crate.

## Fix

Point the install/build commands at the `whitenoise-cli` crate:

- `cargo install --path crates/whitenoise-cli`
- `cargo build --release -p whitenoise-cli --bin wn --bin wnd`

Verified locally — both now produce `wn` + `wnd`.

Updates `README.md` and the `install-cli` recipe in `justfile`. (Surfacing the bins from the root crate would be an alternative; the docs fix is the minimal correct change.)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-rs/pull/850">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->